### PR TITLE
fix select status outside of selection bug

### DIFF
--- a/src/components/dropdown.jsx
+++ b/src/components/dropdown.jsx
@@ -102,7 +102,7 @@ const OptionsStyled = styled.div`
   transition: height 0.3s;
 `
 
-const Dropdown = ({ children, value, style, options, message }) => {
+const Dropdown = ({ children, value, style, options, message, onOpen, onClose }) => {
   const [isOpen, setIsOpen] = useState(false)
 
   // number of options to choose from sets height for animation
@@ -115,11 +115,19 @@ const Dropdown = ({ children, value, style, options, message }) => {
 
   return (
     <>
-      {isOpen && <BackdropStyled onClick={() => setIsOpen(false)} />}
+      {isOpen && (
+        <BackdropStyled
+          onClick={() => {
+            setIsOpen(false)
+            onClose && onClose()
+          }}
+        />
+      )}
       <ContainerStyled
         onClick={(e) => {
           e.stopPropagation()
           setIsOpen(!isOpen)
+          isOpen ? onClose && onClose() : onOpen && onOpen()
         }}
         style={style}
         height={closedHeight}
@@ -146,6 +154,8 @@ Dropdown.propTypes = {
   style: PropTypes.object,
   options: PropTypes.array.isRequired,
   message: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+  onOpen: PropTypes.func,
+  onClose: PropTypes.func,
 }
 
 export default Dropdown

--- a/src/components/status/statusSelect.jsx
+++ b/src/components/status/statusSelect.jsx
@@ -12,6 +12,7 @@ const StatusSelect = ({
   align,
   onChange,
   multipleSelected,
+  onClick,
 }) => {
   const [changedValue, setChangedValue] = useState(null)
 
@@ -48,6 +49,7 @@ const StatusSelect = ({
       options={statuses}
       style={{ maxWidth, height }}
       message={multipleSelected > 1 && `${multipleSelected} Selected`}
+      onOpen={onClick}
     >
       {(props) =>
         props.isOpen ? (
@@ -89,6 +91,7 @@ StatusSelect.propTypes = {
   onChange: PropTypes.func.isRequired,
   maxWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   multipleSelected: PropTypes.number,
+  onClick: PropTypes.func,
 }
 
 export default StatusSelect

--- a/src/pages/browser/subsets.jsx
+++ b/src/pages/browser/subsets.jsx
@@ -105,9 +105,11 @@ const Subsets = () => {
   // update subset status
   const handleStatusChange = async (value, selectedId) => {
     try {
+      // get selected ids
+      let ids = focusedSubsets.includes(selectedId) ? focusedSubsets : [selectedId]
       // create operations array of all entities
       // currently only supports changing one status
-      const operations = focusedSubsets.map((id) => ({
+      const operations = ids.map((id) => ({
         type: 'update',
         entityType: 'subset',
         entityId: id,
@@ -130,6 +132,15 @@ const Subsets = () => {
     } catch (error) {
       console.error(error)
       toast.error('Unable to update subset status')
+    }
+  }
+
+  const handleStatusOpen = (id) => {
+    // handles the edge case where the use foccusess multiple subsets but then changes a different status
+    if (!focusedSubsets.includes(id)) {
+      // not in focused selection
+      // reset selection to status id
+      dispatch(setFocusedSubsets([id]))
     }
   }
 
@@ -176,6 +187,7 @@ const Subsets = () => {
             onChange={(v) => handleStatusChange(v, node.data.id)}
             maxWidth="100%"
             multipleSelected={focusedSubsets.length}
+            onClick={() => handleStatusOpen(node.data.id)}
           />
         )
       },


### PR DESCRIPTION
### Brief Description

When a user selects multiple subsets and then goes to change a status outside of that subset it would only change the selection. 

### Old Behaviour

![image](https://cdn.discordapp.com/attachments/1001811244535259207/1059238913715228702/status_bug.gif)

### New Behaviour

![status_select_outside_bug](https://user-images.githubusercontent.com/49156310/210325406-1299dfc8-b2e4-4d11-a347-f844ebc9cde1.gif)

### Description

- Now selecting a status outside a selection removes the selection and changes only the one status.
- Other behaviours could be that the "outside" subset is added to the selection.

### Testing

1. Select multiple subsets.
2. Click on a status of a subset outside the selection.
3. The status dropdown should not show "x selected".
4. The selection should jump to only the new status clicked on.

