### PR TITLE
Feature: Subsets and Editor column reordering, resizing and filtering

### DIFF
--- a/src/components/dropdown.jsx
+++ b/src/components/dropdown.jsx
@@ -32,6 +32,7 @@ const ContainerStyled = styled.div`
   position: relative;
   height: ${({ height }) => `${height}px`};
   width: 100%;
+  display: inline-block;
 
   /* show warning when changing multiple entities */
   ${({ isOpen, message }) =>

--- a/src/components/status/statusSelect.jsx
+++ b/src/components/status/statusSelect.jsx
@@ -21,8 +21,6 @@ const StatusSelect = ({
     }
   }, [value, changedValue, setChangedValue])
 
-  console.log({ value, changedValue })
-
   if (!value) return null
 
   const handleChange = (status) => {

--- a/src/pages/browser/subsets.jsx
+++ b/src/pages/browser/subsets.jsx
@@ -238,12 +238,23 @@ const Subsets = () => {
     },
   ]
 
-  const filterOptions = columns.map(({ field }) => ({ value: field, label: field }))
-  const selectedFilteredOptions = filterOptions.map(({ value }) => value)
-
-  const [shownColumns, setShownColumns] = useState(selectedFilteredOptions)
   // enabled the folder column to always be seen regardless of focusedFolders
   const [folderOveride, setFolderOveride] = useState(false)
+
+  const filterOptions = columns.map(({ field }) => ({ value: field, label: field }))
+
+  let selectedFilteredOptions = []
+  try {
+    selectedFilteredOptions = JSON.parse(localStorage.getItem('subsets-columns-filter'))
+    // set overide if folders is included
+    if (selectedFilteredOptions.includes('folder')) {
+      if (!folderOveride) setFolderOveride(true)
+    }
+  } catch (error) {
+    selectedFilteredOptions = filterOptions.map(({ value }) => value)
+  }
+
+  const [shownColumns, setShownColumns] = useState(selectedFilteredOptions)
 
   // when multi folders selected show 'folders' column
   useEffect(() => {
@@ -282,6 +293,10 @@ const Subsets = () => {
       // make sure there's always at least one column
       setShownColumns(newArray)
     }
+
+    // save state to local storage
+    const localState = JSON.stringify(newArray)
+    localStorage.setItem('subsets-columns-filter', localState)
   }
 
   // only filter columns if required

--- a/src/pages/browser/subsets.jsx
+++ b/src/pages/browser/subsets.jsx
@@ -145,36 +145,6 @@ const Subsets = () => {
     }
   }
 
-  const storeColumnWidth = (e, key) => {
-    const field = e.column.props.field
-    const width = e.element.offsetWidth
-
-    // set localstorage for column size change
-    let oldWidthState = {}
-    if (localStorage.getItem(key)) {
-      oldWidthState = JSON.parse(localStorage.getItem(key))
-    }
-
-    const newWidthState = { ...oldWidthState, [field]: width }
-
-    localStorage.setItem(key, JSON.stringify(newWidthState))
-
-    return { field, width }
-  }
-
-  const handleColumnResize = (e) => {
-    const key = 'subsets-columns-widths'
-    const { field, width } = storeColumnWidth(e, key)
-
-    // update status column size state for status size "icon | short | full"
-    field === 'status' && setStatusColumnWidth(width)
-  }
-
-  const columnsWidthsState = useMemo(
-    () => JSON.parse(localStorage.getItem('subsets-columns-widths')) || {},
-    [],
-  )
-
   let columns = [
     {
       field: 'name',
@@ -293,13 +263,6 @@ const Subsets = () => {
     }
   }
 
-  const shownColumns = isMultiSelected ? shownColumnsMultiFocused : shownColumnsSingleFocused
-
-  // only filter columns if required
-  if (shownColumns.length < columns.length) {
-    columns = columns.filter(({ field }) => shownColumns.includes(field))
-  }
-
   // sort columns if localstorage set
   let columnsOrder = localStorage.getItem('subsets-columns-order')
   if (columnsOrder) {
@@ -313,6 +276,13 @@ const Subsets = () => {
     }
   }
 
+  const shownColumns = isMultiSelected ? shownColumnsMultiFocused : shownColumnsSingleFocused
+
+  // only filter columns if required
+  if (shownColumns.length < columns.length) {
+    columns = columns.filter(({ field }) => shownColumns.includes(field))
+  }
+
   const handleColumnReorder = (e) => {
     const localStorageOrder = e.columns.reduce(
       (acc, cur, i) => ({ ...acc, [cur.props.field]: i }),
@@ -321,6 +291,36 @@ const Subsets = () => {
 
     localStorage.setItem('subsets-columns-order', JSON.stringify(localStorageOrder))
   }
+
+  const storeColumnWidth = (e, key) => {
+    const field = e.column.props.field
+    const width = e.element.offsetWidth
+
+    // set localstorage for column size change
+    let oldWidthState = {}
+    if (localStorage.getItem(key)) {
+      oldWidthState = JSON.parse(localStorage.getItem(key))
+    }
+
+    const newWidthState = { ...oldWidthState, [field]: width }
+
+    localStorage.setItem(key, JSON.stringify(newWidthState))
+
+    return { field, width }
+  }
+
+  const handleColumnResize = (e) => {
+    const key = 'subsets-columns-widths'
+    const { field, width } = storeColumnWidth(e, key)
+
+    // update status column size state for status size "icon | short | full"
+    field === 'status' && setStatusColumnWidth(width)
+  }
+
+  const columnsWidthsState = useMemo(
+    () => JSON.parse(localStorage.getItem('subsets-columns-widths')) || {},
+    [],
+  )
 
   //
   // Hooks
@@ -450,7 +450,7 @@ const Subsets = () => {
           options={filterOptions}
           value={shownColumns}
           onChange={handleColumnsFilter}
-          placeholder={`Filter Columns (${focusedFolders.length > 1 ? 'Multiple' : 'Single'})`}
+          placeholder={`Show Columns (${focusedFolders.length > 1 ? 'Multiple' : 'Single'})`}
           fixedPlaceholder={shownColumns.length + 1 >= filterOptions.length}
         />
       </Toolbar>

--- a/src/pages/browser/subsets.jsx
+++ b/src/pages/browser/subsets.jsx
@@ -145,6 +145,30 @@ const Subsets = () => {
     }
   }
 
+  const handleColumnResize = (e) => {
+    const field = e.column.props.field
+    const width = e.element.offsetWidth
+    const key = 'subsets-columns-widths'
+
+    // set localstorage for column size change
+    let oldWidthState = {}
+    if (localStorage.getItem(key)) {
+      oldWidthState = JSON.parse(localStorage.getItem(key))
+    }
+
+    const newWidthState = { ...oldWidthState, [field]: width }
+
+    localStorage.setItem(key, JSON.stringify(newWidthState))
+
+    // update status column size state for status size "icon | short | full"
+    field === 'status' && setStatusColumnWidth(e.element.offsetWidth)
+  }
+
+  const columnsWidthsState = useMemo(
+    () => JSON.parse(localStorage.getItem('subsets-columns-widths')) || {},
+    [],
+  )
+
   let columns = [
     {
       field: 'name',
@@ -258,9 +282,7 @@ const Subsets = () => {
       return null
     }
   }
-
   const [shownColumnsSingleFocusedInit = [], shownColumnsMultiFocusedInit = []] = useMemo(() => {
-    console.log('getting columns')
     let single = getLocalStorageArray('subsets-columns-filter-single')
     // if not local storage found/valid
     if (!single) {
@@ -490,9 +512,7 @@ const Subsets = () => {
           onRowClick={onRowClick}
           onContextMenu={(e) => ctxMenuRef.current?.show(e.originalEvent)}
           onContextMenuSelectionChange={onContextMenuSelectionChange}
-          onColumnResizeEnd={(e) =>
-            e.column.key === '.$status' && setStatusColumnWidth(e.element.offsetWidth)
-          }
+          onColumnResizeEnd={handleColumnResize}
           reorderableColumns
           onColReorder={handleColumnReorder}
         >
@@ -500,7 +520,7 @@ const Subsets = () => {
             return (
               <Column
                 key={col.field}
-                style={{ ...col.style, width: col.width }}
+                style={{ ...col.style, width: columnsWidthsState[col.field] || col.width }}
                 expander={i === 0}
                 resizeable={true}
                 field={col.field}

--- a/src/pages/browser/subsets.jsx
+++ b/src/pages/browser/subsets.jsx
@@ -26,6 +26,7 @@ import {
 
 import { SUBSET_QUERY, parseSubsetData, VersionList } from './subsetsUtils'
 import StatusSelect from '../../components/status/statusSelect'
+import { MultiSelect } from 'primereact/multiselect'
 
 const Subsets = () => {
   const dispatch = useDispatch()
@@ -133,7 +134,7 @@ const Subsets = () => {
     }
   }
 
-  const columns = [
+  let columns = [
     {
       field: 'name',
       header: 'Subset',
@@ -224,6 +225,16 @@ const Subsets = () => {
       width: 120,
     },
   ]
+
+  const filterOptions = columns.map(({ field }) => ({ value: field, label: field }))
+  const selectedFilteredOptions = filterOptions.map(({ value }) => value)
+
+  const [shownColumns, setShownColumns] = useState(selectedFilteredOptions)
+
+  // only filter columns if required
+  if (shownColumns.length < columns.length) {
+    columns = columns.filter(({ field }) => shownColumns.includes(field))
+  }
 
   //
   // Hooks
@@ -349,6 +360,13 @@ const Subsets = () => {
     <Section className="wrap">
       <Toolbar>
         <InputText style={{ width: '200px' }} placeholder="Filter subsets..." />
+        <MultiSelect
+          options={filterOptions}
+          value={shownColumns}
+          onChange={(e) => setShownColumns(e.target.value)}
+          placeholder="Filter Columns"
+          fixedPlaceholder={shownColumns.length >= filterOptions.length}
+        />
       </Toolbar>
 
       <TablePanel loading={loading}>

--- a/src/pages/browser/subsets.jsx
+++ b/src/pages/browser/subsets.jsx
@@ -248,6 +248,8 @@ const Subsets = () => {
     columns = columns.filter(({ field }) => shownColumns.includes(field))
   }
 
+  console.log(columns)
+
   //
   // Hooks
   //
@@ -375,7 +377,7 @@ const Subsets = () => {
         <MultiSelect
           options={filterOptions}
           value={shownColumns}
-          onChange={(e) => setShownColumns(e.target.value)}
+          onChange={(e) => e.target.value.length && setShownColumns(e.target.value)}
           placeholder="Filter Columns"
           fixedPlaceholder={shownColumns.length >= filterOptions.length}
         />

--- a/src/pages/browser/subsets.jsx
+++ b/src/pages/browser/subsets.jsx
@@ -45,8 +45,7 @@ const Subsets = () => {
   const ctxMenuRef = useRef(null)
   const [showDetail, setShowDetail] = useState(false) // false or 'subset' or 'version'
   // sets size of status based on status column width
-  const initStatusColumnWidth = 150
-  const [statusColumnWidth, setStatusColumnWidth] = useState(initStatusColumnWidth)
+  const [columnsWidths, setColumnWidths] = useLocalStorage('subsets-columns-widths', {})
 
   // Columns definition
   // It must be here since we are referencing the component state and the context :-(
@@ -169,7 +168,7 @@ const Subsets = () => {
     {
       field: 'status',
       header: 'Status',
-      width: initStatusColumnWidth,
+      width: 150,
       style: { overflow: 'visible' },
       body: (node) => {
         if (node.data.isGroup) return ''
@@ -179,8 +178,8 @@ const Subsets = () => {
             value={node.data.status}
             statuses={context.project.statuses}
             size={
-              statusColumnWidth < statusMaxWidth
-                ? statusColumnWidth < 60
+              columnsWidths['status'] < statusMaxWidth
+                ? columnsWidths['status'] < 60
                   ? 'icon'
                   : 'short'
                 : 'full'
@@ -292,7 +291,8 @@ const Subsets = () => {
     localStorage.setItem('subsets-columns-order', JSON.stringify(localStorageOrder))
   }
 
-  const storeColumnWidth = (e, key) => {
+  const handleColumnResize = (e) => {
+    const key = 'subsets-columns-widths'
     const field = e.column.props.field
     const width = e.element.offsetWidth
 
@@ -304,23 +304,10 @@ const Subsets = () => {
 
     const newWidthState = { ...oldWidthState, [field]: width }
 
-    localStorage.setItem(key, JSON.stringify(newWidthState))
-
-    return { field, width }
+    setColumnWidths(newWidthState)
   }
 
-  const handleColumnResize = (e) => {
-    const key = 'subsets-columns-widths'
-    const { field, width } = storeColumnWidth(e, key)
-
-    // update status column size state for status size "icon | short | full"
-    field === 'status' && setStatusColumnWidth(width)
-  }
-
-  const columnsWidthsState = useMemo(
-    () => JSON.parse(localStorage.getItem('subsets-columns-widths')) || {},
-    [],
-  )
+  // update status width
 
   //
   // Hooks
@@ -486,7 +473,7 @@ const Subsets = () => {
             return (
               <Column
                 key={col.field}
-                style={{ ...col.style, width: columnsWidthsState[col.field] || col.width }}
+                style={{ ...col.style, width: columnsWidths[col.field] || col.width }}
                 expander={i === 0}
                 resizeable={true}
                 field={col.field}

--- a/src/pages/browser/subsets.jsx
+++ b/src/pages/browser/subsets.jsx
@@ -248,7 +248,27 @@ const Subsets = () => {
     columns = columns.filter(({ field }) => shownColumns.includes(field))
   }
 
-  console.log(columns)
+  // sort columns if localstorage set
+  let columnsOrder = localStorage.getItem('subsets-columns-order')
+  if (columnsOrder) {
+    try {
+      columnsOrder = JSON.parse(columnsOrder)
+      columns.sort((a, b) => columnsOrder[a.field] - columnsOrder[b.field])
+    } catch (error) {
+      console.log(error)
+      // remove local stage
+      localStorage.removeItem('subsets-columns-order')
+    }
+  }
+
+  const handleColumnReorder = (e) => {
+    const localStorageOrder = e.columns.reduce(
+      (acc, cur, i) => ({ ...acc, [cur.props.field]: i }),
+      {},
+    )
+
+    localStorage.setItem('subsets-columns-order', JSON.stringify(localStorageOrder))
+  }
 
   //
   // Hooks
@@ -409,6 +429,8 @@ const Subsets = () => {
           onColumnResizeEnd={(e) =>
             e.column.key === '.$status' && setStatusColumnWidth(e.element.offsetWidth)
           }
+          reorderableColumns
+          onColReorder={handleColumnReorder}
         >
           {columns.map((col, i) => {
             return (

--- a/src/pages/browser/subsets.jsx
+++ b/src/pages/browser/subsets.jsx
@@ -290,11 +290,6 @@ const Subsets = () => {
       isMultiSelected
         ? setShownColumnsMultiFocused(newArray)
         : setShownColumnsSingleFocused(newArray)
-      // save state to local storage
-      const localState = JSON.stringify(newArray)
-      const stateKey = `subsets-columns-filter-${isMultiSelected ? 'multi' : 'single'}`
-
-      localStorage.setItem(stateKey, localState)
     }
   }
 

--- a/src/pages/browser/subsets.jsx
+++ b/src/pages/browser/subsets.jsx
@@ -242,6 +242,47 @@ const Subsets = () => {
   const selectedFilteredOptions = filterOptions.map(({ value }) => value)
 
   const [shownColumns, setShownColumns] = useState(selectedFilteredOptions)
+  // enabled the folder column to always be seen regardless of focusedFolders
+  const [folderOveride, setFolderOveride] = useState(false)
+
+  // when multi folders selected show 'folders' column
+  useEffect(() => {
+    if (folderOveride) return
+
+    if (focusedFolders.length > 1) {
+      if (shownColumns.indexOf('folder') === -1) {
+        console.log('1')
+        setShownColumns([...shownColumns, 'folder'])
+      }
+    } else {
+      if (shownColumns.indexOf('folder') > -1) {
+        const newColumns = [...shownColumns]
+        newColumns.splice(newColumns.indexOf('folder'), 1)
+        console.log('2')
+        setShownColumns(newColumns)
+      }
+    }
+  }, [focusedFolders, shownColumns, folderOveride])
+
+  const handleColumnsFilter = (e) => {
+    e.preventDefault()
+    const newArray = e.target.value || []
+
+    if (!folderOveride) {
+      // set overide if selecting folder
+      if (newArray.includes('folder')) {
+        setFolderOveride(true)
+      } else if (shownColumns.includes('folder') && focusedFolders.length) {
+        // removing folder column when multi folders selected
+        setFolderOveride(true)
+      }
+    }
+
+    if (newArray.length) {
+      // make sure there's always at least one column
+      setShownColumns(newArray)
+    }
+  }
 
   // only filter columns if required
   if (shownColumns.length < columns.length) {
@@ -397,9 +438,9 @@ const Subsets = () => {
         <MultiSelect
           options={filterOptions}
           value={shownColumns}
-          onChange={(e) => e.target.value.length && setShownColumns(e.target.value)}
+          onChange={handleColumnsFilter}
           placeholder="Filter Columns"
-          fixedPlaceholder={shownColumns.length >= filterOptions.length}
+          fixedPlaceholder={shownColumns.length + 1 >= filterOptions.length}
         />
       </Toolbar>
 


### PR DESCRIPTION
### Brief Description

Resize, reorder and filter columns in subsets and editor.

### Description

- Resizing columns saves to `localStorage` for persistence.
- Reordering columns saves to `localStorage` for persistence.
- Filtering columns saves to `localStorage` for persistence.
- Subsets has two separate column filters, single and multiple selected folders. 

![subsets_columns_resize_reorder_v001](https://user-images.githubusercontent.com/49156310/210598193-b5e0de9e-697b-4892-8e92-659e3f4bf2be.gif)

![subsets_columns_filter_v001](https://user-images.githubusercontent.com/49156310/210598216-45d89606-a65e-4321-b896-db39c31ec2b1.gif)

### Issues

There's currently a lot of repeated code between `src/pages/browser/subsets.jsx` and `src/pages/editor/index.jsx`. I tried to share as much as possible but both are set up differently so it was tricky. If another pages uses these features it might be worth creating a wrapper/HOC. 

### Testing Filtering

1. Go to `/projects/demo_Commercial/browser`.
2. Check/uncheck columns in the dropdown.
3. Now select multiple folders in the hierarchy (on the left)
4. The previous filters should reset (or change to its own state)
5. Now check/uncheck columns in the dropdown.
6. Selecting a single folder should switch back to the filters from step 2.
7. Refresh the page, all filters should have persisted.