### PR TITLE
fix wrong focusedType of tags editor

### DIFF
--- a/src/containers/hierarchy.jsx
+++ b/src/containers/hierarchy.jsx
@@ -20,6 +20,7 @@ import {
   setDialog,
 } from '/src/features/context'
 import { getFolderTypeIcon } from '/src//utils'
+import { setFocusedType } from '../features/context'
 
 const filterHierarchy = (text, folder) => {
   let result = []
@@ -68,6 +69,7 @@ const Hierarchy = (props) => {
   const context = useSelector((state) => ({ ...state.context }))
   const projectName = context.projectName
   const folderTypes = context.project.folderTypes
+  const focusedType = context.focused.type
   const expandedFolders = context.expandedFolders
   const focusedFolders = context.focused.folders
 
@@ -182,6 +184,18 @@ const Hierarchy = (props) => {
     return 'Folder types'
   }
 
+  const handleEditTags = () => {
+    // set focused type if not already
+    if (focusedType !== 'folder') dispatch(setFocusedType('folder'))
+
+    // open dialog
+    dispatch(
+      setDialog({
+        type: 'tags',
+      }),
+    )
+  }
+
   const ctxMenuModel = [
     {
       label: 'Detail',
@@ -190,12 +204,7 @@ const Hierarchy = (props) => {
     },
     {
       label: 'Edit Tags',
-      command: () =>
-        dispatch(
-          setDialog({
-            type: 'tags',
-          }),
-        ),
+      command: handleEditTags,
     },
   ]
 

--- a/src/features/context.js
+++ b/src/features/context.js
@@ -64,6 +64,9 @@ const contextSlice = createSlice({
         state.focused.tasks = []
       }
     },
+    setFocusedType: (state, action) => {
+      state.focused.type = action.payload
+    },
     setSelectedVersions: (state, action) => {
       state.selectedVersions = action.payload
     },
@@ -137,6 +140,7 @@ export const {
   setPairing,
   setDialog,
   setReload,
+  setFocusedType,
 } = contextSlice.actions
 
 export default contextSlice.reducer


### PR DESCRIPTION
### Description

Fixes a bug where the wrong `focusedType` was set when opening the folder tags editor.

This would happen because right clicking of a folder doesn't change the `focusedType` to `folder`. This is now fixed.

### Testing

1. Click on a folder
2. Click on a subset/version/task
3. Right click on the same folder and click 'Edit Tags'
4. The tags editor should be editing the folders tags (before it would be stuck to the selection on step 2).