### PR TITLE
Fix: use selector rerender fixes

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -25,7 +25,7 @@ import { login } from './features/user'
 import { SocketProvider } from './context/websocketContext'
 
 const App = () => {
-  const user = useSelector((state) => ({ ...state.user }))
+  const user = useSelector((state) => state.user)
   const dispatch = useDispatch()
   const [loading, setLoading] = useState(false)
   const [serverError, setServerError] = useState(false)
@@ -99,23 +99,19 @@ const App = () => {
               element={<Navigate replace to="/projectManager/dashboard" />}
             />
             <Route path="/projectManager/:module" element={<ProjectManager />} />
-
             <Route path={'/projects/:projectName/:module'} element={<ProjectPage />} />
             <Route path={'/projects/:projectName/addon/:addonName'} element={<ProjectPage />} />
-
             <Route
               path="/settings"
               exact
               element={<Navigate replace to="/settings/anatomyPresets" />}
             />
             <Route path="/settings/:module" exact element={<SettingsPage />} />
-
             <Route path="/explorer" element={<ExplorerPage />} />
             <Route path="/doc/api" element={<APIDocsPage />} />
             <Route path="/profile" element={<ProfilePage />} />
             <Route path="/events" element={<EventViewer />} />
             <Route path="/services" element={<ServicesPage />} />
-
             <Route element={<ErrorPage code="404" />} />
           </Routes>
         </BrowserRouter>

--- a/src/components/status/statusSelect.jsx
+++ b/src/components/status/statusSelect.jsx
@@ -2,10 +2,10 @@ import React, { useEffect, useState } from 'react'
 import PropTypes from 'prop-types'
 import Dropdown from '../dropdown'
 import StatusField from './statusField'
+import { useSelector } from 'react-redux'
 
 const StatusSelect = ({
   value,
-  statuses = [],
   size = 'full',
   maxWidth,
   height,
@@ -14,6 +14,7 @@ const StatusSelect = ({
   multipleSelected,
   onClick,
 }) => {
+  const statuses = useSelector((state) => state.context.project.statuses)
   const [changedValue, setChangedValue] = useState(null)
 
   useEffect(() => {

--- a/src/containers/header/breadcrumbs.jsx
+++ b/src/containers/header/breadcrumbs.jsx
@@ -13,9 +13,9 @@ const Breadcrumbs = () => {
     op:// USD uri.
     */
 
-  const context = useSelector((state) => ({ ...state.context }))
-  const crumbData = context.breadcrumbs || {}
-  const projectName = context.projectName
+  const crumbData = useSelector((state) => state.context.breadcrumbs)
+
+  const projectName = useSelector((state) => state.context.projectName)
 
   const [breadcrumbs, uri] = useMemo(() => {
     let crumbs = [projectName]

--- a/src/containers/header/projectMenu.jsx
+++ b/src/containers/header/projectMenu.jsx
@@ -8,10 +8,7 @@ import { useSelector } from 'react-redux'
 const ProjectMenu = ({ visible, onHide }) => {
   const navigate = useNavigate()
 
-  // get project context
-  const context = useSelector((state) => ({ ...state.context }))
-  // get current project name (id)
-  const projectName = context.projectName
+  const projectName = useSelector((state) => state.context.projectName)
 
   const footer = (
     <Button

--- a/src/containers/hierarchy.jsx
+++ b/src/containers/hierarchy.jsx
@@ -65,12 +65,11 @@ const filterHierarchy = (text, folder) => {
 }
 
 const Hierarchy = (props) => {
-  const context = useSelector((state) => ({ ...state.context }))
-  const projectName = context.projectName
-  const folderTypes = context.project.folderTypes
-  const focusedType = context.focused.type
-  const expandedFolders = context.expandedFolders
-  const focusedFolders = context.focused.folders
+  const projectName = useSelector((state) => state.context.projectName)
+  const folderTypes = useSelector((state) => state.context.project.folderTypes)
+  // const focusedType = useSelector((state) => state.context.focused.type)
+  const expandedFolders = useSelector((state) => state.context.expandedFolders)
+  const focusedFolders = useSelector((state) => state.context.focused.folders)
 
   const dispatch = useDispatch()
   const [query, setQuery] = useState('')
@@ -164,7 +163,7 @@ const Hierarchy = (props) => {
 
   const handleEditTags = () => {
     // set focused type if not already
-    if (focusedType !== 'folder') dispatch(setFocusedType('folder'))
+    dispatch(setFocusedType('folder'))
 
     // open dialog
     dispatch(

--- a/src/containers/tagsEditor/index.jsx
+++ b/src/containers/tagsEditor/index.jsx
@@ -6,15 +6,18 @@ import { useGetEntitiesDetailsQuery } from '/src/services/getEntitiesDetails'
 import { useUpdateEntitiesDetailsMutation } from '/src/services/updateEntitiesDetails'
 
 export const TagsEditorContainer = () => {
-  const focused = useSelector((state) => state.context.focused)
   const projectTags = useSelector((state) => state.context.project.tags)
   const projectName = useSelector((state) => state.context.projectName)
-  const type = useSelector((state) => state.context.dialog.type)
+  // entity type folder, version, subset, task
+  const type = useSelector((state) => state.context.focused.type)
+  const dialogType = useSelector((state) => state.context.dialog.type)
+  const focused = useSelector((state) => state.context.focused)
 
   let ids = []
   if (type) {
     ids = focused[`${type}s`]
   }
+  console.log({ focused, projectTags, projectName, type, ids })
   // get redux context state
   const dispatch = useDispatch()
 
@@ -28,7 +31,7 @@ export const TagsEditorContainer = () => {
   // update tags hook
   const [updateTags] = useUpdateEntitiesDetailsMutation()
 
-  if (type !== 'tags' || !ids?.length) return null
+  if (dialogType !== 'tags' || !ids?.length) return null
 
   if (isLoading || isError) return null
 

--- a/src/containers/tagsEditor/index.jsx
+++ b/src/containers/tagsEditor/index.jsx
@@ -17,7 +17,7 @@ export const TagsEditorContainer = () => {
   if (type) {
     ids = focused[`${type}s`]
   }
-  console.log({ focused, projectTags, projectName, type, ids })
+
   // get redux context state
   const dispatch = useDispatch()
 

--- a/src/containers/tagsEditor/index.jsx
+++ b/src/containers/tagsEditor/index.jsx
@@ -1,11 +1,20 @@
 import React from 'react'
-import { useDispatch } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 import { setDialog } from '/src/features/context'
 import TagsEditorDialog from './dialog'
 import { useGetEntitiesDetailsQuery } from '/src/services/getEntitiesDetails'
 import { useUpdateEntitiesDetailsMutation } from '/src/services/updateEntitiesDetails'
 
-export const TagsEditorContainer = ({ ids, type, projectName, projectTags }) => {
+export const TagsEditorContainer = () => {
+  const focused = useSelector((state) => state.context.focused)
+  const projectTags = useSelector((state) => state.context.project.tags)
+  const projectName = useSelector((state) => state.context.projectName)
+  const type = useSelector((state) => state.context.dialog.type)
+
+  let ids = []
+  if (type) {
+    ids = focused[`${type}s`]
+  }
   // get redux context state
   const dispatch = useDispatch()
 
@@ -14,10 +23,12 @@ export const TagsEditorContainer = ({ ids, type, projectName, projectTags }) => 
     data: entitiesData,
     isLoading,
     isError,
-  } = useGetEntitiesDetailsQuery({ projectName, type, ids })
+  } = useGetEntitiesDetailsQuery({ projectName, type, ids }, { skip: !type })
 
   // update tags hook
   const [updateTags] = useUpdateEntitiesDetailsMutation()
+
+  if (type !== 'tags' || !ids?.length) return null
 
   if (isLoading || isError) return null
 

--- a/src/features/context.js
+++ b/src/features/context.js
@@ -15,7 +15,9 @@ const contextSlice = createSlice({
     },
     selectedVersions: {},
     pairing: [],
-    dialog: {},
+    dialog: {
+      type: null,
+    },
     reload: {},
   },
   reducers: {
@@ -82,7 +84,11 @@ const contextSlice = createSlice({
     setPairing: (state, action) => {
       state.pairing = action.payload
     },
-
+    subsetSelected: (state, action) => {
+      state.focused.type = 'version'
+      state.focused.versions = action.payload.versions
+      state.focused.subsets = action.payload.subsets
+    },
     setBreadcrumbs: (state, action) => {
       let bc = state.breadcrumbs || {}
       if (action.payload.parents) {
@@ -141,6 +147,7 @@ export const {
   setDialog,
   setReload,
   setFocusedType,
+  subsetSelected,
 } = contextSlice.actions
 
 export default contextSlice.reducer

--- a/src/features/context.js
+++ b/src/features/context.js
@@ -19,6 +19,7 @@ const contextSlice = createSlice({
       type: null,
     },
     reload: {},
+    breadcrumbs: {},
   },
   reducers: {
     selectProject: (state, action) => {

--- a/src/pages/browser/BrowserPage.jsx
+++ b/src/pages/browser/BrowserPage.jsx
@@ -1,5 +1,4 @@
 import { Splitter, SplitterPanel } from 'primereact/splitter'
-import { useSelector } from 'react-redux'
 import { Section } from '@ynput/ayon-react-components'
 
 import Hierarchy from '/src/containers/hierarchy'
@@ -10,18 +9,6 @@ import Detail from './detail/Detail'
 import TagsEditorContainer from '/src/containers/tagsEditor'
 
 const BrowserPage = () => {
-  const context = useSelector((state) => ({ ...state.context }))
-  // check if tags dialog is open
-  const dialogType = context.dialog.type
-  const projectName = context.projectName
-  // get all tags for project
-  const projectTags = context.project.tags
-  const focusedType = context.focused.type
-  let focusedIds = []
-  if (focusedType) {
-    focusedIds = context.focused[`${focusedType}s`]
-  }
-
   return (
     <main>
       <Splitter layout="horizontal" style={{ width: '100%', height: '100%' }}>
@@ -31,7 +18,6 @@ const BrowserPage = () => {
             <TaskList style={{ maxHeight: 300 }} />
           </Section>
         </SplitterPanel>
-
         <SplitterPanel size={82}>
           <Splitter layout="horizontal" style={{ height: '100%' }}>
             <SplitterPanel style={{ minWidth: 500 }}>
@@ -43,13 +29,8 @@ const BrowserPage = () => {
           </Splitter>
         </SplitterPanel>
       </Splitter>
-      {dialogType === 'tags' && !!focusedIds?.length && (
-        <TagsEditorContainer
-          ids={focusedIds}
-          type={focusedType}
-          {...{ projectName, projectTags }}
-        />
-      )}
+
+      <TagsEditorContainer />
     </main>
   )
 }

--- a/src/pages/browser/RepresentationList.jsx
+++ b/src/pages/browser/RepresentationList.jsx
@@ -33,7 +33,6 @@ const columns = [
 ]
 
 const RepresentationList = ({ representations }) => {
-  //const context = useSelector((state) => ({ ...state.context }))
   const dispatch = useDispatch()
   const [selectedRepresentation, setSelectedRepresentation] = useState(null)
   //const [focusedRepresentation, setFocusedRepresentation] = useState(null)

--- a/src/pages/browser/Subsets.jsx
+++ b/src/pages/browser/Subsets.jsx
@@ -27,14 +27,13 @@ import { MultiSelect } from 'primereact/multiselect'
 
 const Subsets = () => {
   const dispatch = useDispatch()
-  const context = useSelector((state) => ({ ...state.context }))
 
-  const projectName = context.projectName
-  const focusedVersions = context.focused.versions
-  const focusedFolders = context.focused.folders
-  const selectedVersions = context.selectedVersions
-  const focusedSubsets = context.focused.subsets
-  const pairing = context.pairing
+  const projectName = useSelector((state) => state.context.projectName)
+  const focusedVersions = useSelector((state) => state.context.focused.versions)
+  const focusedFolders = useSelector((state) => state.context.focused.folders)
+  const selectedVersions = useSelector((state) => state.context.selectedVersions)
+  const focusedSubsets = useSelector((state) => state.context.focused.subsets)
+  const pairing = useSelector((state) => state.context.pairing)
 
   const ctxMenuRef = useRef(null)
   const [focusOnReload, setFocusOnReload] = useState(null) // version id to refocus to after reload
@@ -62,7 +61,6 @@ const Subsets = () => {
   const {
     data: subsetData = [],
     isLoading,
-    isFetching,
     isSuccess,
     refetch,
   } = useGetSubsetsListQuery(
@@ -160,7 +158,6 @@ const Subsets = () => {
         return (
           <StatusSelect
             value={node.data.status}
-            statuses={context.project.statuses}
             size={
               columnsWidths['status'] < statusMaxWidth
                 ? columnsWidths['status'] < 60
@@ -424,7 +421,7 @@ const Subsets = () => {
         />
       </Toolbar>
 
-      <TablePanel loading={isLoading || isFetching}>
+      <TablePanel loading={isLoading}>
         <ContextMenu model={ctxMenuModel} ref={ctxMenuRef} />
         <EntityDetail
           projectName={projectName}

--- a/src/pages/browser/Subsets.jsx
+++ b/src/pages/browser/Subsets.jsx
@@ -17,6 +17,7 @@ import {
   setBreadcrumbs,
   setPairing,
   setDialog,
+  subsetSelected,
 } from '/src/features/context'
 import VersionList from './VersionList'
 import StatusSelect from '/src/components/status/statusSelect'
@@ -363,20 +364,19 @@ const Subsets = () => {
   }
 
   const onSelectionChange = (event) => {
-    let result = []
+    let versions = []
     let subsets = []
     const selection = Object.keys(event.value)
     for (const sdata of subsetData) {
       if (selection.includes(sdata.id)) {
-        result.push(sdata.versionId)
+        versions.push(sdata.versionId)
         subsets.push(sdata.id)
       }
     }
     // we need to set the focused versions first
     // otherwise setFocusedSubsets will clear the selection
     // of versions.
-    dispatch(setFocusedSubsets(subsets))
-    dispatch(setFocusedVersions(result))
+    dispatch(subsetSelected({ subsets, versions }))
   }
 
   const onContextMenuSelectionChange = (event) => {

--- a/src/pages/browser/detail/Detail.jsx
+++ b/src/pages/browser/detail/Detail.jsx
@@ -6,11 +6,11 @@ import VersionDetail from './VersionDetail'
 import TaskDetail from './TaskDetail'
 
 const Detail = () => {
-  const context = useSelector((state) => ({ ...state.context }))
+  const type = useSelector((state) => state.context.focused.type)
 
   let detailComponent = null
 
-  switch (context.focused.type) {
+  switch (type) {
     case 'folder':
       detailComponent = <FolderDetail />
       break
@@ -24,9 +24,7 @@ const Detail = () => {
       break
   }
 
-  const header = context.focused.type
-    ? context.focused.type.charAt(0).toUpperCase() + context.focused.type.slice(1)
-    : 'No selection'
+  const header = type ? type.charAt(0).toUpperCase() + type.slice(1) : 'No selection'
 
   return (
     <Section className="wrap">

--- a/src/pages/browser/detail/FolderDetail.jsx
+++ b/src/pages/browser/detail/FolderDetail.jsx
@@ -10,9 +10,8 @@ import StatusSelect from '/src/components/status/statusSelect'
 import usePubSub from '/src/hooks/usePubSub'
 
 const FolderDetail = () => {
-  const context = useSelector((state) => ({ ...state.context }))
-  const projectName = context.projectName
-  const focusedFolders = context.focused.folders
+  const projectName = useSelector((state) => state.context.projectName)
+  const focusedFolders = useSelector((state) => state.context.focused.folders)
   const folderId = focusedFolders.length === 1 ? focusedFolders[0] : null
 
   // GET RTK QUERY
@@ -88,7 +87,6 @@ const FolderDetail = () => {
             value: (
               <StatusSelect
                 value={folder.status}
-                statuses={context.project.statuses}
                 align={'right'}
                 onChange={(v) => handleStatusChange(v, folder)}
               />

--- a/src/pages/browser/detail/TaskDetail.jsx
+++ b/src/pages/browser/detail/TaskDetail.jsx
@@ -9,9 +9,8 @@ import StatusSelect from '/src/components/status/statusSelect'
 import usePubSub from '/src/hooks/usePubSub'
 
 const TaskDetail = () => {
-  const context = useSelector((state) => ({ ...state.context }))
-  const projectName = context.projectName
-  const focusedTasks = context.focused.tasks
+  const projectName = useSelector((state) => state.context.projectName)
+  const focusedTasks = useSelector((state) => state.context.focused.tasks)
   const taskId = focusedTasks.length === 1 ? focusedTasks[0] : null
 
   // GET RTK QUERY
@@ -84,7 +83,6 @@ const TaskDetail = () => {
             value: (
               <StatusSelect
                 value={task.status}
-                statuses={context.project.statuses}
                 align={'right'}
                 onChange={(v) => handleStatusChange(v, task)}
               />

--- a/src/pages/browser/detail/VersionDetail.jsx
+++ b/src/pages/browser/detail/VersionDetail.jsx
@@ -85,12 +85,17 @@ const VersionDetail = () => {
   if (!versions || !versions.length) return null
 
   const handleStatusChange = async (value, entity) => {
+    const patches = [...versionsData].map(({ node }) =>
+      node.id === entity.id ? { ...node, status: value } : node,
+    )
+
     try {
       const payload = await updateFolder({
         projectName,
         type: 'version',
         data: { status: value },
         ids: [entity.id],
+        patches,
       }).unwrap()
 
       console.log('fulfilled', payload)

--- a/src/pages/browser/detail/VersionDetail.jsx
+++ b/src/pages/browser/detail/VersionDetail.jsx
@@ -51,9 +51,9 @@ const transformVersionsData = (versions) => {
 }
 
 const VersionDetail = () => {
-  const context = useSelector((state) => ({ ...state.context }))
-  const projectName = context.projectName
-  const focusedVersions = context.focused.versions
+  const projectName = useSelector((state) => state.context.projectName)
+  const focusedVersions = useSelector((state) => state.context.focused.versions)
+  const statuses = useSelector((state) => state.context.project.statuses)
 
   // GET RTK QUERY
   const {
@@ -134,7 +134,7 @@ const VersionDetail = () => {
               value: (
                 <StatusSelect
                   value={versions[0].status}
-                  statuses={context.project.statuses}
+                  statuses={statuses}
                   align={'right'}
                   onChange={(v) => handleStatusChange(v, versions[0])}
                 />

--- a/src/pages/browser/detail/VersionDetail.jsx
+++ b/src/pages/browser/detail/VersionDetail.jsx
@@ -53,7 +53,6 @@ const transformVersionsData = (versions) => {
 const VersionDetail = () => {
   const projectName = useSelector((state) => state.context.projectName)
   const focusedVersions = useSelector((state) => state.context.focused.versions)
-  const statuses = useSelector((state) => state.context.project.statuses)
 
   // GET RTK QUERY
   const {
@@ -134,7 +133,6 @@ const VersionDetail = () => {
               value: (
                 <StatusSelect
                   value={versions[0].status}
-                  statuses={statuses}
                   align={'right'}
                   onChange={(v) => handleStatusChange(v, versions[0])}
                 />

--- a/src/pages/editor/index.jsx
+++ b/src/pages/editor/index.jsx
@@ -32,8 +32,11 @@ import { useLocalStorage } from '../../utils'
 const EditorPage = () => {
   const [loading, setLoading] = useState(false)
 
-  const context = useSelector((state) => ({ ...state.context }))
-  const projectName = context.projectName
+  const projectName = useSelector((state) => state.context.projectName)
+  const focusedFolders = useSelector((state) => state.context.focused.folders)
+  const focusedTasks = useSelector((state) => state.context.focused.tasks)
+  const expandedFolders = useSelector((state) => state.context.expandedFolders)
+
   const dispatch = useDispatch()
 
   const [nodeData, setNodeData] = useState({})
@@ -49,10 +52,10 @@ const EditorPage = () => {
     // so it is compatible with the treetable selection argument and it
     // also provides complete node information
     const result = {}
-    for (const key of context.focused.folders) result[key] = nodeData[key]
-    for (const key of context.focused.tasks) result[key] = nodeData[key]
+    for (const key of focusedFolders) result[key] = nodeData[key]
+    for (const key of focusedTasks) result[key] = nodeData[key]
     return result
-  }, [context.focused.folders, context.focused.tasks, nodeData])
+  }, [focusedFolders, focusedTasks, nodeData])
 
   //
   // Helpers
@@ -82,14 +85,14 @@ const EditorPage = () => {
 
   useEffect(() => {
     setLoading(true)
-    const expandedKeys = [...Object.keys(context.expandedFolders), 'root']
+    const expandedKeys = [...Object.keys(expandedFolders), 'root']
     getUpdatedNodeData(nodeData, newNodes, expandedKeys, parents, query, projectName).then(
       (result) => {
         setNodeData(result)
         setLoading(false)
       },
     )
-  }, [context.expandedFolders, newNodes])
+  }, [expandedFolders, newNodes])
 
   //
   // External events handling
@@ -185,7 +188,7 @@ const EditorPage = () => {
         }
         if (!node.leaf) {
           node.children = []
-          if (childId in context.expandedFolders) buildHierarchy(childId, node.children)
+          if (childId in expandedFolders) buildHierarchy(childId, node.children)
         }
         target.push(node)
       }
@@ -212,7 +215,7 @@ const EditorPage = () => {
     })
 
     // Force table render when selection is locked
-    if (selectionLocked) dispatch(setFocusedFolders(context.focused.folders))
+    if (selectionLocked) dispatch(setFocusedFolders(focusedFolders))
   }
 
   const updateName = (options, value) => {
@@ -468,7 +471,7 @@ const EditorPage = () => {
 
     if (!root) {
       // Update expanded folders context object
-      const exps = { ...context.expandedFolders }
+      const exps = { ...expandedFolders }
       for (const id of parents) exps[id] = true
       dispatch(setExpandedFolders(exps))
     }
@@ -741,7 +744,7 @@ const EditorPage = () => {
             value={treeData}
             resizableColumns
             columnResizeMode="expand"
-            expandedKeys={context.expandedFolders}
+            expandedKeys={expandedFolders}
             onToggle={onToggle}
             selectionMode="multiple"
             selectionKeys={currentSelection}

--- a/src/pages/workfiles/index.jsx
+++ b/src/pages/workfiles/index.jsx
@@ -169,10 +169,9 @@ const WorkfileList = ({
 const WorkfilesPage = () => {
   const [selectedWorkfile, setSelectedWorkfile] = useState(null)
 
-  const context = useSelector((state) => ({ ...state.context }))
-  const projectName = context.projectName
-  const focusedTasks = context.focused.tasks
-  const pairing = context.pairing
+  const projectName = useSelector((state) => state.context.projectName)
+  const focusedTasks = useSelector((state) => state.context.focused.tasks)
+  const pairing = useSelector((state) => state.context.pairing)
 
   return (
     <main>


### PR DESCRIPTION
### Brief Description

Fix an issue with `useSelector((state) => ({... state}))` would cause re-renders whenever the state changed.

### Description

The spreading of the state into an object meant `useSelector` always returned a new object reference, and so the component would re-render after every action even if the state data didn't change. 

[Redux Essentials, Part 6: Performance and Normalizing Data](https://redux.js.org/tutorials/essentials/part-6-performance-normalization#investigating-render-behavior)

[Deriving Data with Selectors](https://redux.js.org/usage/deriving-data-selectors#optimizing-selectors-with-memoization)

A better way is to be more selective with the selector and use `useSelector` multiple times.

```javascript
  const projectName = useSelector((state) => state.context.projectName)
  const focusedTasks = useSelector((state) => state.context.focused.tasks)
``` 

Now only changes to either `state.context.focused.tasks` or `state.context.projectName` would cause a re-render.

Other improvements include dispatching less state setting `actions` with fewer event driven `actions`.

[Avoid Dispatching Many Actions Sequentially](https://redux.js.org/style-guide/#avoid-dispatching-many-actions-sequentially)

```javascript
// good using one
dispatch(subsetSelected({ subsets, versions }))
// bad using multiple
dispatch(setFocusedSubsets([subsetId]))
dispatch(setFocusedVersions([versionId]))
```

### Testing

1. Pick a massive project with 1000s of folders
2. Open list of folders
3. Select different subsets in one of the folders
4. The folders list shouldn't re-render and cause an expensive life cycle.
