### PR TITLE
Enhancement: User Page Overview

### DIFF
--- a/src/hooks/useSearchFilter.js
+++ b/src/hooks/useSearchFilter.js
@@ -40,11 +40,26 @@ const useSearchFilter = (fields, data) => {
     if (searchArray.length && dataWithKeywords) {
       return dataWithKeywords.filter((user) => {
         const matchingKeys = []
-        user.keywords?.some((key) =>
+        const inverseMatchingKeys = []
+        user.keywords?.forEach((key) => {
           searchArray.forEach((split) => {
-            if (key.includes(split) && !matchingKeys.includes(split)) matchingKeys.push(split)
-          }),
-        )
+            // if split has a ! at the start do opposite
+            if (split[0] === '!') {
+              split = split.slice(1)
+              // if key includes the split without the ! it's not a match
+              if (key.includes(split) && !inverseMatchingKeys.includes(split) && split.length > 2) {
+                inverseMatchingKeys.push(split)
+              } else if (!matchingKeys.includes(split)) {
+                matchingKeys.push(split)
+              }
+            } else {
+              if (key.includes(split) && !matchingKeys.includes(split)) matchingKeys.push(split)
+            }
+          })
+        })
+
+        // if there are any inverse matches return false
+        if (inverseMatchingKeys.length) return false
 
         return matchingKeys.length >= searchArray.length
       })

--- a/src/pages/settings/users/UserImagesStacked.jsx
+++ b/src/pages/settings/users/UserImagesStacked.jsx
@@ -15,7 +15,13 @@ const UserImagesStacked = ({ users = [] }) => {
   return (
     <StackedStyled length={users.length}>
       {users.map((user, i) => (
-        <UserImage src={user.src} key={i} fullName={user.fullName} style={{ zIndex: -i }} />
+        <UserImage
+          src={user.src}
+          key={i}
+          fullName={user.fullName}
+          style={{ zIndex: -i }}
+          highlight={user.self}
+        />
       ))}
     </StackedStyled>
   )

--- a/src/pages/settings/users/UserList.jsx
+++ b/src/pages/settings/users/UserList.jsx
@@ -147,8 +147,9 @@ const UserList = ({
               <UserImage
                 fullName={col.attrib.fullName || col.name}
                 size={25}
-                style={{ margin: 'auto', padding: 5, transform: 'scale(0.8)' }}
+                style={{ margin: 'auto', transform: 'scale(0.8)' }}
                 highlight={col.self}
+                src={col.attrib.avatarUrl}
               />
             )}
             resizeable

--- a/src/pages/settings/users/UserTile.jsx
+++ b/src/pages/settings/users/UserTile.jsx
@@ -1,0 +1,71 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Panel } from '@ynput/ayon-react-components'
+import styled from 'styled-components'
+import UserImage from './UserImage'
+
+// styled panel
+const PanelStyled = styled(Panel)`
+  flex-direction: row;
+  align-items: center;
+  background-color: var(--color-grey-01);
+
+  &:hover {
+    background-color: var(--color-grey-02);
+    cursor: pointer;
+  }
+`
+
+const UserTile = ({ user, onClick }) => {
+  if (!user) return null
+  const {
+    name,
+    attrib: { fullName, avatarUrl, email },
+    updatedAt,
+    self,
+  } = user
+
+  //
+  // format date number days ago
+  // if 0 days ago, show hours ago
+  // if 0 hours ago, show minutes ago
+
+  const createdAtDate = new Date(0)
+  createdAtDate.setUTCSeconds(updatedAt)
+  const now = new Date()
+  const diff = now - createdAtDate
+  const diffDays = Math.floor(diff / (1000 * 60 * 60 * 24))
+  const diffHours = Math.floor(diff / (1000 * 60 * 60))
+  const diffMinutes = Math.floor(diff / (1000 * 60))
+
+  const dateText =
+    diffDays > 0
+      ? `${diffDays} days ago`
+      : diffHours > 0
+      ? `${diffHours} hrs ago`
+      : `${diffMinutes} mins ago`
+
+  return (
+    <PanelStyled onClick={onClick}>
+      <UserImage src={avatarUrl} fullName={fullName} highlight={self} />
+      <div style={{ flex: 1 }}>
+        <strong>
+          {fullName} ({name})
+        </strong>
+        <br />
+        <span style={{ opacity: 0.5 }}>{email}</span>
+      </div>
+      <span style={{ textAlign: 'end', opacity: 0.5 }}>
+        Updated <br />
+        {dateText}
+      </span>
+    </PanelStyled>
+  )
+}
+
+UserTile.propTypes = {
+  user: PropTypes.object.isRequired,
+  onClick: PropTypes.func.isRequired,
+}
+
+export default UserTile

--- a/src/pages/settings/users/UsersOverview.jsx
+++ b/src/pages/settings/users/UsersOverview.jsx
@@ -1,0 +1,102 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Button, Section, Panel } from '@ynput/ayon-react-components'
+import { PanelButtonsStyled } from './userDetail'
+import { Link } from 'react-router-dom'
+import styled from 'styled-components'
+import UserTile from './UserTile'
+
+// panel with two buttons
+// - one to add a new user
+// - add a new user attribute
+
+const LinkStyled = styled(Link)`
+  text-decoration: none;
+  color: unset;
+
+  button {
+    width: 100%;
+  }
+`
+
+const TotalsStyledPanel = styled(Panel)`
+  flex-direction: row;
+  flex: 4;
+`
+
+// total styled Button
+const TotalStyledButton = styled(Button)`
+  flex: 1;
+  background-color: var(--color-grey-01);
+`
+
+const UsersOverview = ({ userList = [], onNewUser, onUserSelect, onTotal, selectedProjects }) => {
+  // get last createdAt user
+  const lastUser = userList.reduce((acc, user) => {
+    if (!acc) return user
+    if (user.createdAt > acc.createdAt) return user
+    return acc
+  }, null)
+
+  //   get self user
+  const selfUser = userList.filter((u) => u.self)[0]
+
+  return (
+    <Section className="wrap" style={{ gap: '5px', bottom: 'unset', maxHeight: '100%' }}>
+      <TotalsStyledPanel style={{ flexWrap: 'wrap' }}>
+        <h2 style={{ width: '100%' }}>{selectedProjects ? selectedProjects.join(', ') : 'All'}</h2>
+        <TotalStyledButton label={`Total - ${userList.length}`} onClick={() => onTotal('total')} />
+        <TotalsStyledPanel
+          style={{
+            padding: '0',
+          }}
+        >
+          <TotalStyledButton
+            label={`Admins - ${userList.filter((u) => u.isAdmin).length}`}
+            onClick={() => onTotal('admin')}
+          />
+          <TotalStyledButton
+            label={`Managers - ${
+              userList.filter((u) => !u.isAdmin && !u.isService && u.isManager).length
+            }
+        `}
+            onClick={() => onTotal('manager')}
+          />
+          <TotalStyledButton
+            label={`Services - ${userList.filter((u) => !u.isAdmin && u.isService).length}`}
+            onClick={() => onTotal('service')}
+          />
+          <TotalStyledButton
+            label={`Users - ${
+              userList.filter((u) => !u.isAdmin && !u.isService && !u.isManager).length
+            }`}
+            onClick={() => onTotal('!admin, !service, !manager')}
+          />
+        </TotalsStyledPanel>
+      </TotalsStyledPanel>
+
+      <Panel>
+        <h2>Latest User</h2>
+        <UserTile user={lastUser} onClick={() => onUserSelect(lastUser)} />
+        <h2>Me</h2>
+        <UserTile user={selfUser} onClick={() => onUserSelect(selfUser)} />
+      </Panel>
+      <PanelButtonsStyled>
+        <Button label="Add New User" icon="person_add" onClick={onNewUser} />
+        <LinkStyled to={'/settings/attributes'}>
+          <Button label="Add New User Attribute" icon="add" />
+        </LinkStyled>
+      </PanelButtonsStyled>
+    </Section>
+  )
+}
+
+UsersOverview.propTypes = {
+  userList: PropTypes.array.isRequired,
+  onNewUser: PropTypes.func.isRequired,
+  onUserSelect: PropTypes.func,
+  onTotal: PropTypes.func,
+  selectedProjects: PropTypes.array,
+}
+
+export default UsersOverview

--- a/src/pages/settings/users/UsersOverview.jsx
+++ b/src/pages/settings/users/UsersOverview.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import { Button, Section, Panel } from '@ynput/ayon-react-components'
 import { PanelButtonsStyled } from './userDetail'
 import { Link } from 'react-router-dom'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import UserTile from './UserTile'
 
 // panel with two buttons
@@ -27,10 +27,29 @@ const TotalsStyledPanel = styled(Panel)`
 // total styled Button
 const TotalStyledButton = styled(Button)`
   flex: 1;
-  background-color: var(--color-grey-01);
+
+  &:focus {
+    outline: none;
+  }
+
+  ${({ highlighted }) =>
+    highlighted &&
+    css`
+      background-color: var(--color-grey-04);
+      &:focus {
+        outline: 1px solid var(--color-hl-00);
+      }
+    `}
 `
 
-const UsersOverview = ({ userList = [], onNewUser, onUserSelect, onTotal, selectedProjects }) => {
+const UsersOverview = ({
+  userList = [],
+  onNewUser,
+  onUserSelect,
+  onTotal,
+  selectedProjects,
+  search,
+}) => {
   // get last createdAt user
   const lastUser = userList.reduce((acc, user) => {
     if (!acc) return user
@@ -45,7 +64,11 @@ const UsersOverview = ({ userList = [], onNewUser, onUserSelect, onTotal, select
     <Section className="wrap" style={{ gap: '5px', bottom: 'unset', maxHeight: '100%' }}>
       <TotalsStyledPanel style={{ flexWrap: 'wrap' }}>
         <h2 style={{ width: '100%' }}>{selectedProjects ? selectedProjects.join(', ') : 'All'}</h2>
-        <TotalStyledButton label={`Total - ${userList.length}`} onClick={() => onTotal('total')} />
+        <TotalStyledButton
+          label={`Total - ${userList.length}`}
+          onClick={() => onTotal('total')}
+          highlighted={search === 'total'}
+        />
         <TotalsStyledPanel
           style={{
             padding: '0',
@@ -54,6 +77,7 @@ const UsersOverview = ({ userList = [], onNewUser, onUserSelect, onTotal, select
           <TotalStyledButton
             label={`Admins - ${userList.filter((u) => u.isAdmin).length}`}
             onClick={() => onTotal('admin')}
+            highlighted={search === 'admin'}
           />
           <TotalStyledButton
             label={`Managers - ${
@@ -61,16 +85,19 @@ const UsersOverview = ({ userList = [], onNewUser, onUserSelect, onTotal, select
             }
         `}
             onClick={() => onTotal('manager')}
+            highlighted={search === 'manager'}
           />
           <TotalStyledButton
             label={`Services - ${userList.filter((u) => !u.isAdmin && u.isService).length}`}
             onClick={() => onTotal('service')}
+            highlighted={search === 'service'}
           />
           <TotalStyledButton
             label={`Users - ${
               userList.filter((u) => !u.isAdmin && !u.isService && !u.isManager).length
             }`}
             onClick={() => onTotal('!admin, !service, !manager')}
+            highlighted={search === '!admin, !service, !manager'}
           />
         </TotalsStyledPanel>
       </TotalsStyledPanel>

--- a/src/pages/settings/users/UsersSettings.jsx
+++ b/src/pages/settings/users/UsersSettings.jsx
@@ -18,6 +18,7 @@ import { useDeleteUserMutation } from '/src/services/user/updateUser'
 import { Splitter, SplitterPanel } from 'primereact/splitter'
 import { SelectButton } from 'primereact/selectbutton'
 import { useSelector } from 'react-redux'
+import UsersOverview from './UsersOverview'
 
 // TODO: Remove classname assignments and do in styled components
 const formatRoles = (rowData, selectedProjects) => {
@@ -57,7 +58,7 @@ const UsersSettings = () => {
   const isSelfSelected = selectedUsers.includes(selfName)
 
   // RTK QUERY HOOKS
-  const { data: userList = [], isLoading, isError, isFetching } = useGetUsersQuery({ selfName })
+  let { data: userList = [], isLoading, isError, isFetching } = useGetUsersQuery({ selfName })
   if (isError) toast.error('Unable to load users')
 
   const {
@@ -72,7 +73,7 @@ const UsersSettings = () => {
 
   let filteredUserList = useMemo(() => {
     // filter out users that are not in project if showProjectUsers is true
-    if (showProjectUsers && selectedProjects) {
+    if (selectedProjects) {
       return userList.filter((user) => {
         // user level not user
         if (user.isManager || user.isAdmin || user.isService) return true
@@ -86,9 +87,8 @@ const UsersSettings = () => {
     } else {
       return userList
     }
-  }, [userList, selectedProjects, showProjectUsers])
+  }, [userList, selectedProjects])
 
-  // TODO: RTK QUERY
   const onDelete = async () => {
     confirmDialog({
       message: `Are you sure you want to delete ${selectedUsers.length} user(s)?`,
@@ -108,9 +108,26 @@ const UsersSettings = () => {
     })
   }
 
+  const onTotal = (total) => {
+    // if "total" select all users
+    // else set search to total
+    if (total === 'total') {
+      setSearch('')
+      setSelectedUsers(filteredUserList.map((user) => user.name))
+      if (selectedProjects) setShowProjectUsers(true)
+    } else {
+      setSearch(total)
+    }
+  }
+
+  // use filteredUserList if showProjectUsers
+  // else use userList
+
+  if (showProjectUsers) userList = filteredUserList
+
   let userListWithRoles = useMemo(
-    () => filteredUserList.map((user) => formatRoles(user, selectedProjects)),
-    [filteredUserList, selectedProjects],
+    () => userList.map((user) => formatRoles(user, selectedProjects)),
+    [userList, selectedProjects],
   )
 
   const searchableFields = ['name', 'attrib.fullName', 'attrib.email', 'rolesList', 'hasPassword']
@@ -187,7 +204,6 @@ const UsersSettings = () => {
           </SplitterPanel>
           <SplitterPanel size={40} style={{ minWidth: 370 }}>
             <UserDetail
-              userList={userList}
               setShowRenameUser={setShowRenameUser}
               selectedUsers={selectedUsers}
               setShowSetPassword={setShowSetPassword}
@@ -196,6 +212,15 @@ const UsersSettings = () => {
               setSelectedUsers={setSelectedUsers}
               isSelfSelected={isSelfSelected}
             />
+            {selectedUsers.length === 0 && (
+              <UsersOverview
+                selectedProjects={selectedProjects}
+                userList={filteredUserList}
+                onNewUser={() => setShowNewUser(true)}
+                onUserSelect={(user) => setSelectedUsers([user.name])}
+                onTotal={onTotal}
+              />
+            )}
           </SplitterPanel>
         </Splitter>
       </Section>

--- a/src/pages/settings/users/UsersSettings.jsx
+++ b/src/pages/settings/users/UsersSettings.jsx
@@ -109,6 +109,9 @@ const UsersSettings = () => {
   }
 
   const onTotal = (total) => {
+    // if total already in serch, remove it
+    if (search === total) return setSearch('')
+
     // if "total" select all users
     // else set search to total
     if (total === 'total') {
@@ -219,6 +222,7 @@ const UsersSettings = () => {
                 onNewUser={() => setShowNewUser(true)}
                 onUserSelect={(user) => setSelectedUsers([user.name])}
                 onTotal={onTotal}
+                search={search}
               />
             )}
           </SplitterPanel>

--- a/src/pages/settings/users/UsersSettings.jsx
+++ b/src/pages/settings/users/UsersSettings.jsx
@@ -121,9 +121,6 @@ const UsersSettings = () => {
 
   // return null
 
-  // log first user
-  console.log(filteredData[0])
-
   return (
     <main>
       <ConfirmDialog />

--- a/src/pages/settings/users/userDetail.jsx
+++ b/src/pages/settings/users/userDetail.jsx
@@ -223,7 +223,7 @@ const UserDetail = ({
 
   // onclose, no users selected but check if changes made
   const onClose = () => {
-    if (changesMade) {
+    if (changesMade && selectedUsers.length === 1) {
       return toast.error('Changes not saved')
     }
     setSelectedUsers([])

--- a/src/pages/settings/users/userDetail.jsx
+++ b/src/pages/settings/users/userDetail.jsx
@@ -237,7 +237,11 @@ const UserDetail = ({
     <Section className="wrap" style={{ gap: '5px', bottom: 'unset', maxHeight: '100%' }}>
       <HeaderStyled>
         <UserImagesStacked
-          users={userDetailData?.users.map((user) => ({ fullName: getUserName(user) }))}
+          users={userDetailData?.users.map((user) => ({
+            fullName: getUserName(user),
+            src: user.attrib.avatarUrl,
+            self: user.self,
+          }))}
         />
         {singleUserEdit ? (
           <h2>{getUserName(singleUserEdit)}</h2>

--- a/src/pages/settings/users/userDetail.jsx
+++ b/src/pages/settings/users/userDetail.jsx
@@ -50,7 +50,7 @@ const UsernameStyled = styled(FormRow)`
   }
 `
 
-const PanelButtonsStyled = styled(Panel)`
+export const PanelButtonsStyled = styled(Panel)`
   flex-direction: row;
 
   & > * {
@@ -59,7 +59,6 @@ const PanelButtonsStyled = styled(Panel)`
 `
 
 const UserDetail = ({
-  userList,
   setShowRenameUser,
   selectedUsers,
   setShowSetPassword,
@@ -246,7 +245,7 @@ const UserDetail = ({
         {singleUserEdit ? (
           <h2>{getUserName(singleUserEdit)}</h2>
         ) : (
-          <h2>{`${userDetailData.users.length}/${userList.length} Users Selected`}</h2>
+          <h2>{`${userDetailData.users.length} Users Selected`}</h2>
         )}
         <span className="material-symbols-outlined" onClick={onClose}>
           close

--- a/src/services/user/getUsers.js
+++ b/src/services/user/getUsers.js
@@ -50,6 +50,8 @@ const USERS_QUERY = `
           roles
           defaultRoles
           hasPassword
+          createdAt
+          updatedAt
           attrib {
             #ATTRS#
           }


### PR DESCRIPTION
### Brief Description

When no user is a selected a panel with helpful stats and shortcut buttons.

### Description

- Show total users, admins, services, managers.
- Clicking between projects changes these values based on the number of users in assigned to the project.
- Clicking on **Total** selects all users shown in list.
- Clicking **Admin, Service, Manager** prefills the search bar with the user type to filter through the list and only show that type.
- Search filter can now do inverse searches and remove results that match the search with adding `!` to the beginning. For example `!admin` will show everything but matches for "admin". 
- Clicking **Users** does the opposite by filling the search bar with `!admin, !service, !manager`. This shows all users that aren't one of those.
- Show last updated user on the project with a quick link to show the user details.
- Show **me** user with quick link.
- Show buttons to **Add New User** and **Add New User Attribute**.

![users_overview_v001_small](https://user-images.githubusercontent.com/49156310/214258729-c8931f89-9a0e-4c19-81bc-d4ac3dfaba94.gif)


