### PR TITLE
Feature: Service Api Keys

### DIFF
--- a/src/components/ApiKeyManager.jsx
+++ b/src/components/ApiKeyManager.jsx
@@ -1,0 +1,108 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import LockedInput from './LockedInput'
+import { useState } from 'react'
+import { v4 as uuidv4 } from 'uuid'
+import { Panel } from '@ynput/ayon-react-components'
+import { useUpdateUserAPIKeyMutation } from '../services/user/updateUser'
+import { toast } from 'react-toastify'
+import styled from 'styled-components'
+
+const PanelStyled = styled(Panel)`
+  flex-direction: row;
+  background-color: var(--color-grey-01);
+  align-items: center;
+
+  span {
+    cursor: pointer;
+    margin-left: auto;
+  }
+`
+
+const ApiKeyManager = ({ preview, name }) => {
+  // temp hold new key
+  const [newKey, setNewKey] = useState()
+
+  //   update apikey mutation
+  const [updateApi] = useUpdateUserAPIKeyMutation()
+
+  // generate new api token using uuid4
+  const createNewKey = async () => {
+    const key = uuidv4().replace(/-/g, '')
+
+    // try catch to update api key using unwrap and toaste results
+    try {
+      const res = await updateApi({
+        name,
+        apiKey: key,
+      }).unwrap()
+
+      setNewKey({ key, preview: res })
+
+      toast.success('API Key Created')
+    } catch (error) {
+      console.log(error)
+      //   toast error
+      toast.error('Error updating API Key')
+    }
+  }
+  const handleDelete = async () => {
+    // try catch to update api key using unwrap and toaste results
+    try {
+      await updateApi({
+        name,
+        apiKey: null,
+      }).unwrap()
+
+      setNewKey(null)
+
+      toast.success('API Key Deleted')
+    } catch (error) {
+      console.log(error)
+      //   toast error
+      toast.error('Error deleting API Key')
+    }
+  }
+
+  const handleCopyKey = () => {
+    navigator.clipboard.writeText(newKey.key)
+    toast.success('API Key Copied')
+  }
+
+  if (preview)
+    return (
+      <>
+        <LockedInput
+          value={preview || newKey.preview}
+          icon={'delete'}
+          onEdit={handleDelete}
+          label={'Api Key'}
+        />
+        {newKey && (
+          <PanelStyled>
+            <div>
+              <strong>{newKey.key}</strong>
+              <br />
+              <div style={{ opacity: 0.5 }}>
+                Make a copy of this key as you will only see it once!
+              </div>
+            </div>
+            <span className="material-symbols-outlined" onClick={handleCopyKey}>
+              content_copy
+            </span>
+          </PanelStyled>
+        )}
+      </>
+    )
+
+  return (
+    <LockedInput onEdit={createNewKey} label="API Key" icon="add" placeholder="Create API Key..." />
+  )
+}
+
+ApiKeyManager.propTypes = {
+  preview: PropTypes.string,
+  name: PropTypes.string.isRequired,
+}
+
+export default ApiKeyManager

--- a/src/components/LockedInput.jsx
+++ b/src/components/LockedInput.jsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import { FormRow, InputText, Button } from '@ynput/ayon-react-components'
+
+const UsernameStyled = styled(FormRow)`
+  .field {
+    flex-direction: row;
+    gap: 5px;
+
+    input {
+      flex: 1;
+    }
+  }
+`
+
+const LockedInput = ({ value, onEdit, label, icon = 'edit', type = 'text', placeholder }) => {
+  return (
+    <UsernameStyled label={label} key={label}>
+      <InputText
+        label={label}
+        value={value}
+        disabled={true}
+        type={type}
+        placeholder={placeholder}
+      />
+      {onEdit && <Button icon={icon} onClick={onEdit} />}
+    </UsernameStyled>
+  )
+}
+
+LockedInput.propTypes = {
+  value: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  onEdit: PropTypes.func,
+  icon: PropTypes.string,
+  type: PropTypes.string,
+  placeholder: PropTypes.string,
+}
+
+export default LockedInput

--- a/src/hooks/useSearchFilter.js
+++ b/src/hooks/useSearchFilter.js
@@ -17,7 +17,7 @@ const useSearchFilter = (fields, data) => {
             } else if (typeof v === 'boolean' && v) {
               return k.toLowerCase()
             } else return []
-          } else if (typeof v === 'object') {
+          } else if (v && typeof v === 'object') {
             return Object.entries(v).flatMap(([k2, v2]) =>
               fields.includes(`${k}.${k2}`) && v2 ? v2.toLowerCase() : [],
             )

--- a/src/pages/settings/users/ServiceDetails.jsx
+++ b/src/pages/settings/users/ServiceDetails.jsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Panel } from '@ynput/ayon-react-components'
+import LockedInput from '/src/components/LockedInput'
+import ApiKeyManager from '/src/components/ApiKeyManager'
+
+const ServiceDetails = ({ user, editName }) => {
+  return (
+    <Panel>
+      <LockedInput value={user.name} label={'Username'} onEdit={editName} />
+      <ApiKeyManager preview={user.apiKeyPreview} name={user.name} />
+    </Panel>
+  )
+}
+
+ServiceDetails.propTypes = {
+  user: PropTypes.object,
+  editPassword: PropTypes.func,
+}
+
+export default ServiceDetails

--- a/src/pages/settings/users/SetPasswordDialog.jsx
+++ b/src/pages/settings/users/SetPasswordDialog.jsx
@@ -46,7 +46,7 @@ const SetPasswordDialog = ({ onHide, selectedUsers }) => {
   )
 }
 
-SetPasswordDialog.PropTypes = {
+SetPasswordDialog.propTypes = {
   onHide: PropTypes.func,
   selectedUsers: PropTypes.array,
 }

--- a/src/pages/settings/users/UserAccessForm.jsx
+++ b/src/pages/settings/users/UserAccessForm.jsx
@@ -2,7 +2,13 @@ import { InputSwitch, FormLayout, FormRow } from '@ynput/ayon-react-components'
 import { SelectButton } from 'primereact/selectbutton'
 import RolesDropdown from '/src/containers/rolesDropdown'
 
-const UserAccessForm = ({ formData, setFormData, selectedProjects, isSelfSelected }) => {
+const UserAccessForm = ({
+  formData,
+  setFormData,
+  selectedProjects,
+  isSelfSelected,
+  hideProjectRoles,
+}) => {
   const userLevels = [
     { label: 'User', value: 'user' },
     { label: 'Manager', value: 'manager' },
@@ -59,27 +65,29 @@ const UserAccessForm = ({ formData, setFormData, selectedProjects, isSelfSelecte
           <FormRow label={'Default Roles'}>
             <RolesDropdown
               style={{ flexGrow: 1 }}
-              selectedRoles={selectedProjects ? formData.defaultRoles : formData.roles}
-              setSelectedRoles={(value) => updateFormData('roles', value)}
+              selectedRoles={formData.defaultRoles}
+              setSelectedRoles={(value) => updateFormData('defaultRoles', value)}
               disabled={selectedProjects || !userLevel || isSelfSelected}
               placeholder={!userLevel && 'all roles'}
             />
           </FormRow>
-          <FormRow label={'Project Roles'}>
-            <RolesDropdown
-              style={{ flexGrow: 1 }}
-              selectedRoles={selectedProjects ? formData.roles : []}
-              setSelectedRoles={(value) => updateFormData('roles', value)}
-              disabled={!selectedProjects || !userLevel || isSelfSelected}
-              placeholder={
-                !userLevel
-                  ? 'all roles'
-                  : !selectedProjects
-                  ? 'select a project'
-                  : 'select roles...'
-              }
-            />
-          </FormRow>
+          {!hideProjectRoles && (
+            <FormRow label={'Project Roles'}>
+              <RolesDropdown
+                style={{ flexGrow: 1 }}
+                selectedRoles={selectedProjects ? formData.roles : []}
+                setSelectedRoles={(value) => updateFormData('roles', value)}
+                disabled={!selectedProjects || !userLevel || isSelfSelected}
+                placeholder={
+                  !userLevel
+                    ? 'all roles'
+                    : !selectedProjects
+                    ? 'select a project'
+                    : 'select roles...'
+                }
+              />
+            </FormRow>
+          )}
         </>
       </FormLayout>
     </>

--- a/src/pages/settings/users/UserList.jsx
+++ b/src/pages/settings/users/UserList.jsx
@@ -56,7 +56,6 @@ const UserList = ({
   ]
 
   // Render
-  // TODO: remove onStateChange handles
 
   return (
     <Section className="wrap">
@@ -87,8 +86,6 @@ const UserList = ({
           onRowClick={(e) => {
             setLastSelectedUser(e.data.name)
           }}
-          onStateRestore={(e) => console.log('state restored', e)}
-          onStateSave={(e) => console.log('state saved', e)}
         >
           <Column
             field="profile"

--- a/src/pages/settings/users/UserList.jsx
+++ b/src/pages/settings/users/UserList.jsx
@@ -4,7 +4,6 @@ import { Column } from 'primereact/column'
 import { ContextMenu } from 'primereact/contextmenu'
 import { TablePanel, Section } from '@ynput/ayon-react-components'
 import './users.scss'
-import useColumnResize from '/src/hooks/useColumnResize'
 import UserImage from './UserImage'
 import { useMemo } from 'react'
 
@@ -23,9 +22,6 @@ const UserList = ({
   setLastSelectedUser,
 }) => {
   const contextMenuRef = useRef(null)
-
-  // COLUMN WIDTH
-  const [columnsWidths, setColumnWidths] = useColumnResize('users')
 
   // Selection
   const selection = useMemo(
@@ -60,6 +56,7 @@ const UserList = ({
   ]
 
   // Render
+  // TODO: remove onStateChange handles
 
   return (
     <Section className="wrap">
@@ -83,7 +80,6 @@ const UserList = ({
           selection={selection}
           columnResizeMode="expand"
           resizableColumns
-          onColumnResizeEnd={setColumnWidths}
           responsive="true"
           stateKey="users-datatable"
           stateStorage={'local'}
@@ -91,6 +87,8 @@ const UserList = ({
           onRowClick={(e) => {
             setLastSelectedUser(e.data.name)
           }}
+          onStateRestore={(e) => console.log('state restored', e)}
+          onStateSave={(e) => console.log('state saved', e)}
         >
           <Column
             field="profile"
@@ -110,7 +108,7 @@ const UserList = ({
             header="Username"
             sortable
             body={(rowData) => (rowData.self ? `${rowData.name} (me)` : rowData.name)}
-            // resizeable
+            resizeable
           />
           <Column field="attrib.fullName" header="Full name" sortable resizeable />
           <Column field="attrib.email" header="Email" sortable />
@@ -126,7 +124,6 @@ const UserList = ({
               ))
             }
             sortable
-            style={{ flex: `1 1 ${columnsWidths['rolesList']}px` }}
             resizeable
           />
           <Column

--- a/src/pages/settings/users/UsersSettings.jsx
+++ b/src/pages/settings/users/UsersSettings.jsx
@@ -100,6 +100,8 @@ const UsersSettings = () => {
           try {
             await deleteUser({ user }).unwrap()
             toast.success(`Deleted user: ${user}`)
+            setSelectedUsers([])
+            setLastSelectedUser(null)
           } catch {
             toast.error(`Unable to delete user: ${user}`)
           }

--- a/src/pages/settings/users/newUserDialog.jsx
+++ b/src/pages/settings/users/newUserDialog.jsx
@@ -102,10 +102,9 @@ const NewUserDialog = ({ onHide }) => {
           ]}
           password={password}
           setPassword={setPassword}
-          x
         />
         <DividerSmallStyled />
-        <UserAccessForm formData={formData} setFormData={setFormData} />
+        <UserAccessForm formData={formData} setFormData={setFormData} hideProjectRoles />
         {formData.userLevel === 'user' && (
           <>
             <DividerSmallStyled />

--- a/src/pages/settings/users/newUserDialog.jsx
+++ b/src/pages/settings/users/newUserDialog.jsx
@@ -41,7 +41,7 @@ const NewUserDialog = ({ onHide }) => {
     else if (formData.userLevel === 'manager') payload.data.isManager = true
     else if (formData.userLevel === 'service') payload.data.isService = true
     else {
-      payload.data.defaultRoles = formData.roles || []
+      payload.data.defaultRoles = formData.defaultRoles || []
       if (selectedProjects) {
         const roles = {}
         for (const projectName of selectedProjects) roles[projectName] = payload.data.defaultRoles
@@ -102,6 +102,7 @@ const NewUserDialog = ({ onHide }) => {
           ]}
           password={password}
           setPassword={setPassword}
+          x
         />
         <DividerSmallStyled />
         <UserAccessForm formData={formData} setFormData={setFormData} />

--- a/src/pages/settings/users/userDetail.jsx
+++ b/src/pages/settings/users/userDetail.jsx
@@ -221,7 +221,7 @@ const UserDetail = ({
 
       if (!selectedProjects) {
         // no project is selected. update default roles
-        data.defaultRoles = formData.roles
+        data.defaultRoles = formData.defaultRoles
       } else {
         // project(s) selected. update roles
         for (const projectName of selectedProjects) roles[projectName] = formData.roles

--- a/src/pages/settings/users/userDetail.jsx
+++ b/src/pages/settings/users/userDetail.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { toast } from 'react-toastify'
-import { Button, Section, Panel, InputText, FormRow } from '@ynput/ayon-react-components'
+import { Button, Section, Panel } from '@ynput/ayon-react-components'
 import { isEmpty } from '/src/utils'
 import { useUpdateUserMutation } from '/src/services/user/updateUser'
 import styled from 'styled-components'
@@ -9,6 +9,8 @@ import ayonClient from '/src/ayon'
 import UserAttribForm from './UserAttribForm'
 import UserAccessForm from './UserAccessForm'
 import { confirmDialog } from 'primereact/confirmdialog'
+import LockedInput from '/src/components/LockedInput'
+import ServiceDetails from './ServiceDetails'
 
 const HeaderStyled = styled(Panel)`
   gap: 10px;
@@ -18,10 +20,12 @@ const HeaderStyled = styled(Panel)`
   h2 {
     font-size: 1.1rem;
     margin: 0;
-    flex: 1;
   }
 
-  span {
+  /* icon */
+  & > span {
+    flex: 1;
+    text-align: end;
     cursor: pointer;
   }
 `
@@ -36,17 +40,6 @@ const FormsStyled = styled.section`
 
   & > *:last-child {
     /* flex: 1; */
-  }
-`
-
-const UsernameStyled = styled(FormRow)`
-  .field {
-    flex-direction: row;
-    gap: 5px;
-
-    input {
-      flex: 1;
-    }
   }
 `
 
@@ -167,6 +160,8 @@ const UserDetail = ({
 
   // editing a single user, so show attributes form too
   const singleUserEdit = selectedUsers.length === 1 ? formUsers[0] : null
+  // check if any users have the userLevel of service
+  const hasServiceUser = formUsers.some((user) => user.isService)
 
   const [updateUser] = useUpdateUserMutation()
 
@@ -278,6 +273,21 @@ const UserDetail = ({
   // Render
   //
 
+  const headerRoles = formUsers.reduce((acc, user) => {
+    let roles = Object.entries(user.roles)
+      .map(([project, role]) =>
+        selectedProjects ? (selectedProjects?.includes(project) ? role : []) : role,
+      )
+      .flat()
+
+    // add admin, manager, service
+    if (user.isAdmin) roles.push('admin')
+    else if (user.isService) roles.push('service')
+    else if (user.isManager) roles.push('manager')
+
+    return [...new Set([...acc, ...roles])]
+  }, [])
+
   return (
     <Section className="wrap" style={{ gap: '5px', bottom: 'unset', maxHeight: '100%' }}>
       <HeaderStyled>
@@ -288,46 +298,56 @@ const UserDetail = ({
             self: user.self,
           }))}
         />
-        {singleUserEdit ? (
-          <h2>{getUserName(singleUserEdit)}</h2>
-        ) : (
-          <h2>{`${selectedUsers.length} Users Selected`}</h2>
-        )}
+        <div>
+          {singleUserEdit ? (
+            <h2>{getUserName(singleUserEdit)}</h2>
+          ) : (
+            <h2>{`${selectedUsers.length} Users Selected`}</h2>
+          )}
+          <span>{headerRoles.length ? headerRoles.join(', ') : 'No Roles'}</span>
+        </div>
         <span className="material-symbols-outlined" onClick={onClose}>
           close
         </span>
       </HeaderStyled>
-      <FormsStyled>
-        {formData && singleUserEdit && (
-          <Panel>
-            <UsernameStyled label={'Username'} key={'Username'}>
-              <InputText label="Username" value={singleUserEdit.name} disabled={true} />
-              <Button icon="edit" onClick={() => setShowRenameUser(true)} />
-            </UsernameStyled>
-            <UsernameStyled label={'Password'} key={'Password'}>
-              <InputText
-                label="Password"
+      {hasServiceUser && singleUserEdit ? (
+        <FormsStyled>
+          <ServiceDetails editName={() => setShowRenameUser(true)} user={singleUserEdit} />
+        </FormsStyled>
+      ) : (
+        <FormsStyled>
+          {formData && singleUserEdit && (
+            <Panel>
+              <LockedInput
+                value={singleUserEdit.name}
+                label={'Username'}
+                onEdit={() => setShowRenameUser(true)}
+              />
+              <LockedInput
                 value={singleUserEdit.hasPassword ? '1234567890' : ''}
-                disabled={true}
+                label={'Password'}
+                onEdit={() => setShowSetPassword(true)}
                 type="password"
               />
-              <Button icon="edit" onClick={() => setShowSetPassword(true)} />
-            </UsernameStyled>
-
-            <UserAttribForm formData={formData} setFormData={setFormData} attributes={attributes} />
-          </Panel>
-        )}
-        <Panel>
-          {formData && (
-            <UserAccessForm
-              formData={formData}
-              setFormData={setFormData}
-              selectedProjects={selectedProjects}
-              isSelfSelected={isSelfSelected}
-            />
+              <UserAttribForm
+                formData={formData}
+                setFormData={setFormData}
+                attributes={attributes}
+              />
+            </Panel>
           )}
-        </Panel>
-      </FormsStyled>
+          <Panel>
+            {formData && (
+              <UserAccessForm
+                formData={formData}
+                setFormData={setFormData}
+                selectedProjects={selectedProjects}
+                isSelfSelected={isSelfSelected}
+              />
+            )}
+          </Panel>
+        </FormsStyled>
+      )}
       <PanelButtonsStyled>
         <Button
           onClick={onCancel}

--- a/src/services/user/getUsers.js
+++ b/src/services/user/getUsers.js
@@ -52,6 +52,7 @@ const USERS_QUERY = `
           hasPassword
           createdAt
           updatedAt
+          apiKeyPreview
           attrib {
             #ATTRS#
           }

--- a/src/services/user/updateUser.js
+++ b/src/services/user/updateUser.js
@@ -46,6 +46,15 @@ const updateUser = ayonApi.injectEndpoints({
       transformErrorResponse: (res) => res.data,
       invalidatesTags: () => ['user'],
     }),
+    updateUserAPIKey: build.mutation({
+      query: ({ name, apiKey }) => ({
+        url: `/api/users/${name}/password`,
+        method: 'PATCH',
+        body: { apiKey },
+      }),
+      transformErrorResponse: (res) => res.data,
+      invalidatesTags: () => ['user'],
+    }),
   }),
 })
 
@@ -55,4 +64,5 @@ export const {
   useUpdateUserPasswordMutation,
   useAddUserMutation,
   useDeleteUserMutation,
+  useUpdateUserAPIKeyMutation,
 } = updateUser


### PR DESCRIPTION
### Description

- Create and delete API Keys for `service` users.
- One time copy of new key.
- Blurred preview of key.
- Removed a lot of irrelevant fields for `service` users.
- The user header now displays all the roles for those users.

![user_api_generator_v001](https://user-images.githubusercontent.com/49156310/214519263-e09b0858-51f7-48a1-bd30-ae456645d06c.gif)

### Testing

1. Create a new user with the `userLevel: service`.
2. Click on new user and click the plus button in the API Key field.
3. A new key should appear with a copy icon.
4. Click off and then onto the user, the key should now be gone and only the preview can be seen.
5. Click on the trash icon to delete the key.