### PR TITLE
Enhancement/op 3251 browser store splitter state

### DIFF
--- a/src/containers/attributeTable.jsx
+++ b/src/containers/attributeTable.jsx
@@ -5,6 +5,9 @@ const AttributeTableContainer = styled.div`
   display: flex;
   flex-direction: column;
   padding: 3px;
+
+  overflow: auto;
+  flex: 1;
 `
 
 const AttributeTableRow = styled.div`

--- a/src/containers/thumbnail.jsx
+++ b/src/containers/thumbnail.jsx
@@ -10,6 +10,7 @@ const ThumbnailStyled = styled.div`
   overflow: hidden;
   border-radius: 3px;
   margin: auto;
+  max-width: 250px;
 
   /* icon */
   span {

--- a/src/pages/browser/BrowserPage.jsx
+++ b/src/pages/browser/BrowserPage.jsx
@@ -11,7 +11,11 @@ import TagsEditorContainer from '/src/containers/tagsEditor'
 const BrowserPage = () => {
   return (
     <main>
-      <Splitter layout="horizontal" style={{ width: '100%', height: '100%' }}>
+      <Splitter
+        layout="horizontal"
+        style={{ width: '100%', height: '100%' }}
+        stateKey="browser-splitter-1"
+      >
         <SplitterPanel size={18} style={{ minWidth: 250, maxWidth: 600 }}>
           <Section className="wrap">
             <Hierarchy />
@@ -19,7 +23,7 @@ const BrowserPage = () => {
           </Section>
         </SplitterPanel>
         <SplitterPanel size={82}>
-          <Splitter layout="horizontal" style={{ height: '100%' }}>
+          <Splitter layout="horizontal" style={{ height: '100%' }} stateKey="browser-splitter-2">
             <SplitterPanel style={{ minWidth: 500 }}>
               <Subsets />
             </SplitterPanel>

--- a/src/pages/browser/detail/FolderDetail.jsx
+++ b/src/pages/browser/detail/FolderDetail.jsx
@@ -69,7 +69,7 @@ const FolderDetail = () => {
   }
 
   return (
-    <Panel>
+    <Panel style={{ overflow: 'hidden' }}>
       <h3>
         <span className="material-symbols-outlined" style={{ verticalAlign: 'bottom' }}>
           {getFolderTypeIcon(folder.folderType)}

--- a/src/pages/browser/detail/TaskDetail.jsx
+++ b/src/pages/browser/detail/TaskDetail.jsx
@@ -68,7 +68,7 @@ const TaskDetail = () => {
   if (!task) return null
 
   return (
-    <Panel>
+    <Panel style={{ overflow: 'hidden' }}>
       <h3>
         <span className="material-symbols-outlined" style={{ verticalAlign: 'bottom' }}>
           {getTaskTypeIcon(task.taskType)}

--- a/src/pages/browser/detail/VersionDetail.jsx
+++ b/src/pages/browser/detail/VersionDetail.jsx
@@ -118,7 +118,7 @@ const VersionDetail = () => {
   // One version selected. Show the detail
   else {
     versionDetailWidget = (
-      <Panel>
+      <Panel style={{ overflow: 'hidden' }}>
         <h3>
           <span className="material-symbols-outlined" style={{ verticalAlign: 'bottom' }}>
             {getFamilyIcon(versions[0].family)}


### PR DESCRIPTION
### Description

- Store `Browser` page splitter state to local storage.
- Fix an issue where the `DetailsPanel` could overflow.