### PR TITLE
Cosmetic: double click expand tree

### DIFF
--- a/src/containers/hierarchy.jsx
+++ b/src/containers/hierarchy.jsx
@@ -147,7 +147,6 @@ const Hierarchy = (props) => {
     let heirarchyObject = {}
 
     data.forEach((item) => {
-      console.log(item)
       heirarchyObject[item.id] = { ...item, isLeaf: !item.children?.length }
 
       if (item.children?.length > 0) {
@@ -240,6 +239,7 @@ const Hierarchy = (props) => {
   }
 
   const onToggle = (event) => {
+    console.log(event)
     dispatch(setExpandedFolders(event.value))
   }
 
@@ -253,6 +253,48 @@ const Hierarchy = (props) => {
         type: 'tags',
       }),
     )
+  }
+
+  const handleDoubleClick = () => {
+    // folder is always selected when row is double clicked
+
+    // filter out selected folders that are isLeaf
+    let doubleClickedFolders = []
+    for (const id in selectedFolders) {
+      if (!heirarchyObjectData[id].isLeaf) {
+        doubleClickedFolders.push(id)
+      }
+    }
+
+    // return if no folders are selected
+    if (!doubleClickedFolders.length) return
+
+    // separate folders that are already expanded
+    // separate folders that are not expanded
+    const alreadyExpandedFolders = []
+    const notExpandedFolders = []
+    for (const id of doubleClickedFolders) {
+      if (expandedFolders[id]) {
+        alreadyExpandedFolders.push(id)
+      } else {
+        notExpandedFolders.push(id)
+      }
+    }
+
+    // remove already expanded folders
+    const newExpandedFolders = { ...expandedFolders }
+    for (const id of alreadyExpandedFolders) {
+      console.log(newExpandedFolders[id])
+      delete newExpandedFolders[id]
+    }
+
+    // add not expanded folders
+    for (const id of notExpandedFolders) {
+      newExpandedFolders[id] = true
+    }
+
+    // update redux
+    dispatch(setExpandedFolders(newExpandedFolders))
   }
 
   const ctxMenuModel = [
@@ -286,6 +328,7 @@ const Hierarchy = (props) => {
         onRowClick={onRowClick}
         onContextMenu={(e) => ctxMenuRef.current?.show(e.originalEvent)}
         onContextMenuSelectionChange={onContextMenuSelectionChange}
+        onDoubleClick={handleDoubleClick}
       >
         <Column header="Hierarchy" field="body" expander={true} style={{ width: '100%' }} />
       </TreeTable>

--- a/src/pages/projectManager/index.jsx
+++ b/src/pages/projectManager/index.jsx
@@ -96,12 +96,12 @@ const ProjectManager = () => {
       <nav className="secondary">
         {links.map(
           (link, i) =>
-            isUser &&
-            userAccess.includes(link.module) && (
+            (isUser && userAccess.includes(link.module)) ||
+            (!isUser && (
               <NavLink to={link.path} key={i}>
                 {link.name}
               </NavLink>
-            ),
+            )),
         )}
       </nav>
       <main>


### PR DESCRIPTION
### Description

- Double click a folder in Hierarchy to expand/close it.
- Selecting multiple folders and then double clicking (whilst still holding down `shift`) expands all selected.
- Not implemented on editor as double clicking currently puts your into edit mode.
- Fix: projectManager toolbar links were wrongly hidden for admins and managers.

![double_click_expand_v001](https://user-images.githubusercontent.com/49156310/215057519-e51a086d-f962-45f3-8ccb-99b6039dd109.gif)
