### PR TITLE
fix: share image overflow fixed

### DIFF
--- a/src/components/ShareDialog.jsx
+++ b/src/components/ShareDialog.jsx
@@ -22,12 +22,39 @@ const ShareStyled = styled.div`
   /* top right corner */
   button {
     position: absolute;
-    top: 8px;
+    top: 16px;
     right: 8px;
+  }
+
+  pre {
+    background-color: var(--color-grey-00);
+    padding: 16px;
+    border-radius: 3px;
+    margin-top: 0;
+  }
+
+  background-color: unset;
+  padding-right: 48px;
+
+  button {
+    background-color: var(--color-grey-00);
   }
 
   img {
     max-width: 30vw;
+    box-shadow: 0 0 10px 0px var(--color-grey-01);
+  }
+
+  /* if panel is url link */
+  :has(> span) {
+    background-color: var(--color-grey-00);
+    padding: 16px 48px 16px 16px;
+
+    button {
+      padding: 0;
+      top: 50%;
+      transform: translateY(-50%);
+    }
   }
 `
 
@@ -54,7 +81,7 @@ const ShareDialog = () => {
   return (
     <Dialog header={`Share: ${name}`} visible onHide={() => dispatch(closeShare())}>
       <ShareStyled>
-        {link}
+        <span>{link}</span>
         <Button icon="content_copy" onClick={() => copyToClipboard(link)} />
       </ShareStyled>
       <br />

--- a/src/pages/projectDashboard/panels/GridLayout.jsx
+++ b/src/pages/projectDashboard/panels/GridLayout.jsx
@@ -9,7 +9,7 @@ import { useRef } from 'react'
 const GridStyled = styled.div`
   display: grid;
   grid-template-columns: 1fr 0.8fr 1.2fr;
-  grid-template-rows: 1fr 1fr;
+  grid-template-rows: 1fr auto;
   gap: 8px;
 
   /* overflow y */
@@ -42,11 +42,17 @@ const GridLayout = ({ children, projectName }) => {
     let img
     if (childRef) {
       dispatch(onShare(share))
+      // remove overflows
+      ref.current.style.overflowY = 'visible'
+      childRef.style.minWidth = 'fit-content'
       // hide share icon
-      childRef.querySelector('header button').style.display = 'none'
+      childRef.querySelector('header button').style.opacity = 0
       img = await toPng(childRef).catch((err) => console.log(err))
       // show share icon
-      childRef.querySelector('header button').style.display = 'block'
+      childRef.querySelector('header button').style.opacity = 1
+      // restore overflows
+      ref.current.style.overflowY = 'clip'
+      childRef.style.minWidth = null
       dispatch(onShare({ ...share, img }))
     } else {
       dispatch(onShare(share))

--- a/src/pages/projectDashboard/panels/ProgressBar.jsx
+++ b/src/pages/projectDashboard/panels/ProgressBar.jsx
@@ -48,7 +48,7 @@ const LineStyled = styled.hr`
 
   &::before {
     /* expand the hover zone but keep hidden */
-    background-color: red;
+    background-color: transparent;
     bottom: -10px;
     width: 100%;
     content: '';

--- a/src/pages/projectDashboard/panels/ProgressTile.jsx
+++ b/src/pages/projectDashboard/panels/ProgressTile.jsx
@@ -12,6 +12,10 @@ const HeaderStyled = styled.div`
   h3 {
     flex: 1;
   }
+
+  & > * {
+    white-space: nowrap;
+  }
 `
 
 const ProgressStyled = styled(TileStyled)`


### PR DESCRIPTION
### Description

If the panel was overflowing and showing scrollbars then the created share image would also show them. This is now fixed so that the whole panel is captured.

Other improvements to the share dialog UI.