### PR TITLE
Fix/op 4940 editor ws child attrib editor slice

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -1,6 +1,5 @@
 import ayonClient from '/src/ayon'
 import axios from 'axios'
-import short from 'short-uuid'
 
 import { LoaderShade } from '@ynput/ayon-react-components'
 import { useEffect, useState, Suspense, lazy, useContext } from 'react'
@@ -38,7 +37,7 @@ const App = () => {
   if (storedAccessToken) {
     axios.defaults.headers.common['Authorization'] = `Bearer ${storedAccessToken}`
   }
-  axios.defaults.headers.common['X-Sender'] = short.generate()
+  axios.defaults.headers.common['X-Sender'] = window.senderId
 
   // Call /api/info to check whether the user is logged in
   // and to acquire server settings

--- a/src/context/websocketContext.jsx
+++ b/src/context/websocketContext.jsx
@@ -1,4 +1,3 @@
-import axios from 'axios'
 import { useEffect, useState, createContext } from 'react'
 import { useSelector } from 'react-redux'
 import { toast } from 'react-toastify'
@@ -57,7 +56,7 @@ export const SocketProvider = (props) => {
 
     if (data.topic === 'server.restart_requested') setServerRestartingVisible(true)
 
-    if (data.sender === axios.defaults.headers.common['X-Sender']) {
+    if (data.sender === window.senderId) {
       return // my own message. ignore
     }
     if (data.topic === 'shout' && data?.summary?.text) toast.info(data.summary.text)

--- a/src/features/editor.js
+++ b/src/features/editor.js
@@ -41,9 +41,9 @@ const editorSlice = createSlice({
         state.changes[id] = node
       }
     },
-    onRevert: (state, { payload = [] }) => {
+    onRevert: (state, { payload }) => {
       // if ids are provided only delete those
-      if (payload.length) {
+      if (payload) {
         for (const id of payload) {
           if (state.new[id]) delete state.new[id]
           if (state.changes[id]) delete state.changes[id]

--- a/src/features/editor.js
+++ b/src/features/editor.js
@@ -1,0 +1,62 @@
+import { createSlice } from '@reduxjs/toolkit'
+
+const editorSlice = createSlice({
+  name: 'editor',
+  initialState: {
+    nodes: {},
+    new: {},
+    changes: {},
+  },
+  reducers: {
+    branchesLoaded: (state, action) => {
+      // add all new nodes
+      for (const id in action.payload) {
+        state.nodes[id] = action.payload[id]
+      }
+    },
+    nodesUpdated: (state, action) => {
+      const { updated = [], deleted = [] } = action.payload
+      // add new updated nodes
+      for (const node of updated) {
+        state.nodes[node?.data?.id] = node
+      }
+      // delete nodes
+      for (const id of deleted) {
+        delete state.nodes[id]
+      }
+      // reset any changes
+      state.new = {}
+      state.changes = {}
+    },
+    newNodesAdded: (state, { payload = [] }) => {
+      for (const node of payload) {
+        const id = node.id
+        state.new[id] = node
+      }
+    },
+    onNewChanges: (state, { payload = [] }) => {
+      for (const node of payload) {
+        const id = node.id
+        delete node.id
+        state.changes[id] = node
+      }
+    },
+    onRevert: (state, { payload = [] }) => {
+      // if ids are provided only delete those
+      if (payload.length) {
+        for (const id of payload) {
+          if (state.new[id]) delete state.new[id]
+          if (state.changes[id]) delete state.changes[id]
+        }
+      } else {
+        // reset all changes
+        state.new = {}
+        state.changes = {}
+      }
+    },
+  },
+})
+
+export const { branchesLoaded, nodesUpdated, onRevert, newNodesAdded, onNewChanges } =
+  editorSlice.actions
+export default editorSlice.reducer

--- a/src/helpers/sortByKey.js
+++ b/src/helpers/sortByKey.js
@@ -1,9 +1,18 @@
+import { isString } from 'lodash'
+
 const sortByKey = (array, key) => {
   // Return a copy of array of objects sorted
   // by the given key
   return array.sort(function (a, b) {
     var x = a[key]
     var y = b[key]
+
+    // check if string and put to lowercase
+    if (isString(x)) {
+      x = x.toLowerCase()
+      y = y.toLowerCase()
+    }
+
     return x < y ? -1 : x > y ? 1 : 0
   })
 }

--- a/src/hooks/usePubSub.js
+++ b/src/hooks/usePubSub.js
@@ -2,16 +2,21 @@ import { debounce } from 'lodash'
 import { useEffect } from 'react'
 import PubSub from '/src/pubsub'
 
-const usePubSub = (topic, callback, ids) => {
-  const handlePubSub = debounce((topicName, message) => {
+const usePubSub = (topic, callback, ids, useDebounce = true) => {
+  const handlePubSub = (topicName, message) => {
     if (ids && !ids.includes(message?.summary?.entityId)) return
     console.log('WS Version Refetch', topicName)
 
     callback(topicName, message)
-  }, 100)
+  }
+
+  const handlePubSubDebounce = debounce(
+    (topicName, message) => handlePubSub(topicName, message),
+    100,
+  )
 
   useEffect(() => {
-    const token = PubSub.subscribe(topic, handlePubSub)
+    const token = PubSub.subscribe(topic, useDebounce ? handlePubSubDebounce : handlePubSub)
     return () => PubSub.unsubscribe(token)
   }, [ids])
 }

--- a/src/hooks/usePubSub.js
+++ b/src/hooks/usePubSub.js
@@ -2,9 +2,10 @@ import { debounce } from 'lodash'
 import { useEffect } from 'react'
 import PubSub from '/src/pubsub'
 
-const usePubSub = (topic, callback, ids, useDebounce = true) => {
+const usePubSub = (topic, callback, ids, config = {}) => {
+  const { acceptNew = false, disableDebounce = false } = config
   const handlePubSub = (topicName, message) => {
-    if (ids && !ids.includes(message?.summary?.entityId)) return
+    if (ids && !ids.includes(message?.summary?.entityId) && !acceptNew) return
     console.log('WS Version Refetch', topicName)
 
     callback(topicName, message)
@@ -16,7 +17,7 @@ const usePubSub = (topic, callback, ids, useDebounce = true) => {
   )
 
   useEffect(() => {
-    const token = PubSub.subscribe(topic, useDebounce ? handlePubSubDebounce : handlePubSub)
+    const token = PubSub.subscribe(topic, disableDebounce ? handlePubSub : handlePubSubDebounce)
     return () => PubSub.unsubscribe(token)
   }, [ids])
 }

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -9,7 +9,7 @@ import { ToastContainer, Flip } from 'react-toastify'
 import userReducer from './features/user'
 import contextReducer from './features/context'
 import projectReducer from './features/project'
-// import editorReducer from './features/editor'
+import editorReducer from './features/editor'
 
 import App from './app'
 
@@ -31,7 +31,7 @@ const store = configureStore({
     user: userReducer,
     context: contextReducer,
     project: projectReducer,
-
+    editor: editorReducer,
     [ayonApi.reducerPath]: ayonApi.reducer,
   },
   middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(ayonApi.middleware),

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -9,6 +9,7 @@ import { ToastContainer, Flip } from 'react-toastify'
 import userReducer from './features/user'
 import contextReducer from './features/context'
 import projectReducer from './features/project'
+// import editorReducer from './features/editor'
 
 import App from './app'
 
@@ -20,12 +21,17 @@ import '@ynput/ayon-react-components/dist/style.css'
 import './styles/index.scss'
 import { ayonApi } from './services/ayon'
 import { setupListeners } from '@reduxjs/toolkit/dist/query'
+import short from 'short-uuid'
+
+// generate unique session id
+window.senderId = short.generate()
 
 const store = configureStore({
   reducer: {
     user: userReducer,
     context: contextReducer,
     project: projectReducer,
+
     [ayonApi.reducerPath]: ayonApi.reducer,
   },
   middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(ayonApi.middleware),

--- a/src/pages/editor/index.jsx
+++ b/src/pages/editor/index.jsx
@@ -31,7 +31,7 @@ import useLocalStorage from '/src/hooks/useLocalStorage'
 import { useGetHierarchyQuery } from '/src/services/getHierarchy'
 import SearchDropdown from '/src/components/SearchDropdown'
 import useColumnResize from '/src/hooks/useColumnResize'
-import { isEmpty } from 'lodash'
+import { camelCase, isEmpty } from 'lodash'
 import { useLazyGetExpandedBranchQuery } from '/src/services/editor/getEditor'
 import { useUpdateEditorMutation } from '/src/services/editor/updateEditor'
 import usePubSub from '/src/hooks/usePubSub'
@@ -129,7 +129,7 @@ const EditorPage = () => {
   // OVERVIEW
   // 1. check entity has been expanded
   // 2. get entity data
-  // 3. patch new entity data into rootDataCache
+  // 3. patch new entity data into editor nodes state
   const handlePubSub = async (topic = '', message) => {
     // check entity changing on current project
     if (!topic.includes('entity')) return
@@ -521,8 +521,13 @@ const EditorPage = () => {
 
         for (const key in changes[entityId]) {
           if (key.startsWith('__')) continue
-          if (key.startsWith('_')) entityChanges[key.substring(1)] = changes[entityId][key]
-          else attribChanges[key] = changes[entityId][key]
+          if (key.startsWith('_')) {
+            if (key === '_name') {
+              entityChanges[key.substring(1)] = camelCase(changes[entityId][key])
+            } else {
+              entityChanges[key.substring(1)] = changes[entityId][key]
+            }
+          } else attribChanges[key] = changes[entityId][key]
         }
 
         // patch is original data with updated data
@@ -579,6 +584,7 @@ const EditorPage = () => {
       const patch = {
         data: {
           ...newEntity,
+          name: camelCase(newEntity.name),
           attrib: patchAttrib,
           ownAttrib,
         },

--- a/src/pages/editor/utils.jsx
+++ b/src/pages/editor/utils.jsx
@@ -22,8 +22,6 @@ const formatName = (node, changes, styled = true, project) => {
   const chobj = changes[node.id]
   let value = chobj?._name ? chobj._name : node.name
 
-  console.log(chobj)
-
   if (!styled) return value
 
   let icon

--- a/src/pages/editor/utils.jsx
+++ b/src/pages/editor/utils.jsx
@@ -6,7 +6,7 @@ import { stringEditor, integerEditor, floatEditor, enumEditor } from './editors'
 const formatAttribute = (node, changes, fieldName, styled = true) => {
   const chobj = changes[node.id]
   let className = ''
-  let value = node.attrib[fieldName]
+  let value = node.attrib && node.attrib[fieldName]
   if (chobj && fieldName in chobj) {
     value = chobj[fieldName]
     className = 'changed'
@@ -20,13 +20,16 @@ const formatAttribute = (node, changes, fieldName, styled = true) => {
 
 const formatName = (node, changes, styled = true, project) => {
   const chobj = changes[node.id]
-  let value = chobj?._name ? chobj._name : node.name
+  let value = chobj?._name || chobj?._name === '' ? chobj._name : node.name
 
   if (!styled) return value
 
   let icon
   const textStyle = {}
-  if (!value) textStyle.color = 'var(--color-hl-error)'
+  // check for errors
+  if (chobj?.errors?._name) {
+    textStyle.color = 'var(--color-hl-error)'
+  }
   if (chobj && '_name' in chobj) textStyle.color = 'var(--color-hl-changed)'
 
   if (node.__entityType === 'task') {

--- a/src/services/ayon.js
+++ b/src/services/ayon.js
@@ -41,6 +41,7 @@ export const ayonApi = createApi({
     'anatomyPresets',
     'hierarchy',
     'branch',
+    'entity',
   ],
   endpoints: () => ({}),
 })

--- a/src/services/ayon.js
+++ b/src/services/ayon.js
@@ -1,6 +1,5 @@
 // Need to use the React-specific entry point to allow generating React hooks
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
-import short from 'short-uuid'
 
 // Util function
 export const buildOperations = (ids, type, data) =>
@@ -22,7 +21,7 @@ export const ayonApi = createApi({
         headers.set('Authorization', `Bearer ${storedAccessToken}`)
       }
       //   headers.common['X-Sender'] = short.generate()
-      headers.set('X-Sender', short.generate())
+      headers.set('X-Sender', window.senderId)
 
       return headers
     },

--- a/src/services/editor/getEditor.js
+++ b/src/services/editor/getEditor.js
@@ -45,13 +45,7 @@ const getEditor = ayonApi.injectEndpoints({
         },
       }),
       transformResponse: (response) => transformEditorData(response.data?.project),
-      providesTags: (res) => [
-        'project',
-        'folder',
-        'subset',
-        'task',
-        ...Object.keys(res).map((id) => ({ type: 'branch', id })),
-      ],
+      providesTags: () => ['project', 'folder', 'subset', 'task'],
     }),
     getExpandedBranch: build.query({
       query: ({ projectName, parentId }) => ({
@@ -90,4 +84,5 @@ const getEditor = ayonApi.injectEndpoints({
   }),
 })
 
-export const { useGetEditorRootQuery, useGetExpandedBranchQuery } = getEditor
+export const { useGetEditorRootQuery, useGetExpandedBranchQuery, useLazyGetExpandedBranchQuery } =
+  getEditor

--- a/src/services/editor/updateEditor.js
+++ b/src/services/editor/updateEditor.js
@@ -1,4 +1,6 @@
+import { isEmpty } from 'lodash'
 import { ayonApi } from '../ayon'
+import { nodesUpdated } from '/src/features/editor'
 
 const updateEditor = ayonApi.injectEndpoints({
   endpoints: (build) => ({
@@ -18,32 +20,67 @@ const updateEditor = ayonApi.injectEndpoints({
       }),
       invalidatesTags: (result, error, { updates }) =>
         updates.map((op) => ({ type: 'branch', id: op.id })),
-      async onQueryStarted({ projectName, updates = [] }, { dispatch, queryFulfilled }) {
-        if (!updates) return
+      async onCacheEntryAdded({ updates, rootData }, { cacheDataLoaded, dispatch }) {
+        try {
+          // wait for the initial query to resolve before proceeding
+          await cacheDataLoaded
 
-        // now patch in new branches into rootData
-        const patchResult = dispatch(
-          ayonApi.util.updateQueryData('getEditorRoot', { projectName }, (draft) => {
-            const updatedBranches = {}
+          const updated = []
+          const childrenUpdated = []
+          const deleted = []
 
-            // create object of updated/new branches
-            for (const op of updates) {
-              if (op.type === 'delete') {
-                delete draft[op.entityId]
-              } else {
-                updatedBranches[op.entityId] = op.patch
+          // create object of updated/new branches
+          for (const op of updates) {
+            if (op.type === 'delete') {
+              deleted.push(op.id)
+            } else {
+              updated.push(op.patch)
+              // find all children of patch
+              for (const id in rootData) {
+                const childData = rootData[id].data
+                if (childData?.__parentId === op.id) {
+                  const newAttrib = {}
+                  const currentAttrib = childData?.attrib || {}
+
+                  // is childData, check ownAttribs for updates
+                  for (const key in op?.data?.attrib) {
+                    if (
+                      !childData?.ownAttrib?.includes(key) &&
+                      currentAttrib[key] !== op.data.attrib[key]
+                    ) {
+                      newAttrib[key] = op.data.attrib[key]
+                    }
+                  }
+
+                  if (!isEmpty(newAttrib)) {
+                    // add new child to updates
+                    childrenUpdated.push({
+                      ...rootData[id],
+                      data: {
+                        ...childData,
+                        attrib: { ...currentAttrib, ...newAttrib },
+                      },
+                    })
+                  }
+                }
               }
             }
+          }
 
-            console.log('patching root data')
-            console.log(updatedBranches)
-            Object.assign(draft, { ...draft, ...updatedBranches })
-          }),
-        )
-        try {
-          await queryFulfilled
-        } catch {
-          patchResult.undo()
+          // for each update check if children attribs need updating
+          for (const patch of updated) {
+            // find all children of patch
+            for (const id in rootData) {
+              if (rootData[id].data.__parentId === patch.data.__parentId) {
+                // is child, check ownAttribs for updates
+              }
+            }
+          }
+
+          // add new branches to redux editor slice
+          dispatch(nodesUpdated({ updated: [...updated, ...childrenUpdated], deleted }))
+        } catch (error) {
+          console.error(error)
         }
       },
     }),

--- a/src/services/editor/updateEditor.js
+++ b/src/services/editor/updateEditor.js
@@ -1,4 +1,3 @@
-import { isEmpty } from 'lodash'
 import { ayonApi } from '../ayon'
 import { nodesUpdated } from '/src/features/editor'
 
@@ -20,13 +19,12 @@ const updateEditor = ayonApi.injectEndpoints({
       }),
       invalidatesTags: (result, error, { updates }) =>
         updates.map((op) => ({ type: 'branch', id: op.id })),
-      async onCacheEntryAdded({ updates, rootData }, { cacheDataLoaded, dispatch }) {
+      async onCacheEntryAdded({ updates }, { cacheDataLoaded, dispatch }) {
         try {
           // wait for the initial query to resolve before proceeding
           await cacheDataLoaded
 
           const updated = []
-          const childrenUpdated = []
           const deleted = []
 
           // create object of updated/new branches
@@ -35,50 +33,10 @@ const updateEditor = ayonApi.injectEndpoints({
               deleted.push(op.id)
             } else {
               updated.push(op.patch)
-              // find all children of patch
-              for (const id in rootData) {
-                const childData = rootData[id].data
-                if (childData?.__parentId === op.id) {
-                  const newAttrib = {}
-                  const currentAttrib = childData?.attrib || {}
-
-                  // is childData, check ownAttribs for updates
-                  for (const key in op?.data?.attrib) {
-                    if (
-                      !childData?.ownAttrib?.includes(key) &&
-                      currentAttrib[key] !== op.data.attrib[key]
-                    ) {
-                      newAttrib[key] = op.data.attrib[key]
-                    }
-                  }
-
-                  if (!isEmpty(newAttrib)) {
-                    // add new child to updates
-                    childrenUpdated.push({
-                      ...rootData[id],
-                      data: {
-                        ...childData,
-                        attrib: { ...currentAttrib, ...newAttrib },
-                      },
-                    })
-                  }
-                }
-              }
             }
           }
-
-          // for each update check if children attribs need updating
-          for (const patch of updated) {
-            // find all children of patch
-            for (const id in rootData) {
-              if (rootData[id].data.__parentId === patch.data.__parentId) {
-                // is child, check ownAttribs for updates
-              }
-            }
-          }
-
           // add new branches to redux editor slice
-          dispatch(nodesUpdated({ updated: [...updated, ...childrenUpdated], deleted }))
+          dispatch(nodesUpdated({ updated: updated, deleted }))
         } catch (error) {
           console.error(error)
         }

--- a/src/services/entity/getEntity.js
+++ b/src/services/entity/getEntity.js
@@ -191,8 +191,19 @@ const getEntity = ayonApi.injectEndpoints({
       transformResponse: (response, meta, { entities }) =>
         formatEntityTiles(response.data?.project, entities),
     }),
+    getEntity: build.query({
+      query: ({ projectName, entityType, entityId }) => ({
+        url: `/api/projects/${projectName}/${entityType}s/${entityId}`,
+      }),
+      providesTags: (res, error, { entityId }) => [{ type: 'entity', id: entityId }],
+    }),
   }),
 })
 
-export const { useGetEntitiesDetailsQuery, useGetEventTileQuery, useGetEntityTilesQuery } =
-  getEntity
+export const {
+  useGetEntitiesDetailsQuery,
+  useGetEventTileQuery,
+  useGetEntityTilesQuery,
+  useGetEntityQuery,
+  useLazyGetEntityQuery,
+} = getEntity


### PR DESCRIPTION
### Description

- Fix issue where self ws messages were being received
- Add back pubsub to editor
- Add back inherited attrib field changes propagate to children
- Same named folders now causes a warning
- Moved `nodes` `changes` `new` to new `editor` slice state