### PR TITLE
fix: merge project name into context

### DIFF
--- a/src/pages/projectAddon.jsx
+++ b/src/pages/projectAddon.jsx
@@ -16,7 +16,10 @@ const ProjectAddon = ({ addonName, addonVersion, sidebar }) => {
   const addonRef = useRef(null)
   const [loading, setLoading] = useState(true)
 
-  const context = useSelector((state) => ({ ...state.context }))
+  let context = useSelector((state) => state.context)
+  const projectName = useSelector((state) => state.project.name)
+  // merge in project name
+  context.projectName = projectName
   const focusedFolders = context.focused.folders
 
   const addonUrl = `${window.location.origin}/addons/${addonName}/${addonVersion}/frontend/`

--- a/src/pages/projectAddon.jsx
+++ b/src/pages/projectAddon.jsx
@@ -16,12 +16,9 @@ const ProjectAddon = ({ addonName, addonVersion, sidebar }) => {
   const addonRef = useRef(null)
   const [loading, setLoading] = useState(true)
 
-  let context = useSelector((state) => state.context)
+  const context = useSelector((state) => state.context)
   const projectName = useSelector((state) => state.project.name)
-  // merge in project name
-  context.projectName = projectName
   const focusedFolders = context.focused.folders
-
   const addonUrl = `${window.location.origin}/addons/${addonName}/${addonVersion}/frontend/`
 
   const pushContext = () => {
@@ -29,7 +26,10 @@ const ProjectAddon = ({ addonName, addonVersion, sidebar }) => {
     addonWnd.postMessage({
       scope: 'project',
       accessToken: localStorage.getItem('accessToken'),
-      context,
+      context: {
+        ...context,
+        projectName,
+      },
       addonName,
       addonVersion,
     })


### PR DESCRIPTION
### Brief Description

Access to project name was lost in Addon when context was split out into project and context.

Found by @Minkiu 