### PR TITLE
Op 5215/toggleable attribute inheritance

### DIFF
--- a/src/containers/attributes/attributeEditor.jsx
+++ b/src/containers/attributes/attributeEditor.jsx
@@ -2,7 +2,14 @@ import { useEffect, useState } from 'react'
 import { Dialog } from 'primereact/dialog'
 import { MultiSelect } from 'primereact/multiselect'
 import { Dropdown } from 'primereact/dropdown'
-import { Button, Spacer, FormLayout, FormRow, InputText } from '@ynput/ayon-react-components'
+import {
+  Button,
+  Spacer,
+  FormLayout,
+  FormRow,
+  InputText,
+  InputSwitch,
+} from '@ynput/ayon-react-components'
 import EnumEditor from './enumEditor'
 import LockedInput from '/src/components/LockedInput'
 import { camelCase } from 'lodash'
@@ -18,10 +25,14 @@ const SCOPE_OPTIONS = [
 ]
 
 // Fields used on all types
-const GLOBAL_FIELDS = ['description', 'example', 'default', 'regex']
+const GLOBAL_FIELDS = ['description', 'example', 'default', 'inherit']
 
 const TYPE_OPTIONS = {
-  string: { value: 'string', label: 'String', fields: ['minLength', 'maxLength', 'enum'] },
+  string: {
+    value: 'string',
+    label: 'String',
+    fields: ['minLength', 'maxLength', 'enum', 'regex'],
+  },
   integer: {
     value: 'integer',
     label: 'Integer',
@@ -100,6 +111,9 @@ const AttributeEditor = ({ attribute, existingNames, onHide, onEdit }) => {
     enum: (value = [], onChange) => (
       <EnumEditor values={value} onChange={(value) => onChange({ target: { value: value } })} />
     ),
+    inherit: (value, onChange) => (
+      <InputSwitch checked={value} onChange={(e) => onChange(e.target.checked)} />
+    ),
   }
 
   const handleTitleChange = (e) => {
@@ -151,7 +165,7 @@ const AttributeEditor = ({ attribute, existingNames, onHide, onEdit }) => {
           {dataFields.map((field) => (
             <FormRow label={field} key={field}>
               {field in customFields ? (
-                customFields[field](formData?.data[field], (e) => setData(field, e.target.value))
+                customFields[field](formData?.data[field], (value) => setData(field, value))
               ) : (
                 <InputText
                   value={formData?.data[field] || ''}

--- a/src/pages/editor/index.jsx
+++ b/src/pages/editor/index.jsx
@@ -125,6 +125,14 @@ const EditorPage = () => {
     }
   }
 
+  const inheritableAttribs = useMemo(() => {
+    let result = []
+    for (const attr of attribsData) {
+      if (attr.data.inherit) result.push(attr.name)
+    }
+    return result
+  }, [attribsData])
+
   // on mount only load root
   // and any other expanded folders
   useEffect(() => {
@@ -161,6 +169,7 @@ const EditorPage = () => {
 
           // is childData, check ownAttribs for updates
           for (const key in update?.data?.attrib) {
+            if (!inheritableAttribs.includes(key)) continue
             if (
               !childData?.ownAttrib?.includes(key) &&
               currentAttrib[key] !== update.data.attrib[key]

--- a/src/pages/settings/Attributes.jsx
+++ b/src/pages/settings/Attributes.jsx
@@ -159,6 +159,7 @@ const Attributes = () => {
             <Column field="data.type" header="Type" style={{ maxWidth: 150 }} sortable />
             <Column field="data.example" header="Example" style={{ maxWidth: 200 }} sortable />
             <Column field="data.description" header="Description" sortable />
+            <Column field="data.inherit" header="Inherit" sortable style={{ maxWidth: 80 }} />
           </DataTable>
         </TablePanel>
       </Section>

--- a/src/pages/settings/users/UsersSettings.jsx
+++ b/src/pages/settings/users/UsersSettings.jsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useRef } from 'react'
 import { toast } from 'react-toastify'
 import { confirmDialog, ConfirmDialog } from 'primereact/confirmdialog'
 import { Button, Section, Toolbar, InputText } from '@ynput/ayon-react-components'
@@ -51,6 +51,8 @@ const UsersSettings = () => {
   const [searchParams] = useSearchParams()
   const queryNames = searchParams.getAll('name')
   const [selectedUsers, setSelectedUsers] = useQueryParam('name', withDefault(ArrayParam, []))
+
+  const toastId = useRef(null)
 
   // set initial selected users
   useEffect(() => {
@@ -110,16 +112,23 @@ const UsersSettings = () => {
       header: 'Delete users',
       icon: 'pi pi-exclamation-triangle',
       accept: async () => {
+        toastId.current = toast.info('Deleting users...')
+        let i = 0
         for (const user of selectedUsers) {
           try {
             await deleteUser({ user }).unwrap()
-            toast.success(`Deleted user: ${user}`)
+            toast.update(toastId.current, {
+              render: `Deleted user: ${user}`,
+              type: toast.TYPE.SUCCESS,
+            })
             setSelectedUsers([])
             setLastSelectedUser(null)
+            i += 1
           } catch {
             toast.error(`Unable to delete user: ${user}`)
           }
         }
+        toast.update(toastId.current, { render: `Deleted ${i} user(s)`, type: toast.TYPE.SUCCESS })
       },
       reject: () => {},
     })

--- a/src/pages/settings/users/userDetail.jsx
+++ b/src/pages/settings/users/userDetail.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { toast } from 'react-toastify'
 import { Button, Section, Panel, FormRow } from '@ynput/ayon-react-components'
 import { isEmpty } from 'lodash'
@@ -111,6 +111,7 @@ const UserDetail = ({
   const [initData, setInitData] = useState({})
   const [changesMade, setChangesMade] = useState(false)
   const [formUsers, setFormUsers] = useState([])
+  const toastId = useRef(null)
 
   const attributes = ayonClient.getAttribsByScope('user')
 
@@ -187,6 +188,8 @@ const UserDetail = ({
   }
 
   const onSave = async () => {
+    toastId.current = toast.info('Updating user(s)...')
+    let i = 0
     for (const user of formUsers) {
       const data = {}
       const attrib = {}
@@ -230,13 +233,14 @@ const UserDetail = ({
           patch,
         }).unwrap()
 
-        toast.success(`Updated user: ${user.name} `)
-        console.log('user updated')
+        toast.update(toastId.current, { render: `Updated user: ${user.name} ` })
+        i += 1
       } catch (error) {
         toast.error(`Unable to update user ${user.name} `)
         console.error(error)
       }
     } // for user
+    toast.update(toastId.current, { render: `Updated ${i} user(s) `, type: toast.TYPE.SUCCESS })
   }
 
   const onCancel = () => {


### PR DESCRIPTION
Adds a boolean setting on attributes which turns on/off its inheritance. When set to on (default), children entities inherit the value from the parent unless the value is explicitly set. This is useful for metadata such as 'description' which only make sense on a single entity.