### PR TITLE
fix: entity name check regex + uses snake_case on fail

### DIFF
--- a/src/helpers/checkName.js
+++ b/src/helpers/checkName.js
@@ -1,0 +1,15 @@
+import { snakeCase } from 'lodash'
+
+const checkName = (name) => {
+  let newName = name
+  // check name matches regex
+  const regex = /^[a-zA-Z0-9_][a-zA-Z0-9_.-]*[a-zA-Z0-9_]$/
+  // if not, convert to snake_case
+  if (name && !name.match(regex)) {
+    newName = snakeCase(name)
+  }
+
+  return newName
+}
+
+export default checkName

--- a/src/pages/EditorPage/EditorPage.jsx
+++ b/src/pages/EditorPage/EditorPage.jsx
@@ -23,7 +23,7 @@ import useLocalStorage from '/src/hooks/useLocalStorage'
 import { useGetHierarchyQuery } from '/src/services/getHierarchy'
 import SearchDropdown from '/src/components/SearchDropdown'
 import useColumnResize from '/src/hooks/useColumnResize'
-import { camelCase, capitalize, debounce, isEmpty } from 'lodash'
+import { capitalize, debounce, isEmpty } from 'lodash'
 import { useLazyGetExpandedBranchQuery } from '/src/services/editor/getEditor'
 import { useUpdateEditorMutation } from '/src/services/editor/updateEditor'
 import usePubSub from '/src/hooks/usePubSub'
@@ -40,6 +40,7 @@ import { Splitter, SplitterPanel } from 'primereact/splitter'
 import NameField from './fields/NameField'
 import { useGetAttributesQuery } from '/src/services/getAttributes'
 import NewEntity from './NewEntity'
+import checkName from '/src/helpers/checkName'
 
 const EditorPage = () => {
   const project = useSelector((state) => state.project)
@@ -587,7 +588,7 @@ const EditorPage = () => {
           if (key.startsWith('__')) continue
           if (key.startsWith('_')) {
             if (key === '_name') {
-              entityChanges[key.substring(1)] = camelCase(changes[entityId][key])
+              entityChanges[key.substring(1)] = checkName(changes[entityId][key])
             } else {
               entityChanges[key.substring(1)] = changes[entityId][key]
             }
@@ -650,8 +651,8 @@ const EditorPage = () => {
         }
       }
 
-      // name always camelCase
-      newEntity.name = camelCase(newEntity.name)
+      // check name
+      newEntity.name = checkName(newEntity.name)
 
       const patch = {
         data: {


### PR DESCRIPTION
- Checks the regex `/^[a-zA-Z0-9_][a-zA-Z0-9_.-]*[a-zA-Z0-9_]$/`
- If regex fails it converts the string to camel_case