### PR TITLE
fix: Project/Studio settings toolbar broken

### DIFF
--- a/src/containers/addonSettings/AddonSettings.jsx
+++ b/src/containers/addonSettings/AddonSettings.jsx
@@ -98,7 +98,13 @@ const sameKeysStructure = (obj1, obj2) => {
   return true
 }
 
-const AddonSettings = ({ projectName, showSites = false, toolbar, projectList }) => {
+const AddonSettings = ({
+  projectName,
+  showSites = false,
+  toolbar,
+  projectList,
+  projectManager,
+}) => {
   const [showHelp, setShowHelp] = useState(false)
   const [selectedAddons, setSelectedAddons] = useState([])
   const [reloadTrigger, setReloadTrigger] = useState({})
@@ -455,16 +461,22 @@ const AddonSettings = ({ projectName, showSites = false, toolbar, projectList })
     )
   }, [showHelp, currentSelection, localOverrides])
 
+  const commitToolbar = useMemo(
+    () => (
+      <>
+        <Spacer />
+        <Button label="Dismiss all changes" icon="refresh" onClick={onRevertAllChanges} />
+        <Button label="Save changes" icon="check" onClick={onSave} />
+      </>
+    ),
+    [onRevertAllChanges, onSave],
+  )
+
   return (
     <ProjectManagerPageLayout
       {...{ toolbar, projectList }}
-      toolbarMore={
-        <>
-          <Spacer />
-          <Button label="Dismiss all changes" icon="refresh" onClick={onRevertAllChanges} />
-          <Button label="Save changes" icon="check" onClick={onSave} />
-        </>
-      }
+      toolbarMore={commitToolbar}
+      passthrough={!projectManager}
     >
       <Splitter layout="horizontal" style={{ width: '100%', height: '100%' }}>
         <SplitterPanel size={80} style={{ display: 'flex', flexDirection: 'row', gap: 8 }}>
@@ -542,6 +554,7 @@ const AddonSettings = ({ projectName, showSites = false, toolbar, projectList })
         </SplitterPanel>
         <SplitterPanel>
           <Section className="wrap" style={{ minWidth: 300 }}>
+            {!projectManager && <Toolbar>{commitToolbar}</Toolbar>}
             <SettingsChangesTable changes={localOverrides} onRevert={onRevertChange} />
           </Section>
         </SplitterPanel>

--- a/src/pages/ProjectManagerPage/ProjectManagerPageContainer.jsx
+++ b/src/pages/ProjectManagerPage/ProjectManagerPageContainer.jsx
@@ -17,6 +17,7 @@ const ProjectManagerPageContainer = ({
   const childrenWithProps = React.Children.map(children, (child) => {
     if (React.isValidElement(child)) {
       return React.cloneElement(child, {
+        projectManager: true,
         projectName: selection,
         isUser: isUser,
         projectList: (

--- a/src/pages/ProjectManagerPage/ProjectManagerPageLayout.jsx
+++ b/src/pages/ProjectManagerPage/ProjectManagerPageLayout.jsx
@@ -2,7 +2,8 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Toolbar } from '@ynput/ayon-react-components'
 
-const ProjectManagerPageLayout = ({ toolbar, projectList, children, toolbarMore }) => {
+const ProjectManagerPageLayout = ({ toolbar, projectList, children, toolbarMore, passthrough }) => {
+  if (passthrough) return children
   return (
     <>
       <Toolbar style={{ padding: 8, paddingBottom: 0 }}>


### PR DESCRIPTION
`<ProjectManagerPageLayout />` was causing the layout to be wrong in settings. So now it is completely ignored outside of Project Manager page context.