### PR TITLE
Fix: Subset status to version status

### DIFF
--- a/src/pages/BrowserPage/Subsets.jsx
+++ b/src/pages/BrowserPage/Subsets.jsx
@@ -27,6 +27,7 @@ import { MultiSelect } from 'primereact/multiselect'
 import useSearchFilter from '/src/hooks/useSearchFilter'
 import useColumnResize from '/src/hooks/useColumnResize'
 import { useUpdateEntitiesDetailsMutation } from '/src/services/entity/updateEntity'
+import { ayonApi } from '/src/services/ayon'
 
 const Subsets = () => {
   const dispatch = useDispatch()
@@ -94,6 +95,7 @@ const Subsets = () => {
     subsetData.map(({ id }) => id),
   )
 
+  console.log(subsetData)
   const [updateEntity] = useUpdateEntitiesDetailsMutation()
 
   // update subset status
@@ -114,8 +116,25 @@ const Subsets = () => {
         data: { ['status']: value },
       }).unwrap()
 
-      // invalidate subsets query
-      refetch()
+      // create new patch data of subsets
+      const patchData = subsetData.map(({ versionId, versionStatus, ...subset }) => ({
+        ...subset,
+        versionStatus: ids.includes(versionId) ? value : versionStatus,
+        versionId,
+      }))
+
+      console.log(patchData)
+
+      // update subsets cache
+      dispatch(
+        ayonApi.util.updateQueryData(
+          'getSubsetsList',
+          { projectName, ids: focusedFolders, versionOverrides },
+          (draft) => {
+            Object.assign(draft, patchData)
+          },
+        ),
+      )
 
       console.log('fulfilled', payload)
     } catch (error) {

--- a/src/services/entity/getEntity.js
+++ b/src/services/entity/getEntity.js
@@ -166,7 +166,14 @@ const getEntity = ayonApi.injectEndpoints({
       transformResponse: (response, meta, { type }) => response.data.project[type + 's'].edges,
       transformErrorResponse: (error) => error.data?.detail || `Error ${error.status}`,
       providesTags: (result, error, { type }) =>
-        result ? [...result.map(({ node }) => ({ type: type, id: node.id }))] : [type],
+        result
+          ? [
+              ...result.map(({ node }) => {
+                console.log({ type: type, id: node.id })
+                return { type: type, id: node.id }
+              }),
+            ]
+          : [type],
     }),
     getEventTile: build.query({
       query: ({ projectName, id, type }) => ({

--- a/src/services/entity/updateEntity.js
+++ b/src/services/entity/updateEntity.js
@@ -11,7 +11,7 @@ const updateEntity = ayonApi.injectEndpoints({
           operations: buildOperations(ids || patches.map((p) => p.id), type, data),
         },
       }),
-      invalidatesTags: (result, error, { ids, type }) => ids.map((id) => [{ type, id }]),
+      invalidatesTags: (result, error, { ids, type }) => ids.map((id) => ({ type, id })),
       async onQueryStarted(
         { projectName, type, patches, data, ids },
         { dispatch, queryFulfilled },

--- a/src/services/getSubsetsList.js
+++ b/src/services/getSubsetsList.js
@@ -61,6 +61,7 @@ const parseSubsetData = (data) => {
       version: vers ? vers.version : null,
       versionId: vers && vers.id ? vers.id : null,
       versionName: vers && vers.name ? vers.name : '',
+      versionStatus: vers.status || null,
       taskId: vers && vers.taskId ? vers.taskId : null,
       frames: parseSubsetFrames(subset),
       createdAt: vers ? vers.createdAt : subset.createdAt,
@@ -96,6 +97,7 @@ query SubsetsList($projectName: String!, $ids: [String!]!, $versionOverrides: [S
                           author
                           createdAt
                           taskId
+                          status
                           attrib {
                               fps
                               resolutionWidth
@@ -114,6 +116,7 @@ query SubsetsList($projectName: String!, $ids: [String!]!, $versionOverrides: [S
                         author
                         createdAt
                         taskId
+                        status
                         attrib {
                             fps
                             resolutionWidth


### PR DESCRIPTION
### Description

- Before a row in subsets would show the subset status.
- Now the status corresponds to the version selected

![image](https://user-images.githubusercontent.com/49156310/235641696-c54b458f-02ec-44f3-8812-51fd6c147c46.png)
 