### PR TITLE
Preselect name input

### DIFF
--- a/src/pages/EditorPage/NewEntity.jsx
+++ b/src/pages/EditorPage/NewEntity.jsx
@@ -66,6 +66,8 @@ const NewEntity = ({ type, data = {}, visible, onConfirm, onHide }) => {
   const handleShow = () => {
     // focus name input
     nameRef.current?.focus()
+    // select name
+    nameRef.current?.select()
   }
 
   const handleSubmit = (e) => {


### PR DESCRIPTION
When creating a new folder/task in editor, preselect the default text, usually "folder" or "generic", so that you can quickly rename it.

![image](https://github.com/ynput/ayon-frontend/assets/49156310/a4cd4ca1-59d5-43f7-b2ff-4f3fe3e3bfa6)
