### PR TITLE
Op 6096 remove manage projects button from project lists menu

### DIFF
--- a/src/containers/header/projectMenu.jsx
+++ b/src/containers/header/projectMenu.jsx
@@ -1,5 +1,4 @@
 import { useNavigate } from 'react-router-dom'
-import { Button } from '@ynput/ayon-react-components'
 
 import { Sidebar } from 'primereact/sidebar'
 import ProjectList from '/src/containers/projectList'
@@ -40,15 +39,6 @@ const ProjectMenu = ({ visible, onHide }) => {
     navigate(link)
   }
 
-  const footer = (
-    <Button
-      icon="empty_dashboard"
-      label="Manage Projects"
-      style={{ marginTop: 10, width: '100%' }}
-      onClick={() => navigate('/manageProjects')}
-    />
-  )
-
   return (
     <Sidebar position="left" visible={visible} onHide={onHide} icons={() => <h3>Project Menu</h3>}>
       <div
@@ -60,11 +50,7 @@ const ProjectMenu = ({ visible, onHide }) => {
           height: '100%',
         }}
       >
-        <ProjectList
-          footer={footer}
-          onRowClick={(e) => onProjectSelect(e.data.name)}
-          selection={projectName}
-        />
+        <ProjectList onRowClick={(e) => onProjectSelect(e.data.name)} selection={projectName} />
       </div>
     </Sidebar>
   )

--- a/src/containers/header/userMenu.jsx
+++ b/src/containers/header/userMenu.jsx
@@ -95,7 +95,7 @@ const UserMenu = ({ visible, onHide }) => {
     })
 
   return (
-    <Sidebar position="right" visible={visible} onHide={onHide} icons={() => <h3>User Menu</h3>}>
+    <Sidebar position="right" visible={visible} onHide={onHide}>
       <div
         style={{
           height: '100%',

--- a/src/containers/header/userMenu.jsx
+++ b/src/containers/header/userMenu.jsx
@@ -1,14 +1,10 @@
 import axios from 'axios'
-
-import { useDispatch } from 'react-redux'
 import { useLocation, useNavigate } from 'react-router-dom'
-import { toast } from 'react-toastify'
-import { Button, Spacer, UserImage } from '@ynput/ayon-react-components'
+import { Button, Divider, Spacer } from '@ynput/ayon-react-components'
 import { Sidebar } from 'primereact/sidebar'
-import { logout } from '/src/features/user'
 import { useSelector } from 'react-redux'
-import { ayonApi } from '/src/services/ayon'
 import styled, { css } from 'styled-components'
+import { Fragment } from 'react'
 
 const StyledButton = styled(Button)`
   width: 100%;
@@ -32,7 +28,6 @@ const StyledButton = styled(Button)`
 `
 
 const UserMenu = ({ visible, onHide }) => {
-  const dispatch = useDispatch()
   const navigate = useNavigate()
   const location = useLocation()
   // get user from redux store
@@ -41,31 +36,21 @@ const UserMenu = ({ visible, onHide }) => {
   const isUser = user.data.isUser
   const isAdmin = user.data.isAdmin
 
-  const doLogout = () => {
-    axios
-      .post('/api/auth/logout')
-      .then((response) => {
-        toast.info(response.data.detail)
-        dispatch(logout())
-        // reset global state
-        dispatch(ayonApi.util.resetApiState())
-      })
-      .catch(() => {
-        toast.error('Unable to log out. Weird.')
-      })
-  }
+  const divider = <Divider style={{ margin: '10px 0' }} />
+  const spacer = <Spacer />
 
   const allLinks = [
-    {
-      link: '/settings',
-      label: 'Settings',
-      icon: 'settings',
-    },
     {
       link: '/manageProjects',
       label: 'Manage Projects',
       icon: 'empty_dashboard',
     },
+    {
+      link: '/settings',
+      label: 'Settings',
+      icon: 'settings',
+    },
+    { node: divider },
     {
       link: '/doc/api',
       label: 'REST API Docs',
@@ -79,6 +64,7 @@ const UserMenu = ({ visible, onHide }) => {
   ]
 
   const protectedLinks = [
+    { node: divider },
     {
       link: '/events',
       label: 'Event Viewer',
@@ -88,6 +74,9 @@ const UserMenu = ({ visible, onHide }) => {
       link: '/services',
       label: 'Services',
       icon: 'home_repair_service',
+    },
+    {
+      node: spacer,
     },
   ]
 
@@ -116,32 +105,22 @@ const UserMenu = ({ visible, onHide }) => {
           gap: 8,
         }}
       >
-        <StyledButton
-          onClick={() => navigate('/profile')}
-          isActive={location.pathname.includes('/profile')}
-        >
-          <UserImage size={19.5} src={user?.attrib?.avatarUrl} fullName={user?.attrib?.fullName} />
-          Profile ({user.name})
-        </StyledButton>
-        {allLinks.map(({ icon, link, label, onClick }, i) => (
-          <StyledButton
-            key={`${label}-${i}`}
-            onClick={() => {
-              if (link) navigate(link)
-              else if (onClick) onClick()
-            }}
-            label={label}
-            icon={icon}
-            isActive={location.pathname.includes(link)}
-          />
-        ))}
-        <Spacer />
-        <StyledButton
-          style={{ justifyContent: 'center' }}
-          onClick={doLogout}
-          label="Sign Out"
-          icon="logout"
-        />
+        {allLinks.map(({ icon, link, label, onClick, node }, i) =>
+          label ? (
+            <StyledButton
+              key={`${label}-${i}`}
+              onClick={() => {
+                if (link) navigate(link)
+                else if (onClick) onClick()
+              }}
+              label={label}
+              icon={icon}
+              isActive={location.pathname.includes(link)}
+            />
+          ) : (
+            node && <Fragment key={`${node.displayName}-${i}`}>{node}</Fragment>
+          ),
+        )}
       </div>
     </Sidebar>
   )

--- a/src/containers/projectList.jsx
+++ b/src/containers/projectList.jsx
@@ -18,7 +18,6 @@ const ProjectList = ({
   onRowDoubleClick,
   showNull,
   multiselect,
-  footer,
   style,
   styleSection,
   className,
@@ -91,7 +90,6 @@ const ProjectList = ({
 
   return (
     <Section style={{ maxWidth: 400, ...styleSection }} className={className}>
-      {footer}
       <TablePanel loading={isLoading}>
         <DataTable
           value={projectList}

--- a/src/pages/BrowserPage/RepresentationList.jsx
+++ b/src/pages/BrowserPage/RepresentationList.jsx
@@ -65,7 +65,13 @@ const RepresentationList = ({ representations = [] }) => {
           onHide={() => setFocusedRepresentation(null)}
         />
       )*/}
-
+      <h4
+        style={{
+          margin: 0,
+        }}
+      >
+        Representations
+      </h4>
       <TablePanel>
         <TreeTable
           scrollable="true"

--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react'
 import { toast } from 'react-toastify'
 import SessionList from '/src/containers/SessionList'
-
 import { FormRow, Section, Panel, LockedInput, Button } from '@ynput/ayon-react-components'
 import { useGetMeQuery } from '../services/user/getUsers'
 import { useUpdateUserMutation } from '../services/user/updateUser'
@@ -10,6 +9,10 @@ import styled from 'styled-components'
 import UserAttribForm from './SettingsPage/UsersSettings/UserAttribForm'
 import SetPasswordDialog from './SettingsPage/UsersSettings/SetPasswordDialog'
 import ayonClient from '../ayon'
+import axios from 'axios'
+import { useDispatch } from 'react-redux'
+import { logout } from '../features/user'
+import { ayonApi } from '../services/ayon'
 
 const FormsStyled = styled.section`
   flex: 1;
@@ -33,6 +36,7 @@ export const PanelButtonsStyled = styled(Panel)`
 `
 
 const ProfilePage = () => {
+  const dispatch = useDispatch()
   const attributes = ayonClient.getAttribsByScope('user')
   // RTK QUERIES
   // GET USER DATA
@@ -120,6 +124,20 @@ const ProfilePage = () => {
     }
   }
 
+  const doLogout = () => {
+    axios
+      .post('/api/auth/logout')
+      .then((response) => {
+        toast.info(response.data.detail)
+        dispatch(logout())
+        // reset global state
+        dispatch(ayonApi.util.resetApiState())
+      })
+      .catch(() => {
+        toast.error('Unable to log out. Weird.')
+      })
+  }
+
   return (
     <main>
       <Section style={{ flex: 2 }}>
@@ -147,6 +165,14 @@ const ProfilePage = () => {
           <PanelButtonsStyled>
             <Button onClick={onCancel} label="Cancel" icon="cancel" disabled={!changesMade} />
             <Button onClick={onSave} label="Save" icon="check" disabled={!changesMade} />
+          </PanelButtonsStyled>
+          <PanelButtonsStyled>
+            <Button
+              style={{ justifyContent: 'center' }}
+              onClick={doLogout}
+              label="Sign Out"
+              icon="logout"
+            />
           </PanelButtonsStyled>
         </FormsStyled>
       </Section>


### PR DESCRIPTION
![image](https://github.com/ynput/ayon-frontend/assets/49156310/7dbde553-56cf-4405-b9a3-02c8ff661163)

And also...

- Put Manage Projects at the top
- Add dividers to user menu
- Move sign out button to profile page
- Move restart server button to bottom

![image](https://github.com/ynput/ayon-frontend/assets/49156310/ad333073-e19f-4364-b4db-1959f0f0b0df)
