### PR TITLE
Fix: user card buttons switch

### DIFF
--- a/src/components/User/UserDetailsHeader.jsx
+++ b/src/components/User/UserDetailsHeader.jsx
@@ -31,6 +31,8 @@ const UserDetailsHeader = ({ users = [], onClose, subTitle = '', style = {} }) =
 UserDetailsHeader.propTypes = {
   users: PropTypes.arrayOf(PropTypes.object),
   onClose: PropTypes.func,
+  subTitle: PropTypes.string,
+  style: PropTypes.object,
 }
 
 export default UserDetailsHeader

--- a/src/pages/BrowserPage/RepresentationList.jsx
+++ b/src/pages/BrowserPage/RepresentationList.jsx
@@ -65,7 +65,13 @@ const RepresentationList = ({ representations = [] }) => {
           onHide={() => setFocusedRepresentation(null)}
         />
       )*/}
-
+      <h4
+        style={{
+          margin: 0,
+        }}
+      >
+        Representations
+      </h4>
       <TablePanel>
         <TreeTable
           scrollable="true"

--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -145,8 +145,8 @@ const ProfilePage = () => {
             <UserAttribForm formData={formData} setFormData={setFormData} attributes={attributes} />
           </Panel>
           <PanelButtonsStyled>
-            <Button onClick={onCancel} label="Cancel" icon="cancel" disabled={!changesMade} />
             <Button onClick={onSave} label="Save" icon="check" disabled={!changesMade} />
+            <Button onClick={onCancel} label="Cancel" icon="cancel" disabled={!changesMade} />
           </PanelButtonsStyled>
         </FormsStyled>
       </Section>

--- a/src/pages/SettingsPage/UsersSettings/newUser.jsx
+++ b/src/pages/SettingsPage/UsersSettings/newUser.jsx
@@ -171,8 +171,8 @@ const NewUser = ({ onHide, open, onSuccess }) => {
         )}
       </Section>
       <PanelButtonsStyled>
-        <Button onClick={handleCancel} label="Clear" icon="clear" />
         <Button onClick={handleSubmit} label="Create New User" icon="person_add" />
+        <Button onClick={handleCancel} label="Clear" icon="clear" />
       </PanelButtonsStyled>
     </SectionStyled>
   )

--- a/src/pages/SettingsPage/UsersSettings/userDetail.jsx
+++ b/src/pages/SettingsPage/UsersSettings/userDetail.jsx
@@ -320,16 +320,16 @@ const UserDetail = ({
       )}
       <PanelButtonsStyled>
         <Button
-          onClick={onCancel}
-          label="Cancel"
-          icon="cancel"
-          disabled={!changesMade || selectedUsers.length > 1}
-        />
-        <Button
           onClick={() => (selectedUsers.length > 1 ? handleMultiSave() : onSave())}
           label="Save selected users"
           icon="check"
           disabled={!changesMade}
+        />
+        <Button
+          onClick={onCancel}
+          label="Cancel"
+          icon="cancel"
+          disabled={!changesMade || selectedUsers.length > 1}
         />
       </PanelButtonsStyled>
     </Section>

--- a/src/pages/TeamsPage/CreateNewTeam.jsx
+++ b/src/pages/TeamsPage/CreateNewTeam.jsx
@@ -182,16 +182,16 @@ const CreateNewTeam = ({
           }}
         >
           <Button
-            onClick={handleClear}
-            label="Clear"
-            icon="clear"
+            onClick={handleSubmit}
+            label="Create New Team"
+            icon="group_add"
             style={{ flex: 1 }}
             disabled={!nameForm}
           />
           <Button
-            onClick={handleSubmit}
-            label="Create New Team"
-            icon="group_add"
+            onClick={handleClear}
+            label="Clear"
+            icon="clear"
             style={{ flex: 1 }}
             disabled={!nameForm}
           />

--- a/src/pages/TeamsPage/TeamDetails.jsx
+++ b/src/pages/TeamsPage/TeamDetails.jsx
@@ -1,6 +1,13 @@
 import React, { useEffect, useState } from 'react'
 import PropTypes from 'prop-types'
-import { Button, FormLayout, FormRow, LockedInput, Panel } from '@ynput/ayon-react-components'
+import {
+  Button,
+  Divider,
+  FormLayout,
+  FormRow,
+  LockedInput,
+  Panel,
+} from '@ynput/ayon-react-components'
 import DetailHeader from '/src/components/DetailHeader'
 
 const TeamDetails = ({
@@ -73,21 +80,28 @@ const TeamDetails = ({
 
   return (
     <>
-      <DetailHeader>
-        <div
-          style={{
-            overflow: 'hidden',
-          }}
-        >
-          <h2>{title}</h2>
-          <span>{subTitle}</span>
-        </div>
-      </DetailHeader>
       <Panel
         style={{
           overflow: 'auto',
         }}
       >
+        <h2 style={{ marginTop: 0 }}>Team Settings</h2>
+        <DetailHeader
+          style={{
+            padding: 0,
+          }}
+        >
+          <div
+            style={{
+              overflow: 'hidden',
+            }}
+          >
+            <h2>{title}</h2>
+            <span>{subTitle}</span>
+          </div>
+        </DetailHeader>
+        <Divider style={{ margin: '10px 0' }} />
+
         <FormLayout>
           <FormRow label="Team Name">
             <LockedInput

--- a/src/pages/TeamsPage/TeamUsersDetails.jsx
+++ b/src/pages/TeamsPage/TeamUsersDetails.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react'
 import PropTypes from 'prop-types'
 import UserDetailsHeader from '/src/components/User/UserDetailsHeader'
 import {
+  Divider,
   Dropdown,
   FormLayout,
   FormRow,
@@ -229,12 +230,14 @@ const TeamUsersDetails = ({
 
   return (
     <>
-      <UserDetailsHeader
-        users={users}
-        style={{ flex: 'unset' }}
-        subTitle={<OverflowField value={subTitle} align="left" />}
-      />
       <Panel>
+        <h2 style={{ marginTop: 0 }}>Member Settings</h2>
+        <UserDetailsHeader
+          users={users}
+          style={{ flex: 'unset', padding: 0 }}
+          subTitle={<OverflowField value={subTitle} align="left" />}
+        />
+        <Divider style={{ margin: '10px 0' }} />
         <FormLayout>
           <FormRow label="On Teams" style={{ overflow: 'hidden' }}>
             <Dropdown


### PR DESCRIPTION
Switch so that "save" or "create" is always on the left

![image](https://github.com/ynput/ayon-frontend/assets/49156310/9d53a5ce-daf6-43e8-b9d4-2db0d9dad964)

Also... small redesign of team settings panel.

![image](https://github.com/ynput/ayon-frontend/assets/49156310/f547133a-8f5b-41db-bca8-1d24945bcbe4)
