### PR TITLE
Redesign Manage Projects Buttons

### DIFF
--- a/src/containers/addonSettings/AddonSettings.jsx
+++ b/src/containers/addonSettings/AddonSettings.jsx
@@ -77,13 +77,7 @@ const sameKeysStructure = (obj1, obj2) => {
   return true
 }
 
-const AddonSettings = ({
-  projectName,
-  showSites = false,
-  toolbar,
-  projectList,
-  projectManager,
-}) => {
+const AddonSettings = ({ projectName, showSites = false, projectList, projectManager }) => {
   const [showHelp, setShowHelp] = useState(false)
   const [selectedAddons, setSelectedAddons] = useState([])
   const [reloadTrigger, setReloadTrigger] = useState({})
@@ -478,8 +472,8 @@ const AddonSettings = ({
 
   return (
     <ProjectManagerPageLayout
-      {...{ toolbar, projectList }}
-      toolbarMore={commitToolbar}
+      projectList={projectList}
+      toolbar={commitToolbar}
       passthrough={!projectManager}
     >
       <Splitter layout="horizontal" style={{ width: '100%', height: '100%' }}>

--- a/src/containers/addonSettings/AddonSettings.jsx
+++ b/src/containers/addonSettings/AddonSettings.jsx
@@ -457,8 +457,7 @@ const AddonSettings = ({ projectName, showSites = false, projectList, projectMan
   const commitToolbar = useMemo(
     () => (
       <>
-        <Spacer />
-        <Button label="Clear All Changes" icon="clear" onClick={onRevertAllChanges} />
+        <Button label="Clear Changes" icon="clear" onClick={onRevertAllChanges} />
         <Button label="Save Changes" icon="check" onClick={onSave} />
       </>
     ),

--- a/src/containers/header/projectMenu.jsx
+++ b/src/containers/header/projectMenu.jsx
@@ -50,7 +50,11 @@ const ProjectMenu = ({ visible, onHide }) => {
           height: '100%',
         }}
       >
-        <ProjectList onRowClick={(e) => onProjectSelect(e.data.name)} selection={projectName} />
+        <ProjectList
+          onRowClick={(e) => onProjectSelect(e.data.name)}
+          selection={projectName}
+          onHide={onHide}
+        />
       </div>
     </Sidebar>
   )

--- a/src/containers/header/projectMenu.jsx
+++ b/src/containers/header/projectMenu.jsx
@@ -7,6 +7,7 @@ import { selectProject } from '/src/features/project'
 import { selectProject as selectProjectContext, setUri } from '/src/features/context'
 import { onProjectChange } from '/src/features/editor'
 import { ayonApi } from '/src/services/ayon'
+import { Button } from '@ynput/ayon-react-components'
 
 const ProjectMenu = ({ visible, onHide }) => {
   const navigate = useNavigate()
@@ -40,7 +41,7 @@ const ProjectMenu = ({ visible, onHide }) => {
   }
 
   return (
-    <Sidebar position="left" visible={visible} onHide={onHide} icons={() => <h3>Project Menu</h3>}>
+    <Sidebar position="left" visible={visible} onHide={onHide}>
       <div
         style={{
           display: 'flex',
@@ -48,8 +49,15 @@ const ProjectMenu = ({ visible, onHide }) => {
           position: 'relative',
           width: '100%',
           height: '100%',
+          gap: 8,
         }}
       >
+        <Button
+          icon="empty_dashboard"
+          label="Manage Projects"
+          style={{ marginTop: 1, width: '100%' }}
+          onClick={() => navigate('/manageProjects')}
+        />
         <ProjectList
           onRowClick={(e) => onProjectSelect(e.data.name)}
           selection={projectName}

--- a/src/containers/header/userMenu.jsx
+++ b/src/containers/header/userMenu.jsx
@@ -41,11 +41,6 @@ const UserMenu = ({ visible, onHide }) => {
 
   const allLinks = [
     {
-      link: '/manageProjects',
-      label: 'Manage Projects',
-      icon: 'empty_dashboard',
-    },
-    {
       link: '/settings',
       label: 'Settings',
       icon: 'settings',

--- a/src/containers/projectList.jsx
+++ b/src/containers/projectList.jsx
@@ -194,7 +194,9 @@ const ProjectList = ({
     <Section style={{ maxWidth: 400, ...styleSection }} className={className}>
       <ContextMenu model={globalContextMenuModel} ref={globalContextMenuRef} id="global" />
       <ContextMenu model={tableContextMenuModel} ref={tableContextMenuRef} id="table" />
-      {isProjectManager && <Button label="Add New Project" icon="create_new_folder" />}
+      {isProjectManager && (
+        <Button label="Add New Project" icon="create_new_folder" onClick={onNewProject} />
+      )}
       <TablePanel loading={isLoading} onContextMenu={(e) => handleContext(e, 'global')}>
         <DataTable
           value={projectList}

--- a/src/containers/projectList.jsx
+++ b/src/containers/projectList.jsx
@@ -1,10 +1,13 @@
-import { useMemo } from 'react'
+import { useMemo, useRef, useState } from 'react'
 import { TablePanel, Section } from '@ynput/ayon-react-components'
 
 import { DataTable } from 'primereact/datatable'
 import { Column } from 'primereact/column'
 import { useGetAllProjectsQuery } from '../services/project/getProject'
 import { useEffect } from 'react'
+import { ContextMenu } from 'primereact/contextmenu'
+import ContextMenuItem from '../components/ContextMenuItem'
+import { useNavigate } from 'react-router'
 
 const formatName = (rowData, defaultTitle) => {
   if (rowData.name === '_') return defaultTitle
@@ -25,7 +28,13 @@ const ProjectList = ({
   onNoProject,
   onSuccess,
   autoSelect,
+  isProjectManager,
+  onDeleteProject,
+  onNewProject,
+  onHide,
 }) => {
+  const [contextProject, setContextProject] = useState()
+  const navigate = useNavigate()
   // const user = useSelector((state) => state.user)
   // QUERY HOOK
   // ( default ) gets added in transformResponse
@@ -88,9 +97,104 @@ const ProjectList = ({
     } // single select
   } // onSelectionChange
 
+  // Context menu outside of table items
+  const globalContextMenuRef = useRef(null)
+
+  const manage = {
+    label: 'Manage Project',
+    icon: 'empty_dashboard',
+    command: () => {
+      navigate(`/manageProjects/dashboard?project=${contextProject ? contextProject : selection}`)
+      onHide()
+    },
+  }
+
+  const globalContextMenuModel = useMemo(() => {
+    const menuItems = []
+
+    if (!isProjectManager) menuItems.push({ ...manage, label: 'Manage Projects' })
+
+    if (onNewProject)
+      menuItems.push({
+        label: 'Create Project',
+        icon: 'create_new_folder',
+        command: onNewProject,
+      })
+
+    return menuItems.map((item) => ({
+      template: (
+        <ContextMenuItem key={item.label} contextMenuRef={globalContextMenuRef} {...item} />
+      ),
+    }))
+  }, [])
+
+  const tableContextMenuRef = useRef(null)
+  const tableContextMenuModel = useMemo(() => {
+    const managerMenuItems = [
+      {
+        label: 'Open Project',
+        icon: 'event_list',
+        command: () => onRowDoubleClick({ data: { name: selection } }),
+      },
+      {
+        label: 'Create Project',
+        icon: 'create_new_folder',
+        command: onNewProject,
+      },
+      {
+        label: 'Delete Project',
+        icon: 'delete',
+        command: onDeleteProject,
+      },
+    ]
+
+    const globalMenuItems = [
+      {
+        label: 'Open Project',
+        icon: 'event_list',
+        command: () => onRowClick({ data: { name: contextProject || selection } }),
+      },
+      manage,
+    ]
+
+    if (onNewProject)
+      globalMenuItems.push({
+        label: 'Create Project',
+        icon: 'create_new_folder',
+        command: onNewProject,
+      })
+
+    let menuItems = managerMenuItems
+    if (!isProjectManager) menuItems = globalMenuItems
+
+    return menuItems.map((item) => ({
+      template: <ContextMenuItem key={item.label} contextMenuRef={tableContextMenuRef} {...item} />,
+    }))
+  }, [data, selection, contextProject])
+
+  const contextMenuRefs = useMemo(
+    () => [tableContextMenuRef, globalContextMenuRef],
+    [tableContextMenuRef, globalContextMenuRef],
+  )
+
+  const handleContext = (e, id) => {
+    // show context menu and hide others
+    contextMenuRefs.forEach((ref) =>
+      ref?.current?.props?.id !== id ? ref.current?.hide() : ref.current?.show(e),
+    )
+  }
+
+  const onContextMenuSelectionChange = (event) => {
+    if (!selection.includes(event.value.name)) {
+      onSelect ? onSelect(event.value.name) : setContextProject(event.value.name)
+    }
+  }
+
   return (
     <Section style={{ maxWidth: 400, ...styleSection }} className={className}>
-      <TablePanel loading={isLoading}>
+      <ContextMenu model={globalContextMenuModel} ref={globalContextMenuRef} id="global" />
+      <ContextMenu model={tableContextMenuModel} ref={tableContextMenuRef} id="table" />
+      <TablePanel loading={isLoading} onContextMenu={(e) => handleContext(e, 'global')}>
         <DataTable
           value={projectList}
           scrollable="true"
@@ -102,6 +206,8 @@ const ProjectList = ({
           onSelectionChange={onSelect && onSelectionChange}
           onRowClick={onRowClick}
           onRowDoubleClick={onRowDoubleClick}
+          onContextMenu={(e) => handleContext(e.originalEvent, 'table')}
+          onContextMenuSelectionChange={onContextMenuSelectionChange}
         >
           <Column
             field="name"

--- a/src/containers/projectList.jsx
+++ b/src/containers/projectList.jsx
@@ -1,5 +1,5 @@
 import { useMemo, useRef, useState } from 'react'
-import { TablePanel, Section } from '@ynput/ayon-react-components'
+import { TablePanel, Section, Button } from '@ynput/ayon-react-components'
 
 import { DataTable } from 'primereact/datatable'
 import { Column } from 'primereact/column'
@@ -194,6 +194,7 @@ const ProjectList = ({
     <Section style={{ maxWidth: 400, ...styleSection }} className={className}>
       <ContextMenu model={globalContextMenuModel} ref={globalContextMenuRef} id="global" />
       <ContextMenu model={tableContextMenuModel} ref={tableContextMenuRef} id="table" />
+      {isProjectManager && <Button label="Add New Project" icon="create_new_folder" />}
       <TablePanel loading={isLoading} onContextMenu={(e) => handleContext(e, 'global')}>
         <DataTable
           value={projectList}

--- a/src/pages/ProjectDashboard/ProjectDashboard.jsx
+++ b/src/pages/ProjectDashboard/ProjectDashboard.jsx
@@ -28,9 +28,9 @@ const PanelsContainerStyled = styled.div`
   overflow: hidden;
 `
 
-const ProjectDashboard = ({ projectName, toolbar, projectList }) => {
+const ProjectDashboard = ({ projectName, projectList }) => {
   return (
-    <ProjectManagerPageLayout projectList={projectList} toolbar={toolbar}>
+    <ProjectManagerPageLayout projectList={projectList}>
       {projectName && (
         <Section
           style={{

--- a/src/pages/ProjectManagerPage/ProjectAnatomy.jsx
+++ b/src/pages/ProjectManagerPage/ProjectAnatomy.jsx
@@ -1,7 +1,7 @@
 import { toast } from 'react-toastify'
 import { useState, useEffect, useMemo } from 'react'
 import { useDispatch } from 'react-redux'
-import { Section, ScrollPanel, Button, Spacer } from '@ynput/ayon-react-components'
+import { Section, ScrollPanel, Button } from '@ynput/ayon-react-components'
 import SettingsEditor from '/src/containers/SettingsEditor'
 import { useGetAnatomySchemaQuery } from '../../services/anatomy/getAnatomy'
 import { useUpdateProjectAnatomyMutation } from '/src/services/project/updateProject'
@@ -65,12 +65,7 @@ const ProjectAnatomy = ({ projectName, projectList }) => {
   return (
     <ProjectManagerPageLayout
       projectList={projectList}
-      toolbar={
-        <>
-          <Spacer />
-          <Button label="Save Changes" icon="check" onClick={saveAnatomy} />
-        </>
-      }
+      toolbar={<Button label="Save Changes" icon="check" onClick={saveAnatomy} />}
     >
       <Section>
         <Section>

--- a/src/pages/ProjectManagerPage/ProjectAnatomy.jsx
+++ b/src/pages/ProjectManagerPage/ProjectAnatomy.jsx
@@ -9,7 +9,7 @@ import { useGetProjectAnatomyQuery } from '/src/services/project/getProject'
 import { setUri } from '/src/features/context'
 import ProjectManagerPageLayout from './ProjectManagerPageLayout'
 
-const ProjectAnatomy = ({ projectName, toolbar, projectList }) => {
+const ProjectAnatomy = ({ projectName, projectList }) => {
   const [newData, setNewData] = useState(null)
   const dispatch = useDispatch()
 
@@ -64,8 +64,8 @@ const ProjectAnatomy = ({ projectName, toolbar, projectList }) => {
 
   return (
     <ProjectManagerPageLayout
-      {...{ toolbar, projectList }}
-      toolbarMore={
+      projectList={projectList}
+      toolbar={
         <>
           <Spacer />
           <Button label="Save Changes" icon="check" onClick={saveAnatomy} />

--- a/src/pages/ProjectManagerPage/ProjectManagerPage.jsx
+++ b/src/pages/ProjectManagerPage/ProjectManagerPage.jsx
@@ -2,7 +2,6 @@ import { useState, useEffect } from 'react'
 import { useNavigate, useParams, NavLink, useSearchParams } from 'react-router-dom'
 import { useSelector, useDispatch } from 'react-redux'
 import { StringParam, useQueryParam, withDefault } from 'use-query-params'
-import { Spacer } from '@ynput/ayon-react-components'
 
 import { confirmDialog, ConfirmDialog } from 'primereact/confirmdialog'
 import { toast } from 'react-toastify'
@@ -113,14 +112,6 @@ const ProjectManagerPage = () => {
       name: 'Teams',
       path: '/manageProjects/teams',
       module: 'teams',
-    },
-    { node: <Spacer /> },
-    {
-      node: (
-        <a onClick={() => setShowNewProject(true)} href="#" className="nav.secondary">
-          Create New Project
-        </a>
-      ),
     },
   ]
 

--- a/src/pages/ProjectManagerPage/ProjectManagerPage.jsx
+++ b/src/pages/ProjectManagerPage/ProjectManagerPage.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import { useNavigate, useParams, NavLink, useSearchParams } from 'react-router-dom'
 import { useSelector, useDispatch } from 'react-redux'
 import { StringParam, useQueryParam, withDefault } from 'use-query-params'
+import { Spacer } from '@ynput/ayon-react-components'
 
 import { confirmDialog, ConfirmDialog } from 'primereact/confirmdialog'
 import { toast } from 'react-toastify'
@@ -113,6 +114,14 @@ const ProjectManagerPage = () => {
       path: '/manageProjects/teams',
       module: 'teams',
     },
+    { node: <Spacer /> },
+    {
+      node: (
+        <a onClick={() => setShowNewProject(true)} href="#" className="nav.secondary">
+          Create New Project
+        </a>
+      ),
+    },
   ]
 
   // filter links if isUser
@@ -124,11 +133,18 @@ const ProjectManagerPage = () => {
     <>
       <ConfirmDialog />
       <nav className="secondary">
-        {links.map((link, i) => (
-          <NavLink to={link.path + (selectedProject ? `?project=${selectedProject}` : '')} key={i}>
-            {link.name}
-          </NavLink>
-        ))}
+        {links.map((link, i) =>
+          link.node ? (
+            link.node
+          ) : (
+            <NavLink
+              to={link.path + (selectedProject ? `?project=${selectedProject}` : '')}
+              key={i}
+            >
+              {link.name}
+            </NavLink>
+          ),
+        )}
       </nav>
       {/* container wraps all modules and provides selectedProject, ProjectList comp and Toolbar comp as props */}
       <ProjectManagerPageContainer

--- a/src/pages/ProjectManagerPage/ProjectManagerPageContainer.jsx
+++ b/src/pages/ProjectManagerPage/ProjectManagerPageContainer.jsx
@@ -1,9 +1,10 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import ProjectList from '/src/containers/projectList'
-import { Button } from '@ynput/ayon-react-components'
 import { useNavigate } from 'react-router'
 
+// Wraps every page on projectManager and provides the project list
+// and other useful props
 const ProjectManagerPageContainer = ({
   children,
   isUser,
@@ -28,26 +29,14 @@ const ProjectManagerPageContainer = ({
             autoSelect
             onRowDoubleClick={(e) => navigate(`/projects/${e.data.name}/browser`)}
             selection={selection}
+            onDeleteProject={onDeleteProject}
+            onNewProject={onNewProject}
+            isProjectManager
             {...props}
           />
         ),
-        toolbar: (
-          <>
-            {!isUser && (
-              <>
-                <Button label="New project" icon="create_new_folder" onClick={onNewProject} />
-
-                <Button
-                  label="Delete project"
-                  icon="delete"
-                  className="p-button-danger"
-                  disabled={!selection}
-                  onClick={onDeleteProject}
-                />
-              </>
-            )}
-          </>
-        ),
+        onDeleteProject,
+        onNewProject,
       })
     }
     return child

--- a/src/pages/ProjectManagerPage/ProjectManagerPageContainer.jsx
+++ b/src/pages/ProjectManagerPage/ProjectManagerPageContainer.jsx
@@ -33,13 +33,6 @@ const ProjectManagerPageContainer = ({
         ),
         toolbar: (
           <>
-            <Button
-              label="Open project"
-              icon="folder_open"
-              disabled={!selection}
-              onClick={() => navigate(`/projects/${selection}/browser`)}
-            />
-
             {!isUser && (
               <>
                 <Button label="New project" icon="create_new_folder" onClick={onNewProject} />

--- a/src/pages/ProjectManagerPage/ProjectManagerPageContainer.jsx
+++ b/src/pages/ProjectManagerPage/ProjectManagerPageContainer.jsx
@@ -24,7 +24,7 @@ const ProjectManagerPageContainer = ({
         projectList: (
           <ProjectList
             style={{ minWidth: 100 }}
-            styleSection={{ maxWidth: 150, minWidth: 150 }}
+            styleSection={{ maxWidth: 170, minWidth: 170 }}
             hideCode
             autoSelect
             onRowDoubleClick={(e) => navigate(`/projects/${e.data.name}/browser`)}

--- a/src/pages/ProjectManagerPage/ProjectManagerPageLayout.jsx
+++ b/src/pages/ProjectManagerPage/ProjectManagerPageLayout.jsx
@@ -1,20 +1,21 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Toolbar } from '@ynput/ayon-react-components'
+import { Section, Toolbar } from '@ynput/ayon-react-components'
 
-const ProjectManagerPageLayout = ({ toolbar, projectList, children, toolbarMore, passthrough }) => {
+const ProjectManagerPageLayout = ({ projectList, children, passthrough, toolbar }) => {
   if (passthrough) return children
   return (
-    <>
-      <Toolbar style={{ padding: 8, paddingBottom: 0 }}>
-        {toolbar}
-        {toolbarMore && <>{toolbarMore}</>}
-      </Toolbar>
-      <main style={{ overflowY: 'clip' }}>
-        {projectList}
+    <main style={{ overflowY: 'clip' }}>
+      {projectList}
+      <Section
+        style={{
+          alignItems: 'start',
+        }}
+      >
+        {toolbar && <Toolbar>{toolbar}</Toolbar>}
         {children}
-      </main>
-    </>
+      </Section>
+    </main>
   )
 }
 
@@ -22,7 +23,6 @@ ProjectManagerPageLayout.propTypes = {
   toolbar: PropTypes.node,
   projectList: PropTypes.node,
   children: PropTypes.node,
-  toolbarMore: PropTypes.node,
 }
 
 export default ProjectManagerPageLayout

--- a/src/pages/ProjectManagerPage/ProjectRoots.jsx
+++ b/src/pages/ProjectManagerPage/ProjectRoots.jsx
@@ -53,7 +53,7 @@ const ProjectRootForm = ({ projectName, siteName, siteId, roots }) => {
   )
 }
 
-const ProjectRoots = ({ projectName, toolbar, projectList }) => {
+const ProjectRoots = ({ projectName, projectList }) => {
   const {
     data: project,
     isLoading: projectLoading,
@@ -92,7 +92,7 @@ const ProjectRoots = ({ projectName, toolbar, projectList }) => {
 
   // if (forms.length === 0) return <h1>No sites configured</h1>
   return (
-    <ProjectManagerPageLayout {...{ toolbar, projectList }}>
+    <ProjectManagerPageLayout {...{ projectList }}>
       <Section className="invisible" style={{ maxWidth: 600 }}>
         {forms.map((form) => (
           <ProjectRootForm key={form.siteId} {...form} />

--- a/src/pages/TeamsPage/TeamsPage.jsx
+++ b/src/pages/TeamsPage/TeamsPage.jsx
@@ -348,7 +348,7 @@ const TeamsPage = ({ projectName, projectList, isUser }) => {
               <>
                 <Button
                   icon={'group_add'}
-                  label="Create New Team"
+                  label="Add New Team"
                   onClick={() => setCreateTeamOpen(true)}
                   style={{ width: 200 }}
                 />

--- a/src/pages/TeamsPage/TeamsPage.jsx
+++ b/src/pages/TeamsPage/TeamsPage.jsx
@@ -71,7 +71,6 @@ const TeamsPage = ({ projectName, projectList, isUser }) => {
     isError: isErrorUsers,
   } = useGetUsersQuery({}, { skip: !projectName || isUser })
 
-  console.log(users)
   if (isErrorUsers || !Array.isArray(users)) {
     toast.error('Unable to load users')
     users = []
@@ -343,10 +342,16 @@ const TeamsPage = ({ projectName, projectList, isUser }) => {
     <>
       <ProjectManagerPageLayout
         projectList={projectList}
-        toolbarMore={
+        toolbar={
           <>
             {!isUser && (
               <>
+                <Button
+                  icon={'group_add'}
+                  label="Create New Team"
+                  onClick={() => setCreateTeamOpen(true)}
+                  style={{ width: 200 }}
+                />
                 <InputText
                   style={{ width: '200px' }}
                   placeholder="Filter users..."
@@ -360,23 +365,6 @@ const TeamsPage = ({ projectName, projectList, isUser }) => {
                 />
                 Show All Users
                 <Spacer />
-                <Button
-                  icon={'delete'}
-                  label="Delete Teams"
-                  disabled={!selectedTeams.length}
-                  onClick={onDelete}
-                />
-                <Button
-                  icon={'content_copy'}
-                  label="Duplicate Team"
-                  disabled={selectedTeams.length !== 1}
-                  onClick={onDuplicate}
-                />
-                <Button
-                  icon={'group_add'}
-                  label="Create New Team"
-                  onClick={() => setCreateTeamOpen(true)}
-                />
               </>
             )}
           </>
@@ -385,7 +373,6 @@ const TeamsPage = ({ projectName, projectList, isUser }) => {
         <Section
           style={{
             flexDirection: 'row',
-            width: 'calc(100% - 230px)',
           }}
         >
           <TeamList
@@ -396,6 +383,8 @@ const TeamsPage = ({ projectName, projectList, isUser }) => {
             onSelect={(teams) => setSelectedTeams(teams)}
             styleSection={{ height: '100%', flex: 0.4 }}
             onDelete={onDelete}
+            onDuplicate={onDuplicate}
+            onNewTeam={() => setCreateTeamOpen(true)}
           />
           <UserListTeams
             selectedProjects={[projectName]}
@@ -404,6 +393,8 @@ const TeamsPage = ({ projectName, projectList, isUser }) => {
             userList={userList}
             isLoading={isLoading}
             selectedTeams={selectedTeams}
+            onShowAllUsers={() => setShowTeamUsersOnly(!showTeamUsersOnly)}
+            showAllUsers={showTeamUsersOnly}
           />
           {!isUser && (
             <SectionStyled>

--- a/src/pages/TeamsPage/UserListTeams.jsx
+++ b/src/pages/TeamsPage/UserListTeams.jsx
@@ -47,9 +47,10 @@ const UserListTeams = ({
   selectedUsers = [],
   userList = [],
   onSelectUsers,
-  setLastSelectedUser,
   isLoading,
   selectedTeams,
+  showAllUsers,
+  onShowAllUsers,
 }) => {
   const contextMenuRef = useRef(null)
 
@@ -67,21 +68,10 @@ const UserListTeams = ({
   }
 
   const contextMenuModel = [
-    // {
-    //   label: 'Set username',
-    //   disabled: selection.length !== 1,
-    //   command: () => setShowRenameUser(true),
-    // },
-    // {
-    //   label: 'Set password',
-    //   disabled: selection.length !== 1,
-    //   command: () => setShowSetPassword(true),
-    // },
-    // {
-    //   label: 'Delete selected',
-    //   disabled: !selection.length || isSelfSelected,
-    //   command: () => onDelete(),
-    // },
+    {
+      label: showAllUsers ? 'Show All Users' : 'Show Members Only',
+      command: onShowAllUsers,
+    },
   ]
 
   // Render
@@ -93,8 +83,8 @@ const UserListTeams = ({
         flex: 1.5,
       }}
     >
-      <TablePanel loading={isLoading}>
-        <ContextMenu model={contextMenuModel} ref={contextMenuRef} />
+      <ContextMenu model={contextMenuModel} ref={contextMenuRef} />
+      <TablePanel loading={isLoading} onContextMenu={(e) => contextMenuRef.current.show(e)}>
         <DataTable
           value={userList}
           scrollable="true"
@@ -103,13 +93,6 @@ const UserListTeams = ({
           selectionMode="multiple"
           className="user-list-table"
           onSelectionChange={onSelectionChange}
-          onContextMenu={(e) => contextMenuRef.current.show(e.originalEvent)}
-          onContextMenuSelectionChange={(e) => {
-            if (!selectedUsers.includes(e.value.name)) {
-              onSelectUsers([...selection, e.value.name])
-            }
-            setLastSelectedUser(e.data.name)
-          }}
           selection={selection}
           resizableColumns
           responsive="true"

--- a/src/services/entity/getEntity.js
+++ b/src/services/entity/getEntity.js
@@ -111,6 +111,7 @@ export const formatEntityTiles = (project, entities) => {
 
   const allEntities = []
   for (const type in entities) {
+    if (!project) continue
     let entities = project[type + 's']
     // If no entities of this type
     if (!entities) continue


### PR DESCRIPTION
### Description

This is a bit of an experiment but I think it's an improvement.

- Open, Delete buttons have been completely removed.
- Other actions have been added to the context menu.
- This has also been done for the teams page.
- If these changes are made, we might need to rethink the button layout in settings as well.

Only problem might be tablet (touch screen) users not being able to reach "delete project". But then maybe deleting a project shouldn't be done on a touch screen device.

![image](https://github.com/ynput/ayon-frontend/assets/49156310/361ca145-45ad-49e2-bcee-8bd0dec89c68)
![image](https://github.com/ynput/ayon-frontend/assets/49156310/61148959-6050-4c2d-9964-6d30567d946a)
![image](https://github.com/ynput/ayon-frontend/assets/49156310/8444557c-ba51-47e6-91f7-518ecff36ae4)


