### PR TITLE
fix: multiple-select-status-fix

### DIFF
--- a/src/components/status/statusSelect.jsx
+++ b/src/components/status/statusSelect.jsx
@@ -27,7 +27,7 @@ const StatusSelect = ({
   if (!value && !placeholder) return null
 
   const handleChange = (status) => {
-    if (status[0] === value || !status?.length) return
+    if (!status?.length) return
     onChange(status[0])
   }
 


### PR DESCRIPTION
Fix an issue where selecting multiple statuses and then selecting the original (already selected) status wouldn't make any changes.