### PR TITLE
Teams UX Improvements

### DIFF
--- a/src/components/ContextMenuItem.jsx
+++ b/src/components/ContextMenuItem.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Icon } from '@ynput/ayon-react-components'
 
-const ContextMenuItem = ({ icon, label, command, children, contextMenuRef, disabled }) => {
+const ContextMenuItem = ({ icon, label, command, children, contextMenuRef, disabled, items }) => {
   const onCommand = (e) => {
     // hide the context menu
     contextMenuRef.current?.hide()
@@ -16,16 +16,35 @@ const ContextMenuItem = ({ icon, label, command, children, contextMenuRef, disab
     })
   }
 
+  const noItems = items && items.length === 0
+
   return (
     <a
-      className={`p-menuitem-link ${disabled ? 'p-disabled' : ''}`}
+      className={`p-menuitem-link ${disabled || noItems ? 'p-disabled' : ''}`}
       role="menuitem"
       href="#"
       onClick={onCommand}
+      style={{
+        paddingRight: 10,
+      }}
     >
       {icon && <Icon className="p-menuitem-icon" icon={icon} style={{ fontSize: '1.5rem' }} />}
-      {label && <span className="p-menuitem-text">{label}</span>}
+      {label && (
+        <span
+          className="p-menuitem-text"
+          style={{
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {label}
+        </span>
+      )}
       {children}
+
+      <Icon
+        icon="chevron_right"
+        style={{ marginLeft: 'auto', fontSize: '1.5rem', opacity: items ? 1 : 0 }}
+      />
     </a>
   )
 }

--- a/src/pages/TeamsPage/TeamUsersDetails.jsx
+++ b/src/pages/TeamsPage/TeamUsersDetails.jsx
@@ -10,6 +10,7 @@ import {
   OverflowField,
   Panel,
 } from '@ynput/ayon-react-components'
+import addRemoveMembers from './addRemoveMembers'
 
 const getFieldValues = (users, field, selectedTeams) => {
   let values = []
@@ -119,38 +120,12 @@ const TeamUsersDetails = ({
     const removedTeams = teamsValue.filter((team) => !newTeams.includes(team))
 
     // add/remove all users to teams
-    const updatedTeamsWithNewMembers = []
-    teams.forEach((team) => {
-      // remove out the selected users from the team
-      const membersWithRemovedUsers = team.members.filter(
-        (member) => !users.some((user) => user.name === member.name),
-      )
-
-      if (addedTeams.includes(team.name)) {
-        // create new users array with updated roles and leader
-        // if user is already on team, keep their roles and leader
-        const newUsersToAdd = users.map((user) => ({
-          name: user.name,
-          leader: false,
-          roles: [],
-        }))
-
-        // now merge new users with existing team members
-        const newMembers = [...membersWithRemovedUsers, ...newUsersToAdd]
-
-        // add selected members to new team
-        updatedTeamsWithNewMembers.push({
-          name: team.name,
-          members: newMembers,
-        })
-      } else if (removedTeams.includes(team.name)) {
-        // remove members from team
-        updatedTeamsWithNewMembers.push({
-          name: team.name,
-          members: membersWithRemovedUsers,
-        })
-      }
-    })
+    const updatedTeamsWithNewMembers = addRemoveMembers(
+      teams,
+      users.map((u) => u.name),
+      addedTeams,
+      removedTeams,
+    )
 
     onUpdateTeams(updatedTeamsWithNewMembers)
   }

--- a/src/pages/TeamsPage/TeamUsersDetails.jsx
+++ b/src/pages/TeamsPage/TeamUsersDetails.jsx
@@ -7,10 +7,10 @@ import {
   FormLayout,
   FormRow,
   InputSwitch,
-  OverflowField,
   Panel,
 } from '@ynput/ayon-react-components'
 import addRemoveMembers from './addRemoveMembers'
+import UserSubtitle from './UserSubtitle'
 
 const getFieldValues = (users, field, selectedTeams) => {
   let values = []
@@ -97,13 +97,6 @@ const TeamUsersDetails = ({
     : usersOnTeams.length
     ? 'Setting On Team' + (usersOnTeams.length > 1 ? 's' : '') + ': ' + usersOnTeams.join(', ')
     : `Not on ${selectedTeams.join(', ')}`
-
-  const subTitle =
-    users.length > 1
-      ? users.map((user) => user.name).join(', ')
-      : teamsValue.length
-      ? teamsValue.join(', ')
-      : 'No team'
 
   const leaderInit = leaderValue.some((v) => v) && !leaderMultiple
   // EFFECTS
@@ -210,7 +203,15 @@ const TeamUsersDetails = ({
         <UserDetailsHeader
           users={users}
           style={{ flex: 'unset', padding: 0 }}
-          subTitle={<OverflowField value={subTitle} align="left" />}
+          subTitle={
+            <UserSubtitle
+              teams={selectedTeams}
+              users={users}
+              teamsValue={teamsValue}
+              onAddTeam={handleTeamChange}
+            />
+          }
+          subItem={<div style={{ display: 'inline' }}>Test</div>}
         />
         <Divider style={{ margin: '10px 0' }} />
         <FormLayout>

--- a/src/pages/TeamsPage/TeamsPage.jsx
+++ b/src/pages/TeamsPage/TeamsPage.jsx
@@ -126,12 +126,12 @@ const TeamsPage = ({ projectName, projectList, isUser }) => {
         const isTeamSelected = selectedTeams.some((team) => teamsList.includes(team))
 
         const group = isTeamSelected
-          ? 'In A Selected Team'
+          ? 'On A Selected Team'
           : teamsList.filter((t) => !selectedTeams.includes(t)).length
           ? selectedTeams.length
-            ? 'In Other Teams'
-            : 'In Teams'
-          : 'In No Teams'
+            ? 'On Other Teams'
+            : 'On Teams'
+          : 'On No Teams'
 
         // Include any other user data in the merged object
         usersObject[user.name] = {
@@ -297,7 +297,6 @@ const TeamsPage = ({ projectName, projectList, isUser }) => {
       // Success
       setCreateTeamOpen(false)
       setSelectedTeams([name])
-      setShowTeamUsersOnly(true)
       !noToast && toast.success(`Created ${name}`)
     } catch (error) {
       toast.error(`Failed to create ${name}`)
@@ -449,6 +448,8 @@ const TeamsPage = ({ projectName, projectList, isUser }) => {
             selectedTeams={selectedTeams}
             onShowAllUsers={() => setShowTeamUsersOnly(!showTeamUsersOnly)}
             showAllUsers={showTeamUsersOnly}
+            teams={teams}
+            onUpdateTeams={(teams) => handleUpdateTeams(teams, { noInvalidate: true })}
           />
           {!isUser && (
             <SectionStyled>

--- a/src/pages/TeamsPage/TeamsPage.jsx
+++ b/src/pages/TeamsPage/TeamsPage.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { useGetTeamsQuery } from '../../services/team/getTeams'
 import TeamList from '/src/containers/TeamList'
-import { ArrayParam, useQueryParam, withDefault } from 'use-query-params'
+import { ArrayParam, useQueryParam } from 'use-query-params'
 import { Button, InputSwitch, InputText, Section, Spacer } from '@ynput/ayon-react-components'
 import ProjectManagerPageLayout from '../ProjectManagerPage/ProjectManagerPageLayout'
 import UserListTeams from './UserListTeams'
@@ -42,7 +42,7 @@ const TeamsPage = ({ projectName, projectList, isUser }) => {
 
   // STATES
   const [selectedUsers, setSelectedUsers] = useState([])
-  const [showTeamUsersOnly, setShowTeamUsersOnly] = useState(true)
+  const [showTeamUsersOnly, setShowTeamUsersOnly] = useState(false)
   const [isUpdating, setIsUpdating] = useState(false)
   const [createTeamOpen, setCreateTeamOpen] = useState(false)
 
@@ -82,10 +82,18 @@ const TeamsPage = ({ projectName, projectList, isUser }) => {
   // update multiple teams
   const [updateTeams] = useUpdateTeamsMutation()
 
-  const [selectedTeams, setSelectedTeams] = useQueryParam(
-    ['teams'],
-    withDefault(ArrayParam, [teams[0]?.name]),
-  )
+  const [selectedTeams = [], setSelectedTeams] = useQueryParam(['teams'], ArrayParam)
+
+  // When a team is selected, select all users on that team
+  useEffect(() => {
+    if (selectedTeams.length) {
+      const newSelectedUsers = userList
+        .filter((user) => user.teamsList.some((team) => selectedTeams.includes(team)))
+        .map((user) => user.name)
+
+      setSelectedUsers(newSelectedUsers)
+    }
+  }, [selectedTeams])
 
   // Merge users and teams data
   // NOTE: there is a usersObject bellow [userList, usersObject]
@@ -115,12 +123,24 @@ const TeamsPage = ({ projectName, projectList, isUser }) => {
           }
         })
 
+        const isTeamSelected = selectedTeams.some((team) => teamsList.includes(team))
+
+        const group = isTeamSelected
+          ? 'In A Selected Team'
+          : teamsList.filter((t) => !selectedTeams.includes(t)).length
+          ? selectedTeams.length
+            ? 'In Other Teams'
+            : 'In Teams'
+          : 'In No Teams'
+
         // Include any other user data in the merged object
         usersObject[user.name] = {
           ...usersObject[user.name],
           ...user,
           teamsList,
           rolesList,
+          isTeamSelected: isTeamSelected,
+          group,
           leader,
         }
 
@@ -152,11 +172,41 @@ const TeamsPage = ({ projectName, projectList, isUser }) => {
         })
       })
     }
+
     return [userList, usersObject]
-  }, [users, teams])
+  }, [users, teams, selectedTeams])
+
+  // SORTING
+  userList = useMemo(() => {
+    const sortedList = [...userList]
+    // sort users by name
+    sortedList.sort((a, b) => a.name.localeCompare(b.name))
+
+    // then sort by how many teams they are on
+    sortedList.sort((a, b) => {
+      const aTeams = Object.keys(a.teams).length
+      const bTeams = Object.keys(b.teams).length
+
+      if (aTeams > bTeams) return -1
+      if (aTeams < bTeams) return 1
+      return 0
+    })
+
+    // sort by if on selected teams
+    sortedList.sort((a, b) => {
+      const aOnTeam = selectedTeams.some((team) => a.teamsList.includes(team))
+      const bOnTeam = selectedTeams.some((team) => b.teamsList.includes(team))
+
+      if (aOnTeam && !bOnTeam) return -1
+      if (!aOnTeam && bOnTeam) return 1
+      return 0
+    })
+
+    return sortedList
+  }, [userList, selectedTeams])
 
   // filter users by team if showTeamUsersOnly is true
-  userList = useMemo(() => {
+  let filteredUserList = useMemo(() => {
     let filteredUsers = userList
 
     if (showTeamUsersOnly) {
@@ -168,8 +218,12 @@ const TeamsPage = ({ projectName, projectList, isUser }) => {
 
   const searchableFields = ['name', 'attrib.fullName', 'teamsList', 'rolesList', 'leader']
   // filter users using search
-  const [search, setSearch, searchedUsers] = useSearchFilter(searchableFields, userList, 'users')
-  userList = useMemo(() => searchedUsers, [searchedUsers])
+  const [search, setSearch, searchedUsers] = useSearchFilter(
+    searchableFields,
+    filteredUserList,
+    'users',
+  )
+  filteredUserList = useMemo(() => searchedUsers, [searchedUsers])
 
   // find all roles on all teams
   const rolesList = useMemo(() => {
@@ -360,10 +414,10 @@ const TeamsPage = ({ projectName, projectList, isUser }) => {
                   autocomplete="off"
                 />
                 <InputSwitch
-                  checked={!showTeamUsersOnly}
+                  checked={showTeamUsersOnly}
                   onChange={() => setShowTeamUsersOnly(!showTeamUsersOnly)}
                 />
-                Show All Users
+                Hide Other Team Members
                 <Spacer />
               </>
             )}
@@ -390,7 +444,7 @@ const TeamsPage = ({ projectName, projectList, isUser }) => {
             selectedProjects={[projectName]}
             selectedUsers={selectedUsers}
             onSelectUsers={(users) => setSelectedUsers(users)}
-            userList={userList}
+            userList={filteredUserList}
             isLoading={isLoading}
             selectedTeams={selectedTeams}
             onShowAllUsers={() => setShowTeamUsersOnly(!showTeamUsersOnly)}

--- a/src/pages/TeamsPage/UserListTeams.jsx
+++ b/src/pages/TeamsPage/UserListTeams.jsx
@@ -100,11 +100,15 @@ const UserListTeams = ({
           tableStyle={{
             width: '100%',
           }}
+          groupRowsBy={'group'}
+          rowGroupMode="subheader"
+          rowGroupHeaderTemplate={(data) => {
+            return <div>{data.group}</div>
+          }}
         >
           <Column
             field="name"
             header="Username"
-            sortable
             body={(rowData) => ProfileRow({ rowData })}
             style={{
               width: '20%',
@@ -113,7 +117,6 @@ const UserListTeams = ({
           <Column
             field="attrib.fullName"
             header="Full Name"
-            sortable
             style={{
               width: '20%',
             }}
@@ -146,7 +149,6 @@ const UserListTeams = ({
                 </span>
               )
             }}
-            sortable
             sortField="teamsList"
           />
           <Column
@@ -177,7 +179,6 @@ const UserListTeams = ({
                 </span>
               )
             }}
-            sortable
             sortField="rolesList"
           />
         </DataTable>

--- a/src/pages/TeamsPage/UserListTeams.jsx
+++ b/src/pages/TeamsPage/UserListTeams.jsx
@@ -6,6 +6,8 @@ import { TablePanel, Section, UserImage } from '@ynput/ayon-react-components'
 
 import { useMemo } from 'react'
 import styled from 'styled-components'
+import ContextMenuItem from '/src/components/ContextMenuItem'
+import addRemoveMembers from './addRemoveMembers'
 
 const StyledProfileRow = styled.div`
   display: flex;
@@ -51,9 +53,9 @@ const UserListTeams = ({
   selectedTeams,
   showAllUsers,
   onShowAllUsers,
+  teams = [],
+  onUpdateTeams,
 }) => {
-  const contextMenuRef = useRef(null)
-
   // Selection
   const selection = useMemo(
     () => userList.filter((user) => selectedUsers.includes(user.name)),
@@ -67,12 +69,89 @@ const UserListTeams = ({
     onSelectUsers(result)
   }
 
-  const contextMenuModel = [
-    {
-      label: showAllUsers ? 'Show All Users' : 'Show Members Only',
-      command: onShowAllUsers,
-    },
-  ]
+  const handleAddRemove = (add = [], remove = []) => {
+    const updatedTeams = addRemoveMembers(teams, selectedUsers, add, remove)
+
+    console.log(updatedTeams)
+
+    onUpdateTeams(updatedTeams)
+  }
+
+  const onContextSelectionChange = (e) => {
+    const name = e.value.name
+    const index = selectedUsers.indexOf(name)
+    if (index === -1) onSelectUsers([name])
+  }
+
+  // two arrays one for adding to teams and one for removing from teams
+  // only one user that is not in the team is required to add to the team
+  // only one user that is in the team is required to remove from the team
+  const addToList = useMemo(
+    () =>
+      teams.filter((team) =>
+        selectedUsers.some((user) => !team.members.some((mem) => mem.name === user)),
+      ),
+    [selectedTeams, selectedUsers, teams],
+  )
+
+  const removeFromList = useMemo(
+    () =>
+      teams.filter((team) =>
+        selectedUsers.some((user) => team.members.some((mem) => mem.name === user)),
+      ),
+    [selectedTeams, selectedUsers, teams],
+  )
+
+  // CONTEXT
+  // TODO: add/remove user from selectedTeams
+  const contextMenuRef = useRef(null)
+  const contextMenuModel = useMemo(() => {
+    const menuItems = [
+      {
+        label: showAllUsers ? 'Show All Users' : 'Show Members Only',
+        command: onShowAllUsers,
+        icon: showAllUsers ? 'visibility' : 'visibility_off',
+      },
+      {
+        label: 'Add To Team',
+        icon: 'add',
+        items: addToList.map((team) => ({
+          label: team.name,
+          icon: 'add',
+          command: () => handleAddRemove([team.name], []),
+        })),
+      },
+      {
+        label: 'Remove From Team',
+        icon: 'remove',
+        items: removeFromList.map((team) => ({
+          label: team.name,
+          icon: 'remove',
+          command: () => handleAddRemove([], [team.name]),
+        })),
+      },
+    ]
+
+    const addTemplateToItems = (items) => {
+      return items.map((item) => {
+        const newItem = {
+          ...item,
+          template: <ContextMenuItem key={item.label} contextMenuRef={contextMenuRef} {...item} />,
+        }
+        if (newItem.items) {
+          newItem.items = addTemplateToItems(newItem.items)
+        }
+        return newItem
+      })
+    }
+
+    const contextMenuItems = menuItems.map((item) => ({
+      template: <ContextMenuItem key={item.label} contextMenuRef={contextMenuRef} {...item} />,
+      items: item.items ? addTemplateToItems(item.items) : undefined,
+    }))
+
+    return contextMenuItems
+  }, [selectedTeams, selectedUsers, showAllUsers, teams])
 
   // Render
 
@@ -93,6 +172,7 @@ const UserListTeams = ({
           selectionMode="multiple"
           className="user-list-table"
           onSelectionChange={onSelectionChange}
+          onContextMenuSelectionChange={onContextSelectionChange}
           selection={selection}
           resizableColumns
           responsive="true"

--- a/src/pages/TeamsPage/UserSubtitle.jsx
+++ b/src/pages/TeamsPage/UserSubtitle.jsx
@@ -1,0 +1,43 @@
+import React from 'react'
+import styled from 'styled-components'
+import { OverflowField, Button } from '@ynput/ayon-react-components'
+
+const StyledSubtitle = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  height: 20px;
+`
+
+const AddButton = styled(Button)`
+  min-height: unset;
+  padding: 1px 0;
+  padding-right: 4px;
+  gap: 0;
+`
+
+const UserSubtitle = ({ users, teams, onAddTeam, teamsValue }) => {
+  const subTitle =
+    users.length > 1
+      ? users.map((user) => user.name).join(', ')
+      : teamsValue.length
+      ? teamsValue.join(', ')
+      : 'No team'
+
+  const teamsUserNotIn = teams.filter((team) => !teamsValue.includes(team))
+
+  return (
+    <StyledSubtitle>
+      <OverflowField value={subTitle} align="left" />
+      {users.length === 1 &&
+        !!teamsUserNotIn.length &&
+        teamsUserNotIn.map((team) => (
+          <AddButton key={team} icon="add" onClick={() => onAddTeam([...teamsValue, team])}>
+            {team}
+          </AddButton>
+        ))}
+    </StyledSubtitle>
+  )
+}
+
+export default UserSubtitle

--- a/src/pages/TeamsPage/addRemoveMembers.js
+++ b/src/pages/TeamsPage/addRemoveMembers.js
@@ -1,0 +1,41 @@
+// for the provided users and teams, add/remove the selected users to/from the selected teams
+
+const addRemoveMembers = (teams, userNames = [], addedTeams, removedTeams) => {
+  // add/remove all users to teams
+  const updatedTeamsWithNewMembers = []
+  teams.forEach((team) => {
+    // remove out the selected users from the team
+    const membersWithRemovedUsers = team.members.filter(
+      (member) => !userNames.includes(member.name),
+    )
+
+    if (addedTeams.includes(team.name)) {
+      // create new users array with updated roles and leader
+      // if user is already on team, keep their roles and leader
+      const newUsersToAdd = userNames.map((user) => ({
+        name: user,
+        leader: false,
+        roles: [],
+      }))
+
+      // now merge new users with existing team members
+      const newMembers = [...membersWithRemovedUsers, ...newUsersToAdd]
+
+      // add selected members to new team
+      updatedTeamsWithNewMembers.push({
+        name: team.name,
+        members: newMembers,
+      })
+    } else if (removedTeams.includes(team.name)) {
+      // remove members from team
+      updatedTeamsWithNewMembers.push({
+        name: team.name,
+        members: membersWithRemovedUsers,
+      })
+    }
+  })
+
+  return updatedTeamsWithNewMembers
+}
+
+export default addRemoveMembers

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -419,3 +419,14 @@ a {
     background-color: var(--button-background);
   }
 }
+
+// context menu
+.p-contextmenu {
+  min-width: 12.5rem;
+  width: unset;
+  padding: 0;
+
+  .p-submenu-list {
+    padding: 0;
+  }
+}


### PR DESCRIPTION
These changes should make it far easier to understand what users are on what teams and how to add/remove them from a team.

- Fixed a bug where not all users would show when creating a new team
- Show all users by default
- Group users in the table by selected teams
- Add/Remove users to teams using context menu
- "quick add" button on Member Settings panel

- UX testing will be performed on the page to see these changes helped.

![image](https://github.com/ynput/ayon-frontend/assets/49156310/f9fd477b-654d-4f4f-af03-5c7e6aa5755b)
