### PR TITLE
Cosmetic/op 6252 highlight save changes button

### DIFF
--- a/src/components/ContextMenuItem.jsx
+++ b/src/components/ContextMenuItem.jsx
@@ -2,7 +2,17 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Icon } from '@ynput/ayon-react-components'
 
-const ContextMenuItem = ({ icon, label, command, children, contextMenuRef, disabled, items }) => {
+const ContextMenuItem = ({
+  icon,
+  label,
+  command,
+  children,
+  contextMenuRef,
+  disabled,
+  items,
+  isSave,
+  ...props
+}) => {
   const onCommand = (e) => {
     // hide the context menu
     contextMenuRef.current?.hide()
@@ -26,14 +36,24 @@ const ContextMenuItem = ({ icon, label, command, children, contextMenuRef, disab
       onClick={onCommand}
       style={{
         paddingRight: 10,
+        backgroundColor: isSave ? 'var(--color-hl-00)' : 'transparent',
+        ...props?.style,
       }}
+      {...props}
     >
-      {icon && <Icon className="p-menuitem-icon" icon={icon} style={{ fontSize: '1.5rem' }} />}
+      {icon && (
+        <Icon
+          className="p-menuitem-icon"
+          icon={icon}
+          style={{ fontSize: '1.5rem', color: isSave ? 'black' : 'white' }}
+        />
+      )}
       {label && (
         <span
           className="p-menuitem-text"
           style={{
             whiteSpace: 'nowrap',
+            color: isSave ? 'black' : 'white',
           }}
         >
           {label}
@@ -43,7 +63,12 @@ const ContextMenuItem = ({ icon, label, command, children, contextMenuRef, disab
 
       <Icon
         icon="chevron_right"
-        style={{ marginLeft: 'auto', fontSize: '1.5rem', opacity: items ? 1 : 0 }}
+        style={{
+          marginLeft: 'auto',
+          fontSize: '1.5rem',
+          opacity: items ? 1 : 0,
+          color: isSave ? 'black' : 'white',
+        }}
       />
     </a>
   )
@@ -56,6 +81,8 @@ ContextMenuItem.propTypes = {
   command: PropTypes.func,
   contextMenuRef: PropTypes.object.isRequired,
   disabled: PropTypes.bool,
+  items: PropTypes.array,
+  isSave: PropTypes.bool,
 }
 
 export default ContextMenuItem

--- a/src/components/SaveButton.jsx
+++ b/src/components/SaveButton.jsx
@@ -1,0 +1,67 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled, { css, keyframes } from 'styled-components'
+import { Button } from '@ynput/ayon-react-components'
+
+// spin animation
+const spin = keyframes`
+    from {
+        transform: rotate(0deg);
+    }
+    to {
+        transform: rotate(360deg);
+    }
+`
+
+const StyledSaveButton = styled(Button)`
+  transition: background-color 0.3s;
+  /* active styles */
+  ${({ $active }) =>
+    $active &&
+    css`
+      transition: background-color 0s;
+
+      background-color: var(--color-hl-00);
+      color: black;
+
+      .icon {
+        color: black;
+
+        /* saving spine icon */
+        ${({ $saving }) =>
+          $saving &&
+          css`
+            animation: ${spin} 1s linear infinite;
+            cursor: not-allowed;
+            user-select: none;
+          `}
+      }
+
+      &:hover {
+        background-color: #76cbe8;
+      }
+    `}
+`
+const SaveButton = React.forwardRef(({ active, saving, children, ...props }, ref) => {
+  return (
+    <StyledSaveButton
+      ref={ref}
+      disabled={!active}
+      icon={props?.icon || saving ? 'sync' : 'check'}
+      {...props}
+      $active={active}
+      $saving={saving}
+    >
+      {children}
+    </StyledSaveButton>
+  )
+})
+
+SaveButton.displayName = 'SaveButton'
+
+SaveButton.propTypes = {
+  active: PropTypes.bool,
+  saving: PropTypes.bool,
+}
+
+export default SaveButton

--- a/src/containers/SettingsEditor/SettingsEditor.jsx
+++ b/src/containers/SettingsEditor/SettingsEditor.jsx
@@ -8,10 +8,10 @@ import { FieldTemplate, ObjectFieldTemplate, ArrayFieldTemplate } from './fields
 import './SettingsEditor.sass'
 
 const FormWrapper = styled.div`
-  [data-fieldid="${(props) => props.currentSelection}"]{
+  [data-fieldid='${(props) => props.currentSelection}'] {
     border-left: 1px solid var(--color-hl-00) !important;
     border-radius: 4px;
-    background-color: rgba(0,0,0,.2);
+    background-color: rgba(0, 0, 0, 0.2);
   }
 
   .rjsf {
@@ -22,7 +22,6 @@ const FormWrapper = styled.div`
       display: none;
     }
   }
-}
 `
 
 const widgets = {

--- a/src/containers/addonSettings/AddonSettings.jsx
+++ b/src/containers/addonSettings/AddonSettings.jsx
@@ -25,6 +25,7 @@ import {
   useModifyAddonOverrideMutation,
 } from '/src/services/addonSettings'
 import ProjectManagerPageLayout from '/src/pages/ProjectManagerPage/ProjectManagerPageLayout'
+import SaveButton from '/src/components/SaveButton'
 
 /*
  * key is {addonName}|{addonVersion}|{siteId}|{projectKey}
@@ -89,7 +90,7 @@ const AddonSettings = ({ projectName, showSites = false, projectList, projectMan
   const [environment, setEnvironment] = useState('production')
   const [showAllAddons, setShowAllAddons] = useState(false)
 
-  const [setAddonSettings] = useSetAddonSettingsMutation()
+  const [setAddonSettings, { isLoading: setAddonSettingsUpdating }] = useSetAddonSettingsMutation()
   const [deleteAddonSettings] = useDeleteAddonSettingsMutation()
   const [modifyAddonOverride] = useModifyAddonOverrideMutation()
 
@@ -454,11 +455,23 @@ const AddonSettings = ({ projectName, showSites = false, projectList, projectMan
     )
   }, [showHelp, currentSelection, localOverrides])
 
+  const canCommit = useMemo(() => Object.keys(localOverrides).length > 0, [localOverrides])
+
   const commitToolbar = useMemo(
     () => (
       <>
-        <Button label="Clear Changes" icon="clear" onClick={onRevertAllChanges} />
-        <Button label="Save Changes" icon="check" onClick={onSave} />
+        <Button
+          label="Clear Changes"
+          icon="clear"
+          onClick={onRevertAllChanges}
+          disabled={!canCommit}
+        />
+        <SaveButton
+          label="Save Changes"
+          onClick={onSave}
+          active={canCommit}
+          saving={setAddonSettingsUpdating}
+        />
       </>
     ),
     [onRevertAllChanges, onSave],

--- a/src/pages/EditorPage/EditorPage.jsx
+++ b/src/pages/EditorPage/EditorPage.jsx
@@ -1353,7 +1353,8 @@ const EditorPage = () => {
                 onRowClick={onRowClick}
                 rowClassName={(rowData) => {
                   return {
-                    changed: rowData.key in changes || rowData.key in newNodes,
+                    changed: rowData.key in changes,
+                    new: rowData.key in newNodes,
                     deleted: rowData.key in changes && changes[rowData.key]?.__action == 'delete',
                   }
                 }}

--- a/src/pages/EditorPage/EditorPage.jsx
+++ b/src/pages/EditorPage/EditorPage.jsx
@@ -36,6 +36,7 @@ import { useGetAttributesQuery } from '/src/services/attributes/getAttributes'
 import NewEntity from './NewEntity'
 import checkName from '/src/helpers/checkName'
 import useCreateContext from '/src/hooks/useCreateContext'
+import SaveButton from '/src/components/SaveButton'
 
 const EditorPage = () => {
   const project = useSelector((state) => state.project)
@@ -1015,6 +1016,7 @@ const EditorPage = () => {
         icon: 'check',
         command: onCommit,
         disabled: !canCommit,
+        isSave: canCommit,
       },
       {
         label: 'Clear All Changes',
@@ -1053,11 +1055,13 @@ const EditorPage = () => {
         icon: 'check',
         command: onCommit,
         disabled: !canCommit,
+        isSave: canCommit,
       },
       {
         label: 'Clear Changes',
         icon: 'clear',
         command: revertChangesOnSelection,
+        disabled: !canCommit,
       },
     ],
 
@@ -1150,6 +1154,13 @@ const EditorPage = () => {
     )
 
     localStorage.setItem('editor-columns-order', JSON.stringify(localStorageOrder))
+  }
+
+  const handleDeselect = (e) => {
+    // target class is p-treetable-scrollable-body
+    if (e.target.classList.contains('p-treetable-scrollable-body')) {
+      handleSelectionChange({})
+    }
   }
 
   let allColumns = useMemo(
@@ -1309,13 +1320,14 @@ const EditorPage = () => {
             isLoading={isSearchLoading}
           />
           <Spacer />
+          {canCommit && <>Unsaved Changes</>}
           <Button
             icon="clear"
             label="Clear All Changes"
             onClick={handleRevert}
             disabled={!canCommit}
           />
-          <Button icon="check" label="Save Changes" onClick={onCommit} disabled={!canCommit} />
+          <SaveButton label="Save Changes" onClick={onCommit} active={canCommit} />
         </Toolbar>
         <Splitter
           style={{ width: '100%', height: '100%' }}
@@ -1337,6 +1349,7 @@ const EditorPage = () => {
                 selectionMode="multiple"
                 selectionKeys={currentSelection}
                 onSelectionChange={(e) => handleSelectionChange(e.value)}
+                onClick={handleDeselect}
                 onRowClick={onRowClick}
                 rowClassName={(rowData) => {
                   return {

--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -13,6 +13,7 @@ import axios from 'axios'
 import { useDispatch } from 'react-redux'
 import { logout } from '../features/user'
 import { ayonApi } from '../services/ayon'
+import SaveButton from '../components/SaveButton'
 
 const FormsStyled = styled.section`
   flex: 1;
@@ -44,7 +45,7 @@ const ProfilePage = () => {
   const [showSetPassword, setShowSetPassword] = useState(false)
 
   // UPDATE USER DATA
-  const [updateUser] = useUpdateUserMutation()
+  const [updateUser, { isLoading: isUpdatingUser }] = useUpdateUserMutation()
 
   // build initial form data
   const initialFormData = {}
@@ -163,8 +164,13 @@ const ProfilePage = () => {
             <UserAttribForm formData={formData} setFormData={setFormData} attributes={attributes} />
           </Panel>
           <PanelButtonsStyled>
-            <Button onClick={onSave} label="Save" icon="check" disabled={!changesMade} />
             <Button onClick={onCancel} label="Cancel" icon="cancel" disabled={!changesMade} />
+            <SaveButton
+              onClick={onSave}
+              label="Save"
+              active={changesMade}
+              saving={isUpdatingUser}
+            />
           </PanelButtonsStyled>
           <PanelButtonsStyled>
             <Button

--- a/src/pages/ProjectManagerPage/ProjectRoots.jsx
+++ b/src/pages/ProjectManagerPage/ProjectRoots.jsx
@@ -2,19 +2,32 @@ import ayonClient from '/src/ayon'
 import { useState, useMemo, useEffect } from 'react'
 import { useGetProjectQuery } from '../../services/project/getProject'
 import { useGetCustomRootsQuery, useSetCustomRootsMutation } from '/src/services/customRoots'
-import {
-  InputText,
-  Button,
-  FormLayout,
-  FormRow,
-  Panel,
-  Section,
-} from '@ynput/ayon-react-components'
+import { InputText, FormLayout, FormRow, Panel, Section } from '@ynput/ayon-react-components'
 import ProjectManagerPageLayout from './ProjectManagerPageLayout'
+import { toast } from 'react-toastify'
+import SaveButton from '/src/components/SaveButton'
 
 const ProjectRootForm = ({ projectName, siteName, siteId, roots }) => {
-  const [setCustomRoots] = useSetCustomRootsMutation()
+  const [setCustomRoots, { isLoading }] = useSetCustomRootsMutation()
   const [rootValues, setRootValues] = useState(null)
+
+  const handleSave = async () => {
+    try {
+      await setCustomRoots({ projectName, siteId, data: rootValues }).unwrap()
+
+      toast.success(`Roots saved`)
+    } catch (error) {
+      toast.error(`Error saving roots: ${error?.message}`)
+    }
+  }
+
+  const isChange = useMemo(() => {
+    if (!rootValues) return false
+    for (const root of roots) {
+      if (rootValues[root.name] !== root.customPath) return true
+    }
+    return false
+  }, [rootValues, roots])
 
   useEffect(() => {
     const res = {}
@@ -43,10 +56,7 @@ const ProjectRootForm = ({ projectName, siteName, siteId, roots }) => {
           </FormRow>
         ))}
         <FormRow>
-          <Button
-            label="Save"
-            onClick={() => setCustomRoots({ projectName, siteId, data: rootValues })}
-          />
+          <SaveButton label="Save" onClick={handleSave} active={isChange} saving={isLoading} />
         </FormRow>
       </FormLayout>
     </Panel>

--- a/src/pages/SettingsPage/AnatomyPresets/AnatomyPresets.jsx
+++ b/src/pages/SettingsPage/AnatomyPresets/AnatomyPresets.jsx
@@ -20,6 +20,8 @@ import {
   useUpdatePresetMutation,
   useUpdatePrimaryPresetMutation,
 } from '/src/services/anatomy/updateAnatomy'
+import { isEqual } from 'lodash'
+import SaveButton from '/src/components/SaveButton'
 
 const AnatomyPresets = () => {
   const [originalData, setOriginalData] = useState(null)
@@ -55,12 +57,17 @@ const AnatomyPresets = () => {
     }
   }, [selectedPreset, isSuccess, anatomyData])
 
+  const isChanged = useMemo(() => {
+    if (!originalData || !newData) return false
+    return !isEqual(originalData, newData)
+  }, [newData, originalData])
+
   //
   // Actions
   //
 
   // RTK Query updateAnatomy.js mutations
-  const [updatePreset] = useUpdatePresetMutation()
+  const [updatePreset, { isLoading: isUpdating }] = useUpdatePresetMutation()
   const [deletePreset] = useDeletePresetMutation()
   const [updatePrimaryPreset] = useUpdatePrimaryPresetMutation()
 
@@ -150,13 +157,28 @@ const AnatomyPresets = () => {
     <main>
       <ConfirmDialog />
       {showNameDialog && (
-        <Dialog header="Preset name" visible="true" onHide={() => setShowNameDialog(false)}>
+        <Dialog
+          header="Preset name"
+          visible="true"
+          onHide={() => setShowNameDialog(false)}
+          style={{ minWidth: 300 }}
+          footer={
+            <SaveButton
+              label="Create New Preset"
+              onClick={() => savePreset(newPresetName)}
+              active={newPresetName}
+              style={{ marginLeft: 'auto' }}
+            />
+          }
+        >
           <InputText
             value={newPresetName}
             onChange={(e) => setNewPresetName(e.target.value)}
             placeholder="Preset name"
+            style={{
+              width: '100%',
+            }}
           />
-          <Button label="Save" onClick={() => savePreset(newPresetName)} />
         </Dialog>
       )}
 
@@ -193,10 +215,10 @@ const AnatomyPresets = () => {
               setShowNameDialog(true)
             }}
           />
-          <Button
+          <SaveButton
             label="Save Current Preset"
-            icon="check"
-            disabled={selectedPreset === '_'}
+            saving={isUpdating}
+            active={isChanged && selectedPreset !== '_'}
             onClick={() => savePreset(selectedPreset)}
           />
         </Toolbar>

--- a/src/pages/SettingsPage/Attributes.jsx
+++ b/src/pages/SettingsPage/Attributes.jsx
@@ -17,6 +17,8 @@ import useSearchFilter from '/src/hooks/useSearchFilter'
 import { ConfirmDialog, confirmDialog } from 'primereact/confirmdialog'
 import { useRestartServerMutation } from '/src/services/restartServer'
 import useCreateContext from '/src/hooks/useCreateContext'
+import SaveButton from '/src/components/SaveButton'
+import { isEqual } from 'lodash'
 
 const Attributes = () => {
   const [attributes, setAttributes] = useState([])
@@ -32,6 +34,12 @@ const Attributes = () => {
       setAttributes(data)
     }
   }, [data, isLoading, isFetching, updateLoading])
+
+  // check for changes
+  const isChanges = useMemo(() => {
+    if (!data || !attributes) return false
+    return !isEqual(data, attributes)
+  }, [data, attributes])
 
   if (isError) {
     console.error(error)
@@ -164,7 +172,20 @@ const Attributes = () => {
               onChange={(e) => setSearch(e.target.value)}
             />
             <Spacer />
-            <Button label="Save Attributes" icon="check" onClick={onSave} />
+            {isChanges && 'Unsaved Changes'}
+            <Button
+              label="Clear changes"
+              icon="clear"
+              disabled={!isChanges}
+              onClick={() => setAttributes(data)}
+            />
+            <SaveButton
+              label="Save attributes changes"
+              icon="check"
+              onClick={onSave}
+              active={isChanges}
+              saving={updateLoading}
+            />
           </Toolbar>
           <TablePanel loading={isLoading || updateLoading || isFetching}>
             <DataTable

--- a/src/pages/SettingsPage/Roles/rolesList.jsx
+++ b/src/pages/SettingsPage/Roles/rolesList.jsx
@@ -110,6 +110,7 @@ const RolesList = ({ projectName, selectedRole, onSelectRole, reloadTrigger }) =
     })
   }
 
+  // FIXME: this doesn't update when role details updates
   const getRowClass = (rowData) => {
     return { 'changed-project': rowData.isProjectLevel }
   }

--- a/src/pages/SettingsPage/UsersSettings/userDetail.jsx
+++ b/src/pages/SettingsPage/UsersSettings/userDetail.jsx
@@ -10,6 +10,7 @@ import UserAccessForm from './UserAccessForm'
 import { confirmDialog } from 'primereact/confirmdialog'
 import ServiceDetails from './ServiceDetails'
 import UserDetailsHeader from '/src/components/User/UserDetailsHeader'
+import SaveButton from '/src/components/SaveButton'
 
 const FormsStyled = styled.section`
   flex: 1;
@@ -145,7 +146,7 @@ const UserDetail = ({
   // check if any users have the userLevel of service
   const hasServiceUser = formUsers.some((user) => user.isService)
 
-  const [updateUser] = useUpdateUserMutation()
+  const [updateUser, { isLoading: isUpdating }] = useUpdateUserMutation()
 
   //
   // API
@@ -320,16 +321,16 @@ const UserDetail = ({
       )}
       <PanelButtonsStyled>
         <Button
-          onClick={() => (selectedUsers.length > 1 ? handleMultiSave() : onSave())}
-          label="Save selected users"
-          icon="check"
-          disabled={!changesMade}
-        />
-        <Button
           onClick={onCancel}
           label="Cancel"
-          icon="cancel"
+          icon="clear"
           disabled={!changesMade || selectedUsers.length > 1}
+        />
+        <SaveButton
+          onClick={() => (selectedUsers.length > 1 ? handleMultiSave() : onSave())}
+          label="Save selected users"
+          active={changesMade}
+          saving={isUpdating}
         />
       </PanelButtonsStyled>
     </Section>

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -136,13 +136,27 @@ input:-webkit-autofill:focus {
 }
 .editor-field {
   &.changed {
-    border: 1px solid var(--color-hl-changed);
+    outline: 1px solid var(--color-hl-changed);
+    background-color: var(--color-hl-changed);
+    border-radius: var(--border-radius);
   }
   &.inherited {
     color: var(--color-grey-06);
     font-style: italic;
   }
 }
+
+.p-treetable .p-treetable-tbody > tr.changed {
+  outline: 2px solid var(--color-hl-changed);
+  outline-offset: -2px;
+}
+
+.p-treetable .p-treetable-tbody > tr.new {
+  outline: 2px solid var(--color-hl-studio);
+  outline-offset: -2px;
+  border-left: 4px solid var(--color-hl-studio);
+}
+
 .table-editor {
   margin: 0;
   .p-inputwrapper {


### PR DESCRIPTION
### Description

Improve the save button to be more obvious and provide better feedback. 

- New `SaveButton` component
- Saving progress spinner
- Turns blue when changes need to be saved

```javascript
<SaveButton
    label="Save Changes"
    onClick={onSave}
    active={canCommit}
    saving={setAddonSettingsUpdating}
/>
```

![SaveButton_v001](https://github.com/ynput/ayon-frontend/assets/49156310/99945a93-dcd0-4fbf-8176-8902abf869cf)
