### PR TITLE
Fix: task selection highlights products

### DIFF
--- a/src/containers/taskList.jsx
+++ b/src/containers/taskList.jsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useRef } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import { TablePanel, Section } from '@ynput/ayon-react-components'
 
@@ -25,6 +25,8 @@ const TaskList = ({ style = {} }) => {
   const userName = useSelector((state) => state.user.name)
 
   const [showDetail, setShowDetail] = useState(false)
+
+  const tableRef = useRef(null)
 
   //
   // Hooks
@@ -103,6 +105,22 @@ const TaskList = ({ style = {} }) => {
     dispatch(setUri(uri))
   }
 
+  const handleDeselect = (e) => {
+    const tableRefElement = tableRef.current?.getElement()
+
+    const tableHeader = tableRefElement?.querySelector('table')
+    const table = tableRefElement?.querySelector('.p-treetable-scrollable-body-table')
+
+    // check if e.target is inside either table or tableHeader
+    // do nothing
+    if (tableHeader?.contains(e.target) || table?.contains(e.target)) return
+
+    // deselect all
+    dispatch(setFocusedTasks([]))
+    // remove paring
+    dispatch(setPairing([]))
+  }
+
   // CONTEXT MENU
   const ctxMenuItems = [
     {
@@ -153,6 +171,8 @@ const TaskList = ({ style = {} }) => {
             onContextMenuSelectionChange={onContextMenuSelectionChange}
             onRowClick={onRowClick}
             className={isFetching ? 'table-loading' : undefined}
+            onClick={handleDeselect}
+            ref={tableRef}
           >
             <Column field="name" header="Task" expander="true" body={nameRenderer} />
             {folderIds.length > 1 && <Column field="folderName" header="Folder" />}

--- a/src/pages/BrowserPage/Products.jsx
+++ b/src/pages/BrowserPage/Products.jsx
@@ -13,7 +13,6 @@ import {
   setFocusedProducts,
   setSelectedVersions,
   setUri,
-  setPairing,
   productSelected,
   onFocusChanged,
 } from '/src/features/context'
@@ -36,16 +35,22 @@ const Products = () => {
   const dispatch = useDispatch()
 
   // context
-  const productTypes = useSelector((state) => state.project.productTypes)
-
-  const projectName = useSelector((state) => state.project.name)
-  const focusedVersions = useSelector((state) => state.context.focused.versions)
-  const focusedFolders = useSelector((state) => state.context.focused.folders)
-  const statusesObject = useSelector((state) => state.project.statuses)
+  // project redux
+  const {
+    productTypes,
+    name: projectName,
+    statuses: statusesObject,
+  } = useSelector((state) => state.project)
+  // focused redux
+  const {
+    versions: focusedVersions,
+    folders: focusedFolders,
+    products: focusedProducts,
+    lastFocused,
+  } = useSelector((state) => state.context.focused)
+  // context redux
   const selectedVersions = useSelector((state) => state.context.selectedVersions)
-  const focusedProducts = useSelector((state) => state.context.focused.products)
   const pairing = useSelector((state) => state.context.pairing)
-  const lastFocused = useSelector((state) => state.context.focused.lastFocused)
 
   const [focusOnReload, setFocusOnReload] = useState(null) // version id to refocus to after reload
   const [showDetail, setShowDetail] = useState(false) // false or 'product' or 'version'
@@ -158,100 +163,116 @@ const Products = () => {
     }
   }
 
-  let columns = [
-    {
-      field: 'name',
-      header: 'Product',
-      width: 200,
-      body: (node) => {
-        let className = ''
-        let i = 0
-        for (const pair of pairing) {
-          i++
-          if (pair.taskId === node.data.taskId) {
-            className = `row-hl-${i}`
-            break
-          }
-        }
-
-        const icon = node.data.isGroup
-          ? 'folder'
-          : productTypes[node.data.productType]?.icon || 'inventory_2'
-
-        return <CellWithIcon icon={icon} iconClassName={className} text={node.data.name} />
-      },
-    },
-    {
-      field: 'versionStatus',
-      header: 'Status',
-      width: 150,
-      style: { overflow: 'visible' },
-      body: (node) => {
-        if (node.data.isGroup) return ''
-        const statusMaxWidth = 120
-        return (
-          <StatusSelect
-            value={node.data.versionStatus}
-            size={
-              columnsWidths['versionStatus'] < statusMaxWidth
-                ? columnsWidths['versionStatus'] < 60
-                  ? 'icon'
-                  : 'short'
-                : 'full'
+  let columns = useMemo(
+    () => [
+      {
+        field: 'name',
+        header: 'Product',
+        width: 200,
+        body: (node) => {
+          let className = ''
+          let i = 0
+          for (const pair of pairing) {
+            i++
+            if (pair.taskId === node.data.taskId) {
+              className = `row-hl-${i}`
+              break
             }
-            onChange={(v) => handleStatusChange(v, node.data.id)}
-            multipleSelected={focusedProducts.length}
-            onOpen={() => handleStatusOpen(node.data.id)}
-            style={{ maxWidth: '100%' }}
-          />
-        )
+          }
+
+          const icon = node.data.isGroup
+            ? 'folder'
+            : productTypes[node.data.productType]?.icon || 'inventory_2'
+
+          return <CellWithIcon icon={icon} iconClassName={className} text={node.data.name} />
+        },
       },
-    },
-    {
-      field: 'folder',
-      header: 'Folder',
-      width: 200,
-    },
-    {
-      field: 'productType',
-      header: 'Product type',
-      width: 120,
-    },
-    {
-      field: 'versionList',
-      header: 'Version',
-      width: 70,
-      body: (node) =>
-        VersionList(node.data, (productId, versionId) => {
-          // TODO changing version doesn't auto update version detail
-          let newSelection = { ...selectedVersions[node.data.folderId] }
-          newSelection[productId] = versionId
-          dispatch(
-            setSelectedVersions({
-              ...selectedVersions,
-              [node.data.folderId]: newSelection,
-            }),
+      {
+        field: 'versionStatus',
+        header: 'Version Status',
+        width: 150,
+        style: { overflow: 'visible' },
+        body: (node) => {
+          if (node.data.isGroup) return ''
+          const statusMaxWidth = 120
+          return (
+            <StatusSelect
+              value={node.data.versionStatus}
+              size={
+                columnsWidths['versionStatus'] < statusMaxWidth
+                  ? columnsWidths['versionStatus'] < 60
+                    ? 'icon'
+                    : 'short'
+                  : 'full'
+              }
+              onChange={(v) => handleStatusChange(v, node.data.id)}
+              multipleSelected={focusedProducts.length}
+              onOpen={() => handleStatusOpen(node.data.id)}
+              style={{ maxWidth: '100%' }}
+            />
           )
-          setFocusOnReload(versionId)
-        }), // end VersionList
-    },
-    {
-      field: 'createdAt',
-      header: 'Created At',
-      width: 150,
-      body: (node) => node.data.createdAt && <TimestampField value={node.data.createdAt} />,
-    },
-    {
-      field: 'author',
-      header: 'Author',
-      width: 120,
-    },
-    {
-      field: 'frames',
-      header: 'Frames',
-      width: 120,
-    },
-  ]
+        },
+      },
+      {
+        field: 'productType',
+        header: 'Product type',
+        width: 120,
+      },
+      {
+        field: 'taskName',
+        header: 'Task',
+        width: 120,
+      },
+      {
+        field: 'folder',
+        header: 'Folder',
+        width: 120,
+      },
+      {
+        field: 'versionList',
+        header: 'Version',
+        width: 70,
+        body: (node) =>
+          VersionList(node.data, (productId, versionId) => {
+            let newSelection = { ...selectedVersions[node.data.folderId] }
+            newSelection[productId] = versionId
+            dispatch(
+              setSelectedVersions({
+                ...selectedVersions,
+                [node.data.folderId]: newSelection,
+              }),
+            )
+            setFocusOnReload(versionId)
+          }), // end VersionList
+      },
+      {
+        field: 'createdAt',
+        header: 'Created At',
+        width: 150,
+        body: (node) => node.data.createdAt && <TimestampField value={node.data.createdAt} />,
+      },
+      {
+        field: 'author',
+        header: 'Author',
+        width: 120,
+      },
+      {
+        field: 'frames',
+        header: 'Frames',
+        width: 120,
+      },
+    ],
+    [
+      columnsWidths,
+      focusedProducts,
+      pairing,
+      productTypes,
+      selectedVersions,
+      handleStatusChange,
+      handleStatusOpen,
+      setFocusOnReload,
+    ],
+  )
 
   const filterOptions = columns.map(({ field, header }) => ({
     value: field,
@@ -318,29 +339,6 @@ const Products = () => {
       }
     }
     return productIds
-  }, [productData, focusedVersions])
-
-  // Since using dispatch in useMemo causes errors,
-  // we need to use useEffect to update task-version pairing
-  // in the context
-
-  useEffect(() => {
-    if (!focusedVersions.length) return
-    const pairs = []
-    for (const sdata of productData) {
-      if (focusedVersions.includes(sdata.versionId)) {
-        if (sdata.taskId) {
-          pairs.push({
-            taskId: sdata.taskId,
-            folderId: sdata.folderId,
-            versionId: sdata.versionId,
-          })
-        }
-      }
-    }
-    dispatch(setPairing(pairs))
-    // shut up about missing dispatch dependency
-    // eslint-disable-next-line
   }, [productData, focusedVersions])
 
   // Transform the product data into a TreeTable compatible format

--- a/src/pages/BrowserPage/ProductsList.jsx
+++ b/src/pages/BrowserPage/ProductsList.jsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react'
 import { TreeTable } from 'primereact/treetable'
 import { Column } from 'primereact/column'
+import { useSelector } from 'react-redux'
 
 const ProductsList = ({
   data,
@@ -14,6 +15,11 @@ const ProductsList = ({
   columns,
   isLoading,
 }) => {
+  // get focused task ids
+  const focusedTasks = useSelector((state) => state.context.focused.tasks)
+  // get focused type
+  const focusedType = useSelector((state) => state.context.focused.type)
+
   const handleColumnReorder = (e) => {
     const localStorageOrder = e.columns.reduce(
       (acc, cur, i) => ({ ...acc, [cur.props.field]: i }),
@@ -48,6 +54,14 @@ const ProductsList = ({
       selectionKeys={selectedRows}
       onSelectionChange={onSelectionChange}
       onRowClick={onRowClick}
+      rowClassName={(rowData) => {
+        if (!focusedTasks.length || focusedType !== 'task') return {}
+        const matchingTask = focusedTasks.some((id) => id === rowData.data.taskId)
+        return {
+          'focused-task': matchingTask,
+          'not-focused-task': !matchingTask,
+        }
+      }}
       onContextMenu={(e) => ctxMenuShow(e.originalEvent)}
       onContextMenuSelectionChange={onContextMenuSelectionChange}
       onColumnResizeEnd={setColumnWidths}

--- a/src/services/entity/getEntity.js
+++ b/src/services/entity/getEntity.js
@@ -170,7 +170,7 @@ const getEntity = ayonApi.injectEndpoints({
         result
           ? [
               ...result.map(({ node }) => {
-                console.log({ type: type, id: node.id })
+                // console.log({ type: type, id: node.id })
                 return { type: type, id: node.id }
               }),
             ]

--- a/src/services/getProductList.js
+++ b/src/services/getProductList.js
@@ -63,6 +63,7 @@ const parseProductData = (data) => {
       versionName: vers && vers.name ? vers.name : '',
       versionStatus: vers.status || null,
       taskId: vers && vers.taskId ? vers.taskId : null,
+      taskName: vers && vers.task ? vers.task.name : null,
       frames: parseProductFrames(product),
       createdAt: vers ? vers.createdAt : product.createdAt,
     }
@@ -97,6 +98,9 @@ query ProductsList($projectName: String!, $ids: [String!]!, $versionOverrides: [
                           author
                           createdAt
                           taskId
+                          task {
+                            name
+                          }
                           status
                           attrib {
                               fps
@@ -116,6 +120,9 @@ query ProductsList($projectName: String!, $ids: [String!]!, $versionOverrides: [
                         author
                         createdAt
                         taskId
+                        task {
+                          name
+                        }
                         status
                         attrib {
                             fps

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -162,6 +162,12 @@ input:-webkit-autofill:focus {
   border-left: 4px solid var(--color-hl-studio);
 }
 
+.p-treetable .p-treetable-tbody {
+  tr.not-focused-task {
+    opacity: 0.5;
+  }
+}
+
 .table-editor {
   margin: 0;
   .p-inputwrapper {


### PR DESCRIPTION
Based on user research with @jakubjezek001, thanks! 🙏

### Description

- Selecting a task highlights matching products (by fading out non matching products)
- When a product is selected the normal view returns
- Ability to deselect tasks
- "Task" column in products table
- Removed two way pairing; selecting a product doesn't set the pairing, only selecting a task sets it now.

![products_list_task_pairing_v001](https://github.com/ynput/ayon-frontend/assets/49156310/92003dd0-2c88-4d0c-a73d-ab5225342469)