### PR TITLE
enhancement: change product version loads only version

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@reduxjs/toolkit": "^1.8.2",
     "@rjsf/core": "^4.2.0",
     "@rtk-query/graphql-request-base-query": "^2.2.0",
-    "@ynput/ayon-react-components": "^0.3.20",
+    "@ynput/ayon-react-components": "^0.3.21",
     "axios": "^0.27.2",
     "chart.js": "^4.2.0",
     "date-fns": "^2.29.3",

--- a/src/components/status/statusSelect.jsx
+++ b/src/components/status/statusSelect.jsx
@@ -53,6 +53,10 @@ const StatusSelect = ({
       value={dropdownValue}
       onChange={handleChange}
       disabled={disabled}
+      buttonStyle={{
+        backgroundColor: 'transparent',
+      }}
+      listInline
       valueTemplate={() => (
         <StatusField
           value={isMixed ? `Mixed Statuses` : dropdownValue[0]}

--- a/src/containers/entityDetail.jsx
+++ b/src/containers/entityDetail.jsx
@@ -3,21 +3,14 @@ import { toast } from 'react-toastify'
 import { useGetEntitiesDetailsQuery } from '../services/entity/getEntity'
 import PropTypes from 'prop-types'
 
-const EntityDetail = ({
-  projectName,
-  entityType,
-  entityIds,
-  visible,
-  onHide,
-  versionOverrides,
-}) => {
+const EntityDetail = ({ projectName, entityType, entityIds, visible, onHide }) => {
   const {
     data = [],
     isLoading,
     isError,
     error,
   } = useGetEntitiesDetailsQuery(
-    { projectName, type: entityType, ids: entityIds, versionOverrides },
+    { projectName, type: entityType, ids: entityIds },
     { skip: !visible },
   )
 
@@ -51,7 +44,6 @@ EntityDetail.propTypes = {
   entityIds: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
   visible: PropTypes.bool.isRequired,
   onHide: PropTypes.func.isRequired,
-  versionOverrides: PropTypes.arrayOf(PropTypes.string),
 }
 
 export default EntityDetail

--- a/src/pages/BrowserPage/Detail.jsx
+++ b/src/pages/BrowserPage/Detail.jsx
@@ -12,11 +12,9 @@ import { useEffect, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useGetUsersAssigneeQuery } from '/src/services/user/getUsers'
 import { ayonApi } from '/src/services/ayon'
-import { current } from '@reduxjs/toolkit'
 
 const Detail = () => {
   const focused = useSelector((state) => state.context.focused)
-  const selectedVersions = useSelector((state) => state.context.selectedVersions)
   const { type, folders: focusedFolders } = focused
 
   const ids = focused[type + 's'] || []
@@ -80,37 +78,16 @@ const Detail = () => {
     // if the type is version and the is field is status or version, patch products list
     // because the version status/version is also shown in the product list
     if (isVersion && ['status', 'name'].includes(field)) {
-      // version overrides
-      // Get a list of version overrides for the current set of folders
-      let versionOverrides = []
-      for (const folderId of focusedFolders) {
-        const c = selectedVersions[folderId]
-        if (!c) continue
-        for (const productId in c) {
-          const versionId = c[productId]
-          if (versionOverrides.includes(versionId)) continue
-          versionOverrides.push(versionId)
-        }
-      }
-      if (versionOverrides.length === 0) {
-        // We need at least one item in the array to filter.
-        versionOverrides = ['00000000000000000000000000000000']
-      }
-
-      console.log(versionOverrides)
-
       // patching new products cache in redux
       productsPatch = dispatch(
         ayonApi.util.updateQueryData(
           'getProductList',
-          { versionOverrides, projectName, ids: focusedFolders },
+          { projectName, ids: focusedFolders },
           (draft) => {
-            console.log('run')
             // find the product in the cache that match the ids
             // and update the versionStatus
             for (const id of ids) {
               draft.forEach((p) => {
-                console.log(current(p))
                 if (p.versionId === id) {
                   console.log('here')
                   p.versionStatus = value

--- a/src/pages/BrowserPage/ProductsList.jsx
+++ b/src/pages/BrowserPage/ProductsList.jsx
@@ -14,6 +14,7 @@ const ProductsList = ({
   columnsWidths,
   columns,
   isLoading,
+  loadingProducts,
 }) => {
   // get focused task ids
   const focusedTasks = useSelector((state) => state.context.focused.tasks)
@@ -55,9 +56,14 @@ const ProductsList = ({
       onSelectionChange={onSelectionChange}
       onRowClick={onRowClick}
       rowClassName={(rowData) => {
-        if (!focusedTasks.length || focusedType !== 'task') return {}
+        const className = {
+          loading: loadingProducts.includes(rowData.data.id),
+        }
+        if (!focusedTasks.length || focusedType !== 'task') return className
         const matchingTask = focusedTasks.some((id) => id === rowData.data.taskId)
+
         return {
+          ...className,
           'focused-task': matchingTask,
           'not-focused-task': !matchingTask,
         }

--- a/src/pages/EditorPage/EditorPanel.jsx
+++ b/src/pages/EditorPage/EditorPanel.jsx
@@ -532,11 +532,8 @@ const EditorPanel = ({ onDelete, onChange, onRevert, attribs, projectName, onFor
                       emptyIcon={false}
                       onChange={(v) => handleLocalChange(v, changeKey, field)}
                       editor
-                      style={{
-                        ...changedStyles,
-                        border: '1px solid var(--color-grey-03)',
-                        ...disabledStyles,
-                      }}
+                      buttonStyle={{ border: '1px solid var(--color-grey-03)', overflow: 'hidden' }}
+                      isChanged={isChanged}
                       widthExpand
                     />
                   )

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -520,14 +520,21 @@ a {
 .p-datatable-tbody {
   tr.loading {
     td {
+      // hide anything inside
+      > * {
+        opacity: 0;
+      }
+
       position: relative;
       &::after {
         content: '';
         display: block;
         position: absolute;
-        inset: 6px;
+        inset: 4px;
+        left: 0;
         border-radius: 3px;
         opacity: 1;
+        z-index: 100;
         background-color: var(--color-grey-02);
         @include getShimmerStyles(var(--color-grey-02), var(--color-grey-03));
       }


### PR DESCRIPTION
- When selecting a new version, only the product version is loaded and not all the versions again.
- Increases speed of loading new versions.
- Improves the UX with single row loading.
- Removes hacky `versionOverrides` code.

![version_change_single_load_v001](https://github.com/ynput/ayon-frontend/assets/49156310/bee4574c-2a97-42cf-a693-63567c8dbec3)

- bumped components library version
- fixed a couple dropdown styles