### PR TITLE
Fix: closing hierarchy parent when children selected + multiple close

### DIFF
--- a/src/containers/hierarchy.jsx
+++ b/src/containers/hierarchy.jsx
@@ -263,6 +263,7 @@ const Hierarchy = (props) => {
   }
 
   const onToggle = (event) => {
+    const isMetaKey = event.originalEvent.metaKey || event.originalEvent.ctrlKey
     const newExpandedFolders = event.value
     // what folders have been removed from the expandedFolders
     const removedExpandedFolders = Object.keys(expandedFolders).filter(
@@ -276,7 +277,7 @@ const Hierarchy = (props) => {
 
     // are any removed folders in the focusedFolders?
     const focusedFoldersRemoved = focusedFolders.some((id) => removedExpandedFolders.includes(id))
-    if (focusedFoldersRemoved) {
+    if (focusedFoldersRemoved && isMetaKey) {
       // close (remove from expanded) all those folders
       for (const id of focusedFolders) {
         delete newExpandedFolders[id]
@@ -285,7 +286,7 @@ const Hierarchy = (props) => {
 
     // do you same but for added folders, add them to expandedFolders
     const focusedFoldersAdded = focusedFolders.some((id) => addedExpandedFolders.includes(id))
-    if (focusedFoldersAdded) {
+    if (focusedFoldersAdded && isMetaKey) {
       // add them to expandedFolders
       for (const id of focusedFolders) {
         newExpandedFolders[id] = true

--- a/src/containers/hierarchy.jsx
+++ b/src/containers/hierarchy.jsx
@@ -263,49 +263,36 @@ const Hierarchy = (props) => {
   }
 
   const onToggle = (event) => {
-    console.log('toggle')
+    const newExpandedFolders = event.value
+    // what folders have been removed from the expandedFolders
+    const removedExpandedFolders = Object.keys(expandedFolders).filter(
+      (id) => !newExpandedFolders[id],
+    )
+
+    // find ones that are added
+    const addedExpandedFolders = Object.keys(newExpandedFolders).filter(
+      (id) => !expandedFolders[id],
+    )
+
+    // are any removed folders in the focusedFolders?
+    const focusedFoldersRemoved = focusedFolders.some((id) => removedExpandedFolders.includes(id))
+    if (focusedFoldersRemoved) {
+      // close (remove from expanded) all those folders
+      for (const id of focusedFolders) {
+        delete newExpandedFolders[id]
+      }
+    }
+
+    // do you same but for added folders, add them to expandedFolders
+    const focusedFoldersAdded = focusedFolders.some((id) => addedExpandedFolders.includes(id))
+    if (focusedFoldersAdded) {
+      // add them to expandedFolders
+      for (const id of focusedFolders) {
+        newExpandedFolders[id] = true
+      }
+    }
+
     dispatch(setExpandedFolders(event.value))
-  }
-
-  const handleDoubleClick = () => {
-    // folder is always selected when row is double clicked
-
-    // filter out selected folders that are isLeaf
-    let doubleClickedFolders = []
-    for (const id in selectedFolders) {
-      if (!hierarchyObjectData[id].isLeaf) {
-        doubleClickedFolders.push(id)
-      }
-    }
-
-    // return if no folders are selected
-    if (!doubleClickedFolders.length) return
-
-    // separate folders that are already expanded
-    // separate folders that are not expanded
-    const alreadyExpandedFolders = []
-    const notExpandedFolders = []
-    for (const id of doubleClickedFolders) {
-      if (expandedFolders[id]) {
-        alreadyExpandedFolders.push(id)
-      } else {
-        notExpandedFolders.push(id)
-      }
-    }
-
-    // remove already expanded folders
-    const newExpandedFolders = { ...expandedFolders }
-    for (const id of alreadyExpandedFolders) {
-      delete newExpandedFolders[id]
-    }
-
-    // add not expanded folders
-    for (const id of notExpandedFolders) {
-      newExpandedFolders[id] = true
-    }
-
-    // update redux
-    dispatch(setExpandedFolders(newExpandedFolders))
   }
 
   // Context Menu
@@ -353,7 +340,6 @@ const Hierarchy = (props) => {
         onRowClick={onRowClick}
         onContextMenu={(e) => ctxMenuShow(e.originalEvent)}
         onContextMenuSelectionChange={onContextMenuSelectionChange}
-        onDoubleClick={handleDoubleClick}
         className={isFetching ? 'table-loading' : undefined}
       >
         <Column header="Hierarchy" field="body" expander={true} style={{ width: '100%' }} />

--- a/src/containers/hierarchy.jsx
+++ b/src/containers/hierarchy.jsx
@@ -70,6 +70,7 @@ const Hierarchy = (props) => {
   // const focusedType = useSelector((state) => state.context.focused.type)
   const expandedFolders = useSelector((state) => state.context.expandedFolders)
   const focusedFolders = useSelector((state) => state.context.focused.folders)
+  const uri = useSelector((state) => state.context.uri)
 
   const dispatch = useDispatch()
   const [query, setQuery] = useState('')
@@ -183,10 +184,9 @@ const Hierarchy = (props) => {
   // Selection
   //
 
-  // when selection changes programatically, expand the parent folders
+  // when selection changes programmatically, expand the parent folders
+  // runs every time the uri changes
   useEffect(() => {
-    // TODO: This prevents closing the branch if there's a focused folder inside
-    // This might be a problem...
     if (!focusedFolders?.length) return
 
     let toExpand = [...Object.keys(expandedFolders)]
@@ -206,7 +206,7 @@ const Hierarchy = (props) => {
       newExpandedFolders[id] = true
     }
     dispatch(setExpandedFolders(newExpandedFolders))
-  }, [focusedFolders, expandedFolders])
+  }, [uri])
 
   // Transform the plain list of focused folder ids to a map
   // {id: true}, which is needed for the Treetable
@@ -263,6 +263,7 @@ const Hierarchy = (props) => {
   }
 
   const onToggle = (event) => {
+    console.log('toggle')
     dispatch(setExpandedFolders(event.value))
   }
 

--- a/src/pages/EditorPage/EditorPage.jsx
+++ b/src/pages/EditorPage/EditorPage.jsx
@@ -1121,12 +1121,43 @@ const EditorPage = () => {
   //
 
   const onToggle = async (event) => {
-    // updated expanded folders context object
-    dispatch(setExpandedFolders(event.value))
+    const newExpanded = { ...event.value }
+    const removedIds = Object.keys(expandedFolders).filter((id) => !(id in newExpanded))
 
-    let newIds = Object.keys(event.value)
+    let newIds = Object.keys(newExpanded)
     // filter out ids that are already in the expandedFolders object
     newIds = newIds.filter((id) => !(id in expandedFolders))
+
+    if (newIds.length) {
+      // find if any of the newIds are in selected folders
+      const selected = Object.keys(currentSelection).filter((id) => newIds.includes(id))
+      if (selected.length) {
+        // we open all selected folders
+        newIds = Object.keys(currentSelection)
+        // expand all currentSelection folders
+        for (const id of newIds) {
+          if (rootData[id]?.data.__entityType === 'folder') {
+            newExpanded[id] = true
+          }
+        }
+      }
+    }
+
+    if (removedIds.length) {
+      // find if any of the newIds are in selected folders
+      const selected = Object.keys(currentSelection).filter((id) => removedIds.includes(id))
+      if (selected.length) {
+        // close all selected folders
+        for (const id in currentSelection) {
+          if (rootData[id]?.data.__entityType === 'folder') {
+            delete newExpanded[id]
+          }
+        }
+      }
+    }
+
+    // updated expanded folders context object
+    dispatch(setExpandedFolders(newExpanded))
 
     // load new branches
     loadNewBranches(newIds)

--- a/src/pages/EditorPage/EditorPage.jsx
+++ b/src/pages/EditorPage/EditorPage.jsx
@@ -1121,6 +1121,7 @@ const EditorPage = () => {
   //
 
   const onToggle = async (event) => {
+    const isMetaKey = event.originalEvent.metaKey || event.originalEvent.ctrlKey
     const newExpanded = { ...event.value }
     const removedIds = Object.keys(expandedFolders).filter((id) => !(id in newExpanded))
 
@@ -1128,7 +1129,7 @@ const EditorPage = () => {
     // filter out ids that are already in the expandedFolders object
     newIds = newIds.filter((id) => !(id in expandedFolders))
 
-    if (newIds.length) {
+    if (newIds.length && isMetaKey) {
       // find if any of the newIds are in selected folders
       const selected = Object.keys(currentSelection).filter((id) => newIds.includes(id))
       if (selected.length) {
@@ -1143,7 +1144,7 @@ const EditorPage = () => {
       }
     }
 
-    if (removedIds.length) {
+    if (removedIds.length && isMetaKey) {
       // find if any of the newIds are in selected folders
       const selected = Object.keys(currentSelection).filter((id) => removedIds.includes(id))
       if (selected.length) {

--- a/src/pages/EditorPage/EditorPanel.jsx
+++ b/src/pages/EditorPage/EditorPanel.jsx
@@ -411,7 +411,7 @@ const EditorPanel = ({ onDelete, onChange, onRevert, attribs, projectName, onFor
 
   const handleForceSave = (e) => {
     // we save input straight away with meta + enter key
-    if (e.metaKey && e.key === 'Enter') {
+    if ((e.metaKey || e.ctrl) && e.key === 'Enter') {
       const value = e.target.value
       const changeKey = e.target.id
       onForceChange(changeKey, value, nodeIds, type)


### PR DESCRIPTION
Thanks @LiborBatek 

### 🐛  Bugs 
- Fix bug that meant hierarchy parent folder couldn't be closed when child was selected.

### 💅 Enhancements  
- Select multiple folders and hold down `ctrl` (`cmd` for mac) to expand/close all selected folders.

![editor_open_multiple_folders](https://github.com/ynput/ayon-frontend/assets/49156310/15d7c54d-90a7-42b2-8d4b-7f770d234335)

### 💔 Breaking changes 
- Removed double clicking to expand/close all in Hierarchy.


