### PR TITLE
fix: firefox scrollbar width to thin

### DIFF
--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -11,6 +11,14 @@ input {
   color: var(--color-text);
 }
 
+html {
+  scrollbar-width: thin;
+}
+
+body {
+  scrollbar-width: thin;
+}
+
 #root {
   position: absolute;
   overflow: hidden;


### PR DESCRIPTION
- Sets default scroll width for firefox to be thin based on @BigRoy feedback.
- Set for the whole app, we will have to see if it's okay on windows, seems good on mac.
- Only affects firefox as it's the only browser that supports it. 