### PR TITLE
fix: replace all old icons with <Icon /> component

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@reduxjs/toolkit": "^1.8.2",
     "@rjsf/core": "^4.2.0",
     "@rtk-query/graphql-request-base-query": "^2.2.0",
-    "@ynput/ayon-react-components": "^0.3.23",
+    "@ynput/ayon-react-components": "^0.3.26",
     "axios": "^0.27.2",
     "chart.js": "^4.2.0",
     "date-fns": "^2.29.3",

--- a/src/components/ApiKeyManager.jsx
+++ b/src/components/ApiKeyManager.jsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react'
 import PropTypes from 'prop-types'
 import { useState } from 'react'
 import { v4 as uuidv4 } from 'uuid'
-import { Panel, LockedInput } from '@ynput/ayon-react-components'
+import { Panel, LockedInput, Icon } from '@ynput/ayon-react-components'
 import { useUpdateUserAPIKeyMutation } from '../services/user/updateUser'
 import { toast } from 'react-toastify'
 import styled from 'styled-components'
@@ -110,9 +110,7 @@ const ApiKeyManager = ({ preview, name }) => {
                 Make a copy of this key as you will only see it once!
               </div>
             </div>
-            <span className="material-symbols-outlined" onClick={handleCopyKey}>
-              content_copy
-            </span>
+            <Icon onClick={handleCopyKey} icon="content_copy" />
           </PanelStyled>
         )}
       </>

--- a/src/components/EntityGridTile.jsx
+++ b/src/components/EntityGridTile.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled, { css } from 'styled-components'
-import { Panel, UserImage } from '@ynput/ayon-react-components'
+import { Icon, Panel, UserImage } from '@ynput/ayon-react-components'
 import Thumbnail from '/src/containers/thumbnail'
 import { useRef } from 'react'
 import getShimmerStyles from '../styles/getShimmerStyles'
@@ -147,7 +147,7 @@ const ThumbnailStyled = styled.div`
   }
 `
 
-const IconStyled = styled.span`
+const IconStyled = styled(Icon)`
   background-color: var(--color-grey-01);
   width: 25px;
   min-width: 25px;
@@ -196,8 +196,8 @@ const EntityGridTile = ({
         <ThumbnailStyled>
           <Thumbnail isLoading className={'thumbnail'} disabled={isError} />
           <div>
-            <IconStyled className="material-symbols-outlined"></IconStyled>
-            <IconStyled className="material-symbols-outlined"></IconStyled>
+            <IconStyled />
+            <IconStyled />
           </div>
         </ThumbnailStyled>
         <span></span>
@@ -223,10 +223,8 @@ const EntityGridTile = ({
           className={'thumbnail'}
         />
         <div>
-          <IconStyled className="material-symbols-outlined">{typeIcon}</IconStyled>
-          <IconStyled className="material-symbols-outlined" style={{ color: statusColor }}>
-            {statusIcon}
-          </IconStyled>
+          <IconStyled icon={typeIcon} />
+          <IconStyled icon={statusIcon} style={{ color: statusColor }} />
         </div>
       </ThumbnailStyled>
       <span style={{ padding: '0 4px' }}>{name}</span>

--- a/src/components/SearchDropdown.jsx
+++ b/src/components/SearchDropdown.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react'
 import PropTypes from 'prop-types'
-import { InputText } from '@ynput/ayon-react-components'
+import { Icon, InputText } from '@ynput/ayon-react-components'
 import styled, { css, keyframes } from 'styled-components'
 
 const SearchStyled = styled.form`
@@ -312,9 +312,7 @@ const SearchDropdown = ({
                   onMouseEnter={() => handleMouseEnter(i)}
                   onMouseLeave={() => handleMouseLeave(i)}
                 >
-                  {item?.icon && (
-                    <span className="material-symbols-outlined icon">{item?.icon}</span>
-                  )}
+                  {item?.icon && <Icon icon={item?.icon} />}
                   <span className="text">{item.label || item.value}</span>
                 </SuggestionItemStyled>
               ),

--- a/src/components/icons.jsx
+++ b/src/components/icons.jsx
@@ -1,3 +1,5 @@
+import { Icon } from '@ynput/ayon-react-components'
+
 const CellWithIcon = ({
   icon,
   iconClassName,
@@ -13,12 +15,11 @@ const CellWithIcon = ({
       className={className || ''}
       style={{ alignItems: 'center', position: 'relative', overflow: 'hidden', ...style }}
     >
-      <span
-        className={`material-symbols-outlined ${iconClassName || ''}`}
+      <Icon
+        icon={icon}
+        className={iconClassName || ''}
         style={{ marginRight: '0.6rem', ...iconStyle }}
-      >
-        {icon}
-      </span>
+      />
       <span
         style={{ whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', ...textStyle }}
         className={`cell-with-icon-text ${textClassName}`}

--- a/src/components/status/statusField.jsx
+++ b/src/components/status/statusField.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled, { css } from 'styled-components'
+import { Icon } from '@ynput/ayon-react-components'
 
 const hoverStyle = css`
   background-color: var(--color-grey-02);
@@ -145,7 +146,7 @@ const StatusField = ({
       size={size}
       placeholder={!value && placeholder ? placeholder : ''}
     >
-      {icon && <span className="material-symbols-outlined">{icon}</span>}
+      {icon && <Icon icon={icon} />}
       {size !== 'icon' && (size === 'full' ? shownValue : shortName)}
     </StatusStyled>
   )

--- a/src/containers/thumbnail.jsx
+++ b/src/containers/thumbnail.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import styled, { keyframes } from 'styled-components'
 import getShimmerStyles from '../styles/getShimmerStyles'
+import { Icon } from '@ynput/ayon-react-components'
 
 const fadeIn = keyframes`
   from { opacity: 0; }
@@ -48,7 +49,7 @@ const ImageStyled = styled.img`
   background-color: #161616;
 `
 
-const ImagePlaceholder = () => <span className="material-symbols-outlined">image</span>
+const ImagePlaceholder = () => <Icon icon="image" />
 
 const Thumbnail = ({
   projectName,

--- a/src/pages/EditorPage/EditorPage.jsx
+++ b/src/pages/EditorPage/EditorPage.jsx
@@ -2,7 +2,7 @@ import { useEffect, useState, useMemo, useCallback } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import { toast } from 'react-toastify'
 import { v1 as uuid1 } from 'uuid'
-import { Spacer, Button, Section, Toolbar, TablePanel } from '@ynput/ayon-react-components'
+import { Spacer, Button, Section, Toolbar, TablePanel, Icon } from '@ynput/ayon-react-components'
 
 import { TreeTable } from 'primereact/treetable'
 import { Column } from 'primereact/column'
@@ -285,15 +285,7 @@ const EditorPage = () => {
     // as tooltip.
     const error = errors[rowData.id]
     if (error) {
-      return (
-        <span
-          className={`material-symbols-outlined`}
-          style={{ color: 'var(--color-hl-error)' }}
-          title={error}
-        >
-          warning
-        </span>
-      )
+      return <Icon icon="warning" style={{ color: 'var(--color-hl-error)' }} title={error} />
     }
   }
 

--- a/src/pages/ProjectDashboard/panels/ListStatsTile.jsx
+++ b/src/pages/ProjectDashboard/panels/ListStatsTile.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import getShimmerStyles from '/src/styles/getShimmerStyles'
+import { Icon } from '@ynput/ayon-react-components'
 
 export const TileStyled = styled.div`
   display: flex;
@@ -43,7 +44,7 @@ const StyledLoading = styled.div`
 const ListStatsTile = ({ title, stat, icon, isLoading, onClick }) => {
   return (
     <TileStyled onClick={onClick}>
-      {icon && <span className="material-symbols-outlined">{icon}</span>}
+      {icon && <Icon icon={icon} />}
       <h3>{title}</h3>
       <span>{isLoading ? '' : stat || 'unknown'}</span>
       {isLoading && <StyledLoading />}

--- a/src/pages/ProjectDashboard/panels/ProgressTile.jsx
+++ b/src/pages/ProjectDashboard/panels/ProgressTile.jsx
@@ -4,6 +4,7 @@ import { TileStyled } from './ListStatsTile'
 import styled from 'styled-components'
 import ProgressBar from './ProgressBar'
 import getShimmerStyles from '/src/styles/getShimmerStyles'
+import { Icon } from '@ynput/ayon-react-components'
 
 const HeaderStyled = styled.div`
   display: flex;
@@ -50,7 +51,7 @@ const ProgressTile = ({
   return (
     <ProgressStyled onClick={onClick}>
       <HeaderStyled>
-        {icon && <span className="material-symbols-outlined">{icon}</span>}
+        {icon && <Icon icon={icon} />}
         <h3>{title || ''}</h3>
         <span>{subTitle || ''}</span>
       </HeaderStyled>

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -173,11 +173,6 @@ input:-webkit-autofill:focus {
     color: var(--color-hl-00) !important;
   }
 
-  // icons
-  .material-symbols-outlined {
-    color: var(--color-hl-00);
-  }
-
   // dates
   td > div > span {
     color: var(--color-hl-00) !important;
@@ -238,7 +233,7 @@ input:-webkit-autofill:focus {
   }
 }
 .copy-uri-button {
-  .material-symbols-outlined {
+  .icon {
     font-size: 1.2em !important;
   }
 }


### PR DESCRIPTION
- All icons now use `<Icon icon="icon_name" />` component.
- The classname "icon" is always attached to the span to make styling easier. 
- Update components library that uses offline icons.