### PR TITLE
fix: addon prompt server restart

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -31,6 +31,7 @@ import { useLazyGetInfoQuery } from './services/auth/getAuth'
 import { ContextMenuProvider } from './context/contextMenuContext'
 import { GlobalContextMenu } from './components/GlobalContextMenu'
 import LoadingPage from './pages/LoadingPage'
+import { ConfirmDialog } from 'primereact/confirmdialog'
 
 const App = () => {
   const user = useSelector((state) => state.user)
@@ -119,6 +120,7 @@ const App = () => {
               >
                 <Header />
                 <ShareDialog />
+                <ConfirmDialog />
                 <Routes>
                   <Route
                     path="/"

--- a/src/hooks/useServerRestart.js
+++ b/src/hooks/useServerRestart.js
@@ -1,0 +1,20 @@
+import { confirmDialog } from 'primereact/confirmdialog'
+import { useRestartServerMutation } from '../services/restartServer'
+
+const useServerRestart = () => {
+  const [restartServer] = useRestartServerMutation()
+
+  // ask if the user wants to restart the server after saving
+  const confirmRestart = (message = 'Restart Server?') =>
+    confirmDialog({
+      message,
+      header: 'Restart Server',
+      icon: 'pi pi-exclamation-triangle',
+      accept: () => restartServer(),
+      reject: () => {},
+    })
+
+  return { confirmRestart }
+}
+
+export default useServerRestart

--- a/src/pages/ProjectManagerPage/ProjectManagerPage.jsx
+++ b/src/pages/ProjectManagerPage/ProjectManagerPage.jsx
@@ -3,7 +3,7 @@ import { useNavigate, useParams, NavLink, useSearchParams } from 'react-router-d
 import { useSelector, useDispatch } from 'react-redux'
 import { StringParam, useQueryParam, withDefault } from 'use-query-params'
 
-import { confirmDialog, ConfirmDialog } from 'primereact/confirmdialog'
+import { confirmDialog } from 'primereact/confirmdialog'
 import { toast } from 'react-toastify'
 
 import AddonSettings from '/src/containers/AddonSettings'
@@ -69,7 +69,7 @@ const ProjectManagerPage = () => {
 
   const deletePreset = () => {
     confirmDialog({
-      header: 'Delete Preset',
+      header: 'Delete Project',
       message: `Are you sure you want to delete the project: ${selectedProject}?`,
       icon: 'pi pi-exclamation-triangle',
       acceptLabel: 'Delete',
@@ -138,7 +138,6 @@ const ProjectManagerPage = () => {
 
   return (
     <>
-      <ConfirmDialog />
       <nav className="secondary">
         {links.map((link, i) =>
           link.node ? (

--- a/src/pages/SettingsPage/AddonInstall/AddonUpload.jsx
+++ b/src/pages/SettingsPage/AddonInstall/AddonUpload.jsx
@@ -100,7 +100,9 @@ const AddonUpload = ({ onClose }) => {
           {isUploading && <StyledProgressBar $progress={progress} />}
           {!isComplete && !isUploading && 'Supports multiple .zip files.'}
           <div>
-            {onClose && <Button onClick={onClose} label="Close" />}
+            {onClose && (
+              <Button onClick={() => onClose(!errorMessage && isComplete)} label="Close" />
+            )}
             <SaveButton
               active={files.length}
               label="Install addons"

--- a/src/pages/SettingsPage/AnatomyPresets/AnatomyPresets.jsx
+++ b/src/pages/SettingsPage/AnatomyPresets/AnatomyPresets.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useMemo } from 'react'
 
 import { Dialog } from 'primereact/dialog'
-import { confirmDialog, ConfirmDialog } from 'primereact/confirmdialog'
+import { confirmDialog } from 'primereact/confirmdialog'
 import { InputText } from 'primereact/inputtext'
 
 import { toast } from 'react-toastify'
@@ -155,7 +155,6 @@ const AnatomyPresets = () => {
 
   return (
     <main>
-      <ConfirmDialog />
       {showNameDialog && (
         <Dialog
           header="Preset name"

--- a/src/pages/SettingsPage/Attributes.jsx
+++ b/src/pages/SettingsPage/Attributes.jsx
@@ -14,11 +14,10 @@ import AttributeEditor from '../../containers/attributes/attributeEditor'
 import { useGetAttributesQuery } from '/src/services/attributes/getAttributes'
 import { useUpdateAttributesMutation } from '/src/services/attributes/updateAttributes'
 import useSearchFilter from '/src/hooks/useSearchFilter'
-import { ConfirmDialog, confirmDialog } from 'primereact/confirmdialog'
-import { useRestartServerMutation } from '/src/services/restartServer'
 import useCreateContext from '/src/hooks/useCreateContext'
 import SaveButton from '/src/components/SaveButton'
 import { isEqual } from 'lodash'
+import useServerRestart from '/src/hooks/useServerRestart'
 
 const Attributes = () => {
   const [attributes, setAttributes] = useState([])
@@ -54,24 +53,14 @@ const Attributes = () => {
     [attributes],
   )
 
-  const [restartServer] = useRestartServerMutation()
-
-  // ask if the user wants to restart the server after saving
-  const confirmRestart = () =>
-    confirmDialog({
-      message: 'Restart the server to apply changes?',
-      header: 'Restart Server',
-      icon: 'pi pi-exclamation-triangle',
-      accept: () => restartServer(),
-      reject: () => {},
-    })
+  const { confirmRestart } = useServerRestart()
 
   const onSave = async () => {
     await updateAttributes({ attributes, deleteMissing: true, patches: attributes })
       .unwrap()
       .then(() => {
         toast.success('Attribute set saved')
-        confirmRestart()
+        confirmRestart('Restart the server to apply changes?')
       })
       .catch((err) => {
         console.error(err)
@@ -146,7 +135,6 @@ const Attributes = () => {
 
   return (
     <>
-      <ConfirmDialog />
       <main>
         {showEditor && (
           <AttributeEditor

--- a/src/pages/SettingsPage/Bundles/Bundles.jsx
+++ b/src/pages/SettingsPage/Bundles/Bundles.jsx
@@ -19,6 +19,7 @@ import { Dialog } from 'primereact/dialog'
 import AddonUpload from '../AddonInstall/AddonUpload'
 import { useGetAddonSettingsQuery } from '/src/services/addonSettings'
 import getLatestSemver from './getLatestSemver'
+import useServerRestart from '/src/hooks/useServerRestart'
 
 const Bundles = () => {
   // addon install dialog
@@ -148,6 +149,17 @@ const Bundles = () => {
     setSelectedBundle(null)
   }
 
+  const { confirmRestart } = useServerRestart()
+
+  const handleAddonInstallFinish = (newAddons) => {
+    setAddonInstallOpen(false)
+    if (newAddons) {
+      // ask if you want to restart the server
+      const message = 'Restart the server to apply addon changes?'
+      confirmRestart(message)
+    }
+  }
+
   return (
     <>
       <Dialog
@@ -156,7 +168,7 @@ const Bundles = () => {
         header="Install addons"
         onHide={() => setAddonInstallOpen(false)}
       >
-        <AddonUpload onClose={() => setAddonInstallOpen(false)} />
+        <AddonUpload onClose={handleAddonInstallFinish} />
       </Dialog>
       <main style={{ overflow: 'hidden' }}>
         <Section style={{ minWidth: 400, maxWidth: 400 }}>

--- a/src/pages/SettingsPage/UsersSettings/UsersSettings.jsx
+++ b/src/pages/SettingsPage/UsersSettings/UsersSettings.jsx
@@ -1,6 +1,6 @@
 import { useState, useMemo, useRef } from 'react'
 import { toast } from 'react-toastify'
-import { confirmDialog, ConfirmDialog } from 'primereact/confirmdialog'
+import { confirmDialog } from 'primereact/confirmdialog'
 import { Button, Section, Toolbar, InputText, Spacer } from '@ynput/ayon-react-components'
 // Comps
 import SetPasswordDialog from './SetPasswordDialog'
@@ -206,7 +206,6 @@ const UsersSettings = () => {
 
   return (
     <main>
-      <ConfirmDialog />
       <Section>
         <Toolbar>
           <SelectButton


### PR DESCRIPTION
- Created useServerRestart hook for easier use across the app.
- If a new addon has been installed on Bundles page, ask if server should restart.
- Move `<ConfirmDialog />` component to app.jsx file only.

```javascript
  const { confirmRestart } = useServerRestart()
  
  confirmRestart('Confirmation message here')
```
