### PR TITLE
Feature: universal shortcuts

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -29,6 +29,7 @@ import ErrorFallback from './components/ErrorFallback'
 import ServerRestartBanner from './components/ServerRestartBanner'
 import { useLazyGetInfoQuery } from './services/auth/getAuth'
 import { ContextMenuProvider } from './context/contextMenuContext'
+import { ShortcutsProvider } from './context/shortcutsContext'
 import { GlobalContextMenu } from './components/GlobalContextMenu'
 import LoadingPage from './pages/LoadingPage'
 import { ConfirmDialog } from 'primereact/confirmdialog'
@@ -112,55 +113,57 @@ const App = () => {
             <GlobalContextMenu />
             <RestartIndicator />
             <BrowserRouter>
-              <QueryParamProvider
-                adapter={ReactRouter6Adapter}
-                options={{
-                  updateType: 'replaceIn',
-                }}
-              >
-                <Header />
-                <ShareDialog />
-                <ConfirmDialog />
-                <Routes>
-                  <Route
-                    path="/"
-                    exact
-                    element={<Navigate replace to="/manageProjects/dashboard" />}
-                  />
-                  <Route
-                    path="/manageProjects"
-                    exact
-                    element={<Navigate replace to="/manageProjects/dashboard" />}
-                  />
+              <ShortcutsProvider>
+                <QueryParamProvider
+                  adapter={ReactRouter6Adapter}
+                  options={{
+                    updateType: 'replaceIn',
+                  }}
+                >
+                  <Header />
+                  <ShareDialog />
+                  <ConfirmDialog />
+                  <Routes>
+                    <Route
+                      path="/"
+                      exact
+                      element={<Navigate replace to="/manageProjects/dashboard" />}
+                    />
+                    <Route
+                      path="/manageProjects"
+                      exact
+                      element={<Navigate replace to="/manageProjects/dashboard" />}
+                    />
 
-                  <Route path="/manageProjects/:module" element={<ProjectManagerPage />} />
-                  <Route path={'/projects/:projectName/:module'} element={<ProjectPage />} />
-                  <Route
-                    path={'/projects/:projectName/addon/:addonName'}
-                    element={<ProjectPage />}
-                  />
-                  <Route
-                    path="/settings"
-                    exact
-                    element={<Navigate replace to="/settings/anatomyPresets" />}
-                  />
-                  <Route path="/settings/:module" exact element={<SettingsPage />} />
-                  <Route path="/settings/addon/:addonName" exact element={<SettingsPage />} />
-                  <Route
-                    path="/services"
-                    element={
-                      <ProtectedRoute isAllowed={!isUser} redirectPath="/">
-                        <ServicesPage />
-                      </ProtectedRoute>
-                    }
-                  />
-                  <Route path="/explorer" element={<ExplorerPage />} />
-                  <Route path="/doc/api" element={<APIDocsPage />} />
-                  <Route path="/profile" element={<ProfilePage />} />
-                  <Route path="/events" element={<EventsPage />} />
-                  <Route element={<ErrorPage code="404" />} />
-                </Routes>
-              </QueryParamProvider>
+                    <Route path="/manageProjects/:module" element={<ProjectManagerPage />} />
+                    <Route path={'/projects/:projectName/:module'} element={<ProjectPage />} />
+                    <Route
+                      path={'/projects/:projectName/addon/:addonName'}
+                      element={<ProjectPage />}
+                    />
+                    <Route
+                      path="/settings"
+                      exact
+                      element={<Navigate replace to="/settings/anatomyPresets" />}
+                    />
+                    <Route path="/settings/:module" exact element={<SettingsPage />} />
+                    <Route path="/settings/addon/:addonName" exact element={<SettingsPage />} />
+                    <Route
+                      path="/services"
+                      element={
+                        <ProtectedRoute isAllowed={!isUser} redirectPath="/">
+                          <ServicesPage />
+                        </ProtectedRoute>
+                      }
+                    />
+                    <Route path="/explorer" element={<ExplorerPage />} />
+                    <Route path="/doc/api" element={<APIDocsPage />} />
+                    <Route path="/profile" element={<ProfilePage />} />
+                    <Route path="/events" element={<EventsPage />} />
+                    <Route element={<ErrorPage code="404" />} />
+                  </Routes>
+                </QueryParamProvider>
+              </ShortcutsProvider>
             </BrowserRouter>
           </ContextMenuProvider>
         </SocketProvider>

--- a/src/containers/header/index.jsx
+++ b/src/containers/header/index.jsx
@@ -18,9 +18,8 @@ const Header = () => {
   const userMenuVisible = useSelector((state) => state.context.userMenuOpen)
   const setUserMenuVisible = (open) => dispatch(setUserMenuOpen(open))
 
-  const setProjectMenuVisible = (open) => {
-    dispatch(setProjectMenuOpen(open))
-  }
+  const projectMenuVisible = useSelector((state) => state.context.projectMenuOpen)
+  const setProjectMenuVisible = (open) => dispatch(setProjectMenuOpen(open))
 
   // Hide sidebars when location changes
   useEffect(() => {
@@ -30,7 +29,7 @@ const Header = () => {
 
   return (
     <nav className="primary">
-      <ProjectMenu onHide={() => setProjectMenuVisible(false)} />
+      <ProjectMenu visible={projectMenuVisible} onHide={() => setProjectMenuVisible(false)} />
       <UserMenu visible={userMenuVisible} onHide={() => setUserMenuVisible(false)} />
 
       <HeaderButton

--- a/src/containers/header/index.jsx
+++ b/src/containers/header/index.jsx
@@ -6,14 +6,19 @@ import Breadcrumbs from './breadcrumbs'
 import HeaderButton from './HeaderButton'
 import UserMenu from './userMenu'
 import ProjectMenu from './projectMenu'
-import { useSelector } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
+import { setProjectMenuOpen } from '/src/features/context'
 
 const Header = () => {
-  const [projectMenuVisible, setProjectMenuVisible] = useState(false)
+  const dispatch = useDispatch()
   const [userMenuVisible, setUserMenuVisible] = useState(false)
   const location = useLocation()
   // get user from redux store
   const user = useSelector((state) => state.user)
+
+  const setProjectMenuVisible = (open) => {
+    dispatch(setProjectMenuOpen(open))
+  }
 
   // Hide sidebars when location changes
   useEffect(() => {
@@ -23,7 +28,7 @@ const Header = () => {
 
   return (
     <nav className="primary">
-      <ProjectMenu visible={projectMenuVisible} onHide={() => setProjectMenuVisible(false)} />
+      <ProjectMenu onHide={() => setProjectMenuVisible(false)} />
       <UserMenu visible={userMenuVisible} onHide={() => setUserMenuVisible(false)} />
 
       <HeaderButton

--- a/src/containers/header/index.jsx
+++ b/src/containers/header/index.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useEffect } from 'react'
 import { Link, useLocation } from 'react-router-dom'
 import { Spacer, UserImage } from '@ynput/ayon-react-components'
 
@@ -7,14 +7,16 @@ import HeaderButton from './HeaderButton'
 import UserMenu from './userMenu'
 import ProjectMenu from './projectMenu'
 import { useDispatch, useSelector } from 'react-redux'
-import { setProjectMenuOpen } from '/src/features/context'
+import { setProjectMenuOpen, setUserMenuOpen } from '/src/features/context'
 
 const Header = () => {
   const dispatch = useDispatch()
-  const [userMenuVisible, setUserMenuVisible] = useState(false)
   const location = useLocation()
   // get user from redux store
   const user = useSelector((state) => state.user)
+  // user menu
+  const userMenuVisible = useSelector((state) => state.context.userMenuOpen)
+  const setUserMenuVisible = (open) => dispatch(setUserMenuOpen(open))
 
   const setProjectMenuVisible = (open) => {
     dispatch(setProjectMenuOpen(open))

--- a/src/containers/header/projectMenu.jsx
+++ b/src/containers/header/projectMenu.jsx
@@ -4,25 +4,16 @@ import { Sidebar } from 'primereact/sidebar'
 import ProjectList from '/src/containers/projectList'
 import { useDispatch, useSelector } from 'react-redux'
 import { selectProject } from '/src/features/project'
-import {
-  selectProject as selectProjectContext,
-  setProjectMenuOpen,
-  setUri,
-} from '/src/features/context'
+import { selectProject as selectProjectContext, setUri } from '/src/features/context'
 import { onProjectChange } from '/src/features/editor'
 import { ayonApi } from '/src/services/ayon'
 import { Button } from '@ynput/ayon-react-components'
 
-const ProjectMenu = () => {
+const ProjectMenu = ({ visible, onHide }) => {
   const navigate = useNavigate()
   const dispatch = useDispatch()
 
   const projectName = useSelector((state) => state.project.name)
-  const projectMenuOpen = useSelector((state) => state.context.projectMenuOpen)
-
-  const onHide = () => {
-    dispatch(setProjectMenuOpen(false))
-  }
 
   const onProjectSelect = (projectName) => {
     onHide()
@@ -50,7 +41,7 @@ const ProjectMenu = () => {
   }
 
   return (
-    <Sidebar position="left" visible={projectMenuOpen} onHide={onHide}>
+    <Sidebar position="left" visible={visible} onHide={onHide}>
       <div
         style={{
           display: 'flex',

--- a/src/containers/header/projectMenu.jsx
+++ b/src/containers/header/projectMenu.jsx
@@ -4,16 +4,25 @@ import { Sidebar } from 'primereact/sidebar'
 import ProjectList from '/src/containers/projectList'
 import { useDispatch, useSelector } from 'react-redux'
 import { selectProject } from '/src/features/project'
-import { selectProject as selectProjectContext, setUri } from '/src/features/context'
+import {
+  selectProject as selectProjectContext,
+  setProjectMenuOpen,
+  setUri,
+} from '/src/features/context'
 import { onProjectChange } from '/src/features/editor'
 import { ayonApi } from '/src/services/ayon'
 import { Button } from '@ynput/ayon-react-components'
 
-const ProjectMenu = ({ visible, onHide }) => {
+const ProjectMenu = () => {
   const navigate = useNavigate()
   const dispatch = useDispatch()
 
   const projectName = useSelector((state) => state.project.name)
+  const projectMenuOpen = useSelector((state) => state.context.projectMenuOpen)
+
+  const onHide = () => {
+    dispatch(setProjectMenuOpen(false))
+  }
 
   const onProjectSelect = (projectName) => {
     onHide()
@@ -41,7 +50,7 @@ const ProjectMenu = ({ visible, onHide }) => {
   }
 
   return (
-    <Sidebar position="left" visible={visible} onHide={onHide}>
+    <Sidebar position="left" visible={projectMenuOpen} onHide={onHide}>
       <div
         style={{
           display: 'flex',

--- a/src/containers/projectList.jsx
+++ b/src/containers/projectList.jsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useMemo, useRef, useState } from 'react'
 import { TablePanel, Section, Button, Icon } from '@ynput/ayon-react-components'
 
 import { DataTable } from 'primereact/datatable'
@@ -102,6 +102,8 @@ const ProjectList = ({
 }) => {
   const [contextProject, setContextProject] = useState()
   const navigate = useNavigate()
+  const tableRef = useRef(null)
+
   // const user = useSelector((state) => state.user)
   // QUERY HOOK
   // ( default ) gets added in transformResponse
@@ -109,6 +111,16 @@ const ProjectList = ({
   if (isError) {
     console.error(error)
   }
+
+  useEffect(() => {
+    // set focus to table
+    if (tableRef.current && !isLoading) {
+      const tableEl = tableRef.current.getTable()
+      const focusableEl = tableEl?.querySelector('.p-selectable-row')
+
+      if (focusableEl) focusableEl.focus()
+    }
+  }, [tableRef, isLoading])
 
   // localstorage collapsible state
   let [collapsed, setCollapsed] = useLocalStorage('projectListCollapsed', false)
@@ -302,6 +314,7 @@ const ProjectList = ({
           style={{
             maxWidth: 'unset',
           }}
+          ref={tableRef}
         >
           <Column
             field="name"

--- a/src/context/shortcutsContext.jsx
+++ b/src/context/shortcutsContext.jsx
@@ -2,7 +2,7 @@ import React, { createContext, useContext, useEffect, useMemo, useState } from '
 import useKeyPress from '../hooks/useKeyPress'
 import { useNavigate } from 'react-router'
 import { useDispatch, useSelector } from 'react-redux'
-import { setProjectMenuOpen } from '../features/context'
+import { setProjectMenuOpen, setUserMenuOpen } from '../features/context'
 
 const ShortcutsContext = createContext()
 
@@ -11,7 +11,7 @@ function ShortcutsProvider(props) {
   const dispatch = useDispatch()
 
   const projectMenuOpen = useSelector((state) => state.context.projectMenuOpen)
-
+  const userMenuOpen = useSelector((state) => state.context.userMenuOpen)
   // keep track of the last key pressed
   const [lastPressed, setLastPressed] = useState(null)
 
@@ -49,7 +49,13 @@ function ShortcutsProvider(props) {
       key: 'ctrl_p',
       action: () => dispatch(setProjectMenuOpen(!projectMenuOpen)),
     },
+    {
+      key: 'ctrl_m',
+      action: () => dispatch(setUserMenuOpen(!userMenuOpen)),
+    },
   ]
+  // when these variables change, update shortcuts
+  const deps = [projectMenuOpen, userMenuOpen]
 
   const defaultShortcuts = [...settings, ...manageProjects, ...globalActions]
 
@@ -59,7 +65,7 @@ function ShortcutsProvider(props) {
   // update shortcuts when these variables change
   useEffect(() => {
     setShortcuts(defaultShortcuts)
-  }, [projectMenuOpen])
+  }, deps)
 
   const handleKeyPress = (e) => {
     // check target isn't an input
@@ -77,7 +83,7 @@ function ShortcutsProvider(props) {
     setLastPressed(singleKey)
 
     if (!shortcut?.action) return
-    console.log(shortcut)
+    // console.log(shortcut)
 
     // if it is, prevent default browser behavior
     e.preventDefault()

--- a/src/context/shortcutsContext.jsx
+++ b/src/context/shortcutsContext.jsx
@@ -1,13 +1,96 @@
-import React, { createContext, useContext } from 'react'
+import React, { createContext, useContext, useEffect, useState } from 'react'
+import useKeyPress from '../hooks/useKeyPress'
+import { useNavigate } from 'react-router'
 
 const ShortcutsContext = createContext()
 
-function ContextMenuProvider(props) {
-  return <ShortcutsContext.Provider value={{}}>{props.children}</ShortcutsContext.Provider>
+function ShortcutsProvider(props) {
+  const navigate = useNavigate()
+  // keep track of the last key pressed
+  const [lastPressed, setLastPressed] = useState(null)
+
+  // last key pressed should be reset after 200ms
+  useEffect(() => {
+    const timer = setTimeout(() => setLastPressed(null), 400)
+    return () => clearTimeout(timer)
+  }, [lastPressed])
+
+  const settings = [
+    { key: 's_s', action: () => navigate('/settings/studio') },
+    { key: 's_b', action: () => navigate('/settings/bundles') },
+    { key: 's_u', action: () => navigate('/settings/users') },
+    { key: 's_a', action: () => navigate('/settings/attributes') },
+    { key: 's_p', action: () => navigate('/settings/anatomyPresets') },
+  ]
+
+  // dashboard, teams, anatomy, projectSettings
+
+  const manageProjects = [
+    { key: 'm_m', action: () => navigate('/manageProjects/dashboard') },
+    { key: 'm_t', action: () => navigate('/manageProjects/teams') },
+    { key: 'm_a', action: () => navigate('/manageProjects/anatomy') },
+    { key: 'm_s', action: () => navigate('/manageProjects/projectSettings') },
+  ]
+
+  const defaultShortcuts = [...settings, ...manageProjects]
+
+  // start off with global shortcuts but others can be set per page
+  const [shortcuts, setShortcuts] = useState(defaultShortcuts)
+
+  // create function that can be used in components to add shortcuts, when the component mounts
+  // and removes them when it unmounts
+  const addShortcuts = (newShortcuts) => {
+    // console.log('adding shortcuts', newShortcuts)
+    setShortcuts((oldShortcuts) => [...oldShortcuts, ...newShortcuts])
+  }
+
+  const removeShortcuts = (shortcutsToRemove) => {
+    // console.log('removing shortcuts', shortcutsToRemove)
+    setShortcuts((oldShortcuts) => oldShortcuts.filter((s) => !shortcutsToRemove.includes(s.key)))
+  }
+
+  const handleKeyPress = (e) => {
+    // check target isn't an input
+    if (e.target.tagName === 'INPUT') return
+
+    let singleKey = e.key
+    // add ctrl_ prefix if ctrl or cmd is pressed
+    if (e.ctrlKey || e.metaKey) singleKey = 'ctrl_' + singleKey
+
+    const combo = lastPressed + '_' + singleKey
+    // first check if the key pressed is a shortcut
+    // const shortcut = shortcuts[e.key] || shortcuts[combo]
+    const shortcut = shortcuts.find((s) => s.key === combo || s.key === singleKey)
+
+    setLastPressed(singleKey)
+
+    if (!shortcut?.action) return
+    // console.log(shortcut.key)
+
+    // if it is, prevent default browser behavior
+    e.preventDefault()
+
+    // and run the action
+    shortcut.action()
+  }
+
+  // listen for key presses
+  useKeyPress(handleKeyPress)
+
+  return (
+    <ShortcutsContext.Provider
+      value={{
+        addShortcuts,
+        removeShortcuts,
+      }}
+    >
+      {props.children}
+    </ShortcutsContext.Provider>
+  )
 }
 
 function useShortcutsContext() {
   return useContext(ShortcutsContext)
 }
 
-export { ContextMenuProvider, useShortcutsContext }
+export { ShortcutsProvider, useShortcutsContext }

--- a/src/context/shortcutsContext.jsx
+++ b/src/context/shortcutsContext.jsx
@@ -1,0 +1,13 @@
+import React, { createContext, useContext } from 'react'
+
+const ShortcutsContext = createContext()
+
+function ContextMenuProvider(props) {
+  return <ShortcutsContext.Provider value={{}}>{props.children}</ShortcutsContext.Provider>
+}
+
+function useShortcutsContext() {
+  return useContext(ShortcutsContext)
+}
+
+export { ContextMenuProvider, useShortcutsContext }

--- a/src/features/context.js
+++ b/src/features/context.js
@@ -149,9 +149,13 @@ const contextSlice = createSlice({
     },
     setProjectMenuOpen: (state, action) => {
       state.projectMenuOpen = action.payload
+      // close user menu
+      state.userMenuOpen = action.payload ? false : state.userMenuOpen
     },
     setUserMenuOpen: (state, action) => {
       state.userMenuOpen = action.payload
+      // close project menu
+      state.projectMenuOpen = action.payload ? false : state.projectMenuOpen
     },
   }, // reducers
 })

--- a/src/features/context.js
+++ b/src/features/context.js
@@ -21,6 +21,7 @@ const initialState = {
   uri: null,
   uriChanged: 0,
   projectMenuOpen: false,
+  userMenuOpen: false,
 }
 
 const contextSlice = createSlice({
@@ -149,6 +150,9 @@ const contextSlice = createSlice({
     setProjectMenuOpen: (state, action) => {
       state.projectMenuOpen = action.payload
     },
+    setUserMenuOpen: (state, action) => {
+      state.userMenuOpen = action.payload
+    },
   }, // reducers
 })
 
@@ -174,6 +178,7 @@ export const {
   selectProject,
   onFocusChanged,
   setProjectMenuOpen,
+  setUserMenuOpen,
 } = contextSlice.actions
 
 export default contextSlice.reducer

--- a/src/features/context.js
+++ b/src/features/context.js
@@ -20,6 +20,7 @@ const initialState = {
   share: { name: null, data: null, link: null, img: null },
   uri: null,
   uriChanged: 0,
+  projectMenuOpen: false,
 }
 
 const contextSlice = createSlice({
@@ -145,6 +146,9 @@ const contextSlice = createSlice({
         link: null,
       }
     },
+    setProjectMenuOpen: (state, action) => {
+      state.projectMenuOpen = action.payload
+    },
   }, // reducers
 })
 
@@ -169,6 +173,7 @@ export const {
   closeShare,
   selectProject,
   onFocusChanged,
+  setProjectMenuOpen,
 } = contextSlice.actions
 
 export default contextSlice.reducer

--- a/src/hooks/useKeyPress.js
+++ b/src/hooks/useKeyPress.js
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 
 function useKeyPress(callback) {
   // State for keeping track of whether key is pressed
-  const [keyPressed, setKeyPressed] = useState('')
+  const [keyPressed, setKeyPressed] = useState(null)
 
   useEffect(() => {
     if (keyPressed && callback) {
@@ -11,12 +11,12 @@ function useKeyPress(callback) {
   }, [keyPressed])
 
   // If pressed key is our target key then set to true
-  function downHandler({ key }) {
-    setKeyPressed(key)
+  function downHandler(e) {
+    setKeyPressed(e)
   }
   // If released key is our target key then set to false
   const upHandler = () => {
-    setKeyPressed('')
+    setKeyPressed(null)
   }
   // Add event listeners
   useEffect(() => {

--- a/src/hooks/useKeyPress.js
+++ b/src/hooks/useKeyPress.js
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react'
+
+function useKeyPress(callback) {
+  // State for keeping track of whether key is pressed
+  const [keyPressed, setKeyPressed] = useState('')
+
+  useEffect(() => {
+    if (keyPressed && callback) {
+      callback(keyPressed)
+    }
+  }, [keyPressed])
+
+  // If pressed key is our target key then set to true
+  function downHandler({ key }) {
+    setKeyPressed(key)
+  }
+  // If released key is our target key then set to false
+  const upHandler = () => {
+    setKeyPressed('')
+  }
+  // Add event listeners
+  useEffect(() => {
+    window.addEventListener('keydown', downHandler)
+    window.addEventListener('keyup', upHandler)
+    // Remove event listeners on cleanup
+    return () => {
+      window.removeEventListener('keydown', downHandler)
+      window.removeEventListener('keyup', upHandler)
+    }
+  }, []) // Empty array ensures that effect is only run on mount and unmount
+  return keyPressed || undefined
+}
+
+export default useKeyPress

--- a/src/hooks/useShortcuts.js
+++ b/src/hooks/useShortcuts.js
@@ -1,0 +1,15 @@
+import { useEffect } from 'react'
+import { useShortcutsContext } from '../context/shortcutsContext'
+
+const userShortcuts = (shortcuts) => {
+  const { addShortcuts, removeShortcuts } = useShortcutsContext()
+
+  useEffect(() => {
+    addShortcuts(shortcuts)
+    return () => {
+      removeShortcuts(shortcuts)
+    }
+  }, [])
+}
+
+export default userShortcuts

--- a/src/hooks/useShortcuts.js
+++ b/src/hooks/useShortcuts.js
@@ -1,7 +1,7 @@
 import { useEffect } from 'react'
 import { useShortcutsContext } from '../context/shortcutsContext'
 
-const userShortcuts = (shortcuts) => {
+const userShortcuts = (shortcuts, deps = []) => {
   const { addShortcuts, removeShortcuts } = useShortcutsContext()
 
   useEffect(() => {
@@ -9,7 +9,7 @@ const userShortcuts = (shortcuts) => {
     return () => {
       removeShortcuts(shortcuts)
     }
-  }, [])
+  }, deps)
 }
 
 export default userShortcuts


### PR DESCRIPTION
Lets test how useful some shortcuts would be!

I started by creating a shortcutsContext that wraps the whole app and handles keyDown and keyUp.

In that context there are some "global" shortcuts that can be triggered from anywhere in the app.

There is a hook called `useShortcuts` that can be used on a component level to listen for component only shortcuts. For example the Editor Page can have a new folder shortcut shift+n to create new folders/tasks and this shortcut will only be triggered on the Editor Page.

For now there are only global shortcuts but overtime we can add more component scoped shortcuts.

#### Global Shortcuts
Name | Shortcut (key) | Action
-- | -- | --
Studio Settings | s+s | navigate('/settings/studio')
Bundles Settings | s+b | navigate('/settings/bundles')
Users Settings | s+u | navigate('/settings/users')
Attributes Settings | s+a | navigate('/settings/attributes')
Anatomy Presets Settings | s+p | navigate('/settings/anatomyPresets')
Dashboard | m+m | navigate('/manageProjects/dashboard')
Teams | m+t | navigate('/manageProjects/teams')
Anatomy | m+a | navigate('/manageProjects/anatomy')
Project Settings | m+s | navigate('/manageProjects/projectSettings')
Project Menu | ctrl+p | setProjectMenuOpen(!projectMenuOpen)
User Menu | ctrl+m | setUserMenuOpen(!userMenuOpen)

#### useShortcuts example

```javascript
  // define shortcuts
  const shortcuts = [
    {
      key: 'N',
      action: () => createNewFolder(),
    },
    {
      key: 'ctrl+k',
      action: () => setSearchOpen(!searchOpen),
    },
  ]

  // add shortcuts to shortcuts context
  // add any variables that should trigger a shortcut update to the deps array
  userShortcuts(shortcuts, [searchOpen])
```

#### Shortcut Model
```typescript
type Shortcut = {
  // single key press = key: "s"
  // double key press = key: "s+s"
  // ctrl/meta + key press = key: "ctrl+s"
  // shift + key press = key: "S"
  key: string
  action: () => void
}
```

