### PR TITLE
bundles fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "react-transition-group": "^4.4.2",
     "react-use-websocket": "^4.2.0",
     "sass": "^1.62.0",
+    "semver": "^7.5.4",
     "short-uuid": "^4.2.0",
     "styled-components": "^5.3.6",
     "use-query-params": "^2.1.2",

--- a/src/containers/AddonList.jsx
+++ b/src/containers/AddonList.jsx
@@ -18,7 +18,7 @@ const AddonList = ({
   siteId, // used for chaged addons
   setBundleName,
 }) => {
-  const { data, loading } = useGetAddonSettingsListQuery({
+  const { data, loading, isError } = useGetAddonSettingsListQuery({
     projectName,
     siteId,
     variant: environment,
@@ -57,10 +57,14 @@ const AddonList = ({
   }, [data, environment, siteSettings])
 
   useEffect(() => {
-    if (setBundleName && data?.bundleName) {
-      setBundleName(data.bundleName)
+    if (setBundleName) {
+      if (data?.bundleName && !isError) {
+        setBundleName(data?.bundleName)
+      } else {
+        setBundleName(null)
+      }
     }
-  }, [data?.bundleName])
+  }, [data?.bundleName, isError])
 
   useEffect(() => {
     // Maintain selection when addons are changed due to environment change
@@ -106,13 +110,14 @@ const AddonList = ({
     <Section style={{ minWidth: 250 }}>
       <TablePanel loading={loading}>
         <DataTable
-          value={addons}
+          value={isError ? [] : addons}
           selectionMode="multiple"
           scrollable="true"
           scrollHeight="flex"
           selection={selectedAddons}
           onSelectionChange={onSelectionChange}
           rowClassName={rowDataClassNameFormatter}
+          emptyMessage={isError ? `WARNING: No bundle set to ${environment}` : 'No addons found'}
         >
           <Column field="title" header="Addon" />
           <Column field="version" header="Version" style={{ maxWidth: 80 }} />

--- a/src/containers/AddonSettings/AddonSettings.jsx
+++ b/src/containers/AddonSettings/AddonSettings.jsx
@@ -2,15 +2,7 @@ import { useState, useMemo, useEffect } from 'react'
 import { useSelector } from 'react-redux'
 import { toast } from 'react-toastify'
 
-import {
-  Button,
-  Spacer,
-  Section,
-  InputText,
-  Panel,
-  Toolbar,
-  ScrollPanel,
-} from '@ynput/ayon-react-components'
+import { Button, Spacer, Section, Panel, Toolbar, ScrollPanel } from '@ynput/ayon-react-components'
 import { Splitter, SplitterPanel } from 'primereact/splitter'
 
 import AddonList from '/src/containers/AddonList'
@@ -25,6 +17,7 @@ import {
 } from '/src/services/addonSettings'
 import SaveButton from '/src/components/SaveButton'
 import { isEqual } from 'lodash'
+import { useNavigate } from 'react-router'
 
 /*
  * key is {addonName}|{addonVersion}|{environment}|{siteId}|{projectKey}
@@ -123,6 +116,7 @@ const compareObjects = (obj1, obj2, path = []) => {
 }
 
 const AddonSettings = ({ projectName, showSites = false }) => {
+  const navigate = useNavigate()
   const [showHelp, setShowHelp] = useState(false)
   const [selectedAddons, setSelectedAddons] = useState([])
   const [originalData, setOriginalData] = useState({})
@@ -445,14 +439,13 @@ const AddonSettings = ({ projectName, showSites = false }) => {
           disabled={environment === 'staging'}
           style={environment === 'staging' ? styleHlStag : {}}
         />
-        <InputText
-          tooltip="Bundle name"
-          value={bundleName || ''}
-          style={{ flexGrow: 1 }}
-          readOnly
+        <Button
+          label={`Bundle: ${bundleName || 'NONE'}`}
+          onClick={() => navigate(`/settings/bundles?selected=${bundleName || 'latest'}`)}
         />
         <Button
           icon="local_shipping"
+          label="Push to production"
           tooltip="Push to production"
           onClick={onPushToProduction}
           disabled={environment !== 'staging' || canCommit}
@@ -464,6 +457,7 @@ const AddonSettings = ({ projectName, showSites = false }) => {
   const settingsListHeader = useMemo(() => {
     return (
       <Toolbar>
+        <Spacer />
         <Button
           onClick={() => {
             setShowHelp(!showHelp)

--- a/src/context/websocketContext.jsx
+++ b/src/context/websocketContext.jsx
@@ -1,10 +1,11 @@
 import { useEffect, useState, createContext } from 'react'
-import { useSelector } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 import { toast } from 'react-toastify'
 import PubSub from '/src/pubsub'
 import arrayEquals from '../helpers/arrayEquals'
 import useWebSocket, { ReadyState } from 'react-use-websocket'
 import { debounce } from 'lodash'
+import { ayonApi } from '../services/ayon'
 
 export const SocketContext = createContext()
 
@@ -12,6 +13,7 @@ const proto = window.location.protocol.replace('http', 'ws')
 const wsAddress = `${proto}//${window.location.host}/ws`
 
 export const SocketProvider = (props) => {
+  const dispatch = useDispatch()
   // get user logged in
   const [serverRestartingVisible, setServerRestartingVisible] = useState(false)
   const [topics, setTopics] = useState([])
@@ -68,7 +70,11 @@ export const SocketProvider = (props) => {
 
   useEffect(() => {
     if (readyState === ReadyState.OPEN) {
-      setServerRestartingVisible(false)
+      if (serverRestartingVisible) {
+        setServerRestartingVisible(false)
+        // clear ayonApi
+        dispatch(ayonApi.util.resetApiState())
+      }
       getWebSocket().onmessage = onMessage
       subscribe()
       // Dispatch a fake event to the frontend components

--- a/src/pages/SettingsPage/Bundles/AddonList.jsx
+++ b/src/pages/SettingsPage/Bundles/AddonList.jsx
@@ -1,8 +1,9 @@
-import React, { useMemo } from 'react'
+import React, { useContext, useEffect, useMemo } from 'react'
 import { VersionSelect } from '@ynput/ayon-react-components'
 import { useGetAddonListQuery } from '../../../services/addons/getAddons'
 import { DataTable } from 'primereact/datatable'
 import { Column } from 'primereact/column'
+import { SocketContext } from '/src/context/websocketContext'
 import { rcompare } from 'semver'
 
 const AddonListItem = ({ version, setVersion, selection, addons = [], versions }) => {
@@ -39,7 +40,16 @@ const AddonList = React.forwardRef(
     { formData, setFormData, readOnly, selected = [], setSelected, style, diffAddonVersions },
     ref,
   ) => {
-    const { data: addons = [] } = useGetAddonListQuery({ showVersions: true })
+    const { data: addons = [], refetch } = useGetAddonListQuery({
+      showVersions: true,
+    })
+
+    const readyState = useContext(SocketContext).readyState
+    useEffect(() => {
+      refetch()
+    }, [readyState])
+
+    // every time readyState changes, refetch selected addons
 
     const onSetVersion = (addonName, version) => {
       const versionsToSet = selected.length > 1 ? selected.map((s) => s.name) : [addonName]

--- a/src/pages/SettingsPage/Bundles/AddonList.jsx
+++ b/src/pages/SettingsPage/Bundles/AddonList.jsx
@@ -3,6 +3,7 @@ import { VersionSelect } from '@ynput/ayon-react-components'
 import { useGetAddonListQuery } from '../../../services/addons/getAddons'
 import { DataTable } from 'primereact/datatable'
 import { Column } from 'primereact/column'
+import { rcompare } from 'semver'
 
 const AddonListItem = ({ version, setVersion, selection, addons = [], versions }) => {
   const options = useMemo(
@@ -11,7 +12,9 @@ const AddonListItem = ({ version, setVersion, selection, addons = [], versions }
         ? selection.map((s) => {
             const foundAddon = addons.find((a) => a.name === s.name)
             if (!foundAddon) return ['NONE']
-            const versionList = Object.keys(foundAddon.versions || {})
+            const versionList = Object.keys(foundAddon.versions || {}).sort((a, b) =>
+              rcompare(a, b),
+            )
             return [...versionList, 'NONE']
           })
         : [[...versions, 'NONE']],

--- a/src/pages/SettingsPage/Bundles/Bundles.jsx
+++ b/src/pages/SettingsPage/Bundles/Bundles.jsx
@@ -80,7 +80,7 @@ const Bundles = () => {
 
     // delete
     search.delete('selected')
-    window.history.replaceState({}, '', `${location.pathname}${search.length ? '?' : ''}${search}`)
+    window.history.replaceState({}, '', `${location.pathname}${search.size ? '?' : ''}${search}`)
   }, [location.search, isLoading, bundleList])
 
   // REDUX MUTATIONS

--- a/src/pages/SettingsPage/Bundles/Bundles.jsx
+++ b/src/pages/SettingsPage/Bundles/Bundles.jsx
@@ -151,7 +151,7 @@ const Bundles = () => {
 
   const getVersionedName = (name) => {
     let newName
-    const versionNumber = parseInt(name.split('-')[4])
+    const versionNumber = parseInt(name.split('-').pop())
     if (!isNaN(versionNumber)) {
       newName = name.replace(/(\d+)$/, () => {
         return (versionNumber + 1).toString().padStart(2, '0')

--- a/src/pages/SettingsPage/Bundles/getLatestSemver.js
+++ b/src/pages/SettingsPage/Bundles/getLatestSemver.js
@@ -1,11 +1,11 @@
-const getLatestSemver = (versionList) => {
+import { rcompare } from 'semver'
+
+const getLatestSemver = (versionList = []) => {
   if (!versionList.length) return
-  // get the latest semver version from versionList
-  // TODO: this is not correct. need to use semver to compare versions
-  const latestVersion = versionList.reduce((acc, cur) => {
-    return acc > cur ? acc : cur
-  })
-  return latestVersion
+  // sort the version list by semver, with the latest version first
+  const sortedVersions = versionList.sort((a, b) => rcompare(a, b))
+  // return the latest version
+  return sortedVersions[0]
 }
 
 export default getLatestSemver

--- a/src/pages/SettingsPage/SettingsPage.jsx
+++ b/src/pages/SettingsPage/SettingsPage.jsx
@@ -83,11 +83,6 @@ const SettingsPage = () => {
         module: 'bundles',
       },
       {
-        name: 'Anatomy presets',
-        path: '/settings/anatomyPresets',
-        module: 'anatomyPresets',
-      },
-      {
         name: 'Studio settings',
         path: '/settings/studio',
         module: 'studio',
@@ -96,6 +91,11 @@ const SettingsPage = () => {
         name: 'Site settings',
         path: '/settings/site',
         module: 'site',
+      },
+      {
+        name: 'Anatomy presets',
+        path: '/settings/anatomyPresets',
+        module: 'anatomyPresets',
       },
       {
         name: 'Attributes',


### PR DESCRIPTION
- use semver package to get sort version dropdown and get latest version
- versioning up a bundle name was broken if there were more than 4 digits
- resetApiState on server restart connect
- Move Anatomy Presets nav item further down 
![image](https://github.com/ynput/ayon-frontend/assets/49156310/8a4ae087-d5c3-43cf-aa0f-819537d93100)
- bundles page search query fix
- improved settings bundle name can now be clicked to navigate to the bundle.
![image](https://github.com/ynput/ayon-frontend/assets/49156310/11054d1c-09a0-4c38-b604-0c74886914f8)
- addons list not updating when switching to an environment that had no bundle. `isError` is thrown but the addonsList data wasn't cleared, fixed now.