### PR TITLE
Fix/less release calls

### DIFF
--- a/src/pages/OnBoarding/Step/AddonSelectStep.jsx
+++ b/src/pages/OnBoarding/Step/AddonSelectStep.jsx
@@ -1,57 +1,51 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import * as Styled from '../util/OnBoardingStep.styled'
 import AddonCard from '/src/components/AddonCard/AddonCard'
-import { isEmpty } from 'lodash'
-import { toast } from 'react-toastify'
 
 export const AddonSelectStep = ({
   Header,
   Footer,
-  selectedAddons,
+  selectedAddons = [],
+  selectedPreset,
+  releases = [],
   setSelectedAddons,
   onSubmit,
-  release,
-  previousStep,
+  isLoadingRelease,
 }) => {
   // FIX: get release by name from /api/onboarding/release/:name
   // for now import release.230807.json
 
   const [sortedAddons, setSortedAddons] = useState([])
 
+  const release = useMemo(
+    () => releases.find((release) => release.name === selectedPreset),
+    [selectedPreset, releases],
+  )
+  const addons = useMemo(() => release?.addons || [], [release])
+  const mandatory = useMemo(() => release?.mandatoryAddons || [], [release])
+
   useEffect(() => {
-    const sortedAddons = release?.addons?.map((addon) => addon)
+    const sortedAddons = [...addons]
     // order addons by selected and then by addon.mandatory
     sortedAddons.sort((a, b) => {
-      const aSelected = selectedAddons.includes(a.name)
-      const bSelected = selectedAddons.includes(b.name)
+      const aSelected = selectedAddons.includes(a)
+      const bSelected = selectedAddons.includes(b)
       if (aSelected && !bSelected) return -1
       if (!aSelected && bSelected) return 1
-      if (a.mandatory && !b.mandatory) return -1
-      if (!a.mandatory && b.mandatory) return 1
+      if (mandatory.includes(a) && !mandatory.includes(b)) return -1
+      if (!mandatory.includes(a) && mandatory.includes(b)) return 1
       return 0
     })
     setSortedAddons(sortedAddons)
-  }, [release])
+  }, [releases])
 
   const handleAddonClick = (name) => {
-    const addon = release?.addons?.find((addon) => addon.name === name)
-    if (!addon) return
     // if it's already selected, remove it
     if (selectedAddons.includes(name)) {
-      if (addon.mandatory) {
-        return // prevent removing the "Core" addon
-      }
       setSelectedAddons(selectedAddons.filter((addon) => addon !== name))
     } else {
       setSelectedAddons([...selectedAddons, name])
     }
-  }
-
-  // no release
-  if (isEmpty(release)) {
-    toast.error('Release not found!')
-    previousStep()
-    return null
   }
 
   return (
@@ -60,18 +54,23 @@ export const AddonSelectStep = ({
       <Styled.AddonsContainer>
         {sortedAddons.map(
           (addon) =>
-            !addon.mandatory && (
+            !mandatory.includes(addon) && (
               <AddonCard
-                key={addon.name}
-                name={addon.name}
-                icon={selectedAddons.includes(addon.name) ? 'check_circle' : 'circle'}
-                isSelected={selectedAddons.includes(addon.name)}
-                onClick={() => handleAddonClick(addon.name)}
+                key={addon}
+                name={addon}
+                icon={selectedAddons.includes(addon) ? 'check_circle' : 'circle'}
+                isSelected={selectedAddons.includes(addon)}
+                onClick={() => handleAddonClick(addon)}
               />
             ),
         )}
       </Styled.AddonsContainer>
-      <Footer next="Confirm" onNext={onSubmit} />
+      <Footer
+        next="Confirm"
+        onNext={onSubmit}
+        nextProps={{ saving: isLoadingRelease }}
+        showIcon={isLoadingRelease}
+      />
     </Styled.Section>
   )
 }

--- a/src/pages/OnBoarding/Step/AddonSelectStep.jsx
+++ b/src/pages/OnBoarding/Step/AddonSelectStep.jsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useState } from 'react'
 import * as Styled from '../util/OnBoardingStep.styled'
 import AddonCard from '/src/components/AddonCard/AddonCard'
+import { isEmpty } from 'lodash'
+import { toast } from 'react-toastify'
 
 export const AddonSelectStep = ({
   Header,
@@ -9,6 +11,7 @@ export const AddonSelectStep = ({
   setSelectedAddons,
   onSubmit,
   release,
+  previousStep,
 }) => {
   // FIX: get release by name from /api/onboarding/release/:name
   // for now import release.230807.json
@@ -16,7 +19,7 @@ export const AddonSelectStep = ({
   const [sortedAddons, setSortedAddons] = useState([])
 
   useEffect(() => {
-    const sortedAddons = release.addons.map((addon) => addon)
+    const sortedAddons = release?.addons?.map((addon) => addon)
     // order addons by selected and then by addon.mandatory
     sortedAddons.sort((a, b) => {
       const aSelected = selectedAddons.includes(a.name)
@@ -31,7 +34,7 @@ export const AddonSelectStep = ({
   }, [release])
 
   const handleAddonClick = (name) => {
-    const addon = release.addons.find((addon) => addon.name === name)
+    const addon = release?.addons?.find((addon) => addon.name === name)
     if (!addon) return
     // if it's already selected, remove it
     if (selectedAddons.includes(name)) {
@@ -42,6 +45,13 @@ export const AddonSelectStep = ({
     } else {
       setSelectedAddons([...selectedAddons, name])
     }
+  }
+
+  // no release
+  if (isEmpty(release)) {
+    toast.error('Release not found!')
+    previousStep()
+    return null
   }
 
   return (

--- a/src/pages/OnBoarding/util/OnBoardingContext.jsx
+++ b/src/pages/OnBoarding/util/OnBoardingContext.jsx
@@ -8,6 +8,7 @@ import {
   useGetInstallEventsQuery,
   useGetReleaseQuery,
   useInstallPresetMutation,
+  useLazyGetReleaseQuery,
 } from '/src/services/onBoarding/onBoarding'
 import { useGetReleasesQuery } from '/src/services/getRelease'
 import useLocalStorage from '/src/hooks/useLocalStorage'
@@ -121,7 +122,7 @@ export const OnBoardingProvider = ({ children, initStep, onFinish }) => {
   // get selected release data
   const { data: release = {} } = useGetReleaseQuery(
     { name: selectedPreset },
-    { skip: !selectedPreset },
+    { skip: !selectedPreset || stepIndex !== 7 },
   )
 
   // // once releases are loaded, set selectedPreset to the first one and pre-cache each release
@@ -176,9 +177,13 @@ export const OnBoardingProvider = ({ children, initStep, onFinish }) => {
     }
   }, [isSuccess, isFetching, isFinished])
 
+  const [getRelease, { isFetching: isLoadingRelease }] = useLazyGetReleaseQuery()
+
   const handleSubmit = async () => {
     // install addons, installers, dep packages
     try {
+      // get release data
+      const release = await getRelease({ name: selectedPreset }).unwrap()
       // create array of addon urls based on selected addons
       const addons = release.addons
         .filter((addon) => selectedAddons.includes(addon.name) && !!addon.url)
@@ -261,6 +266,7 @@ export const OnBoardingProvider = ({ children, initStep, onFinish }) => {
     isLoadingReleases,
     setIsConnecting,
     isConnecting,
+    isLoadingRelease,
   }
 
   return <OnBoardingContext.Provider value={contextValue}>{children}</OnBoardingContext.Provider>

--- a/src/pages/OnBoarding/util/OnBoardingContext.jsx
+++ b/src/pages/OnBoarding/util/OnBoardingContext.jsx
@@ -8,7 +8,6 @@ import {
   useGetInstallEventsQuery,
   useGetReleaseQuery,
   useInstallPresetMutation,
-  useLazyGetReleaseQuery,
 } from '/src/services/onBoarding/onBoarding'
 import { useGetReleasesQuery } from '/src/services/getRelease'
 import useLocalStorage from '/src/hooks/useLocalStorage'
@@ -124,14 +123,11 @@ export const OnBoardingProvider = ({ children, initStep, onFinish }) => {
     { name: selectedPreset },
     { skip: !selectedPreset },
   )
-  // lazy
-  const [getRelease] = useLazyGetReleaseQuery()
 
-  // once releases are loaded, set selectedPreset to the first one and pre-cache each release
+  // // once releases are loaded, set selectedPreset to the first one and pre-cache each release
   useEffect(() => {
     if (releases.length) {
       setSelectedPreset(releases[0].name)
-      releases.forEach(({ name }) => getRelease({ name }))
     }
   }, [releases])
 


### PR DESCRIPTION
Only make the api call for `releases/{release_name}` once when the user clicks submit