### PR TITLE
Fix: breadcrumbs show scope name

### DIFF
--- a/src/containers/Breadcrumbs/Breadcrumbs.jsx
+++ b/src/containers/Breadcrumbs/Breadcrumbs.jsx
@@ -80,6 +80,21 @@ const Breadcrumbs = () => {
   useEffect(() => {
     if (!editMode) return
     inputRef.current.select()
+
+    // reselect to counter mouse movement
+    const timeout = setTimeout(() => {
+      inputRef.current.select()
+    }, 50)
+
+    // reselect again to really make sure
+    const timeout2 = setTimeout(() => {
+      inputRef.current.select()
+    }, 400)
+
+    return () => {
+      clearTimeout(timeout)
+      clearTimeout(timeout2)
+    }
   }, [editMode])
 
   const focusEntities = (entities) => {

--- a/src/containers/Breadcrumbs/Breadcrumbs.jsx
+++ b/src/containers/Breadcrumbs/Breadcrumbs.jsx
@@ -28,7 +28,7 @@ const uri2crumbs = (uri = '', pathname) => {
   if (scope?.includes('ayon+settings')) {
     let settingsScope = ''
     if (query?.includes('project')) {
-      settingsScope = 'Project Settings'
+      settingsScope = 'Projects Manager'
     } else {
       settingsScope = 'Studio Settings'
     }
@@ -41,7 +41,7 @@ const uri2crumbs = (uri = '', pathname) => {
     let pageTitle = pathname.split('/')[1]
 
     if (pageTitle.includes('settings')) pageTitle = 'Studio Settings'
-    else if (pageTitle.includes('manageProjects')) pageTitle = 'Project Settings'
+    else if (pageTitle.includes('manageProjects')) pageTitle = 'Projects Manager'
     // just a regular url
     crumbs.unshift(upperFirst(pageTitle))
   }

--- a/src/containers/Breadcrumbs/Breadcrumbs.styled.js
+++ b/src/containers/Breadcrumbs/Breadcrumbs.styled.js
@@ -1,4 +1,4 @@
-import styled, { keyframes } from 'styled-components'
+import styled from 'styled-components'
 
 export const Wrapper = styled.div`
   position: absolute;
@@ -14,15 +14,6 @@ export const Crumbtainer = styled.div`
   flex-direction: row;
   align-items: center;
   gap: 8px;
-`
-
-const InputOpenAnimation = keyframes`
-    from {
-        scale: 0.95;
-    }
-    to {
-        scale: 1;
-    }
 `
 
 export const CrumbsForm = styled.form`
@@ -50,21 +41,28 @@ export const CrumbsForm = styled.form`
       background: none;
       appearance: none;
 
-      background-color: var(--md-sys-color-surface-container);
+      background-color: var(--md-sys-color-secondary-container);
       border: 1px solid;
       border-color: transparent;
       transition: all 0.1s;
-      font-size: var(--md-sys-typescale-label-large-font-size);
       max-height: unset;
-
       transform-origin: center;
       min-width: 0;
       text-align: center;
+      cursor: pointer;
+      user-select: none;
+
+      font-family: var(--md-sys-typescale-title-medium-font-family-name);
+      font-style: var(--md-sys-typescale-title-medium-font-family-style);
+      font-weight: var(--md-sys-typescale-title-medium-font-weight);
+      font-size: var(--md-sys-typescale-title-medium-font-size);
+      letter-spacing: var(--md-sys-typescale-title-medium-letter-spacing);
+      line-height: var(--md-sys-typescale-title-medium-line-height);
     }
 
     input {
       &:hover {
-        background-color: var(--md-sys-color-surface-container-hover);
+        background-color: var(--md-sys-color-secondary-container-hover);
       }
     }
 
@@ -76,24 +74,14 @@ export const CrumbsForm = styled.form`
 
     &:focus-within {
       input {
-        background-color: var(--md-sys-color-secondary-container);
+        user-select: text;
+        cursor: text;
         background-color: var(--md-sys-color-surface-container-high);
         color: var(--md-sys-color-on-secondary-container);
         outline: none;
         border-color: var(--md-sys-color-outline);
 
         box-shadow: 0px 0px 10px 0px rgba(0, 0, 0, 0.15);
-      }
-      &::after,
-      input {
-        /* font-size: var(--md-sys-typescale-title-small-font-size); */
-        /* animate */
-        animation: ${InputOpenAnimation} 0.05s forwards;
-        transform-origin: center;
-
-        /* padding: 8px; */
-        /* transform: translateY(4px); */
-        /* border-radius: 8px; */
       }
     }
   }

--- a/src/pages/ProjectPage.jsx
+++ b/src/pages/ProjectPage.jsx
@@ -69,11 +69,12 @@ const ProjectPage = () => {
     // so i commented this out - this means project change won't trigger
     // breadcrumbs update, until something is clicked. but i think that's ok for now.
 
+    const newUri = `ayon+entity://${projectName}`
     // this might work
-    if (!uri) {
+    if (!uri?.includes(newUri)) {
       dispatch(setUri(`ayon+entity://${projectName}`))
     }
-  }, [projectName])
+  }, [projectName, uri])
 
   useEffect(() => {
     // Clear URI when project page is unmounted


### PR DESCRIPTION
- Fix bug where project name wasn't getting set in uri
- Now show page name as a default
- Settings page shows "Studio Settings"
- Manage Projects page shows "Projects Manager"

- Make font size bigger and give secondary blue background to make breadcrumbs more prominent
- Fix auto selection bug not always selecting whole text

Thanks @m-u-r-p-h-y for the feedback

![image](https://github.com/ynput/ayon-frontend/assets/49156310/1014a1cd-2d6f-4a99-a477-ee692c92120e)
