### PR TITLE
Fix: propagating new complex items of arrays in settings

### DIFF
--- a/src/containers/AddonSettings/AddonSettings.jsx
+++ b/src/containers/AddonSettings/AddonSettings.jsx
@@ -557,6 +557,9 @@ const AddonSettings = ({ projectName, showSites = false }) => {
         <Section wrap style={{ minWidth: 300 }}>
           <Toolbar>{commitToolbar}</Toolbar>
           <SettingsChangesTable changes={changedKeys} onRevert={onRevertChange} />
+          <ScrollPanel className="transparent nopad" style={{ flexGrow: 1 }}>
+            <pre style={{ whiteSpace: 'pre-wrap' }}>{JSON.stringify(localData, null, 2)}</pre>
+          </ScrollPanel>
         </Section>
       </SplitterPanel>
     </Splitter>

--- a/src/containers/AddonSettings/AddonSettings.jsx
+++ b/src/containers/AddonSettings/AddonSettings.jsx
@@ -183,6 +183,7 @@ const AddonSettings = ({ projectName, showSites = false }) => {
         updatedKeys.push(key)
       } catch (e) {
         allOk = false
+        console.error(e)
         toast.error(
           <>
             <strong>Unable to save {variant} settings</strong>

--- a/src/containers/AddonSettings/AddonSettings.jsx
+++ b/src/containers/AddonSettings/AddonSettings.jsx
@@ -189,7 +189,16 @@ const AddonSettings = ({ projectName, showSites = false }) => {
             <br />
             {addonName} {addonVersion}
             <br />
-            {e}
+            {e.detail}
+            {e.errors?.length && (
+              <ul>
+                {e.errors.map((error, i) => (
+                  <li key={i}>
+                    {error.loc.join('/')}: {error.msg}
+                  </li>
+                ))}
+              </ul>
+            )}
           </>,
         )
       }

--- a/src/containers/AddonSettings/AddonSettings.jsx
+++ b/src/containers/AddonSettings/AddonSettings.jsx
@@ -27,7 +27,6 @@ import {
 } from '/src/services/addonSettings'
 
 import { usePromoteBundleMutation } from '/src/services/bundles'
-//import { useNavigate } from 'react-router'
 import { confirmDialog } from 'primereact/confirmdialog'
 
 import { getValueByPath, setValueByPath, sameKeysStructure, compareObjects } from './utils'
@@ -101,6 +100,7 @@ const AddonSettings = ({ projectName, showSites = false }) => {
 
   const onSettingsChange = (addonName, addonVersion, variant, siteId, data) => {
     const key = `${addonName}|${addonVersion}|${variant}|${siteId}|${projectKey}`
+
     setLocalData((localData) => {
       localData[key] = data
       return { ...localData }

--- a/src/containers/AddonSettings/AddonSettings.jsx
+++ b/src/containers/AddonSettings/AddonSettings.jsx
@@ -566,9 +566,11 @@ const AddonSettings = ({ projectName, showSites = false }) => {
         <Section wrap style={{ minWidth: 300 }}>
           <Toolbar>{commitToolbar}</Toolbar>
           <SettingsChangesTable changes={changedKeys} onRevert={onRevertChange} />
+          {/*}
           <ScrollPanel className="transparent nopad" style={{ flexGrow: 1 }}>
             <pre style={{ whiteSpace: 'pre-wrap' }}>{JSON.stringify(localData, null, 2)}</pre>
           </ScrollPanel>
+          */}
         </Section>
       </SplitterPanel>
     </Splitter>

--- a/src/containers/AddonSettings/CopySettings.jsx
+++ b/src/containers/AddonSettings/CopySettings.jsx
@@ -364,7 +364,8 @@ const CopySettingsButton = ({
       // Iterate over the changes and apply them to the target addon
 
       for (const change of node.children) {
-        addonSettings = setValueByPath(addonSettings, change.data.path, change.data.sourceValue)
+        const value = cloneDeep(change.data.sourceValue)
+        addonSettings = setValueByPath(addonSettings, change.data.path, value)
         addonOverrides.push(change.data.path)
       } // for change of node.children
 

--- a/src/containers/SettingsEditor/SettingsEditor.jsx
+++ b/src/containers/SettingsEditor/SettingsEditor.jsx
@@ -164,7 +164,6 @@ const SettingsEditor = ({
         formData={formData}
         formContext={fullContext}
         widgets={widgets}
-        liveValidate={false}
         FieldTemplate={FieldTemplate}
         ObjectFieldTemplate={ObjectFieldTemplate}
         ArrayFieldTemplate={ArrayFieldTemplate}

--- a/src/containers/SettingsEditor/SettingsEditor.jsx
+++ b/src/containers/SettingsEditor/SettingsEditor.jsx
@@ -168,6 +168,7 @@ const SettingsEditor = ({
         ObjectFieldTemplate={ObjectFieldTemplate}
         ArrayFieldTemplate={ArrayFieldTemplate}
         onChange={(evt) => onChange(evt.formData)}
+        onError={(evt) => console.log('Form contains errors:', evt)}
       >
         <div />
       </Form>

--- a/src/containers/SettingsEditor/SettingsPanel.jsx
+++ b/src/containers/SettingsEditor/SettingsPanel.jsx
@@ -44,7 +44,7 @@ const PanelHeader = styled.div`
 
     .new-object {
       font-style: italic;
-      color: var(--color-hl-error);
+      color: red;
     }
   }
 

--- a/src/containers/SettingsEditor/SettingsPanel.jsx
+++ b/src/containers/SettingsEditor/SettingsPanel.jsx
@@ -36,6 +36,7 @@ const PanelHeader = styled.div`
     border: 0;
     font-size: 1rem;
     color: white;
+    white-space: nowrap;
 
     display: flex;
     align-items: center;
@@ -51,6 +52,9 @@ const PanelHeader = styled.div`
   small {
     margin-left: 20px;
     opacity: 0.4;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   .panel-toggler {

--- a/src/containers/SettingsEditor/fields.jsx
+++ b/src/containers/SettingsEditor/fields.jsx
@@ -174,9 +174,6 @@ function ObjectFieldTemplate(props) {
 
   if (['compact', 'root', 'expanded'].includes(props.schema.layout)) return fields
 
-  // In case of "pseudo-dicts" (array of objects with a "name" attribute)
-  // use the "name" attributeas the title
-
   const contextMenuItems = [
     {
       label: 'Copy',
@@ -197,6 +194,8 @@ function ObjectFieldTemplate(props) {
   // Title + handle root object
 
   let title = props.title
+  // In case of "pseudo-dicts" (array of objects with a "name" attribute)
+  // use the "name" attributeas the title
   if ('name' in props.schema.properties) {
     let label = null
     if ('label' in props.schema.properties) label = props.formData.label
@@ -447,11 +446,7 @@ const ArrayItemTemplate = (props) => {
     const parentId = props.children.props.idSchema.$id.split('_').slice(0, -1).join('_')
     const formContext = props.children._owner.memoizedProps.formContext
     const path = formContext.overrides[parentId].path
-    // const newChangedKeys = formContext.changedKeys
-    //   .filter((key) => !arrayEquals(key, path))
-    //   .concat([path])
     formContext.onSetChangedKeys([{ path, isChanged: true }])
-    //console.log('Array changed, new changed keys: ', newChangedKeys)
   }
 
   const onRemoveItem = () => {
@@ -495,13 +490,27 @@ const ArrayFieldTemplate = (props) => {
     const id = props.idSchema.$id
     const formContext = props.formContext
     const path = formContext.overrides[id].path
-    // const newChangedKeys = formContext.changedKeys
-    //   .filter((key) => !arrayEquals(key, path))
-    //   .concat([path])
+
     formContext.onSetChangedKeys([{ path, isChanged: true }])
     props.onAddClick()
   }
+  return (
+    <FormArrayField>
+      {props.items.map((element) => (
+        <ArrayItemTemplate key={element.name} {...element} />
+      ))}
 
+      {props.canAdd && (
+        <ArrayItemControls>
+          <Button onClick={onAddItem} icon="add" />
+        </ArrayItemControls>
+      )}
+    </FormArrayField>
+  )
+
+  /*
+   * THIS IS THE ORIGINAL CODE,
+   * apparently we cannot memoize this
   const res = useMemo(
     () => (
       <FormArrayField>
@@ -520,6 +529,7 @@ const ArrayFieldTemplate = (props) => {
   )
 
   return res
+  */
 }
 
 export { ObjectFieldTemplate, FieldTemplate, ArrayFieldTemplate }

--- a/src/containers/SettingsEditor/fields.jsx
+++ b/src/containers/SettingsEditor/fields.jsx
@@ -489,7 +489,7 @@ const ArrayFieldTemplate = (props) => {
   const onAddItem = () => {
     const id = props.idSchema.$id
     const formContext = props.formContext
-    const path = formContext.overrides[id].path
+    const path = formContext.overrides[id]?.path
 
     formContext.onSetChangedKeys([{ path, isChanged: true }])
     props.onAddClick()

--- a/src/containers/SettingsEditor/widgets.jsx
+++ b/src/containers/SettingsEditor/widgets.jsx
@@ -10,6 +10,8 @@ import {
   IconSelect,
 } from '@ynput/ayon-react-components'
 
+import { isEqual } from 'lodash'
+
 const addDecimalPoint = (value) => {
   const valueString = value.toString(10)
   if (!valueString.match(/\./)) return valueString.concat('.0')
@@ -20,6 +22,22 @@ const updateChangedKeys = (props, changed, path) => {
   if (!props.formContext) return // WARN! (but shouldn't happen)
   if (!path?.length) return // WARN!
   props.formContext.onSetChangedKeys([{ path, isChanged: changed }])
+}
+
+const equiv = (a, b) => {
+  if (typeof a !== typeof b) return false
+
+  if (typeof a === 'object' && a.length) {
+    // compare two arrays. return true if they contain the same elements
+    // order doesn't matter
+    if (a.length !== b.length) return false
+    for (const i of a) {
+      if (!b.includes(i)) return false
+    }
+    return true
+  }
+
+  return isEqual(a, b)
 }
 
 const parseContext = (props) => {
@@ -155,6 +173,14 @@ const SelectWidget = (props) => {
     props.onFocus(e)
   }
 
+  const hlstyle = {}
+  console.log(props.id, props.value, originalValue)
+  if (!equiv(value, props.value)) {
+    hlstyle.outline = '1px solid yellow'
+  } else if (originalValue !== undefined && !equiv(props.value, originalValue)) {
+    hlstyle.outline = '1px solid var(--color-changed)'
+  }
+
   return (
     <Dropdown
       widthExpand
@@ -165,13 +191,13 @@ const SelectWidget = (props) => {
       onFocus={onFocus}
       optionLabel="label"
       optionValue="value"
-      tooltip={tooltip.join('\n')}
+      toolTip={'baaaa'}
       tooltipOptions={{ position: 'bottom' }}
       placeholder={props.schema?.placeholder}
       disabled={props.schema?.disabled}
       className={`form-field`}
       multiSelect={props.multiple}
-      style={value !== props.value ? { outline: '1px solid yellow' } : {}}
+      style={hlstyle}
     />
   )
 }
@@ -326,6 +352,11 @@ const TextWidget = (props) => {
     props.onFocus(e)
   }
 
+  const hlstyle = {}
+  if (value !== props.value) hlstyle.outline = '1px solid yellow'
+  else if (originalValue !== undefined && props.value !== originalValue)
+    hlstyle.outline = '1px solid var(--color-changed)'
+
   return (
     <Input
       className={`form-field ${props.rawErrors?.length ? 'p-invalid error' : ''}`}
@@ -333,7 +364,7 @@ const TextWidget = (props) => {
       tooltip={tooltip.join('\n')}
       tooltipOptions={{ position: 'bottom' }}
       {...opts}
-      style={value !== props.value ? { outline: '1px solid yellow' } : {}}
+      style={hlstyle}
     />
   )
 }

--- a/src/containers/SettingsEditor/widgets.jsx
+++ b/src/containers/SettingsEditor/widgets.jsx
@@ -65,7 +65,6 @@ const CheckboxWidget = function (props) {
 
     setInitialized(true)
     setTimeout(() => {
-      console.log('GenPush')
       props.onChange(value)
     }, 200)
   }, [props.onChange, value])
@@ -74,7 +73,6 @@ const CheckboxWidget = function (props) {
     // Sync the local state with the formData
     if (props.value === undefined) return
     if (value === props.value) return
-    console.log('syncing', props.value, 'to', value)
     setValue(props.value || false)
   }, [props.value])
 
@@ -215,6 +213,7 @@ const SelectWidget = (props) => {
 }
 
 const getDefaultValue = (props) => {
+  //console.log("Creating default value for", props.id)
   if (props.value !== undefined) return props.value
   if (props.schema.widget === 'color') {
     if (props.schema.colorFormat === 'hex') return props.schema.colorAlpha ? '#00000000' : '#000000'
@@ -238,19 +237,19 @@ const TextWidget = (props) => {
     if (value === props.value) return
     if (initialized) return
 
+    //console.log("Initial push for", props.id, "with value", value)
     setInitialized(true)
-    props.onChange(value)
+    setTimeout(() => {
+      props.onChange(value)
+    }, 200)
   }
-
-  useEffect(() => {
-    doInitialPush()
-  }, [props.onChange, value])
 
   useEffect(() => {
     // Sync the local state with the formData
     if (props.value === undefined) return
     if (equiv(value, props.value)) return
-    setValue(props.value || getDefaultValue(props))
+    //console.log("Syncing local state for", props.id, JSON.stringify(props.value))
+    setValue(props.value)
   }, [props.value])
 
   const onChangeCommit = () => {

--- a/src/containers/SettingsEditor/widgets.jsx
+++ b/src/containers/SettingsEditor/widgets.jsx
@@ -35,19 +35,35 @@ const CheckboxWidget = function (props) {
   const [value, setValue] = useState(null)
 
   useEffect(() => {
-    setValue(props.value || false)
+    if (!props.onChange) return
+    if (value === props.value) return
+
+    setTimeout(() => {
+      console.log('Setting value', props.id, value)
+      props.onChange(value)
+    }, 200)
+  }, [props.onChange, value])
+
+  useEffect(() => {
+    if (value === null && props.value !== undefined) {
+      setValue(props.value || false)
+    }
   }, [props.value])
 
   useEffect(() => {
+    if (!props.onChange) return
     if (value === null) return
     if (value !== props.value) {
-      props.onChange(value)
       // this timeout must be here. idk why. if not,
       // the value will be set to the original value or smth
       setTimeout(() => {
+        props.onChange(value)
         const isChanged = value !== originalValue
         updateChangedKeys(props, isChanged, path)
+        //  setTimeout(() => {
+        //    props.onChange(value)
         props.formContext?.onSetBreadcrumbs(path)
+        // }, 100)
       }, 100)
     }
   }, [value])
@@ -62,7 +78,13 @@ const CheckboxWidget = function (props) {
   // right after the component is mounted), but during the
   // same render, we need the value here...
 
-  return <InputSwitch checked={value || false} onChange={onChange} />
+  return (
+    <>
+      <InputSwitch checked={value || false} onChange={onChange} />
+      {JSON.stringify(value)}
+      {JSON.stringify(props.value) || 'und'}
+    </>
+  )
 }
 
 const SelectWidget = (props) => {
@@ -91,14 +113,15 @@ const SelectWidget = (props) => {
   }
 
   useEffect(() => {
-    // Handle new array items
-    if (props.formContext?.overrides && props.formContext.overrides[props.id] === undefined) {
-      props.onChange(value)
-      setTimeout(() => {
-        updateChangedKeys(props, true, path)
-      }, 100)
-    }
-  }, [originalValue, value])
+    if (!props.onChange) return
+    let newValue
+    if (props.multiple) newValue = props.value || []
+    else newValue = props.value || ''
+
+    setTimeout(() => {
+      props.onChange(newValue)
+    }, 100)
+  }, [props.onChange])
 
   const onChange = (value) => {
     props.onChange(value)
@@ -150,20 +173,30 @@ const TextWidget = (props) => {
 
   useEffect(() => {
     // Handle new array items
+    if (!props.onChange) return
     if (props.value === undefined) {
-      props.onChange(value)
+      let newValue
+      if (props.schema.type === 'string' && props.schema.widget !== 'color') newValue = ''
+      else if (props.schema.type === 'integer') newValue = 0
+      else newValue = null
+
       setTimeout(() => {
-        updateChangedKeys(props, true, path)
-      }, 100)
+        props.onChange(newValue)
+        //setTimeout(() => {
+        if (originalValue !== undefined) updateChangedKeys(props, true, path)
+        //}, 100)
+      }, 200)
     }
-  }, [originalValue, value])
+  }, [props.onChange])
 
   const onChangeCommit = () => {
     if (value === props.value) return
     const isChanged = value !== originalValue
     props.onChange(value)
-    props.formContext?.onSetBreadcrumbs(path)
-    updateChangedKeys(props, isChanged, path)
+    //props.formContext?.onSetBreadcrumbs(path)
+    setTimeout(() => {
+      updateChangedKeys(props, isChanged, path)
+    }, 100)
   }
 
   const tooltip = []

--- a/src/services/addonSettings.js
+++ b/src/services/addonSettings.js
@@ -116,7 +116,8 @@ const addonSettings = ayonApi.injectEndpoints({
         },
       ],
       transformResponse: (response) => response,
-      transformErrorResponse: (error) => error.data.detail || `Error ${error.status}`,
+      transformErrorResponse: (error) =>
+        error.data.detail ? error : { detail: `Error ${error.status}` },
     }), // setAddonSettings
 
     deleteAddonSettings: build.mutation({

--- a/src/services/addonSettings.js
+++ b/src/services/addonSettings.js
@@ -117,7 +117,7 @@ const addonSettings = ayonApi.injectEndpoints({
       ],
       transformResponse: (response) => response,
       transformErrorResponse: (error) =>
-        error.data.detail ? error : { detail: `Error ${error.status}` },
+        error.data.detail ? error.data : { detail: `Error ${error.status}` },
     }), // setAddonSettings
 
     deleteAddonSettings: build.mutation({


### PR DESCRIPTION
At the moment we are not able to save settings in case those are list with deep nested attributes. 

Here is the example of what will saving result into:


![Image](https://user-images.githubusercontent.com/40640033/266291141-629f2e92-4dad-4784-b741-64e969e6309b.png)


And here is the example of settings where the issue is occuring:



![Image](https://user-images.githubusercontent.com/40640033/266291351-9f70e48c-fb4f-4c4d-a685-32667f82b1c6.png)



closes #185 