### PR TITLE
fix: onBoarding crashes with loginPageBG

### DIFF
--- a/src/pages/OnBoarding/util/OnBoardingStep.styled.js
+++ b/src/pages/OnBoarding/util/OnBoardingStep.styled.js
@@ -9,6 +9,14 @@ export const Logo = styled.img`
   transform: translateX(-50%);
 `
 
+export const BG = styled.img`
+  position: fixed;
+  z-index: -10;
+  object-fit: cover;
+  width: 100vw;
+  height: 100vh;
+`
+
 export const StepPanel = styled(Panel)`
   display: flex;
   flex-direction: row;

--- a/src/pages/OnBoarding/util/StepWrapper.jsx
+++ b/src/pages/OnBoarding/util/StepWrapper.jsx
@@ -51,8 +51,8 @@ const StepWrapper = ({ children }) => {
         setIsConnecting,
         isConnecting,
       })
-    }
-  })
+    } else return null
+  }).filter((child) => child !== null)
 
   const showLoading = isLoadingConnect || isConnecting
 


### PR DESCRIPTION
- fix an issue where Styled.BG wasn't exported and would cause onboarding to crash if a background was present.