### PR TITLE
Fix: confirmation for delete buttons

### DIFF
--- a/src/components/ApiKeyManager.jsx
+++ b/src/components/ApiKeyManager.jsx
@@ -6,7 +6,7 @@ import { Panel, LockedInput, Icon } from '@ynput/ayon-react-components'
 import { useUpdateUserAPIKeyMutation } from '../services/user/updateUser'
 import { toast } from 'react-toastify'
 import styled from 'styled-components'
-import { confirmDialog } from 'primereact/confirmdialog'
+import confirmDelete from '../helpers/confirmDelete'
 
 const PanelStyled = styled(Panel)`
   flex-direction: row;
@@ -62,28 +62,16 @@ const ApiKeyManager = ({ preview, name }) => {
     // check if target is an input and do nothing
     if (e.target.tagName === 'INPUT') return
 
-    confirmDialog({
-      message: `Delete key: ${preview || newKey.preview}?`,
-      header: 'Delete service key',
-      icon: 'pi pi-exclamation-triangle',
+    confirmDelete({
+      label: 'Service Key',
       accept: async () => {
-        // try catch to update api key using unwrap and toast results
-        try {
-          await updateApi({
-            name,
-            apiKey: null,
-          }).unwrap()
+        await updateApi({
+          name,
+          apiKey: null,
+        }).unwrap()
 
-          setNewKey(null)
-
-          toast.success('API Key Deleted')
-        } catch (error) {
-          console.log(error)
-          //   toast error
-          toast.error('Error deleting API Key')
-        }
+        setNewKey(null)
       },
-      reject: () => {},
     })
   }
 

--- a/src/containers/TeamList.jsx
+++ b/src/containers/TeamList.jsx
@@ -99,6 +99,7 @@ const TeamList = ({
         label: `Delete Team${selection.length > 1 ? 's' : ''}`,
         icon: 'delete',
         command: onDelete,
+        danger: true,
       },
     ],
     [teams, selection],

--- a/src/containers/projectList.jsx
+++ b/src/containers/projectList.jsx
@@ -228,6 +228,7 @@ const ProjectList = ({
         label: 'Delete Project',
         icon: 'delete',
         command: onDeleteProject,
+        danger: true,
       },
     ]
 

--- a/src/context/shortcutsContext.jsx
+++ b/src/context/shortcutsContext.jsx
@@ -33,7 +33,7 @@ function ShortcutsProvider(props) {
       // studio settings
       { key: 's+s', action: () => navigate('/settings/studio') },
       // dashboard
-      { key: 'd+d', action: () => navigate('/manageProjects/projectSettings') },
+      { key: 'd+d', action: () => navigate('/manageProjects/dashboard') },
       // user settings
       { key: 'f+f', action: () => navigate('/settings/users') },
     ],

--- a/src/helpers/confirmDelete.js
+++ b/src/helpers/confirmDelete.js
@@ -1,0 +1,33 @@
+import { confirmDialog } from 'primereact/confirmdialog'
+import { toast } from 'react-toastify'
+
+const confirmDelete = ({
+  label = '',
+  message = 'Are you sure? This cannot be undone',
+  accept = async () => {},
+  showToasts = true,
+  ...props
+}) =>
+  confirmDialog({
+    header: props.header || `Delete ${label}`,
+    message,
+    accept: async () => {
+      // try catch to update api key using unwrap and toast results
+      try {
+        await accept()
+
+        showToasts && toast.success(label + ' deleted')
+      } catch (error) {
+        console.error(error)
+        //   toast error
+        showToasts && toast.error('Error deleting ' + label)
+      }
+    },
+    reject: () => {},
+    acceptLabel: 'Delete',
+    rejectLabel: 'Cancel',
+    acceptClassName: 'button-danger',
+    ...props,
+  })
+
+export default confirmDelete

--- a/src/pages/ProjectManagerPage/ProjectManagerPage.jsx
+++ b/src/pages/ProjectManagerPage/ProjectManagerPage.jsx
@@ -3,9 +3,6 @@ import { useParams, useSearchParams } from 'react-router-dom'
 import { useSelector, useDispatch } from 'react-redux'
 import { StringParam, useQueryParam, withDefault } from 'use-query-params'
 
-import { confirmDialog } from 'primereact/confirmdialog'
-import { toast } from 'react-toastify'
-
 import AddonSettings from '/src/containers/AddonSettings'
 
 import ProjectAnatomy from './ProjectAnatomy'
@@ -19,6 +16,7 @@ import TeamsPage from '../TeamsPage'
 import ProjectManagerPageContainer from './ProjectManagerPageContainer'
 import ProjectManagerPageLayout from './ProjectManagerPageLayout'
 import AppNavLinks from '/src/containers/header/AppNavLinks'
+import confirmDelete from '/src/helpers/confirmDelete'
 
 const ProjectSettings = ({ projectList, projectManager, projectName }) => {
   return (
@@ -67,26 +65,12 @@ const ProjectManagerPage = () => {
 
   const [deleteProject] = useDeleteProjectMutation()
 
-  const deletePreset = () => {
-    confirmDialog({
-      header: 'Delete Project',
-      message: `Are you sure you want to delete the project: ${selectedProject}?`,
-      icon: 'pi pi-exclamation-triangle',
-      acceptLabel: 'Delete',
-      accept: () => {
-        deleteProject({ projectName: selectedProject })
-          .unwrap()
-          .then(() => {
-            toast.info(`Project ${selectedProject} deleted`)
-            setSelectedProject(null)
-          })
-          .catch((err) => {
-            toast.error(err.message)
-          })
-      },
-      rejectLabel: 'Cancel',
-      reject: () => {
-        // do nothing
+  const handleDeleteProject = () => {
+    confirmDelete({
+      label: `Project: ${selectedProject}`,
+      accept: async () => {
+        await deleteProject({ projectName: selectedProject }).unwrap()
+        setSelectedProject(null)
       },
     })
   }
@@ -149,7 +133,7 @@ const ProjectManagerPage = () => {
         onNoProject={(s) => setSelectedProject(s)}
         isUser={isUser}
         onNewProject={() => setShowNewProject(true)}
-        onDeleteProject={deletePreset}
+        onDeleteProject={handleDeleteProject}
       >
         {module === 'dashboard' && <ProjectDashboard />}
         {module === 'anatomy' && <ProjectAnatomy />}

--- a/src/pages/ServicesPage/NewServiceDialog.jsx
+++ b/src/pages/ServicesPage/NewServiceDialog.jsx
@@ -95,8 +95,12 @@ const NewServiceDialog = ({ onHide, onSpawn }) => {
   return (
     <Dialog visible={true} header="New service" onHide={onHide} footer={footer}>
       <FormLayout>
-        <FormRow label="Service name">
-          <InputText value={serviceName} onChange={(e) => setServiceName(e.target.value)} />
+        <FormRow label="Host">
+          <Dropdown
+            options={hostOptions}
+            value={selectedHost}
+            onChange={(e) => setSelectedHost(e.value)}
+          />
         </FormRow>
 
         <FormRow label="Addon name">
@@ -119,16 +123,15 @@ const NewServiceDialog = ({ onHide, onSpawn }) => {
           <Dropdown
             options={serviceOptions}
             value={selectedService}
-            onChange={(e) => setSelectedService(e.value)}
+            onChange={(e) => {
+              setSelectedService(e.value)
+              setServiceName(e.value)
+            }}
           />
         </FormRow>
 
-        <FormRow label="Host">
-          <Dropdown
-            options={hostOptions}
-            value={selectedHost}
-            onChange={(e) => setSelectedHost(e.value)}
-          />
+        <FormRow label="Service name">
+          <InputText value={serviceName} onChange={(e) => setServiceName(e.target.value)} />
         </FormRow>
       </FormLayout>
     </Dialog>

--- a/src/pages/ServicesPage/ServicesPage.jsx
+++ b/src/pages/ServicesPage/ServicesPage.jsx
@@ -7,6 +7,7 @@ import { TimestampField } from '/src/containers/fieldFormat'
 import { TablePanel, Button, Spacer, Section, Toolbar } from '@ynput/ayon-react-components'
 import NewServiceDialog from './NewServiceDialog'
 import useCreateContext from '/src/hooks/useCreateContext'
+import confirmDelete from '/src/helpers/confirmDelete'
 
 const formatStatus = (rowData) => {
   if (!rowData.shouldRun) return rowData.isRunning ? 'STOPPING' : 'DISABLED'
@@ -25,13 +26,23 @@ const ServicesPage = () => {
   }
 
   const deleteSelected = () => {
-    for (const serviceName of selectedServices) {
-      axios
-        .delete(`/api/services/${serviceName}`)
-        .then(() => toast.success(`${serviceName} deleted`))
-        .catch(() => toast.error(`Unable to delete ${serviceName}`))
-        .finally(() => loadServices())
-    }
+    confirmDelete({
+      label: 'Services',
+      accept: async () => {
+        for (const serviceName of selectedServices) {
+          try {
+            await axios.delete(`/api/services/${serviceName}`)
+
+            toast.success(`${serviceName} deleted`)
+          } catch (error) {
+            toast.error(`Unable to delete ${serviceName}`)
+          }
+        }
+
+        loadServices()
+      },
+      showToasts: false,
+    })
   }
 
   const enableSelected = () => {
@@ -69,20 +80,23 @@ const ServicesPage = () => {
   const ctxMenuItems = useMemo(() => {
     return [
       {
-        label: 'Delete selected',
-        disabled: !selectedServices?.length,
-        command: deleteSelected,
-        danger: true,
-      },
-      {
         label: 'Enable selected',
         disabled: !selectedServices?.length,
         command: enableSelected,
+        icon: 'check',
       },
       {
         label: 'Disable selected',
         disabled: !selectedServices?.length,
         command: disableSelected,
+        icon: 'cancel',
+      },
+      {
+        label: 'Delete selected',
+        disabled: !selectedServices?.length,
+        command: deleteSelected,
+        danger: true,
+        icon: 'delete',
       },
     ]
   }, [selectedServices])

--- a/src/pages/SettingsPage/AccessGroups/AccessGroupDetail.jsx
+++ b/src/pages/SettingsPage/AccessGroups/AccessGroupDetail.jsx
@@ -18,6 +18,7 @@ import {
   useDeleteAccessGroupMutation,
   useUpdateAccessGroupMutation,
 } from '/src/services/accessGroups/updateAccessGroups'
+import confirmDelete from '/src/helpers/confirmDelete'
 
 const AccessGroupDetail = ({ projectName, accessGroup }) => {
   const [newData, setNewData] = useState(null)
@@ -58,15 +59,11 @@ const AccessGroupDetail = ({ projectName, accessGroup }) => {
     }
   }
 
-  const onDelete = async () => {
-    try {
-      await deleteAccessGroup({ name: accessGroupName, projectName }).unwrap()
-      toast.success('Access group deleted')
-    } catch (err) {
-      console.error(err)
-      toast.error('Unable to delete access group')
-    }
-  }
+  const onDelete = async () =>
+    confirmDelete({
+      label: 'Access group',
+      accept: async () => await deleteAccessGroup({ name: accessGroupName, projectName }).unwrap(),
+    })
 
   const editor = useMemo(() => {
     if (!(schema && originalData)) return <></>

--- a/src/pages/SettingsPage/AnatomyPresets/AnatomyPresets.jsx
+++ b/src/pages/SettingsPage/AnatomyPresets/AnatomyPresets.jsx
@@ -1,7 +1,6 @@
 import { useEffect, useState, useMemo } from 'react'
 
 import { Dialog } from 'primereact/dialog'
-import { confirmDialog } from 'primereact/confirmdialog'
 import { InputText } from 'primereact/inputtext'
 
 import { toast } from 'react-toastify'
@@ -28,6 +27,7 @@ import {
   useUpdatePrimaryPresetMutation,
 } from '/src/services/anatomy/updateAnatomy'
 import { isEqual } from 'lodash'
+import confirmDelete from '/src/helpers/confirmDelete'
 
 const AnatomyPresets = () => {
   const [originalData, setOriginalData] = useState(null)
@@ -94,27 +94,13 @@ const AnatomyPresets = () => {
   // DELETE PRESET
   const handleDeletePreset = (name, isPrimary) => {
     console.log('handleDeletePreset')
-    confirmDialog({
-      header: 'Delete Preset',
-      message: `Are you sure you want to delete the preset ${name}?`,
-      icon: 'pi pi-exclamation-triangle',
-      acceptLabel: 'Delete',
-      accept: () => {
-        deletePreset({ name })
-          .unwrap()
-          .then(() => {
-            if (isPrimary) {
-              setSelectedPreset('_')
-            }
-            toast.info(`Preset ${name} deleted`)
-          })
-          .catch((err) => {
-            toast.error(err.message)
-          })
-      },
-      rejectLabel: 'Cancel',
-      reject: () => {
-        // do nothing
+    confirmDelete({
+      label: `Preset: ${name}`,
+      accept: async () => {
+        await deletePreset({ name }).unwrap()
+        if (isPrimary) {
+          setSelectedPreset('_')
+        }
       },
     })
   }

--- a/src/pages/SettingsPage/AnatomyPresets/PresetList.jsx
+++ b/src/pages/SettingsPage/AnatomyPresets/PresetList.jsx
@@ -32,6 +32,7 @@ const PresetList = ({
           icon: 'delete',
           disabled: isDefault,
           command: () => onDelete(data.name, primarySelected),
+          danger: true,
         },
       ]
 

--- a/src/pages/SettingsPage/Attributes.jsx
+++ b/src/pages/SettingsPage/Attributes.jsx
@@ -128,6 +128,7 @@ const Attributes = () => {
       label: 'Delete',
       icon: 'delete',
       command: () => onDelete(),
+      danger: true,
     },
   ])
 

--- a/src/pages/SettingsPage/Bundles/Bundles.jsx
+++ b/src/pages/SettingsPage/Bundles/Bundles.jsx
@@ -24,6 +24,7 @@ import { useDispatch } from 'react-redux'
 import useServerRestart from '/src/hooks/useServerRestart'
 import useLocalStorage from '/src/hooks/useLocalStorage'
 import { useLocation } from 'react-router'
+import confirmDelete from '/src/helpers/confirmDelete'
 
 const Bundles = () => {
   const location = useLocation()
@@ -234,12 +235,16 @@ const Bundles = () => {
     }
   }
 
-  const handleDeleteBundle = async () => {
-    setSelectedBundles([])
-    for (const name of selectedBundles) {
-      deleteBundle({ name })
-    }
-  }
+  const handleDeleteBundle = async () =>
+    confirmDelete({
+      label: `${selectedBundles.length} bundles`,
+      accept: async () => {
+        setSelectedBundles([])
+        for (const name of selectedBundles) {
+          await deleteBundle({ name }).unwrap()
+        }
+      },
+    })
 
   const { confirmRestart } = useServerRestart()
 

--- a/src/pages/SettingsPage/Secrets.jsx
+++ b/src/pages/SettingsPage/Secrets.jsx
@@ -7,6 +7,7 @@ import {
 import styled from 'styled-components'
 import { InputText, Button, ScrollPanel, Section, SaveButton } from '@ynput/ayon-react-components'
 import { toast } from 'react-toastify'
+import confirmDelete from '/src/helpers/confirmDelete'
 
 const SecretList = styled.div`
   display: flex;
@@ -64,8 +65,11 @@ const SecretItem = ({ name: initialName, value: initialValue, stored }) => {
     }
   }
 
-  const handleDelete = () => {
-    deleteSecret({ name })
+  const handleDelete = async () => {
+    confirmDelete({
+      label: 'Secret',
+      accept: async () => await deleteSecret({ name }).unwrap(),
+    })
   }
 
   return (

--- a/src/pages/SettingsPage/UsersSettings/UserAttribForm.jsx
+++ b/src/pages/SettingsPage/UsersSettings/UserAttribForm.jsx
@@ -39,7 +39,7 @@ const UserAttribForm = ({
   )
 
   const buildForms = (attribs) =>
-    attribs.map(({ name, data }) => (
+    attribs.map(({ name, data, input }) => (
       <FormRow label={data.title} key={name}>
         {name.includes('password') && setPassword ? (
           <InputPassword
@@ -77,6 +77,7 @@ const UserAttribForm = ({
               })
             }}
             autoComplete="cc-csc"
+            {...input}
           />
         )}
       </FormRow>

--- a/src/pages/SettingsPage/UsersSettings/UserList.jsx
+++ b/src/pages/SettingsPage/UsersSettings/UserList.jsx
@@ -58,6 +58,7 @@ const UserList = ({
         disabled: !selection.length || isSelfSelected,
         command: () => onDelete(),
         icon: 'delete',
+        danger: true,
       },
     ],
     [selection, isSelfSelected, setShowRenameUser, setShowSetPassword, onDelete],

--- a/src/pages/SettingsPage/UsersSettings/UsersSettings.jsx
+++ b/src/pages/SettingsPage/UsersSettings/UsersSettings.jsx
@@ -1,6 +1,5 @@
 import { useState, useMemo, useRef } from 'react'
 import { toast } from 'react-toastify'
-import { confirmDialog } from 'primereact/confirmdialog'
 import { Button, Section, Toolbar, InputText, Spacer } from '@ynput/ayon-react-components'
 // Comps
 import SetPasswordDialog from './SetPasswordDialog'
@@ -20,6 +19,7 @@ import UsersOverview from './UsersOverview'
 import { useEffect } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import NewUser from './newUser'
+import confirmDelete from '/src/helpers/confirmDelete'
 
 // TODO: Remove classname assignments and do in styled components
 const formatAccessGroups = (rowData, selectedProjects) => {
@@ -105,10 +105,9 @@ const UsersSettings = () => {
   }, [userList, selectedProjects])
 
   const onDelete = async () => {
-    confirmDialog({
-      message: `Are you sure you want to delete ${selectedUsers.length} user(s)?`,
-      header: 'Delete users',
-      icon: 'pi pi-exclamation-triangle',
+    confirmDelete({
+      label: `${selectedUsers.length} Users`,
+      showToasts: false,
       accept: async () => {
         toastId.current = toast.info('Deleting users...')
         let i = 0
@@ -127,7 +126,6 @@ const UsersSettings = () => {
         }
         toast.update(toastId.current, { render: `Deleted ${i} user(s)`, type: toast.TYPE.SUCCESS })
       },
-      reject: () => {},
     })
   }
 

--- a/src/pages/SettingsPage/UsersSettings/newUser.jsx
+++ b/src/pages/SettingsPage/UsersSettings/newUser.jsx
@@ -148,7 +148,11 @@ const NewUser = ({ onHide, open, onSuccess }) => {
             formData={formData}
             setFormData={setFormData}
             attributes={[
-              { name: 'Username', data: { title: 'Username' } },
+              {
+                name: 'Username',
+                data: { title: 'Username' },
+                input: { placeholder: 'No spaces allowed' },
+              },
               { name: 'password', data: { title: 'Password' } },
               { name: 'passwordConfirm', data: { title: 'Password Confirm' } },
               ...attributes,

--- a/src/pages/TeamsPage/TeamsPage.jsx
+++ b/src/pages/TeamsPage/TeamsPage.jsx
@@ -18,11 +18,11 @@ import TeamDetails from './TeamDetails'
 import { useDeleteTeamMutation, useUpdateTeamsMutation } from '/src/services/team/updateTeams'
 import { toast } from 'react-toastify'
 import CreateNewTeam from './CreateNewTeam'
-import { confirmDialog } from 'primereact/confirmdialog'
 import styled from 'styled-components'
 import useSearchFilter from '/src/hooks/useSearchFilter'
 import { useSearchParams } from 'react-router-dom'
 import { Dialog } from 'primereact/dialog'
+import confirmDelete from '/src/helpers/confirmDelete'
 
 const SectionStyled = styled(Section)`
   align-items: start;
@@ -362,14 +362,10 @@ const TeamsPage = ({ projectName, projectList, isUser }) => {
   const toastId = useRef(null)
   // DELETE TEAM
   const onDelete = async () => {
-    confirmDialog({
-      message: `Are you sure you want to delete ${selectedTeams.length} team(s)?`,
-      header: 'Delete Teams',
-      icon: 'pi pi-exclamation-triangle',
-      accept: async () => {
-        handleDeleteTeams(selectedTeams)
-      },
-      reject: () => {},
+    confirmDelete({
+      label: `${selectedTeams.length} team(s)`,
+      accept: async () => await handleDeleteTeams(selectedTeams),
+      showToasts: false,
     })
   }
 

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -627,6 +627,13 @@ a {
         span {
           color: var(--md-sys-color-on-error-container);
         }
+
+        &:hover {
+          background-color: var(--md-sys-color-error-container-hover);
+        }
+        &:active {
+          background-color: var(--md-sys-color-error-container-active);
+        }
       }
 
       &.save {
@@ -667,4 +674,47 @@ a {
 // project side bar menu
 .p-sidebar-left {
   align-items: flex-start;
+}
+
+// confirm dialog buttons
+.p-dialog.p-confirm-dialog {
+  .p-dialog-footer {
+    gap: 8px;
+    display: flex;
+    width: 100%;
+    justify-content: flex-end;
+  }
+
+  .p-button {
+    border: none;
+    margin-right: 0;
+    &:focus {
+      outline: none;
+    }
+
+    background-color: var(--md-sys-color-surface-container-highest);
+
+    &:hover {
+      background-color: var(--md-sys-color-surface-container-highest-hover);
+    }
+    &:active {
+      background-color: var(--md-sys-color-surface-container-highest-active);
+    }
+
+    // for reject button
+    &.p-confirm-dialog-reject {
+      background-color: unset;
+    }
+
+    // for delete buttons
+    &.button-danger {
+      background-color: var(--md-sys-color-error-container);
+
+      color: var(--md-sys-color-on-error-container);
+
+      &:hover {
+        background-color: var(--md-sys-color-error-container-hover);
+      }
+    }
+  }
 }


### PR DESCRIPTION
- Anytime something is about to be deleted on the db, using confirmation popup.
- `confirmDelete` helper function that wraps `confirmDialog` with some defaults.
- Make sure all context menu delete items have `danger: true` prop for red bg.

Note: the hover effect on the delete button will be broken until a-r-c `0.4.8` is installed.