### PR TITLE
OP-6657 show warning when name is wrong in create project dialog

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@reduxjs/toolkit": "^1.8.2",
     "@rjsf/core": "^4.2.0",
     "@rtk-query/graphql-request-base-query": "^2.2.0",
-    "@ynput/ayon-react-components": "^0.4.10",
+    "@ynput/ayon-react-components": "0.4.10",
     "axios": "^0.27.2",
     "chart.js": "^4.2.0",
     "date-fns": "^2.29.3",

--- a/src/containers/SettingsEditor/fields.jsx
+++ b/src/containers/SettingsEditor/fields.jsx
@@ -411,10 +411,6 @@ function FieldTemplate(props) {
               onClick={() => {
                 if (props.formContext.onSetBreadcrumbs) {
                   if (override?.path) props.formContext.onSetBreadcrumbs(override.path)
-                  else {
-                    toast.error("Unable to find field path. This shoudn't happen")
-                    console.log(props.formContext)
-                  }
                 }
               }}
               style={labelStyle}

--- a/src/pages/ProjectManagerPage/NewProjectDialog/NewProject.jsx
+++ b/src/pages/ProjectManagerPage/NewProjectDialog/NewProject.jsx
@@ -143,15 +143,6 @@ const NewProjectDialog = ({ onHide }) => {
     </Toolbar>
   )
 
-  const projectNameStyle = {
-    flexGrow: 1,
-  }
-  const projectCodeStyle = codeValidationError ? { outline: '1px solid var(--color-hl-error)' } : {}
-
-  if (nameValidationError) {
-    projectNameStyle.outline = '1px solid var(--color-hl-error)'
-  }
-
   return (
     <Dialog
       header="Create a new project"
@@ -175,10 +166,11 @@ const NewProjectDialog = ({ onHide }) => {
         <Toolbar>
           <InputText
             placeholder="Project Name"
-            style={projectNameStyle}
+            style={{ flexGrow: 1 }}
             value={name}
             onChange={handleNameChange}
             title={nameValidationError}
+            className={nameValidationError ? 'error' : ''}
             autoFocus
           />
           <InputText
@@ -186,7 +178,7 @@ const NewProjectDialog = ({ onHide }) => {
             value={code}
             onChange={handleCodeChange}
             title={codeValidationError}
-            style={projectCodeStyle}
+            className={codeValidationError ? 'error' : ''}
           />
           <AnatomyPresetDropdown
             selectedPreset={selectedPreset}

--- a/src/pages/ProjectManagerPage/NewProjectDialog/NewProject.jsx
+++ b/src/pages/ProjectManagerPage/NewProjectDialog/NewProject.jsx
@@ -11,6 +11,11 @@ import {
 } from '../../../services/anatomy/getAnatomy'
 import { useCreateProjectMutation } from '/src/services/project/updateProject'
 
+// allow only alphanumeric and underscorer,
+// while underscore cannot be the first or last character
+const PROJECT_NAME_REGEX = /^[a-zA-Z0-9][a-zA-Z0-9_]*[a-zA-Z0-9]$/
+const PROJECT_CODE_REGEX = /^[a-zA-Z0-9][a-zA-Z0-9_]*[a-zA-Z0-9]$/
+
 const NewProjectDialog = ({ onHide }) => {
   const [name, setName] = useState('')
   const [code, setCode] = useState('')
@@ -94,6 +99,24 @@ const NewProjectDialog = ({ onHide }) => {
     setCodeSet(true)
   }
 
+  const nameValidationError = useMemo(() => {
+    if (!name) return 'Project name is required'
+    if (name.length < 3) return 'Project name must be at least 3 characters'
+    if (!PROJECT_NAME_REGEX.test(name)) {
+      return 'Project name can only contain alphanumeric characters and underscores'
+    }
+    return null
+  }, [name])
+
+  const codeValidationError = useMemo(() => {
+    if (!code) return 'Project code is required'
+    if (code.length > 10) return 'Project code is too long'
+    if (!PROJECT_CODE_REGEX.test(code)) {
+      return 'Project code can only contain alphanumeric characters and underscores'
+    }
+    return null
+  }, [code])
+
   //
   // Render
   //
@@ -115,9 +138,19 @@ const NewProjectDialog = ({ onHide }) => {
         onClick={handleSubmit}
         active={name && code}
         saving={isLoading}
+        disabled={!!(nameValidationError || codeValidationError)}
       />
     </Toolbar>
   )
+
+  const projectNameStyle = {
+    flexGrow: 1,
+  }
+  const projectCodeStyle = codeValidationError ? { outline: '1px solid var(--color-hl-error)' } : {}
+
+  if (nameValidationError) {
+    projectNameStyle.outline = '1px solid var(--color-hl-error)'
+  }
 
   return (
     <Dialog
@@ -142,12 +175,17 @@ const NewProjectDialog = ({ onHide }) => {
         <Toolbar>
           <InputText
             placeholder="Project Name"
-            style={{ flexGrow: 1 }}
+            style={projectNameStyle}
             value={name}
             onChange={handleNameChange}
             autoFocus
           />
-          <InputText placeholder="Project code" value={code} onChange={handleCodeChange} />
+          <InputText
+            placeholder="Project code"
+            value={code}
+            onChange={handleCodeChange}
+            style={projectCodeStyle}
+          />
           <AnatomyPresetDropdown
             selectedPreset={selectedPreset}
             setSelectedPreset={setSelectedPreset}

--- a/src/pages/ProjectManagerPage/NewProjectDialog/NewProject.jsx
+++ b/src/pages/ProjectManagerPage/NewProjectDialog/NewProject.jsx
@@ -178,12 +178,14 @@ const NewProjectDialog = ({ onHide }) => {
             style={projectNameStyle}
             value={name}
             onChange={handleNameChange}
+            title={nameValidationError}
             autoFocus
           />
           <InputText
             placeholder="Project code"
             value={code}
             onChange={handleCodeChange}
+            title={codeValidationError}
             style={projectCodeStyle}
           />
           <AnatomyPresetDropdown


### PR DESCRIPTION
Project creation dialog: draw a red outline when project name or project code is wrong. Display actual error message as a tooltip.

![image](https://github.com/ynput/ayon-frontend/assets/5007200/267e4eca-7033-46bf-bdb9-341d98a14ee8)

Red outline is var(--color-hl-error) which should be used there, but it is not a very nice color. We should find a better one and include it to ayon-react-components.