### PR TITLE
Editor: Adding Multiple Folders and Tasks

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@reduxjs/toolkit": "^1.8.2",
     "@rjsf/core": "^4.2.0",
     "@rtk-query/graphql-request-base-query": "^2.2.0",
-    "@ynput/ayon-react-components": "^0.4.12",
+    "@ynput/ayon-react-components": "^0.4.13",
     "axios": "^0.27.2",
     "chart.js": "^4.2.0",
     "date-fns": "^2.29.3",

--- a/src/components/FolderSequence/FolderSequence.jsx
+++ b/src/components/FolderSequence/FolderSequence.jsx
@@ -22,6 +22,25 @@ function formatSeq(arr, maxLength, prefix = '') {
   }
 }
 
+function getDefaultIncrements(type) {
+  switch (type) {
+    case 'Shot':
+      return {
+        base: '0010',
+        increment: '0020',
+        length: 10,
+        difference: 10,
+      }
+    default:
+      return {
+        base: '001',
+        increment: '002',
+        length: 10,
+        difference: 1,
+      }
+  }
+}
+
 const FolderSequence = ({
   onChange,
   parentId = null,
@@ -36,10 +55,12 @@ const FolderSequence = ({
   typeSelectRef,
   ...props
 }) => {
+  const { base, increment, length, type, id, entityType, prefix, prefixDepth, parentBases } = props
+
   const folders = useSelector((state) => state.project.folders) || []
   const tasks = useSelector((state) => state.project.tasks) || []
 
-  const { base, increment, length, type, id, entityType, prefix, prefixDepth, parentBases } = props
+  const typeOptions = entityType === 'folder' ? folders : tasks
 
   let initSeq = []
   if (base && increment && length) {
@@ -48,6 +69,7 @@ const FolderSequence = ({
 
   const [sequence, setSequence] = useState(initSeq)
 
+  const baseRef = useRef(null)
   const handleChange = (e) => {
     e?.preventDefault && e?.preventDefault()
 
@@ -60,37 +82,74 @@ const FolderSequence = ({
 
     const newValue = { [fieldId]: value }
 
-    if (entityType === 'task' && fieldId === 'type') {
-      if (type === base || !base) {
-        // update base to match new type
-        newValue.base = value
+    const newState = { ...props, ...newValue }
+
+    // if changing type, look to change base and increment
+    if (fieldId === 'type') {
+      // changing type
+      // update name if newState.name matches any values in typeOptions
+      let matches = false
+      // loop through typeOptions and check if any match, when match is found we can stop looping
+      for (const o in typeOptions) {
+        if (newState.base === '') {
+          matches = true
+          break
+        }
+        const option = typeOptions[o]
+        for (const key in option) {
+          if (newState.base.toLowerCase().includes(option[key].toLowerCase())) {
+            matches = true
+            break
+          }
+        }
       }
+
+      const typeOption = typeOptions[value]
+
+      if (!matches || !typeOption) return
+      // if name is same as type, update name
+      const newName =
+        entityType === 'folder' ? typeOption.shortName || typeOption.name : typeOption.name
+      // add new state to new value
+
+      // get default increments
+      const suffixes = getDefaultIncrements(value)
+
+      newState.base = newName + suffixes.base
+      newState.increment = newName + suffixes.increment
+      newState.length = suffixes.length
     }
 
     if (fieldId === 'base') {
-      let increment = value
+      // get default increments
+      const suffixes = getDefaultIncrements(newState.type)
+      // split value into prefix (letter) and suffix (number)
+      const prefix = value.replace(/[^a-zA-Z]/g, '')
+      const suffix = value.replace(/[^0-9]/g, '')
+      // get interger value of suffix and padding
+      const suffixInt = parseInt(suffix, 10)
+      const suffixPad = suffix.length
 
-      const startNumber = parseInt((value.match(/\d+$/) || [])[0], 10)
-      if (startNumber) {
-        const baseWithoutNumber = value.replace(/\d+$/, '')
-        // count digits in start number and then add ten to the number for the increment
-        const numDigits = startNumber.toString().length
-        const number = startNumber + parseInt('1' + '0'.repeat(Math.max(numDigits - 2, 0)))
-        const paddedNumber = String(number).padStart(value.match(/\d+$/)[0].length, '0')
+      const newIncrement =
+        prefix + (suffixInt + suffixes.difference).toString().padStart(suffixPad, '0')
 
-        increment = baseWithoutNumber + paddedNumber
-      }
-      // also update increment
-      newValue.increment = increment
+      newState.increment = newIncrement.replace('NaN', '')
     }
 
-    onChange(newValue, id, entityType)
+    onChange(newState, id, entityType)
 
-    const newForm = { ...props, ...newValue }
-    if (newForm.base && newForm.increment && newForm.length) {
+    if (newState.base && newState.increment && newState.length) {
       // calculate the sequence
-      const seq = getSequence(newForm.base, newForm.increment, newForm.length)
+      const seq = getSequence(newState.base, newState.increment, newState.length)
       setSequence(seq)
+    }
+
+    // focus base input if changing type
+    if (fieldId === 'type') {
+      setTimeout(() => {
+        baseRef.current.focus()
+        baseRef.current.select()
+      }, 50)
     }
   }
 
@@ -252,6 +311,7 @@ const FolderSequence = ({
               <InputText
                 value={base}
                 id={'base'}
+                ref={baseRef}
                 onChange={handleChange}
                 placeholder="ep101..."
                 autoComplete="off"

--- a/src/components/FolderSequence/FolderSequence.jsx
+++ b/src/components/FolderSequence/FolderSequence.jsx
@@ -33,6 +33,7 @@ const FolderSequence = ({
   isRoot,
   prefixExample = '',
   prefixDisabled,
+  typeSelectRef,
   ...props
 }) => {
   const folders = useSelector((state) => state.project.folders) || []
@@ -129,14 +130,6 @@ const FolderSequence = ({
         <Styled.SequenceForm className="form">
           <Icon icon="task_alt" />
           <strong>Task</strong>
-          <label>label</label>
-          <InputText
-            value={base}
-            id={'base'}
-            onChange={handleChange}
-            placeholder="compositing..."
-            autoComplete="off"
-          />
 
           <label>Type</label>
           <TypeEditor
@@ -145,6 +138,15 @@ const FolderSequence = ({
             options={tasks}
             style={{ width: 160 }}
             align="right"
+          />
+
+          <label>label</label>
+          <InputText
+            value={base}
+            id={'base'}
+            onChange={handleChange}
+            placeholder="compositing..."
+            autoComplete="off"
           />
 
           <Button
@@ -193,17 +195,37 @@ const FolderSequence = ({
         )}
         <Styled.SequenceContainer $isNew={isNew} $nesting={nesting} ref={seqRef}>
           <Styled.SequenceForm className="form folder">
+            <Styled.InputColumn>
+              <label>Type</label>
+              <TypeEditor
+                value={[type]}
+                onChange={(v) => handleChange({ target: { value: v, id: 'type' } })}
+                options={folders}
+                style={{ width: 160 }}
+                align="right"
+                openOnFocus
+                ref={typeSelectRef}
+              />
+            </Styled.InputColumn>
+
+            <Icon icon="trending_flat" />
+
             {(depth !== 0 || !nesting) && (
               <>
-                <Styled.InputColumn>
-                  <label>Prefix</label>
-                  <InputSwitch
-                    checked={prefix}
-                    id={'prefix'}
-                    onChange={() => handleChange({ target: { value: !prefix, id: 'prefix' } })}
-                    disabled={(!nesting && isRoot) || prefixDisabled}
-                  />
-                </Styled.InputColumn>
+                {!((!nesting && isRoot) || prefixDisabled) && (
+                  <>
+                    <Styled.InputColumn>
+                      <label>Prefix</label>
+                      <InputSwitch
+                        checked={prefix}
+                        id={'prefix'}
+                        onChange={() => handleChange({ target: { value: !prefix, id: 'prefix' } })}
+                        disabled={(!nesting && isRoot) || prefixDisabled}
+                      />
+                    </Styled.InputColumn>
+                    <Icon icon="trending_flat" />
+                  </>
+                )}
                 {nesting && prefix && (
                   <Styled.InputColumn>
                     <label>Depth</label>
@@ -218,8 +240,6 @@ const FolderSequence = ({
                 )}
               </>
             )}
-
-            <Icon icon="trending_flat" />
 
             {parentBases && nesting && (
               <Styled.InputColumn style={{ display: prefix ? 'flex' : 'none' }}>
@@ -248,7 +268,7 @@ const FolderSequence = ({
                 autoComplete="off"
               />
             </Styled.InputColumn>
-
+            <Icon icon="trending_flat" />
             <Styled.InputColumn>
               <label>Count</label>
               <InputNumber
@@ -261,16 +281,6 @@ const FolderSequence = ({
               />
             </Styled.InputColumn>
 
-            <Styled.InputColumn>
-              <label>Type</label>
-              <TypeEditor
-                value={[type]}
-                onChange={(v) => handleChange({ target: { value: v, id: 'type' } })}
-                options={folders}
-                style={{ width: 160 }}
-                align="right"
-              />
-            </Styled.InputColumn>
             <Spacer />
             {nesting && (
               <Button

--- a/src/components/FolderSequence/FolderSequence.jsx
+++ b/src/components/FolderSequence/FolderSequence.jsx
@@ -271,20 +271,19 @@ const FolderSequence = ({
 
             {(depth !== 0 || !nesting) && (
               <>
-                {!((!nesting && isRoot) || prefixDisabled) && (
-                  <>
-                    <Styled.InputColumn>
-                      <label>Prefix</label>
-                      <InputSwitch
-                        checked={prefix}
-                        id={'prefix'}
-                        onChange={() => handleChange({ target: { value: !prefix, id: 'prefix' } })}
-                        disabled={(!nesting && isRoot) || prefixDisabled}
-                      />
-                    </Styled.InputColumn>
-                    <Icon icon="trending_flat" />
-                  </>
-                )}
+                <>
+                  <Styled.InputColumn>
+                    <label>Prefix</label>
+                    <InputSwitch
+                      checked={prefix}
+                      id={'prefix'}
+                      onChange={() => handleChange({ target: { value: !prefix, id: 'prefix' } })}
+                      disabled={(!nesting && isRoot) || prefixDisabled}
+                    />
+                  </Styled.InputColumn>
+                  <Icon icon="trending_flat" />
+                </>
+
                 {nesting && prefix && (
                   <Styled.InputColumn>
                     <label>Depth</label>

--- a/src/components/FolderSequence/FolderSequence.jsx
+++ b/src/components/FolderSequence/FolderSequence.jsx
@@ -281,9 +281,7 @@ const FolderSequence = ({
               />
             )}
           </Styled.SequenceForm>
-          {!nesting && base && increment && (
-            <Styled.Example>Example: {sequenceString}</Styled.Example>
-          )}
+          {!nesting && <Styled.Example>Example: {sequenceString}</Styled.Example>}
         </Styled.SequenceContainer>
       </Styled.RowWrapper>
       {nesting && (

--- a/src/pages/EditorPage/EditorPage.jsx
+++ b/src/pages/EditorPage/EditorPage.jsx
@@ -930,7 +930,7 @@ const EditorPage = () => {
     setNewEntity('')
   }
 
-  const addNodes = (entityType, root, nodesData = []) => {
+  const addNodes = (entityType, root, nodesData = [], sequence) => {
     const parents = root ? [null] : futureParents
 
     // for leaf nodes, add parents to parents
@@ -1017,13 +1017,16 @@ const EditorPage = () => {
       // get new branch
       loadNewBranches(loadBranches)
 
-      // update selection to new nodes
-      const newSelection = {}
-      for (const id of folderIds) {
-        newSelection[id] = true
-      }
+      // only auto select for sequences
+      if (sequence) {
+        // update selection to new nodes
+        const newSelection = {}
+        for (const id of folderIds) {
+          newSelection[id] = true
+        }
 
-      if (!isEmpty(newSelection)) handleSelectionChange(newSelection)
+        if (!isEmpty(newSelection)) handleSelectionChange(newSelection)
+      }
     }
   } // Add node
 

--- a/src/pages/EditorPage/EditorPage.jsx
+++ b/src/pages/EditorPage/EditorPage.jsx
@@ -935,7 +935,7 @@ const EditorPage = () => {
     setNewEntity('')
   }
 
-  const addNodes = (entityType, root, nodesData = [], expandBranches = true) => {
+  const addNodes = (entityType, root, nodesData = []) => {
     const parents = root ? [null] : futureParents
 
     // for leaf nodes, add parents to parents
@@ -1008,7 +1008,7 @@ const EditorPage = () => {
     // update new nodes state
     dispatch(newNodesAdded(addingNewNodes))
 
-    if (!root && expandBranches) {
+    if (!root) {
       // Update expanded folders context object
       const exps = { ...expandedFolders }
       const loadBranches = []
@@ -1021,6 +1021,14 @@ const EditorPage = () => {
       dispatch(setExpandedFolders(exps))
       // get new branch
       loadNewBranches(loadBranches)
+
+      // update selection to new nodes
+      const newSelection = {}
+      for (const id of [...folderIds, ...taskIds]) {
+        newSelection[id] = true
+      }
+
+      handleSelectionChange(newSelection)
     }
   } // Add node
 

--- a/src/pages/EditorPage/EditorPage.jsx
+++ b/src/pages/EditorPage/EditorPage.jsx
@@ -597,14 +597,9 @@ const EditorPage = () => {
           attrib: patchAttrib,
           ownAttrib,
         },
-        leaf: !!entity.leaf,
+        leaf: !!entity.leaf || entityType === 'task',
       }
 
-      // check if this newNode has any child newNodes (is it a parent)
-      if (newNodesParentIdsMap.has(id)) {
-        patch.data.hasChildren = true
-        patch.leaf = false
-      }
       // if it's a folder, leaf is false
       if (entityType === 'folder') {
         patch.leaf = false

--- a/src/pages/EditorPage/EditorPage.jsx
+++ b/src/pages/EditorPage/EditorPage.jsx
@@ -1024,11 +1024,11 @@ const EditorPage = () => {
 
       // update selection to new nodes
       const newSelection = {}
-      for (const id of [...folderIds, ...taskIds]) {
+      for (const id of folderIds) {
         newSelection[id] = true
       }
 
-      handleSelectionChange(newSelection)
+      if (!isEmpty(newSelection)) handleSelectionChange(newSelection)
     }
   } // Add node
 

--- a/src/pages/EditorPage/EditorPage.jsx
+++ b/src/pages/EditorPage/EditorPage.jsx
@@ -1491,7 +1491,6 @@ const EditorPage = () => {
             isLoading={isSearchLoading}
           />
           <Spacer />
-          {canCommit && <>Unsaved Changes</>}
           <Button
             icon="clear"
             label="Clear All Changes"

--- a/src/pages/EditorPage/EditorPage.jsx
+++ b/src/pages/EditorPage/EditorPage.jsx
@@ -1445,22 +1445,22 @@ const EditorPage = () => {
         <Toolbar>
           <Button
             icon="create_new_folder"
-            label="Create folder"
+            label="Add folders"
             onClick={() => setNewEntity('folder')}
-            title='Press "n" to create a folder'
+            title='Press "n" to create folders'
           />
           <Button
-            icon="create_new_folder"
-            label="Create multiple"
+            icon="topic"
+            label="Add folder sequence"
             onClick={() => setMultipleFoldersOpen(true)}
-            title='Press "m" to create multiple folders'
+            title='Press "m" to create a folder sequence'
           />
           <Button
             icon="add_task"
-            label="Create task"
+            label="Add tasks"
             disabled={disableAddNew}
             onClick={() => setNewEntity('task')}
-            title='Press "t" to create a task'
+            title='Press "t" to create tasks'
           />
           <BuildHierarchyButton disabled={!focusedFolders.length && focusedTasks.length} />
           <MultiSelect

--- a/src/pages/EditorPage/EditorPage.jsx
+++ b/src/pages/EditorPage/EditorPage.jsx
@@ -1095,7 +1095,7 @@ const EditorPage = () => {
   const ctxMenuGlobalItems = useMemo(
     () => [
       {
-        label: 'Create Folder',
+        label: 'Add Folders',
         icon: 'create_new_folder',
         command: () => setNewEntity('folder'),
       },
@@ -1121,12 +1121,12 @@ const EditorPage = () => {
   const getCtxMenuTableItems = (sel) => {
     return [
       {
-        label: 'Create Folder',
+        label: 'Add Folders',
         icon: 'create_new_folder',
         command: () => setNewEntity('folder'),
       },
       {
-        label: 'Create Task',
+        label: 'Add Tasks',
         icon: 'add_task',
         command: () => setNewEntity('task'),
       },

--- a/src/pages/EditorPage/EditorPage.jsx
+++ b/src/pages/EditorPage/EditorPage.jsx
@@ -83,7 +83,6 @@ const EditorPage = () => {
 
   // NEW STATES
   const [newEntity, setNewEntity] = useState('')
-  const [multipleFoldersOpen, setMultipleFoldersOpen] = useState(false)
 
   // columns widths
   const [columnsWidths, setColumnWidths] = useColumnResize('editor')
@@ -1410,7 +1409,7 @@ const EditorPage = () => {
     },
     {
       key: 'm',
-      action: () => setMultipleFoldersOpen(true),
+      action: () => setNewEntity('sequence'),
     },
     {
       key: 't',
@@ -1426,21 +1425,23 @@ const EditorPage = () => {
 
   return (
     <main className="editor-page">
-      <NewEntity
-        type={newEntity}
-        visible={!!newEntity}
-        onHide={handleCloseNew}
-        onConfirm={addNodes}
-        currentSelection={currentSelection}
-      />
-      {multipleFoldersOpen && (
-        <NewSequence
-          visible={multipleFoldersOpen}
-          onHide={() => setMultipleFoldersOpen(false)}
-          onConfirm={addNodes}
-          currentSelection={currentSelection}
-        />
-      )}
+      {newEntity &&
+        (newEntity === 'sequence' ? (
+          <NewSequence
+            visible={newEntity === 'sequence'}
+            onHide={() => setNewEntity('')}
+            onConfirm={addNodes}
+            currentSelection={currentSelection}
+          />
+        ) : (
+          <NewEntity
+            type={newEntity}
+            visible={!!newEntity}
+            onHide={handleCloseNew}
+            onConfirm={addNodes}
+            currentSelection={currentSelection}
+          />
+        ))}
       <Section>
         <Toolbar>
           <Button
@@ -1452,7 +1453,7 @@ const EditorPage = () => {
           <Button
             icon="topic"
             label="Add folder sequence"
-            onClick={() => setMultipleFoldersOpen(true)}
+            onClick={() => setNewEntity('sequence')}
             title='Press "m" to create a folder sequence'
           />
           <Button

--- a/src/pages/EditorPage/EditorPanel.jsx
+++ b/src/pages/EditorPage/EditorPanel.jsx
@@ -347,6 +347,25 @@ const EditorPanel = ({ onDelete, onChange, onRevert, attribs, projectName, onFor
         isMultiple: oldValue?.isMultiple && !isChanged,
       }
 
+      // if the label is changed and the entity is new, change the name as well
+      // first check if all nodes are newNodes
+      const allNewNodes = nodeIds.every((id) => nodes[id]?.data?.__isNew)
+      if (allNewNodes && changeKey === '_label') {
+        // replace space with underscore, set to lowercase and remove special characters and any non alphanumeric characters from the start
+        const name = newValue
+          .replace(/\s/g, '_')
+          .toLowerCase()
+          .replace(/[^a-z0-9_]/g, '')
+          .replace(/^[^a-z]+/g, '')
+        newForm._name = {
+          ...newForm._name,
+          value: name,
+          isChanged: true,
+          isOwn: true,
+          isMultiple: false,
+        }
+      }
+
       setLocalChange(true)
 
       if (setFormNew) return setFormNew(newForm)

--- a/src/pages/EditorPage/NewEntity.jsx
+++ b/src/pages/EditorPage/NewEntity.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import { capitalize, isEmpty } from 'lodash'
 import { useState } from 'react'
 import { useEffect } from 'react'
-import { InputText, SaveButton } from '@ynput/ayon-react-components'
+import { Button, InputText, SaveButton, Spacer, Toolbar } from '@ynput/ayon-react-components'
 import { useRef } from 'react'
 import { useSelector } from 'react-redux'
 import styled from 'styled-components'
@@ -95,9 +95,7 @@ const NewEntity = ({ type, currentSelection = {}, visible, onConfirm, onHide }) 
     labelRef.current?.select()
   }
 
-  const handleSubmit = (e) => {
-    e?.preventDefault()
-
+  const handleSubmit = (hide = false) => {
     // first check name and type valid
     if (!entityData.label || !entityData.type) return
 
@@ -112,10 +110,23 @@ const NewEntity = ({ type, currentSelection = {}, visible, onConfirm, onHide }) 
 
     // callbacks
     onConfirm(entityType, isRoot, [newData])
-    onHide()
+    hide && onHide()
+  }
+
+  const handleKeyDown = (e) => {
+    // ctrl + enter submit and close
+    if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+      handleSubmit(true)
+    }
+    // shift + enter submit and don't close
+    if (e.shiftKey && e.key === 'Enter') {
+      handleSubmit(false)
+    }
   }
 
   if (!entityType) return null
+
+  const addDisabled = !entityData.label || !entityData.type
 
   return (
     <Dialog
@@ -126,22 +137,31 @@ const NewEntity = ({ type, currentSelection = {}, visible, onConfirm, onHide }) 
       resizable={false}
       draggable={false}
       footer={
-        <SaveButton
-          label={`Add ${type}`}
-          onClick={handleSubmit}
-          style={{ marginLeft: 'auto' }}
-          active={entityData.label && entityData.type}
-        />
+        <Toolbar>
+          <Spacer />
+          <Button
+            label={`Add`}
+            variant="text"
+            onClick={() => handleSubmit(false)}
+            disabled={addDisabled}
+            title={'Shift + Enter'}
+          />
+          <SaveButton
+            label={`Add and Close`}
+            onClick={() => handleSubmit(true)}
+            active={!addDisabled}
+            title="Ctrl/Cmd + Enter"
+          />
+        </Toolbar>
       }
+      onKeyDown={handleKeyDown}
     >
       <ContentStyled>
-        <form onSubmit={handleSubmit}>
-          <InputText
-            value={entityData.label}
-            onChange={(e) => handleChange(e.target.value, 'label')}
-            ref={labelRef}
-          />
-        </form>
+        <InputText
+          value={entityData.label}
+          onChange={(e) => handleChange(e.target.value, 'label')}
+          ref={labelRef}
+        />
         <TypeEditor
           value={[entityData.type]}
           onChange={(v) => handleChange(v, 'type')}

--- a/src/pages/EditorPage/NewEntity.jsx
+++ b/src/pages/EditorPage/NewEntity.jsx
@@ -30,7 +30,7 @@ const NewEntity = ({ type, currentSelection = {}, visible, onConfirm, onHide }) 
 
   //   format title
   const isRoot = isEmpty(currentSelection)
-  let title = 'Creating New '
+  let title = 'Add New '
   if (isRoot) title += 'Root '
   title += capitalize(type)
 
@@ -127,7 +127,7 @@ const NewEntity = ({ type, currentSelection = {}, visible, onConfirm, onHide }) 
       draggable={false}
       footer={
         <SaveButton
-          label={`Create ${type}`}
+          label={`Add ${type}`}
           onClick={handleSubmit}
           style={{ marginLeft: 'auto' }}
           active={entityData.label && entityData.type}

--- a/src/pages/EditorPage/NewEntity.jsx
+++ b/src/pages/EditorPage/NewEntity.jsx
@@ -67,15 +67,33 @@ const NewEntity = ({ type, currentSelection = {}, visible, onConfirm, onHide }) 
     let newState = { ...entityData }
     if (id) {
       newState[id] = value
-      if (
-        value &&
-        id === 'type' &&
-        (entityData.label.toLowerCase() === entityData.type.toLowerCase() ||
-          entityData.label === '')
-      ) {
+      if (value && id === 'type') {
+        // changing type
+        // update name if newState.name matches any values in typeOptions
+        let matches = false
+        // loop through typeOptions and check if any match, when match is found we can stop looping
+        for (const o in typeOptions) {
+          if (newState.name === '') {
+            matches = true
+            break
+          }
+          const option = typeOptions[o]
+          for (const key in option) {
+            if (newState.name.toLowerCase().includes(option[key].toLowerCase())) {
+              matches = true
+              break
+            }
+          }
+        }
+
+        const typeOption = typeOptions[value]
+
+        if (!matches || !typeOption) return
         // if name is same as type, update name
-        newState.name = value.toLowerCase()
-        newState.label = value
+        const newName =
+          type === 'folder' ? typeOption.shortName || typeOption.name : typeOption.name
+        newState.name = newName
+        newState.label = newName
       }
     }
 
@@ -83,6 +101,12 @@ const NewEntity = ({ type, currentSelection = {}, visible, onConfirm, onHide }) 
       newState.name = checkName(value)
     }
     setEntityData(newState)
+
+    if (id === 'type') {
+      setTimeout(() => {
+        labelRef.current.focus()
+      }, 50)
+    }
   }
 
   //   refs

--- a/src/pages/EditorPage/NewEntity.jsx
+++ b/src/pages/EditorPage/NewEntity.jsx
@@ -39,9 +39,6 @@ const NewEntity = ({ type, currentSelection = {}, visible, onConfirm, onHide }) 
   const folders = useSelector((state) => state.project.folders)
   const typeOptions = type === 'folder' ? folders : tasks
 
-  //   refs
-  const labelRef = useRef(null)
-
   // set entity type
   useEffect(() => {
     if (type !== entityType && type) {
@@ -88,11 +85,13 @@ const NewEntity = ({ type, currentSelection = {}, visible, onConfirm, onHide }) 
     setEntityData(newState)
   }
 
+  //   refs
+  const typeSelectRef = useRef(null)
+
   const handleShow = () => {
-    // focus name input
-    labelRef.current?.focus()
-    // select name
-    labelRef.current?.select()
+    const buttonEl = typeSelectRef.current.querySelector('button')
+    // focus name dropdown
+    buttonEl?.focus()
   }
 
   const handleSubmit = (hide = false) => {
@@ -157,16 +156,18 @@ const NewEntity = ({ type, currentSelection = {}, visible, onConfirm, onHide }) 
       onKeyDown={handleKeyDown}
     >
       <ContentStyled>
-        <InputText
-          value={entityData.label}
-          onChange={(e) => handleChange(e.target.value, 'label')}
-          ref={labelRef}
-        />
         <TypeEditor
           value={[entityData.type]}
           onChange={(v) => handleChange(v, 'type')}
           options={typeOptions}
           style={{ width: 160 }}
+          ref={typeSelectRef}
+          openOnFocus
+          onClose={(e) => console.log(e, 'soose')}
+        />
+        <InputText
+          value={entityData.label}
+          onChange={(e) => handleChange(e.target.value, 'label')}
         />
       </ContentStyled>
     </Dialog>

--- a/src/pages/EditorPage/NewEntity.jsx
+++ b/src/pages/EditorPage/NewEntity.jsx
@@ -87,6 +87,7 @@ const NewEntity = ({ type, currentSelection = {}, visible, onConfirm, onHide }) 
 
   //   refs
   const typeSelectRef = useRef(null)
+  const labelRef = useRef(null)
 
   const handleShow = () => {
     const buttonEl = typeSelectRef.current.querySelector('button')
@@ -110,6 +111,11 @@ const NewEntity = ({ type, currentSelection = {}, visible, onConfirm, onHide }) 
     // callbacks
     onConfirm(entityType, isRoot, [newData])
     hide && onHide()
+
+    if (!hide) {
+      // set focus back to typeSelector
+      handleShow()
+    }
   }
 
   const handleKeyDown = (e) => {
@@ -120,6 +126,14 @@ const NewEntity = ({ type, currentSelection = {}, visible, onConfirm, onHide }) 
     // shift + enter submit and don't close
     if (e.shiftKey && e.key === 'Enter') {
       handleSubmit(false)
+    }
+    // if tabbing from dropdown, focus name input
+    if (e.key === 'Tab') {
+      const target = e.target
+      // check if target is inside typeSelectRef.current
+      if (target && typeSelectRef.current.contains(target)) {
+        e.stopPropagation()
+      }
     }
   }
 
@@ -163,11 +177,11 @@ const NewEntity = ({ type, currentSelection = {}, visible, onConfirm, onHide }) 
           style={{ width: 160 }}
           ref={typeSelectRef}
           openOnFocus
-          onClose={(e) => console.log(e, 'soose')}
         />
         <InputText
           value={entityData.label}
           onChange={(e) => handleChange(e.target.value, 'label')}
+          ref={labelRef}
         />
       </ContentStyled>
     </Dialog>

--- a/src/pages/EditorPage/NewSequence.jsx
+++ b/src/pages/EditorPage/NewSequence.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { useState } from 'react'
 import { useEffect } from 'react'
-import { Toolbar, Spacer, SaveButton } from '@ynput/ayon-react-components'
+import { Toolbar, Spacer, SaveButton, Button } from '@ynput/ayon-react-components'
 import { Dialog } from 'primereact/dialog'
 import FolderSequence from '/src/components/FolderSequence/FolderSequence'
 import getSequence from '/src/helpers/getSequence'
@@ -42,7 +42,7 @@ const NewSequence = ({ visible, onConfirm, onHide, currentSelection = {} }) => {
     setCreateSeq(newValue)
   }
 
-  const handleSeqSubmit = () => {
+  const handleSeqSubmit = (hide = false) => {
     // get the sequence
     const seq = getSequence(createSeq.base, createSeq.increment, createSeq.length)
     // for each sequence item, create a new entity
@@ -57,7 +57,18 @@ const NewSequence = ({ visible, onConfirm, onHide, currentSelection = {} }) => {
     }
 
     onConfirm('folder', isRoot, nodes, false)
-    onHide()
+    hide && onHide()
+  }
+
+  const handleKeyDown = (e) => {
+    // ctrl + enter submit and close
+    if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+      handleSeqSubmit(true)
+    }
+    // shift + enter submit and don't close
+    if (e.shiftKey && e.key === 'Enter') {
+      handleSeqSubmit(false)
+    }
   }
 
   const addDisabled =
@@ -73,14 +84,21 @@ const NewSequence = ({ visible, onConfirm, onHide, currentSelection = {} }) => {
       footer={
         <Toolbar>
           <Spacer />
-          <SaveButton label={'Add folders'} onClick={handleSeqSubmit} active={!addDisabled} />
+          <Button
+            label="Add"
+            disabled={addDisabled}
+            onClick={() => handleSeqSubmit(false)}
+            title={'Shift + Enter'}
+          />
+          <SaveButton
+            label={'Add and Close'}
+            onClick={() => handleSeqSubmit(true)}
+            active={!addDisabled}
+            title="Ctrl/Cmd + Enter"
+          />
         </Toolbar>
       }
-      onKeyDown={(e) => {
-        if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
-          handleSeqSubmit()
-        }
-      }}
+      onKeyDown={handleKeyDown}
     >
       <FolderSequence
         {...createSeq}

--- a/src/pages/EditorPage/NewSequence.jsx
+++ b/src/pages/EditorPage/NewSequence.jsx
@@ -78,6 +78,14 @@ const NewSequence = ({ visible, onConfirm, onHide, currentSelection = {} }) => {
     if (e.shiftKey && e.key === 'Enter') {
       handleSeqSubmit(false)
     }
+    // if tabbing from dropdown, focus name input
+    if (e.key === 'Tab') {
+      const target = e.target
+      // check if target is inside typeSelectRef.current
+      if (target && typeSelectRef.current.contains(target)) {
+        e.stopPropagation()
+      }
+    }
   }
 
   const addDisabled =

--- a/src/pages/EditorPage/NewSequence.jsx
+++ b/src/pages/EditorPage/NewSequence.jsx
@@ -68,6 +68,11 @@ const NewSequence = ({ visible, onConfirm, onHide, currentSelection = {} }) => {
 
     onConfirm('folder', isRoot, nodes, false)
     hide && onHide()
+
+    // focus typeSelector again
+    if (!hide) {
+      handleShow()
+    }
   }
 
   const handleKeyDown = (e) => {

--- a/src/pages/EditorPage/NewSequence.jsx
+++ b/src/pages/EditorPage/NewSequence.jsx
@@ -34,7 +34,7 @@ const NewSequence = ({ visible, onConfirm, onHide, currentSelection = {} }) => {
 
   useEffect(() => {
     openCreateSeq()
-  }, [isRoot])
+  }, [isRoot, currentSelection])
 
   //   refs
   const typeSelectRef = useRef(null)

--- a/src/pages/EditorPage/NewSequence.jsx
+++ b/src/pages/EditorPage/NewSequence.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { useState } from 'react'
 import { useEffect } from 'react'
-import { Button, Toolbar, Spacer } from '@ynput/ayon-react-components'
+import { Toolbar, Spacer, SaveButton } from '@ynput/ayon-react-components'
 import { Dialog } from 'primereact/dialog'
 import FolderSequence from '/src/components/FolderSequence/FolderSequence'
 import getSequence from '/src/helpers/getSequence'
@@ -35,7 +35,7 @@ const NewSequence = ({ visible, onConfirm, onHide, currentSelection = {} }) => {
     openCreateSeq()
   }, [isRoot])
 
-  const title = 'Create Folder Sequence'
+  const title = 'Add Folder Sequence'
 
   const handleSeqChange = (value) => {
     const newValue = { ...createSeq, ...value }
@@ -60,6 +60,9 @@ const NewSequence = ({ visible, onConfirm, onHide, currentSelection = {} }) => {
     onHide()
   }
 
+  const addDisabled =
+    !createSeq.base || !createSeq.increment || !createSeq.length || !createSeq.type
+
   return (
     <Dialog
       header={title}
@@ -70,7 +73,7 @@ const NewSequence = ({ visible, onConfirm, onHide, currentSelection = {} }) => {
       footer={
         <Toolbar>
           <Spacer />
-          <Button label={'Create folders'} onClick={handleSeqSubmit} variant="filled" />
+          <SaveButton label={'Add folders'} onClick={handleSeqSubmit} active={!addDisabled} />
         </Toolbar>
       }
       onKeyDown={(e) => {

--- a/src/pages/EditorPage/NewSequence.jsx
+++ b/src/pages/EditorPage/NewSequence.jsx
@@ -66,7 +66,7 @@ const NewSequence = ({ visible, onConfirm, onHide, currentSelection = {} }) => {
       })
     }
 
-    onConfirm('folder', isRoot, nodes, false)
+    onConfirm('folder', isRoot, nodes, true)
     hide && onHide()
 
     // focus typeSelector again

--- a/src/pages/EditorPage/NewSequence.jsx
+++ b/src/pages/EditorPage/NewSequence.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useRef } from 'react'
 import { useState } from 'react'
 import { useEffect } from 'react'
 import { Toolbar, Spacer, SaveButton, Button } from '@ynput/ayon-react-components'
@@ -34,6 +34,15 @@ const NewSequence = ({ visible, onConfirm, onHide, currentSelection = {} }) => {
   useEffect(() => {
     openCreateSeq()
   }, [isRoot])
+
+  //   refs
+  const typeSelectRef = useRef(null)
+
+  const handleShow = () => {
+    const buttonEl = typeSelectRef.current.querySelector('button')
+    // focus name dropdown
+    buttonEl?.focus()
+  }
 
   const title = 'Add Folder Sequence'
 
@@ -79,6 +88,7 @@ const NewSequence = ({ visible, onConfirm, onHide, currentSelection = {} }) => {
       header={title}
       visible={visible}
       onHide={onHide}
+      onShow={handleShow}
       resizable={false}
       draggable={false}
       footer={
@@ -107,6 +117,7 @@ const NewSequence = ({ visible, onConfirm, onHide, currentSelection = {} }) => {
         isRoot={isRoot}
         prefixExample={createSeq.prefix ? examplePrefix : ''}
         prefixDisabled={multipleSelection}
+        typeSelectRef={typeSelectRef}
       />
     </Dialog>
   )

--- a/src/pages/EditorPage/NewSequence.jsx
+++ b/src/pages/EditorPage/NewSequence.jsx
@@ -20,12 +20,13 @@ const NewSequence = ({ visible, onConfirm, onHide, currentSelection = {} }) => {
 
   const openCreateSeq = () => {
     const newSeq = {
-      base: '',
-      increment: '',
+      base: 'Folder010',
+      increment: 'Folder020',
       length: 10,
       type: 'Folder',
       prefix: multipleSelection,
       prefixDepth: !isRoot ? 1 : 0,
+      entityType: 'folder',
     }
 
     setCreateSeq(newSeq)

--- a/src/pages/EditorPage/TypeEditor.jsx
+++ b/src/pages/EditorPage/TypeEditor.jsx
@@ -1,55 +1,67 @@
 import { Dropdown } from '@ynput/ayon-react-components'
+import { forwardRef } from 'react'
 
 //eslint-disable-next-line no-unused-vars
-const TypeEditor = ({
-  value,
-  options,
-  onChange,
-  style,
-  mainStyle,
-  disabled,
-  placeholder,
-  isChanged,
-  align,
-}) => {
-  const optionsTypes = Object.values(options).map((t) => ({
-    name: t?.name,
-    label: t?.name,
-    icon: t?.icon,
-  }))
+const TypeEditor = forwardRef(
+  (
+    {
+      value,
+      options,
+      onChange,
+      style,
+      mainStyle,
+      disabled,
+      placeholder,
+      isChanged,
+      align,
+      ...props
+    },
+    ref,
+  ) => {
+    const optionsTypes = Object.values(options).map((t) => ({
+      name: t?.name,
+      label: t?.name,
+      icon: t?.icon,
+    }))
 
-  // sort by name alphabetically
-  optionsTypes.sort((a, b) => {
-    const nameA = a.name.toLowerCase()
-    const nameB = b.name.toLowerCase()
-    if (nameA < nameB) {
-      return -1
-    }
-    if (nameA > nameB) {
-      return 1
-    }
+    // sort by name alphabetically
+    optionsTypes.sort((a, b) => {
+      const nameA = a.name.toLowerCase()
+      const nameB = b.name.toLowerCase()
+      if (nameA < nameB) {
+        return -1
+      }
+      if (nameA > nameB) {
+        return 1
+      }
 
-    return 0
-  })
+      return 0
+    })
 
-  return (
-    <Dropdown
-      options={optionsTypes}
-      dataKey="name"
-      value={value}
-      valueStyle={style}
-      onChange={(v) => onChange(v[0])}
-      disabled={disabled}
-      isChanged={isChanged}
-      placeholder={placeholder}
-      valueIcon={options[value]?.icon}
-      widthExpand
-      search
-      searchFields={['name']}
-      emptyMessage="None Set"
-      style={mainStyle}
-      align={align}
-    />
-  )
-}
+    return (
+      <Dropdown
+        options={optionsTypes}
+        dataKey="name"
+        value={value}
+        valueStyle={style}
+        onChange={(v) => onChange(v[0])}
+        disabled={disabled}
+        isChanged={isChanged}
+        placeholder={placeholder}
+        valueIcon={options[value]?.icon}
+        widthExpand
+        search
+        searchFields={['name']}
+        emptyMessage="None Set"
+        style={mainStyle}
+        align={align}
+        ref={ref}
+        {...props}
+      />
+    )
+  },
+)
+
+TypeEditor.displayName = 'TypeEditor'
+
 export default TypeEditor

--- a/src/pages/SettingsPage/AnatomyPresets/AnatomyPresets.jsx
+++ b/src/pages/SettingsPage/AnatomyPresets/AnatomyPresets.jsx
@@ -192,10 +192,11 @@ const AnatomyPresets = () => {
             onClick={() => setPrimaryPreset(selectedPreset)}
           />
           <Button
-            label="Delete the preset"
+            label="Delete preset"
             icon="delete"
             disabled={selectedPreset === '_'}
             onClick={() => handleDeletePreset(selectedPreset, isSelectedPrimary)}
+            style={{ visibility: selectedPreset === '_' ? 'hidden' : 'visible' }}
           />
           <Spacer />
           <Button
@@ -205,12 +206,15 @@ const AnatomyPresets = () => {
               setNewPresetName('')
               setShowNameDialog(true)
             }}
+            variant={selectedPreset === '_' ? 'filled' : 'surface'}
           />
+
           <SaveButton
             label="Save Current Preset"
             saving={isUpdating}
             active={isChanged && selectedPreset !== '_'}
             onClick={() => savePreset(selectedPreset)}
+            variant={selectedPreset === '_' ? 'surface' : 'filled'}
           />
         </Toolbar>
 


### PR DESCRIPTION
## Changelog Description

- New "Add folder sequence" tool for creating large amounts of sequential folders at one time.
- Improved UI of the original add folders and tasks tool to make creation quicker.
- New "Add" and "Add and Close" buttons to give the option to keep the dialog open after creating a folder/task.
- `folderType` anatomy now has new field `shortName`. For example "Sequence" has the default shortname "sq".
- New shortcuts:
    - **Open ddd folder:** `n`
    - **Open add folder sequence:** `m`
    - **Open add task:** `t`
- New dialog shortcuts:
    - **Add (but not close)**: `Shift+Enter`
    - **Add and Close**: `Ctrl/Cmd+Enter`

## Additional Info

### Adding Sequence with Tasks GIF (.mov available)
![adding_seq_and_tasks_v001](https://github.com/ynput/ayon-frontend/assets/49156310/45847f8f-7c90-4ae2-9a6b-4e6c6829e4b7)

### Adding Folders GIF (.mov available)
![adding_folders_v001](https://github.com/ynput/ayon-frontend/assets/49156310/6c888b22-3f89-4d41-95d3-2bd309dd5003)

### Adding Tasks GIF (.mov available)
![adding_tasks_v001](https://github.com/ynput/ayon-frontend/assets/49156310/e7823de3-5285-46ec-82d4-ac23fecfe242)

### Adding Tasks on Folders GIF (.mov available)
![adding_tasks_on_folders_v001](https://github.com/ynput/ayon-frontend/assets/49156310/067cf5b6-b700-40f4-94bd-9810bd6d8e70)

## Testing

### Adding Folders
1. Click "Add folders" button or hit "n" key or right click/Add folders
2. Select `Sequence` and `sq` should be set in the label input.
3. Change type again and the label should be updated again.
4. Now change the label to something different, changing the type shouldn't update the label now.
5. Hit `Shift+Enter` to add the folder but not close the dialog. The type dropdown should automatically open.
6. Select new type and then hit `Ctrl+Enter` to add and close the dialog.

### Adding Tasks
1. Select a folder and click "Add tasks" button or hit "t" key or right click/Add tasks.
2. Select `Animation` type and "Animation" should be prefilled on the label.
3. Select a different type and the label should be updated.
4. Hit `Shift+Enter` to add the folder but not close the dialog. The type dropdown should automatically open.
5. Select new type and then hit `Ctrl+Enter` to add and close the dialog.

### Adding Folder Sequence
1. Select a folder and click "Add folder sequence" button or hit "m" key.
2. Select a type and the first and last name should be prefilled with short name and then the default increment.
3. When only one folder is selected the prefix switch should be default off.
4. Check the example matches the first and last name pattern.
5. Hit the "Add" button. The folders should be added and automatically selected. The dialog should stay open and the prefix should be switched on and disabled.
6. Now change the type and try adding those new folders. They should be added to all the previously created folders.

