### PR TITLE
Menu: link menu items us "a" tag for better accessibility

### DIFF
--- a/src/components/Menu/MenuComponents/Menu.jsx
+++ b/src/components/Menu/MenuComponents/Menu.jsx
@@ -4,18 +4,12 @@ import MenuList from './MenuList'
 import copyToClipboard from '/src/helpers/copyToClipboard'
 import { Button } from '@ynput/ayon-react-components'
 
-const Menu = ({ menu = [], onClose, footer = '', navigate, ...props }) => {
+const Menu = ({ menu = [], onClose, footer = '', ...props }) => {
   const [subMenus, setSubMenus] = useState([])
   //   When a menu item is clicked, the following happens:
   const handleClick = (e, onClick, url, disableClose) => {
-    if (url) {
-      if (url.startsWith('http')) {
-        window.open(url, '_blank')
-      } else {
-        navigate(url)
-      }
-      return
-    }
+    // this is handled by Link component inside the MenuItem
+    if (url) return onClose()
 
     onClick && onClick(e)
 

--- a/src/components/Menu/MenuComponents/MenuContainer.jsx
+++ b/src/components/Menu/MenuComponents/MenuContainer.jsx
@@ -2,11 +2,10 @@ import React, { useEffect, useMemo, useRef } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { setMenuOpen } from '/src/features/context'
 import * as Styled from './Menu.styled'
-import { useNavigate } from 'react-router'
 
 const MenuContainer = ({ id, target, children, ...props }) => {
   const dispatch = useDispatch()
-  const navigate = useNavigate()
+
   const isOpen = useSelector((state) => state.context.menuOpen) === id
   const dialogRef = useRef(null)
 
@@ -40,14 +39,9 @@ const MenuContainer = ({ id, target, children, ...props }) => {
 
   if (!isOpen) return null
 
-  const handleNavigate = (path) => {
-    handleClose()
-    if (path) navigate(path)
-  }
-
   // attach the handleClose as a prop to each child
   children = React.Children.map(children, (child, i) => {
-    return React.cloneElement(child, { onClose: handleClose, index: i, navigate: handleNavigate })
+    return React.cloneElement(child, { onClose: handleClose, index: i })
   })
 
   const handleKeyDown = (e) => {

--- a/src/components/Menu/MenuComponents/MenuItem.jsx
+++ b/src/components/Menu/MenuComponents/MenuItem.jsx
@@ -2,12 +2,13 @@ import { Icon } from '@ynput/ayon-react-components'
 import React, { forwardRef } from 'react'
 import * as Styled from './Menu.styled'
 import { isArray } from 'lodash'
+import { Link } from 'react-router-dom'
 
 const MenuItem = forwardRef(
-  ({ label, icon, highlighted, selected, items = [], className, ...props }, ref) => {
+  ({ label, icon, highlighted, selected, items = [], className, isLink, ...props }, ref) => {
     const labelsArray = isArray(label) ? label : [label]
 
-    return (
+    const Item = (
       <Styled.Item
         ref={ref}
         className={`menu-item ${highlighted ? 'highlighted' : ''} ${
@@ -24,6 +25,12 @@ const MenuItem = forwardRef(
         {!!items.length && <Icon icon="arrow_right" className="more" />}
       </Styled.Item>
     )
+
+    if (isLink) {
+      return <Link to={isLink}>{Item}</Link>
+    } else {
+      return Item
+    }
   },
 )
 

--- a/src/components/Menu/MenuComponents/MenuList.jsx
+++ b/src/components/Menu/MenuComponents/MenuList.jsx
@@ -97,6 +97,7 @@ const MenuList = ({
               tabIndex={0}
               key={`${id}-${i}`}
               {...{ label, icon, highlighted, items, selected }}
+              isLink={link}
               onClick={(e) =>
                 items.length
                   ? handleSubMenu(e, id, items)


### PR DESCRIPTION
## Changelog Description

Link menu items use `<Link>` component that adds an `<a>` tag wrapper in the DOM for better accessibility, specifically middle/ctrl/cmd click to open in a new tab. 