### PR TITLE
Workfiles: persist task selection across folder selection changes

### DIFF
--- a/src/containers/Breadcrumbs/Breadcrumbs.jsx
+++ b/src/containers/Breadcrumbs/Breadcrumbs.jsx
@@ -133,7 +133,7 @@ const Breadcrumbs = () => {
     dispatch(setFocusedProducts(focusedProducts))
     dispatch(setFocusedVersions(focusedVersions))
     dispatch(setFocusedRepresentations(focusedRepresentations))
-    dispatch(setFocusedTasks(focusedTasks))
+    dispatch(setFocusedTasks({ ids: focusedTasks }))
     dispatch(setFocusedWorkfiles(focusedWorkfiles))
   }
 

--- a/src/containers/hierarchy.jsx
+++ b/src/containers/hierarchy.jsx
@@ -243,7 +243,7 @@ const Hierarchy = (props) => {
   const onSelectionChange = (event) => {
     const selection = Object.keys(event.value)
     // remove task selection
-    dispatch(setFocusedTasks([]))
+    dispatch(setFocusedTasks({ ids: [] }))
     dispatch(setFocusedFolders(selection))
 
     // for each selected folder, if isLeaf then set expandedFolders

--- a/src/containers/taskList.jsx
+++ b/src/containers/taskList.jsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useRef } from 'react'
+import { useState, useMemo, useRef, useEffect } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import { TablePanel, Section } from '@ynput/ayon-react-components'
 
@@ -13,14 +13,15 @@ import { useGetTasksQuery } from '/src/services/getTasks'
 import useCreateContext from '../hooks/useCreateContext'
 import NoEntityFound from '../components/NoEntityFound'
 
-const TaskList = ({ style = {} }) => {
-  const tasks = useSelector((state) => state.project.tasks)
+const TaskList = ({ style = {}, autoSelect = false }) => {
+  const tasksTypes = useSelector((state) => state.project.tasks)
 
   const dispatch = useDispatch()
 
   const projectName = useSelector((state) => state.project.name)
   const folderIds = useSelector((state) => state.context.focused.folders)
   const focusedTasks = useSelector((state) => state.context.focused.tasks)
+  const previousTasksNames = useSelector((state) => state.context.focused.tasksNames)
   const pairing = useSelector((state) => state.context.pairing)
   const userName = useSelector((state) => state.user.name)
 
@@ -33,7 +34,7 @@ const TaskList = ({ style = {} }) => {
   //
 
   let {
-    data = [],
+    data: tasksData = [],
     isFetching,
     isError,
     error,
@@ -45,12 +46,25 @@ const TaskList = ({ style = {} }) => {
     return r
   }, [focusedTasks])
 
+  // when folder selection changes try to keep the same task(name) selected
+  useEffect(() => {
+    if (autoSelect && !isFetching && tasksData.length && previousTasksNames.length) {
+      // filter out tasks with different names to
+      const matchedTasksIds = tasksData
+        .filter((task) => previousTasksNames.includes(task.data.name))
+        .map((task) => task.data.id)
+
+      dispatch(setFocusedTasks({ ids: matchedTasksIds }))
+      // set pairing
+      setPairs(matchedTasksIds)
+    }
+  }, [folderIds, isFetching, autoSelect, previousTasksNames, tasksData, dispatch])
+
   //
   // Handlers
   //
 
-  const onSelectionChange = (event) => {
-    const taskIds = Object.keys(event.value).filter((k) => k.length === 32)
+  const setPairs = (taskIds) => {
     let pairs = []
     for (const tid of taskIds) {
       pairs.push({
@@ -58,13 +72,26 @@ const TaskList = ({ style = {} }) => {
       })
     }
     dispatch(setPairing(pairs))
-    dispatch(setFocusedTasks(taskIds))
+  }
+
+  const onSelectionChange = (event) => {
+    const taskIds = Object.keys(event.value).filter((k) => k.length === 32)
+
+    setPairs(taskIds)
+
+    const names = []
+    for (const tid of taskIds) {
+      const task = tasksData.find((t) => t.data?.id === tid)
+      if (task) names.push(task.data?.name)
+    }
+
+    dispatch(setFocusedTasks({ ids: taskIds, names }))
   }
 
   const onContextMenuSelectionChange = (event) => {
     if (focusedTasks.includes(event.value)) return
     dispatch(setPairing([{ taskId: event.value }]))
-    dispatch(setFocusedTasks([event.value]))
+    dispatch(setFocusedTasks({ ids: [event.value] }))
   }
 
   //
@@ -72,7 +99,7 @@ const TaskList = ({ style = {} }) => {
   //
 
   const nameRenderer = (node) => {
-    const icon = node.data.isGroup ? 'folder' : tasks[node.data.taskType]?.icon
+    const icon = node.data.isGroup ? 'folder' : tasksTypes[node.data.taskType]?.icon
     let className = ''
     let i = 0
     for (const pair of pairing) {
@@ -117,7 +144,7 @@ const TaskList = ({ style = {} }) => {
     if (tableHeader?.contains(e.target) || table?.contains(e.target)) return
 
     // deselect all
-    dispatch(setFocusedTasks([]))
+    dispatch(setFocusedTasks({ ids: [], names: [] }))
     // remove paring
     dispatch(setPairing([]))
   }
@@ -142,10 +169,10 @@ const TaskList = ({ style = {} }) => {
   }, [])
 
   if (isFetching) {
-    data = loadingData
+    tasksData = loadingData
   }
 
-  const noTasks = !isFetching && data.length === 0
+  const noTasks = !isFetching && tasksData.length === 0
 
   return (
     <Section style={style}>
@@ -161,7 +188,7 @@ const TaskList = ({ style = {} }) => {
           <NoEntityFound type="task" />
         ) : (
           <TreeTable
-            value={data}
+            value={tasksData}
             scrollable="true"
             scrollHeight="100%"
             emptyMessage=" "

--- a/src/features/context.js
+++ b/src/features/context.js
@@ -9,6 +9,7 @@ const initialState = {
     versions: [],
     representations: [],
     tasks: [],
+    tasksNames: [],
     workfiles: [],
     editor: [],
     lastFocused: null,
@@ -56,7 +57,8 @@ const contextSlice = createSlice({
 
     setFocusedTasks: (state, action) => {
       state.focused.type = 'task'
-      state.focused.tasks = action.payload
+      state.focused.tasks = action.payload.ids || []
+      if ('names' in action.payload) state.focused.tasksNames = action.payload.names || []
       state.focused.versions = []
     },
 

--- a/src/pages/BrowserPage/ProductsList.jsx
+++ b/src/pages/BrowserPage/ProductsList.jsx
@@ -60,12 +60,9 @@ const ProductsList = ({
           loading: loadingProducts.includes(rowData.data.id),
         }
         if (!focusedTasks.length || focusedType !== 'task') return className
-        const matchingTask = focusedTasks.some((id) => id === rowData.data.taskId)
 
         return {
           ...className,
-          'focused-task': matchingTask,
-          'not-focused-task': !matchingTask,
         }
       }}
       onContextMenu={(e) => ctxMenuShow(e.originalEvent)}

--- a/src/pages/WorkfilesPage/WorkfilesPage.jsx
+++ b/src/pages/WorkfilesPage/WorkfilesPage.jsx
@@ -17,7 +17,7 @@ const WorkfilesPage = () => {
   return (
     <main>
       <Hierarchy style={{ flex: 1, minWidth: 250, maxWidth: 500 }} />
-      <TaskList style={{ flex: 0.75, minWidth: 250, maxWidth: 500 }} />
+      <TaskList style={{ flex: 0.75, minWidth: 250, maxWidth: 500 }} autoSelect />
       <WorkfileList
         selectedWorkfile={selectedWorkfile}
         setSelectedWorkfile={setSelectedWorkfile}

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -129,12 +129,6 @@ input:-webkit-autofill:focus {
   }
 }
 
-.p-treetable .p-treetable-tbody {
-  tr.not-focused-task {
-    opacity: 0.5;
-  }
-}
-
 .table-editor {
   margin: 0;
   .p-inputwrapper {


### PR DESCRIPTION
## Changelog Description

- Persist task selection across folder selection changes. 
- For example if "fx" task is selected then selecting a different folder that also has the task "fx" will persist that original "fx" task selection.

## Additional Information
![workfiles_task_selection_persists_v001](https://github.com/ynput/ayon-frontend/assets/49156310/bf991d36-623d-4219-83b0-6ce84a30dc03)

## Testing

1. In browser select a folder and then a task. Now select a new folder, the task selection **shouldn't** persist, should it?
2. In workfiles select a folder and then a task. Now select a new folder, the task **should** persist if the names match.
3. Select a folder and task and then copy the breadcrumbs. Now navigate to another page and paste breadcrumbs. Is the task selected on navigation? 