### PR TITLE
Bootstrap: remove exception pages

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -100,12 +100,7 @@ const App = () => {
     return <LoginPage isFirstTime={isOnboarding} />
   }
 
-  const onBoardingSkips = ['events', 'explorer', 'doc/api']
-
-  if (
-    (isOnboarding || noAdminUser) &&
-    onBoardingSkips.every((path) => !location.pathname.includes(path))
-  ) {
+  if (isOnboarding || noAdminUser) {
     return (
       <BrowserRouter>
         <QueryParamProvider


### PR DESCRIPTION
## Changelog Description

-  Previously some pages would be exempt from bootstrapping redirect like '/events'. Now removed as it's confusing and not useful.

## Testing

1. Launch bootstrapping from events page