### PR TITLE
Project: Set project library attribute

### DIFF
--- a/src/pages/ProjectDashboard/panels/ProjectDetails/ProjectDetails.jsx
+++ b/src/pages/ProjectDashboard/panels/ProjectDetails/ProjectDetails.jsx
@@ -26,9 +26,11 @@ const ProjectDetails = ({ projectName }) => {
 
   const [editing, setEditing] = useState(false)
 
+  // this where we add new fields to the editing form
   const projectFormInit = {
     active: false,
     code: '',
+    library: false,
     attrib: {},
   }
 
@@ -37,21 +39,30 @@ const ProjectDetails = ({ projectName }) => {
   // form for project data
   const [projectForm, setProjectForm] = useState(projectFormInit)
 
-  // when data has been loading, update the form
+  const setInitFormState = (projectData) => {
+    const updatedProjectForm = { ...projectFormInit }
+    for (const key in projectFormInit) {
+      updatedProjectForm[key] = projectData[key]
+    }
+    setProjectForm(updatedProjectForm)
+    // update init data to compare changes
+    setInitData(updatedProjectForm)
+  }
+
+  // when data has been loaded, update the form
+  // we add projectFormInit fields to the form along with attrib fields
+  // inside AttribForm we validate attrib fields and any missing fields from schema
   useEffect(() => {
     if (!isFetching && !isEmpty(data)) {
       // update project form with only the fields we need from the projectForm init state
-      const updatedProjectForm = { ...projectFormInit }
-      for (const key in projectFormInit) {
-        updatedProjectForm[key] = data[key]
-      }
-      setProjectForm(updatedProjectForm)
-      setInitData(updatedProjectForm)
+      setInitFormState(data)
     }
   }, [data, isFetching])
 
-  const { attrib = {}, active, code } = data
+  const { attrib = {}, active, code, library } = data
 
+  // Every thing below creates the attribute table
+  // this is where we add new fields to the attribute table
   const attribArray = []
   for (const key in fields) {
     let field = fields[key]
@@ -69,6 +80,11 @@ const ProjectDetails = ({ projectName }) => {
   }
 
   attribArray.unshift({
+    name: 'Library',
+    value: !!library,
+  })
+
+  attribArray.unshift({
     value: (
       <Styled.Active $isLoading={isFetching} $isActive={active}>
         {active ? 'active' : ' inactive'}
@@ -76,6 +92,8 @@ const ProjectDetails = ({ projectName }) => {
     ),
     name: 'Status',
   })
+
+  // HANDLERS
 
   const handleProjectChange = (field, value) => {
     const newProjectForm = { ...projectForm, attrib: { ...projectForm.attrib } }
@@ -124,6 +142,13 @@ const ProjectDetails = ({ projectName }) => {
     }
   }
 
+  const handleCancel = () => {
+    // reset the form to the initial state
+    setProjectForm(initData)
+    // close editing
+    setEditing(false)
+  }
+
   const hasChanges = !isEqual(initData, projectForm)
 
   return (
@@ -148,12 +173,7 @@ const ProjectDetails = ({ projectName }) => {
               />
             ) : (
               <>
-                <Button
-                  label="Cancel"
-                  icon="close"
-                  onClick={() => setEditing(false)}
-                  className="cancel"
-                />
+                <Button label="Cancel" icon="close" onClick={handleCancel} className="cancel" />
                 <SaveButton
                   label="Save"
                   active={hasChanges}

--- a/src/pages/ProjectManagerPage/NewProjectDialog/NewProject.jsx
+++ b/src/pages/ProjectManagerPage/NewProjectDialog/NewProject.jsx
@@ -2,7 +2,7 @@ import { useState, useMemo, useEffect } from 'react'
 import { Dialog } from 'primereact/dialog'
 import { toast } from 'react-toastify'
 
-import { Spacer, InputText, Toolbar, SaveButton } from '@ynput/ayon-react-components'
+import { Spacer, InputText, Toolbar, SaveButton, InputSwitch } from '@ynput/ayon-react-components'
 import SettingsEditor from '/src/containers/SettingsEditor'
 import AnatomyPresetDropdown from './AnatomyPresetDropdown'
 import {
@@ -22,6 +22,7 @@ const NewProjectDialog = ({ onHide }) => {
   const [codeSet, setCodeSet] = useState(false)
   const [newAnatomy, setNewAnatomy] = useState(null)
   const [selectedPreset, setSelectedPreset] = useState(null)
+  const [isLibrary, setIsLibrary] = useState(false)
 
   // GET SCHEMA DATA
   // '/api/anatomy/schema'
@@ -36,7 +37,6 @@ const NewProjectDialog = ({ onHide }) => {
 
   // Logic
   //
-
   const [createProject, { isLoading }] = useCreateProjectMutation()
 
   const handleSubmit = () => {
@@ -44,6 +44,7 @@ const NewProjectDialog = ({ onHide }) => {
       name,
       code,
       anatomy: newAnatomy, // || originalAnatomy,
+      library: isLibrary,
     })
       .unwrap()
       .then(() => {
@@ -132,6 +133,12 @@ const NewProjectDialog = ({ onHide }) => {
 
   const footer = (
     <Toolbar style={{}}>
+      Library project
+      <InputSwitch
+        checked={isLibrary}
+        onChange={(e) => setIsLibrary(e.target.checked)}
+        style={{ marginLeft: 8 }}
+      />
       <Spacer />
       <SaveButton
         label="Create Project"

--- a/src/services/project/updateProject.js
+++ b/src/services/project/updateProject.js
@@ -3,20 +3,21 @@ import { ayonApi } from '../ayon'
 const updateProject = ayonApi.injectEndpoints({
   endpoints: (build) => ({
     createProject: build.mutation({
-      query: ({ name, code, anatomy }) => ({
+      query: ({ name, code, anatomy, library }) => ({
         url: `/api/projects`,
         method: 'POST',
         body: {
           name,
           code,
           anatomy,
+          library,
         },
       }),
       transformErrorResponse: (error) => error.data.detail || `Error ${error.status}`,
       async onQueryStarted({ ...patch }, { dispatch, queryFulfilled }) {
         const patchResult = dispatch(
           ayonApi.util.updateQueryData('getAllProjects', undefined, (draft) => {
-            const newProject = { name: patch.name, code: patch.code }
+            const newProject = { name: patch.name, code: patch.code, library: patch.library }
             draft.push(newProject)
           }),
         )


### PR DESCRIPTION
## Changelog Description

- Add project Library attribute to project details panel, project details form and create new project.
- The library attribute in projects allows studios to load content like assets, images, 3D models, etc., across different projects.

## Testing

1. Navigate to manage projects page.
2. Select project and on right hand side details panel click edit.
3. Turn library on/off.
4. Click save.
5. Library should have updated in the attributes panel.