### PR TITLE
Browser: list, grid, layers toggles improved UI switching

### DIFF
--- a/src/pages/BrowserPage/ViewModeToggle.jsx
+++ b/src/pages/BrowserPage/ViewModeToggle.jsx
@@ -3,53 +3,50 @@ import PropTypes from 'prop-types'
 import { Button } from '@ynput/ayon-react-components'
 
 const ViewModeToggle = ({ onChange, value, grouped, setGrouped }) => {
+  const handleNormalClick = (id) => {
+    setGrouped(false)
+    onChange(id)
+  }
+
+  const handleGroupClick = () => {
+    // set to grid
+    onChange('grid')
+    // set grouped
+    setGrouped(true)
+  }
+
   const items = [
     {
       id: 'list',
       icon: 'format_list_bulleted',
+      onClick: () => handleNormalClick('list'),
+      title: 'List View',
     },
     {
       id: 'grid',
       icon: 'grid_view',
-      children: [
-        {
-          id: 'grouped',
-          icon: 'layers',
-          isActive: grouped && value === 'grid',
-          command: () => {
-            if (value !== 'grid') {
-              onChange('grid')
-              setGrouped(true)
-            } else {
-              setGrouped(!grouped)
-            }
-          },
-        },
-      ],
+      onClick: () => handleNormalClick('grid'),
+      title: 'Grid View',
+    },
+    {
+      id: 'layers',
+      icon: 'layers',
+      onClick: () => handleGroupClick(),
+      title: 'Grouped View',
     },
   ]
+
+  if (grouped) value = 'layers'
 
   return (
     <>
       {items.map((item) => (
-        <Fragment key={item.id}>
-          <Button
-            icon={item.icon}
-            onClick={() => onChange(item.id)}
-            className={value === item.id ? 'active' : ''}
-            selected={value === item.id}
-          />
-          {item.children &&
-            item.children.map((child) => (
-              <Button
-                icon={child.icon}
-                key={child.id}
-                onClick={() => (child.command ? child.command(child.id) : onChange(child.id))}
-                className={value === child.id || child.isActive ? 'active' : ''}
-                selected={value === child.id || child.isActive}
-              />
-            ))}
-        </Fragment>
+        <Button
+          key={item.id}
+          className={value === item.id ? 'active' : ''}
+          selected={value === item.id}
+          {...item}
+        />
       ))}
     </>
   )


### PR DESCRIPTION
## Changelog Description

- Only one option can be selected at one time. Before "Grid" and "Layers" could be selected together which was confusing.

## Additional Information

![image](https://github.com/ynput/ayon-frontend/assets/49156310/1a878d5c-98fe-4c6e-9323-85ceec5c018b)

## Testing

On the browser page, clicking the three buttons should select the button and changed the view. Only one button should ever be selected at one time.