### PR TITLE
Projects Menu: Project code and highlighted

### DIFF
--- a/src/components/ProjectButton/ProjectButton.jsx
+++ b/src/components/ProjectButton/ProjectButton.jsx
@@ -2,9 +2,13 @@ import { Button } from '@ynput/ayon-react-components'
 import React from 'react'
 import * as Styled from './ProjectButton.styled'
 
-const ProjectButton = ({ label, code, onPin, onEdit, ...props }) => {
+const ProjectButton = ({ label, code, onPin, onEdit, className, highlighted, ...props }) => {
   return (
-    <Styled.Project {...props} tabIndex={0}>
+    <Styled.Project
+      {...props}
+      tabIndex={0}
+      className={`${className} ${highlighted ? 'highlighted' : ''}`}
+    >
       <span>{label}</span>
       {/* code hides on hover */}
       {code && <span className="code">{code}</span>}

--- a/src/components/ProjectButton/ProjectButton.jsx
+++ b/src/components/ProjectButton/ProjectButton.jsx
@@ -2,10 +2,13 @@ import { Button } from '@ynput/ayon-react-components'
 import React from 'react'
 import * as Styled from './ProjectButton.styled'
 
-const ProjectButton = ({ label, onPin, onEdit, ...props }) => {
+const ProjectButton = ({ label, code, onPin, onEdit, ...props }) => {
   return (
     <Styled.Project {...props} tabIndex={0}>
       <span>{label}</span>
+      {/* code hides on hover */}
+      {code && <span className="code">{code}</span>}
+      {/* hover buttons */}
       {onEdit && <Button onClick={onEdit} icon="settings_applications" />}
       <Button onClick={onPin} icon={'push_pin'} className="pin" />
     </Styled.Project>

--- a/src/components/ProjectButton/ProjectButton.styled.js
+++ b/src/components/ProjectButton/ProjectButton.styled.js
@@ -22,6 +22,12 @@ export const Project = styled.div`
     }
   }
 
+  .code {
+    flex: 0;
+    padding-right: var(--padding-m);
+    color: var(--md-sys-color-outline);
+  }
+
   /* button default hidden */
   button {
     display: none;
@@ -33,6 +39,11 @@ export const Project = styled.div`
     background-color: var(--md-sys-color-surface-container-highest);
     button {
       display: flex;
+    }
+
+    /* hide code on hover */
+    .code {
+      display: none;
     }
   }
 

--- a/src/components/ProjectButton/ProjectButton.styled.js
+++ b/src/components/ProjectButton/ProjectButton.styled.js
@@ -22,6 +22,10 @@ export const Project = styled.div`
     }
   }
 
+  &.highlighted {
+    background-color: var(--md-sys-color-primary-container);
+  }
+
   .code {
     flex: 0;
     padding-right: var(--padding-m);

--- a/src/containers/ProjectMenu/projectMenu.jsx
+++ b/src/containers/ProjectMenu/projectMenu.jsx
@@ -82,6 +82,7 @@ const ProjectMenu = ({ visible, onHide }) => {
       node: (
         <ProjectButton
           label={project.name}
+          code={project.code}
           className={pinned.includes(project.name) ? 'pinned' : ''}
           onPin={(e) => handlePinChange(project.name, e)}
           onEdit={!isUser && ((e) => handleEditClick(e, project.name))}

--- a/src/containers/ProjectMenu/projectMenu.jsx
+++ b/src/containers/ProjectMenu/projectMenu.jsx
@@ -84,6 +84,7 @@ const ProjectMenu = ({ visible, onHide }) => {
           label={project.name}
           code={project.code}
           className={pinned.includes(project.name) ? 'pinned' : ''}
+          highlighted={projectSelected === project.name}
           onPin={(e) => handlePinChange(project.name, e)}
           onEdit={!isUser && ((e) => handleEditClick(e, project.name))}
           onClick={() => onProjectSelect(project.name)}

--- a/src/containers/ProjectMenu/projectMenu.styled.js
+++ b/src/containers/ProjectMenu/projectMenu.styled.js
@@ -18,6 +18,7 @@ export const ProjectSidebar = styled(Sidebar)`
   h3 {
     border: none;
     color: var(--md-sys-color-outline);
+    padding-left: var(--padding-m);
   }
 
   .p-sidebar-content {

--- a/src/pages/ProjectDashboard/panels/ProjectDetails/ProjectDetails.jsx
+++ b/src/pages/ProjectDashboard/panels/ProjectDetails/ProjectDetails.jsx
@@ -84,6 +84,13 @@ const ProjectDetails = ({ projectName }) => {
     value: !!library,
   })
 
+  // project code
+  attribArray.unshift({
+    name: 'Code',
+    value: code,
+  })
+
+  // Active status
   attribArray.unshift({
     value: (
       <Styled.Active $isLoading={isFetching} $isActive={active}>

--- a/src/pages/ProjectManagerPage/ProjectManagerPageContainer.jsx
+++ b/src/pages/ProjectManagerPage/ProjectManagerPageContainer.jsx
@@ -21,9 +21,7 @@ const ProjectManagerPageContainer = ({
         isUser: isUser,
         projectList: (
           <ProjectList
-            styleSection={{ maxWidth: 180, minWidth: 180 }}
-            hideCode
-            isCollapsible
+            styleSection={{ maxWidth: 300, minWidth: 300 }}
             autoSelect
             selection={selection}
             onDeleteProject={onDeleteProject}


### PR DESCRIPTION
## Changelog Description

- Add project code to projects menu and hide when hovering to reveal action buttons.
- Highlight current project in project menu.
- Add project code to projects table in project settings.
- Add project code to project details attribute table.

## Additional Information

![image](https://github.com/ynput/ayon-frontend/assets/49156310/d012b951-541a-4148-bf9e-2587dd7fb988)

![image](https://github.com/ynput/ayon-frontend/assets/49156310/5fa466f9-4fe1-49f3-8519-01b4e6781700)
