### PR TITLE
Settings: Addon version agnostic URIs

### DIFF
--- a/src/containers/AddonList.jsx
+++ b/src/containers/AddonList.jsx
@@ -13,7 +13,7 @@ const AddonList = ({
   onContextMenu,
   variant = 'production', // 'production' or 'staging'
   siteSettings = false, // 'settings' or 'site' - show addons with settings or site settings
-  onAddonChanged = () => {}, // Triggered when selection is changed by ayon+settings:// uri change
+  onAddonFocus = () => {}, // Triggered when selection is changed by ayon+settings:// uri change
   changedAddonKeys = null, // List of addon keys that have changed
   projectName, // used for chaged addons
   siteId, // used for chaged addons
@@ -94,8 +94,13 @@ const AddonList = ({
         (a) => a.name === addonName && (addonVersion ? a.version === addonVersion : true),
       )
       if (addon) {
-        setSelectedAddons([{ ...addon, siteId, path }])
-        onAddonChanged(addonName)
+        setSelectedAddons([addon])
+        onAddonFocus({
+          addonName,
+          addonVersion: addon.version,
+          siteId,
+          path,
+        })
       }
     }
   }, [addons, uriChanged])

--- a/src/containers/AddonList.jsx
+++ b/src/containers/AddonList.jsx
@@ -85,12 +85,16 @@ const AddonList = ({
     const addonName = url.searchParams.get('addonName')
     const addonVersion = url.searchParams.get('addonVersion')
 
+    // additional properties received from ayon+settings:// uri
+    const siteId = url.searchParams.get('site') || undefined
+    const path = url.searchParams.get('settingsPath')?.split('|') || undefined
+
     if (addonName) {
       const addon = addons.find(
         (a) => a.name === addonName && (addonVersion ? a.version === addonVersion : true),
       )
       if (addon) {
-        setSelectedAddons([addon])
+        setSelectedAddons([{ ...addon, siteId, path }])
         onAddonChanged(addonName)
       }
     }

--- a/src/containers/AddonList.jsx
+++ b/src/containers/AddonList.jsx
@@ -85,8 +85,10 @@ const AddonList = ({
     const addonName = url.searchParams.get('addonName')
     const addonVersion = url.searchParams.get('addonVersion')
 
-    if (addonName && addonVersion) {
-      const addon = addons.find((a) => a.name === addonName && a.version === addonVersion)
+    if (addonName) {
+      const addon = addons.find(
+        (a) => a.name === addonName && (addonVersion ? a.version === addonVersion : true),
+      )
       if (addon) {
         setSelectedAddons([addon])
         onAddonChanged(addonName)

--- a/src/containers/AddonSettings/AddonSettings.jsx
+++ b/src/containers/AddonSettings/AddonSettings.jsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect } from 'react'
+import { useState, useMemo } from 'react'
 import { useSelector } from 'react-redux'
 import { toast } from 'react-toastify'
 
@@ -69,17 +69,7 @@ const AddonSettings = ({ projectName, showSites = false }) => {
 
   const projectKey = projectName || '_'
 
-  useEffect(() => {
-    if (selectedAddons.length !== 1) {
-      setCurrentSelection(null)
-      return
-    }
-
-    const addonName = selectedAddons[0].name
-    const addonVersion = selectedAddons[0].version
-    const siteId = selectedAddons[0].siteId
-    const path = selectedAddons[0].path
-
+  const onAddonFocus = ({ addonName, addonVersion, siteId, path }) => {
     if (!path?.length) {
       setCurrentSelection(null)
       return
@@ -96,7 +86,7 @@ const AddonSettings = ({ projectName, showSites = false }) => {
       path,
       fieldId,
     })
-  }, [selectedAddons])
+  }
 
   const user = useSelector((state) => state.user)
 
@@ -157,19 +147,6 @@ const AddonSettings = ({ projectName, showSites = false }) => {
       }
       return newData
     })
-  }
-
-  const onAddonChanged = (addonName) => {
-    // TODO: deprecated?
-    // not sure why this is here. I think it was used to reload addons when
-    // an addon was changed ouside the form (e.g. copying settings using addon list ctx menu)
-    // But we should probably get rid of outside changes
-    console.warn('Called onAddonChanged. This is deprecated.')
-    for (const key in localData) {
-      if (addonName === key.split('|')[0]) {
-        reloadAddons([key])
-      }
-    }
   }
 
   const onSave = async () => {
@@ -539,7 +516,7 @@ const AddonSettings = ({ projectName, showSites = false }) => {
             selectedAddons={selectedAddons}
             setSelectedAddons={onSelectAddon}
             variant={variant}
-            onAddonChanged={onAddonChanged}
+            onAddonFocus={onAddonFocus}
             setBundleName={setBundleName}
             changedAddonKeys={Object.keys(changedKeys || {})}
             projectName={projectName}

--- a/src/containers/AddonSettings/AddonSettings.jsx
+++ b/src/containers/AddonSettings/AddonSettings.jsx
@@ -67,32 +67,36 @@ const AddonSettings = ({ projectName, showSites = false }) => {
   const [modifyAddonOverride] = useModifyAddonOverrideMutation()
   const [promoteBundle] = usePromoteBundleMutation()
 
-  const uriChanged = useSelector((state) => state.context.uriChanged)
-
   const projectKey = projectName || '_'
 
   useEffect(() => {
-    const url = new URL(window.location.href)
-    const addonName = url.searchParams.get('addonName')
-    const addonVersion = url.searchParams.get('addonVersion')
-    const addonString = `${addonName}@${addonVersion}`
-    const siteId = url.searchParams.get('site')
-    const path = url.searchParams.get('settingsPath')?.split('|') || []
-    const fieldId = path.length ? `root_${path.join('_')}` : 'root'
-
-    if (addonName && addonVersion) {
-      setCurrentSelection({
-        addonName,
-        addonVersion,
-        addonString,
-        siteId,
-        path,
-        fieldId,
-      })
-    } else {
+    if (selectedAddons.length !== 1) {
       setCurrentSelection(null)
+      return
     }
-  }, [uriChanged])
+
+    const addonName = selectedAddons[0].name
+    const addonVersion = selectedAddons[0].version
+    const siteId = selectedAddons[0].siteId
+    const path = selectedAddons[0].path
+
+    if (!path?.length) {
+      setCurrentSelection(null)
+      return
+    }
+
+    const fieldId = path.length ? `root_${path.join('_')}` : 'root'
+    const addonString = `${addonName}@${addonVersion}`
+
+    setCurrentSelection({
+      addonName,
+      addonVersion,
+      addonString,
+      siteId,
+      path,
+      fieldId,
+    })
+  }, [selectedAddons])
 
   const user = useSelector((state) => state.user)
 
@@ -484,7 +488,7 @@ const AddonSettings = ({ projectName, showSites = false }) => {
         />
       </Toolbar>
     )
-  }, [showHelp, currentSelection, changedKeys])
+  }, [showHelp])
 
   const commitToolbar = useMemo(
     () => (

--- a/src/containers/AddonSettings/AddonSettingsPanel.jsx
+++ b/src/containers/AddonSettings/AddonSettingsPanel.jsx
@@ -90,7 +90,6 @@ const AddonSettingsPanel = ({
   }, [localData])
 
   const breadcrumbs = useMemo(() => {
-    console.log('CurrentSel', currentSelection)
     if (!currentSelection) return null
     if (currentSelection.addonString !== `${addon.name}@${addon.version}`) return null
     return currentSelection.path

--- a/src/containers/AddonSettings/AddonSettingsPanel.jsx
+++ b/src/containers/AddonSettings/AddonSettingsPanel.jsx
@@ -90,6 +90,7 @@ const AddonSettingsPanel = ({
   }, [localData])
 
   const breadcrumbs = useMemo(() => {
+    console.log('CurrentSel', currentSelection)
     if (!currentSelection) return null
     if (currentSelection.addonString !== `${addon.name}@${addon.version}`) return null
     return currentSelection.path
@@ -97,7 +98,7 @@ const AddonSettingsPanel = ({
 
   useEffect(() => {
     let uri = `ayon+settings://${addon.name}`
-    if (addon.version) uri += `:${addon.version}`
+    //if (addon.version) uri += `:${addon.version}`
     if (currentSelection?.path) uri += `/${currentSelection.path.join('/')}`
     if (projectName) uri += `?project=${projectName}`
     if (siteId) uri += `&site=${siteId}`

--- a/src/containers/SettingsEditor/SettingsEditor.jsx
+++ b/src/containers/SettingsEditor/SettingsEditor.jsx
@@ -8,7 +8,7 @@ import './SettingsEditor.sass'
 
 const FormWrapper = styled.div`
   [data-fieldid='${(props) => props.currentSelection}'] {
-    border-left: 1px solid var(--color-changed) !important;
+    // border-left: 1px solid var(--color-changed) !important;
     border-radius: 4px;
     background-color: rgba(0, 0, 0, 0.2);
   }

--- a/src/containers/SettingsEditor/SettingsPanel.jsx
+++ b/src/containers/SettingsEditor/SettingsPanel.jsx
@@ -83,11 +83,12 @@ const Panel = ({
   children,
   onHeaderClick,
   onContextMenu,
+  objId,
 }) => {
   const toggleIcon = expanded ? 'expand_more' : 'chevron_right'
 
   return (
-    <PanelWrapper className={`panel ${className}`}>
+    <PanelWrapper className={`panel ${className}`} data-fieldid={objId}>
       <PanelHeader
         className="panel-header"
         onContextMenu={onContextMenu}
@@ -147,6 +148,7 @@ const SettingsPanel = ({
       className={nclass}
       onHeaderClick={onClick}
       onContextMenu={onContextMenu}
+      objId={objId}
     >
       {children}
     </Panel>

--- a/src/containers/SettingsEditor/fields.jsx
+++ b/src/containers/SettingsEditor/fields.jsx
@@ -153,7 +153,7 @@ function ObjectFieldTemplate(props) {
     return (
       <>
         {longDescription}
-        <div className={className}>
+        <div className={className} data-fieldid={props.id}>
           {props.properties
             .filter(
               (element) =>
@@ -376,7 +376,7 @@ function FieldTemplate(props) {
         title={props.schema.title}
         description={props.schema.description}
         className={classes.join(' ')}
-        onMouseUp={() => {
+        onClick={() => {
           if (props.formContext.onSetBreadcrumbs && path) props.formContext.onSetBreadcrumbs(path)
         }}
         onContextMenu={onContextMenu}

--- a/src/containers/SettingsEditor/widgets.jsx
+++ b/src/containers/SettingsEditor/widgets.jsx
@@ -72,7 +72,7 @@ const CheckboxWidget = function (props) {
   }, [props.onChange, value])
 
   useEffect(() => {
-    console.log(props.id, props.value, value)
+    //console.log(props.id, props.value, value)
     // Sync the local state with the formData
     if (props.value === undefined) return
     if (value === props.value) return

--- a/src/hooks/useUriNavigate.js
+++ b/src/hooks/useUriNavigate.js
@@ -110,30 +110,16 @@ const useUriNavigate = () => {
 
         let targetUrl = ''
 
-        if ('project' in qp && 'site' in qp) {
-          targetUrl = `manageProjects/siteSettings?`
-          targetUrl += `project=${qp.project}&site=${qp.site}`
-          targetUrl += `&addonName=${addonName}`
-          if (addonVersion) targetUrl += `&addonVersion=${addonVersion}`
-          targetUrl += `&settingsPath=${settingsPath.join('|')}`
-        } else if ('project' in qp) {
-          targetUrl = `manageProjects/projectSettings?`
-          targetUrl += `project=${qp.project}`
-          targetUrl += `&addonName=${addonName}`
-          if (addonVersion) targetUrl += `&addonVersion=${addonVersion}`
-          targetUrl += `&settingsPath=${settingsPath.join('|')}`
-        } else if ('site' in qp) {
-          targetUrl = `settings/site?`
-          targetUrl += `site=${qp.site}`
-          targetUrl += `&addonName=${addonName}`
-          if (addonVersion) targetUrl += `&addonVersion=${addonVersion}`
-          targetUrl += `&settingsPath=${settingsPath.join('|')}`
-        } else {
-          targetUrl = `settings/studio`
-          targetUrl += `?addonName=${addonName}`
-          if (addonVersion) targetUrl += `&addonVersion=${addonVersion}`
-          targetUrl += `&settingsPath=${settingsPath.join('|')}`
-        }
+        if ('project' in qp && 'site' in qp)
+          targetUrl = `manageProjects/siteSettings?${qp.project}&site=${qp.site}&`
+        else if ('project' in qp)
+          targetUrl = `manageProjects/projectSettings?project=${qp.project}&`
+        else if ('site' in qp) targetUrl = `settings/site?site=${qp.site}&`
+        else targetUrl = `settings/studio?`
+
+        targetUrl += `addonName=${addonName}`
+        if (addonVersion) targetUrl += `&addonVersion=${addonVersion}`
+        if (settingsPath?.length) targetUrl += `&settingsPath=${settingsPath.join('|')}`
 
         navigate(targetUrl)
         dispatch(setUri(localUri))

--- a/src/hooks/useUriNavigate.js
+++ b/src/hooks/useUriNavigate.js
@@ -113,21 +113,25 @@ const useUriNavigate = () => {
         if ('project' in qp && 'site' in qp) {
           targetUrl = `manageProjects/siteSettings?`
           targetUrl += `project=${qp.project}&site=${qp.site}`
-          targetUrl += `&addonName=${addonName}&addonVersion=${addonVersion}`
+          targetUrl += `&addonName=${addonName}`
+          if (addonVersion) targetUrl += `&addonVersion=${addonVersion}`
           targetUrl += `&settingsPath=${settingsPath.join('|')}`
         } else if ('project' in qp) {
           targetUrl = `manageProjects/projectSettings?`
           targetUrl += `project=${qp.project}`
-          targetUrl += `&addonName=${addonName}&addonVersion=${addonVersion}`
+          targetUrl += `&addonName=${addonName}`
+          if (addonVersion) targetUrl += `&addonVersion=${addonVersion}`
           targetUrl += `&settingsPath=${settingsPath.join('|')}`
         } else if ('site' in qp) {
           targetUrl = `settings/site?`
           targetUrl += `site=${qp.site}`
-          targetUrl += `&addonName=${addonName}&addonVersion=${addonVersion}`
+          targetUrl += `&addonName=${addonName}`
+          if (addonVersion) targetUrl += `&addonVersion=${addonVersion}`
           targetUrl += `&settingsPath=${settingsPath.join('|')}`
         } else {
           targetUrl = `settings/studio`
-          targetUrl += `?addonName=${addonName}&addonVersion=${addonVersion}`
+          targetUrl += `?addonName=${addonName}`
+          if (addonVersion) targetUrl += `&addonVersion=${addonVersion}`
           targetUrl += `&settingsPath=${settingsPath.join('|')}`
         }
 


### PR DESCRIPTION
URIs pointing to settings no longer require an addon version. Links point to versions currently enabled by default (the exact specification is still available using `addonName:addonVersion` format.