### PR TITLE
Artist Dashboard: Group tasks by folder name and expand groups shortcut

### DIFF
--- a/src/components/status/statusSelect.jsx
+++ b/src/components/status/statusSelect.jsx
@@ -57,7 +57,7 @@ const StatusSelect = ({
   const longestStatus = statusesSortedByLength?.name?.length
   const calcMaxWidth = longestStatus * charWidth + gap + iconWidth + 16
 
-  maxWidth = maxWidth || calcMaxWidth
+  maxWidth = maxWidth || calcMaxWidth || 'unset'
 
   const dropdownValue = Array.isArray(value) ? uniq(value) : [value]
   const isMixed = dropdownValue.length > 1

--- a/src/context/shortcutsContext.jsx
+++ b/src/context/shortcutsContext.jsx
@@ -11,6 +11,22 @@ function ShortcutsProvider(props) {
   const navigate = useNavigate()
   const dispatch = useDispatch()
 
+  // keep track of what's being hovered
+  const [hovered, setHovered] = useState(null)
+
+  useEffect(() => {
+    document.addEventListener('mouseover', (e) => {
+      setHovered(e.target)
+    })
+
+    return () => {
+      // clean up event listeners
+      document.removeEventListener('mouseover', (e) => {
+        setHovered(e.target)
+      })
+    }
+  }, [])
+
   // logout
   const [logout] = useLogOutMutation()
 
@@ -93,8 +109,14 @@ function ShortcutsProvider(props) {
     // if it is, prevent default browser behavior
     e.preventDefault()
 
+    // check if the shortcut has a closest selector
+    if (shortcut.closest) {
+      // if it does, check if the target matches the selector
+      if (!hovered || !hovered.closest(shortcut.closest)) return
+    }
+
     // and run the action
-    shortcut.action()
+    shortcut.action(hovered)
   }
 
   // listen for key presses

--- a/src/helpers/getPreviousTagElement.js
+++ b/src/helpers/getPreviousTagElement.js
@@ -1,0 +1,14 @@
+function getPreviousTagElement(element, tag) {
+  let previousElement = element.previousElementSibling
+
+  while (previousElement && tag) {
+    if (previousElement.tagName === tag) {
+      return previousElement
+    }
+    previousElement = previousElement.previousElementSibling
+  }
+
+  return null
+}
+
+export default getPreviousTagElement

--- a/src/pages/UserDashboardPage/UserDashboardTasks/DashboardTasksToolbar/DashboardTasksToolbar.jsx
+++ b/src/pages/UserDashboardPage/UserDashboardTasks/DashboardTasksToolbar/DashboardTasksToolbar.jsx
@@ -37,6 +37,7 @@ const DashboardTasksToolbar = ({ allUsers = [], isLoadingAllUsers, view, setView
     { id: 'projectName', label: 'Project', sortOrder: true },
     { id: 'status', label: 'Status', sortOrder: true },
     { id: 'taskType', label: 'Type', sortOrder: true },
+    { id: 'folderName', label: 'Folder', sortOrder: true },
   ]
 
   const assigneesGroupBy = { id: 'assignees', label: 'Assignee', sortOrder: true }

--- a/src/pages/UserDashboardPage/UserDashboardTasks/ListGroup/ListGroup.jsx
+++ b/src/pages/UserDashboardPage/UserDashboardTasks/ListGroup/ListGroup.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
-import { useDispatch, useSelector } from 'react-redux'
-import { onCollapsedColumnsChanged } from '/src/features/dashboard'
+import { useDispatch } from 'react-redux'
+
 import { useGetTaskContextMenu } from '/src/pages/UserDashboardPage/util'
 import * as Styled from './ListGroup.styled'
 import { Button } from '@ynput/ayon-react-components'
@@ -19,22 +19,12 @@ const ListGroup = ({
   onUpdate,
   assigneesIsMe,
   allUsers = [],
+  onCollapseChange,
+  isCollapsed,
   isLoading,
 }) => {
   const dispatch = useDispatch()
   const column = groups[id] || {}
-
-  // COLLAPSED GROUPS
-  const collapsedGroups = useSelector((state) => state.dashboard.tasks.collapsedColumns)
-  const setCollapsedGroups = (ids) => dispatch(onCollapsedColumnsChanged(ids))
-  const isCollapsed = collapsedGroups.includes(id)
-
-  const handleCollapseToggle = (id) => {
-    const newCollapsedGroups = collapsedGroups.includes(id)
-      ? collapsedGroups.filter((groupId) => groupId !== id)
-      : [...collapsedGroups, id]
-    setCollapsedGroups(newCollapsedGroups)
-  }
 
   // CONTEXT MENU
   const { handleContextMenu, closeContext } = useGetTaskContextMenu(tasks, dispatch)
@@ -47,12 +37,20 @@ const ListGroup = ({
             borderBottomColor: !isCollapsed && (column?.color ?? 'var(--md-sys-color-outline)'),
           }}
           $isCollapsed={isCollapsed}
-          onDoubleClick={() => handleCollapseToggle(id)}
+          onDoubleClick={() => onCollapseChange(id)}
           $isLoading={column?.isLoading}
+          className="group-header"
+          id={id}
         >
           {!column.isLoading && (
             <>
-              <Button icon="expand_more" variant="text" onClick={() => handleCollapseToggle(id)} />
+              <Button
+                icon="expand_more"
+                variant="text"
+                onClick={() => onCollapseChange(id)}
+                data-tooltip={'Collapse/Expand'}
+                data-shortcut={'C'}
+              />
               <span>
                 {column?.name} - {column?.tasks?.length}
               </span>

--- a/src/pages/UserDashboardPage/UserDashboardTasks/ListGroup/ListGroup.styled.js
+++ b/src/pages/UserDashboardPage/UserDashboardTasks/ListGroup/ListGroup.styled.js
@@ -4,6 +4,7 @@ export const Header = styled.header`
   display: flex;
   padding: 4px;
   align-items: center;
+  position: relative;
   gap: 8px;
   align-self: stretch;
   width: 100%;

--- a/src/pages/UserDashboardPage/UserDashboardTasks/UserTasksContainer.jsx
+++ b/src/pages/UserDashboardPage/UserDashboardTasks/UserTasksContainer.jsx
@@ -33,8 +33,7 @@ const UserTasksContainer = ({ projectsInfo = {}, isLoadingInfo }) => {
   const taskFields = {
     status: { plural: 'statuses', isEditable: true },
     taskType: { plural: 'task_types', isEditable: true },
-    folderName: { plural: 'folder_names', isEditable: false },
-    projectName: { plural: 'projectNames', isEditable: false },
+    folderType: { plural: 'folder_types', isEditable: false },
   }
 
   //  get kanban tasks for all projects by assigned user (me)

--- a/src/pages/UserDashboardPage/util/getMergedFields.js
+++ b/src/pages/UserDashboardPage/util/getMergedFields.js
@@ -24,8 +24,13 @@ const mergeArrays = (arrays) => {
 
 export const getMergedFields = (projectInfo = {}, splitBy) => {
   if (!splitBy) return []
+
+  // check if splitBy is a valid key
+  // if (!(splitBy in projectInfo)) return []
   // first get all the fields
   const fields = Object.values(projectInfo).map((project) => project[splitBy])
+
+  if (fields.length === 0) return []
   //   then merge them into one array
   const mergedFields = mergeArrays(fields)
 


### PR DESCRIPTION
## Changelog Description

- You can now group tasks by folder name. This is useful for looking at your project from a shot perspective.
- New Shortcut: Press `C` when hovering over any part of the group to open/close it.
- shortcutContext now keeps track of the target hovered and provides it to callback function.

## Additional Information

![group_by_folder_v001](https://github.com/ynput/ayon-frontend/assets/49156310/a1a6cae5-c216-4f04-8098-6d4bcd30ed1a)

## Testing

1. Go to `/dashboard/tasks?view=list`
2. Set "group by" to "folder"
3. Hover anywhere over a group and press "C" and then "C" again.