### PR TITLE
Editor: New folder/task ergonomic improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@rjsf/core": "^4.2.0",
     "@rtk-query/graphql-request-base-query": "^2.2.0",
     "@uiw/react-textarea-code-editor": "^2.1.9",
-    "@ynput/ayon-react-components": "0.5.4",
+    "@ynput/ayon-react-components": "^0.5.4",
     "axios": "^0.27.2",
     "chart.js": "^4.2.0",
     "date-fns": "^2.29.3",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@rjsf/core": "^4.2.0",
     "@rtk-query/graphql-request-base-query": "^2.2.0",
     "@uiw/react-textarea-code-editor": "^2.1.9",
-    "@ynput/ayon-react-components": "^0.5.3",
+    "@ynput/ayon-react-components": "0.5.4",
     "axios": "^0.27.2",
     "chart.js": "^4.2.0",
     "date-fns": "^2.29.3",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@rjsf/core": "^4.2.0",
     "@rtk-query/graphql-request-base-query": "^2.2.0",
     "@uiw/react-textarea-code-editor": "^2.1.9",
-    "@ynput/ayon-react-components": "^0.5.2",
+    "@ynput/ayon-react-components": "^0.5.3",
     "axios": "^0.27.2",
     "chart.js": "^4.2.0",
     "date-fns": "^2.29.3",

--- a/src/components/FolderSequence/FolderSequence.jsx
+++ b/src/components/FolderSequence/FolderSequence.jsx
@@ -53,6 +53,7 @@ const FolderSequence = ({
   prefixExample = '',
   prefixDisabled,
   typeSelectRef,
+  onLastInputKeydown,
   ...props
 }) => {
   const { base, increment, length, type, id, entityType, prefix, prefixDepth, parentBases } = props
@@ -347,6 +348,7 @@ const FolderSequence = ({
                 placeholder="15..."
                 min={2}
                 onFocus={(e) => e.target.select()}
+                onKeyDown={onLastInputKeydown}
               />
             </Styled.InputColumn>
 

--- a/src/components/FolderSequence/FolderSequence.jsx
+++ b/src/components/FolderSequence/FolderSequence.jsx
@@ -288,6 +288,7 @@ const FolderSequence = ({
                       onChange={() => handleChange({ target: { value: !prefix, id: 'prefix' } })}
                       disabled={disablePrefix}
                       ref={prefixRef}
+                      switchStyle={{ margin: '4px 0' }}
                     />
                   </Styled.InputColumn>
                   <Icon icon="trending_flat" />

--- a/src/components/FolderSequence/FolderSequence.jsx
+++ b/src/components/FolderSequence/FolderSequence.jsx
@@ -57,6 +57,8 @@ const FolderSequence = ({
 }) => {
   const { base, increment, length, type, id, entityType, prefix, prefixDepth, parentBases } = props
 
+  const disablePrefix = (!nesting && isRoot) || prefixDisabled
+
   const folders = useSelector((state) => state.project.folders) || []
   const tasks = useSelector((state) => state.project.tasks) || []
 
@@ -70,6 +72,7 @@ const FolderSequence = ({
   const [sequence, setSequence] = useState(initSeq)
 
   const baseRef = useRef(null)
+  const prefixRef = useRef(null)
   const handleChange = (e) => {
     e?.preventDefault && e?.preventDefault()
 
@@ -144,12 +147,18 @@ const FolderSequence = ({
       setSequence(seq)
     }
 
-    // focus base input if changing type
+    // focus switch if not disabled else base input if changing type
     if (fieldId === 'type') {
-      setTimeout(() => {
-        baseRef.current.focus()
-        baseRef.current.select()
-      }, 50)
+      if (disablePrefix) {
+        setTimeout(() => {
+          baseRef.current.focus()
+          baseRef.current.select()
+        }, 50)
+      } else {
+        setTimeout(() => {
+          prefixRef.current.focus()
+        }, 50)
+      }
     }
   }
 
@@ -277,7 +286,8 @@ const FolderSequence = ({
                       checked={prefix}
                       id={'prefix'}
                       onChange={() => handleChange({ target: { value: !prefix, id: 'prefix' } })}
-                      disabled={(!nesting && isRoot) || prefixDisabled}
+                      disabled={disablePrefix}
+                      ref={prefixRef}
                     />
                   </Styled.InputColumn>
                   <Icon icon="trending_flat" />

--- a/src/components/FolderSequence/FolderSequence.styled.js
+++ b/src/components/FolderSequence/FolderSequence.styled.js
@@ -105,7 +105,6 @@ export const InputColumn = styled.div`
   }
 
   label {
-    overflow: hidden;
     width: 100%;
     text-overflow: ellipsis;
     white-space: nowrap;

--- a/src/components/status/statusSelect.jsx
+++ b/src/components/status/statusSelect.jsx
@@ -15,7 +15,7 @@ const StatusSelect = ({
   value,
   size = 'full',
   maxWidth,
-  height,
+  height = 30,
   align,
   onChange,
   onOpen,

--- a/src/pages/BrowserPage/Products.jsx
+++ b/src/pages/BrowserPage/Products.jsx
@@ -237,7 +237,7 @@ const Products = () => {
         field: 'versionStatus',
         header: 'Version Status',
         width: 150,
-        style: { overflow: 'visible' },
+        style: { height: 'max-content' },
         body: (node) => {
           if (node.data.isGroup) return ''
           const statusMaxWidth = 120

--- a/src/pages/BrowserPage/VersionList.jsx
+++ b/src/pages/BrowserPage/VersionList.jsx
@@ -8,7 +8,7 @@ const VersionList = (row, onSelectVersion) => {
 
   const versions = useMemo(() => {
     if (!row.versionList) return []
-    return row.versionList.map((version) => {
+    const versions = row.versionList.map((version) => {
       if (version.id === row.versionId) setCurrentVersion(version.name)
       return {
         id: version.id,
@@ -16,6 +16,15 @@ const VersionList = (row, onSelectVersion) => {
         command: () => onSelectVersion(row.id, version.id),
       }
     })
+
+    // sort versions by name
+    versions.sort((a, b) => {
+      if (b.label < a.label) return -1
+      if (b.label > a.label) return 1
+      return 0
+    })
+
+    return versions
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [row.versionList, row.versionId, row.id, menu])
 

--- a/src/pages/EditorPage/NewEntity.jsx
+++ b/src/pages/EditorPage/NewEntity.jsx
@@ -181,14 +181,15 @@ const NewEntity = ({
     }
   }
 
-  const handleKeyDown = (e) => {
-    // ctrl + enter submit and close
-    if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
-      handleSubmit(true)
-    }
-    // shift + enter submit and don't close
-    if (e.shiftKey && e.key === 'Enter') {
-      handleSubmit(false)
+  const handleKeyDown = (e, lastInput) => {
+    if (e.key === 'Enter') {
+      if (lastInput) {
+        handleSubmit(true)
+      } else if (e.ctrlKey || e.metaKey) {
+        handleSubmit(true)
+      } else if (e.shiftKey) {
+        handleSubmit(false)
+      }
     }
   }
 
@@ -251,6 +252,7 @@ const NewEntity = ({
           onChange={(e) => handleChange(e.target.value, 'label')}
           ref={labelRef}
           onFocus={() => setNameFocused(true)}
+          onKeyDown={(e) => handleKeyDown(e, true)}
         />
       </ContentStyled>
     </Dialog>

--- a/src/pages/EditorPage/NewEntity.jsx
+++ b/src/pages/EditorPage/NewEntity.jsx
@@ -32,6 +32,7 @@ const NewEntity = ({
   folderNames = new Map(),
   taskNames = new Map(),
 }) => {
+  const [nameFocused, setNameFocused] = useState(false)
   const [entityType, setEntityType] = useState(null)
   //   build out form state
   const initData = { label: '', name: '', type: '' }
@@ -136,7 +137,7 @@ const NewEntity = ({
     if (id === 'type') {
       setTimeout(() => {
         labelRef.current.focus()
-      }, 50)
+      }, 100)
     }
   }
 
@@ -191,6 +192,16 @@ const NewEntity = ({
     }
   }
 
+  const handleTypeSelectFocus = () => {
+    if (nameFocused) {
+      setNameFocused(false)
+      // super hacky way to fix clicking on type select when name is focused
+      setTimeout(() => {
+        typeSelectRef.current?.open()
+      }, 100)
+    }
+  }
+
   if (!entityType) return null
 
   const addDisabled = !entityData.label || !entityData.type
@@ -205,7 +216,7 @@ const NewEntity = ({
       draggable={false}
       appendTo={document.getElementById('root')}
       footer={
-        <Toolbar>
+        <Toolbar onFocus={() => setNameFocused(false)}>
           <Spacer />
           <Button
             label={`Add`}
@@ -223,6 +234,7 @@ const NewEntity = ({
         </Toolbar>
       }
       onKeyDown={handleKeyDown}
+      onClick={(e) => e.target.tagName !== 'INPUT' && setNameFocused(false)}
     >
       <ContentStyled>
         <TypeEditor
@@ -231,11 +243,14 @@ const NewEntity = ({
           options={typeOptions}
           style={{ width: 160 }}
           ref={typeSelectRef}
+          onFocus={handleTypeSelectFocus}
+          onClick={() => setNameFocused(false)}
         />
         <InputText
           value={entityData.label}
           onChange={(e) => handleChange(e.target.value, 'label')}
           ref={labelRef}
+          onFocus={() => setNameFocused(true)}
         />
       </ContentStyled>
     </Dialog>

--- a/src/pages/EditorPage/NewSequence.jsx
+++ b/src/pages/EditorPage/NewSequence.jsx
@@ -94,14 +94,15 @@ const NewSequence = ({
     }
   }
 
-  const handleKeyDown = (e) => {
-    // ctrl + enter submit and close
-    if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
-      handleSeqSubmit(true)
-    }
-    // shift + enter submit and don't close
-    if (e.shiftKey && e.key === 'Enter') {
-      handleSeqSubmit(false)
+  const handleKeyDown = (e, lastInput) => {
+    if (e.key === 'Enter') {
+      if (lastInput) {
+        handleSeqSubmit(true)
+      } else if (e.ctrlKey || e.metaKey) {
+        handleSeqSubmit(true)
+      } else if (e.shiftKey) {
+        handleSeqSubmit(false)
+      }
     }
   }
 
@@ -144,6 +145,7 @@ const NewSequence = ({
         prefixExample={createSeq.prefix ? examplePrefix : ''}
         prefixDisabled={multipleSelection}
         typeSelectRef={typeSelectRef}
+        onLastInputKeydown={(e) => handleKeyDown(e, true)}
       />
     </Dialog>
   )

--- a/src/pages/UserDashboardPage/UserDashboardNoProjects/UserDashboardNoProjects.jsx
+++ b/src/pages/UserDashboardPage/UserDashboardNoProjects/UserDashboardNoProjects.jsx
@@ -23,7 +23,7 @@ const UserDashboardNoProjects = () => {
         <NewProjectDialog
           onHide={(name) => {
             setOpenNewProject(false)
-            navigate(`/manageProjects?project=${name}`)
+            navigate(`/manageProjects/anatomy?project=${name}`)
           }}
         />
       )}

--- a/src/pages/UserDashboardPage/UserDashboardPage.jsx
+++ b/src/pages/UserDashboardPage/UserDashboardPage.jsx
@@ -1,6 +1,6 @@
-import React, { useMemo } from 'react'
+import React, { useMemo, useState } from 'react'
 import AppNavLinks from '/src/containers/header/AppNavLinks'
-import { useParams } from 'react-router'
+import { useNavigate, useParams } from 'react-router'
 import UserTasksContainer from './UserDashboardTasks/UserTasksContainer'
 import { Section } from '@ynput/ayon-react-components'
 import ProjectList from '/src/containers/projectList'
@@ -10,6 +10,7 @@ import { useGetProjectsInfoQuery } from '/src/services/userDashboard/getUserDash
 import { useGetAllProjectsQuery } from '/src/services/project/getProject'
 import UserDashboardNoProjects from './UserDashboardNoProjects/UserDashboardNoProjects'
 import ProjectDashboard from '../ProjectDashboard'
+import NewProjectDialog from '../ProjectManagerPage/NewProjectDialog'
 
 const UserDashboardPage = () => {
   let { module } = useParams()
@@ -27,6 +28,9 @@ const UserDashboardPage = () => {
       accessLevels: [],
     },
   ]
+
+  const navigate = useNavigate()
+  const [showNewProject, setShowNewProject] = useState(false)
 
   //   redux states
   const dispatch = useDispatch()
@@ -74,8 +78,12 @@ const UserDashboardPage = () => {
             onSelect={(p) => setSelectedProjects(isProjectsMultiSelect ? p : [p])}
             onNoProject={(p) => p && setSelectedProjects([p])}
             autoSelect
-            onSelectAll={(projects) => setSelectedProjects(projects)}
+            onSelectAll={
+              module !== 'overview' ? (projects) => setSelectedProjects(projects) : undefined
+            }
             onSelectAllDisabled={!isProjectsMultiSelect}
+            isProjectManager={module === 'overview'}
+            onNewProject={() => setShowNewProject(true)}
           />
           {module === 'tasks' && (
             <UserTasksContainer
@@ -86,6 +94,14 @@ const UserDashboardPage = () => {
           {module === 'overview' && <ProjectDashboard projectName={selectedProjects[0]} />}
         </Section>
       </main>
+      {showNewProject && (
+        <NewProjectDialog
+          onHide={(name) => {
+            setShowNewProject(false)
+            navigate(`/manageProjects/anatomy?project=${name}`)
+          }}
+        />
+      )}
     </>
   )
 }


### PR DESCRIPTION
## Changelog Description

- Create new project button added to `dashboard/overview`
- New Folder/Task: focusing back to type selecting automatically opens it.
- New Sequence: If prefix switch isn't disabled focus now jumps top it.
- Bump ARC to `0.5.3` to fix switch.
- Version dropdown sort version descending @kalisp 