### PR TITLE
Use REST endpoint instead of GraphQL to load entity detail

### DIFF
--- a/src/containers/entityDetail.jsx
+++ b/src/containers/entityDetail.jsx
@@ -1,16 +1,16 @@
 import { toast } from 'react-toastify'
-import { useGetEntitiesDetailsQuery } from '../services/entity/getEntity'
+import { useGetEntityQuery } from '../services/entity/getEntity'
 import PropTypes from 'prop-types'
 import { Dialog } from 'primereact/dialog'
 
 const EntityDetail = ({ projectName, entityType, entityIds, visible, onHide }) => {
   const {
-    data = [],
+    data = {},
     isLoading,
     isError,
     error,
-  } = useGetEntitiesDetailsQuery(
-    { projectName, type: entityType, ids: entityIds },
+  } = useGetEntityQuery(
+    { projectName, entityType: entityType, entityId: entityIds[0] },
     { skip: !visible },
   )
 
@@ -22,15 +22,14 @@ const EntityDetail = ({ projectName, entityType, entityIds, visible, onHide }) =
   if (!visible || data.length < 1) return null
 
   return (
-    <Dialog visible={true} onHide={onHide} style={{ width: '50vw' }}>
+    <Dialog
+      visible={true}
+      onHide={onHide}
+      style={{ width: '50vw' }}
+      header={`${entityType} detail`}
+    >
       <pre>
-        {!isLoading &&
-          !isError &&
-          JSON.stringify(
-            data.map(({ node }) => node),
-            null,
-            2,
-          )}
+        {!isLoading && !isError && JSON.stringify(data, null, 2)}
         {isLoading && 'loading...'}
         {isError && 'error...'}
       </pre>


### PR DESCRIPTION
Revert the original behavior of entity detail dialog to use useGetEntityQuery instead of GraphQL.

Reason: This is the only place in the frontend, where a user can see the actual payload as available in REST, which is useful for debugging. It contains a complete entity payload as stored in the database along with its dynamic attributes.

Drawback: Only one entity is loaded at time, but i don't believe that is a major problem