### PR TITLE
Thumbnails: upload thumbnails from Browser, Editor and Dashboard

### DIFF
--- a/src/components/Details/EntityDetailsHeader.jsx
+++ b/src/components/Details/EntityDetailsHeader.jsx
@@ -84,6 +84,7 @@ const EntityDetailsHeader = ({
           thumbnails={thumbnails}
           isLoading={isLoading}
           onUpload={onThumbnailUpload}
+          portalId={'editor-entity-details-container'}
         />
       )}
       {isLoading ? (

--- a/src/components/Details/EntityDetailsHeader.jsx
+++ b/src/components/Details/EntityDetailsHeader.jsx
@@ -27,7 +27,13 @@ const StyledLoading = styled.div`
   ${getShimmerStyles()}
 `
 
-const EntityDetailsHeader = ({ values = [], tools, isLoading, hideThumbnail }) => {
+const EntityDetailsHeader = ({
+  values = [],
+  tools,
+  isLoading,
+  hideThumbnail,
+  onThumbnailUpload,
+}) => {
   const { folders, tasks, productTypes } = useSelector((state) => state.project)
   const changes = useSelector((state) => state.editor.changes)
   const uri = useSelector((state) => state.context.uri)
@@ -73,7 +79,13 @@ const EntityDetailsHeader = ({ values = [], tools, isLoading, hideThumbnail }) =
 
   return (
     <DetailHeader>
-      {!hideThumbnail && <StackedThumbnails thumbnails={thumbnails} isLoading={isLoading} />}
+      {!hideThumbnail && (
+        <StackedThumbnails
+          thumbnails={thumbnails}
+          isLoading={isLoading}
+          onUpload={onThumbnailUpload}
+        />
+      )}
       {isLoading ? (
         <StyledLoading />
       ) : (

--- a/src/components/Details/EntityDetailsPanel.jsx
+++ b/src/components/Details/EntityDetailsPanel.jsx
@@ -77,10 +77,8 @@ const EntityDetailsPanel = ({
     }
   }
 
-  const portalId = 'entity-details-panel'
-
   return (
-    <Panel style={{ height: '100%', overflow: 'hidden', ...style }} id={portalId}>
+    <Panel style={{ height: '100%', overflow: 'hidden', ...style }}>
       <ThumbnailGallery
         thumbnails={nodes.map((n) => ({
           id: n.id,
@@ -89,7 +87,6 @@ const EntityDetailsPanel = ({
         }))}
         type={type}
         isLoading={isLoading}
-        portalId={portalId}
         onUpload={onThumbnailUpload}
       />
       <AttributeTable

--- a/src/components/Details/EntityDetailsPanel.jsx
+++ b/src/components/Details/EntityDetailsPanel.jsx
@@ -13,6 +13,7 @@ const EntityDetailsPanel = ({
   hideNull,
   style,
   isLoading,
+  onThumbnailUpload,
 }) => {
   // NOTE: You are probably looking for EntityDetailsPanelContainer.jsx
   if (nodes.length === 0) return null
@@ -89,6 +90,7 @@ const EntityDetailsPanel = ({
         type={type}
         isLoading={isLoading}
         portalId={portalId}
+        onUpload={onThumbnailUpload}
       />
       <AttributeTable
         entityType={type}

--- a/src/components/Details/EntityDetailsPanel.jsx
+++ b/src/components/Details/EntityDetailsPanel.jsx
@@ -76,8 +76,10 @@ const EntityDetailsPanel = ({
     }
   }
 
+  const portalId = 'entity-details-panel'
+
   return (
-    <Panel style={{ height: '100%', overflow: 'hidden', ...style }}>
+    <Panel style={{ height: '100%', overflow: 'hidden', ...style }} id={portalId}>
       <ThumbnailGallery
         thumbnails={nodes.map((n) => ({
           id: n.id,
@@ -86,6 +88,7 @@ const EntityDetailsPanel = ({
         }))}
         type={type}
         isLoading={isLoading}
+        portalId={portalId}
       />
       <AttributeTable
         entityType={type}

--- a/src/components/Details/ThumbnailGallery.jsx
+++ b/src/components/Details/ThumbnailGallery.jsx
@@ -32,7 +32,7 @@ const ImageStyled = styled.div`
   max-width: 250px;
 `
 
-const ThumbnailGallery = ({ thumbnails = [], type, isLoading }) => {
+const ThumbnailGallery = ({ thumbnails = [], type, isLoading, ...props }) => {
   const projectName = useSelector((state) => state.project.name)
   const [index, setIndex] = useState(0)
 
@@ -69,6 +69,7 @@ const ThumbnailGallery = ({ thumbnails = [], type, isLoading }) => {
             entityUpdatedAt={thumbnails[index].updatedAt}
             isLoading={isLoading}
             shimmer
+            {...props}
           />
           <span style={{ opacity: isMultiple ? 1 : 0 }}>{thumbnails[index].name}</span>
         </ImageStyled>

--- a/src/components/Details/ThumbnailGallery.jsx
+++ b/src/components/Details/ThumbnailGallery.jsx
@@ -69,6 +69,7 @@ const ThumbnailGallery = ({ thumbnails = [], type, isLoading, ...props }) => {
             entityUpdatedAt={thumbnails[index].updatedAt}
             isLoading={isLoading}
             shimmer
+            isUploadButton
             {...props}
           />
           <span style={{ opacity: isMultiple ? 1 : 0 }}>{thumbnails[index].name}</span>

--- a/src/components/Details/ThumbnailGallery.jsx
+++ b/src/components/Details/ThumbnailGallery.jsx
@@ -26,6 +26,7 @@ const ImageStyled = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
+  position: relative;
 
   width: 100%;
   max-width: 250px;
@@ -58,6 +59,7 @@ const ThumbnailGallery = ({ thumbnails = [], type, isLoading }) => {
       {thumbnails[index] && (
         <ImageStyled>
           <Thumbnail
+            uploadEntities={thumbnails}
             entityType={type}
             entityId={thumbnails[index].id}
             projectName={projectName}

--- a/src/components/Details/ThumbnailGallery.jsx
+++ b/src/components/Details/ThumbnailGallery.jsx
@@ -70,6 +70,8 @@ const ThumbnailGallery = ({ thumbnails = [], type, isLoading, ...props }) => {
             isLoading={isLoading}
             shimmer
             isUploadButton
+            portalId={'thumbnail-portal'}
+            id={'thumbnail-portal'}
             {...props}
           />
           <span style={{ opacity: isMultiple ? 1 : 0 }}>{thumbnails[index].name}</span>

--- a/src/components/EntityGridTile.jsx
+++ b/src/components/EntityGridTile.jsx
@@ -225,6 +225,7 @@ const EntityGridTile = ({
           projectName={projectName}
           entityUpdatedAt={updatedAt}
           className={'thumbnail'}
+          disableUpload
         />
         <div>
           <IconStyled icon={typeIcon} />

--- a/src/components/ThumbnailUploader/ThumbnailUploader.jsx
+++ b/src/components/ThumbnailUploader/ThumbnailUploader.jsx
@@ -1,0 +1,157 @@
+import React, { useEffect, useState } from 'react'
+import * as Styled from './ThumbnailUploader.styled'
+import { Icon } from '@ynput/ayon-react-components'
+import axios from 'axios'
+import { ayonApi } from '/src/services/ayon'
+import { useDispatch } from 'react-redux'
+
+const ThumbnailUploader = ({ entityType, entityId, projectName, existingImage }) => {
+  const dispatch = useDispatch()
+  const [dragHover, setDragHover] = useState(false)
+  const [imagePreview, setImagePreview] = useState(null)
+  const [selectedFiles, setSelectedFiles] = useState([])
+  //   progress 0-1
+  const [uploadProgress, setUploadProgress] = useState(0)
+  const [uploadError, setUploadError] = useState('')
+  const [uploadSuccess, setUploadSuccess] = useState(false)
+
+  const handleFileUpload = async (files) => {
+    // we select this to trigger preview image
+    setSelectedFiles(files)
+
+    const abortController = new AbortController()
+    const cancelToken = axios.CancelToken
+    const cancelTokenSource = cancelToken.source()
+
+    const file = files[0]
+
+    const opts = {
+      signal: abortController.signal,
+      cancelToken: cancelTokenSource.token,
+      onUploadProgress: (e) => setUploadProgress(Math.round((e.loaded * 100) / e.total) / 100),
+      headers: {
+        'Content-Type': file.type,
+      },
+    }
+
+    try {
+      // for a single file we just use single entityId
+      await axios.post(
+        `/api/projects/${projectName}/${entityType}s/${entityId}/thumbnail`,
+        files[0],
+        opts,
+      )
+
+      setUploadSuccess(true)
+
+      console.log({ type: entityType, id: entityId })
+
+      // if success then we need to refresh the thumbnail
+      // which means invalidating the entityCache
+      dispatch(ayonApi.util.invalidateTags([{ type: entityType, id: entityId }]))
+    } catch (error) {
+      console.error(error)
+      setUploadError(error.response?.data.detail)
+    }
+
+    // once upload, we can use new thumbnail Id and update the entity
+    // if(res.data && res.data.id) {}
+  }
+
+  //   when selectedFiles changes, show preview image
+  useEffect(() => {
+    if (!selectedFiles || !selectedFiles[0]) return
+
+    const objectUrl = URL.createObjectURL(selectedFiles[0])
+    setImagePreview(objectUrl)
+
+    // free memory when ever this component is unmounted
+    return () => URL.revokeObjectURL(objectUrl)
+  }, [selectedFiles])
+
+  // after 1s seconds of upload success, reset the state
+  useEffect(() => {
+    if (!uploadSuccess) return
+
+    const timer = setTimeout(() => {
+      setUploadSuccess(false)
+      setSelectedFiles([])
+      setImagePreview(null)
+    }, 2000)
+
+    return () => {
+      clearTimeout(timer)
+    }
+  }, [uploadSuccess])
+
+  const handleInputChange = (e) => {
+    e.preventDefault()
+    if (!e.target.files || !e.target.files[0]) return
+
+    handleFileUpload(e.target.files)
+  }
+
+  const handleInputDrop = (e) => {
+    e.preventDefault()
+    setDragHover(false)
+    if (!e.dataTransfer.files || !e.dataTransfer.files[0]) return
+
+    handleFileUpload(e.dataTransfer.files)
+  }
+
+  const totalFileSize = Array.from(selectedFiles).reduce(
+    (acc, file) => acc + file.size / 1024 / 1024,
+    0,
+  )
+
+  return (
+    <>
+      <Styled.ThumbnailUploaderWrapper
+        $dragHover={dragHover}
+        $uploading={!!selectedFiles.length}
+        $existingImage={existingImage}
+        $success={uploadSuccess}
+      >
+        <div className="bg" />
+        <Icon icon="cloud_upload" className="upload" />
+        <Styled.ThumbnailInput
+          type="file"
+          onDragEnter={() => setDragHover(true)}
+          onDragLeave={() => setDragHover(false)}
+          onDrop={handleInputDrop}
+          onChange={handleInputChange}
+          accept="image/*"
+        />
+
+        {!!selectedFiles.length && imagePreview && (
+          <Styled.ThumbnailUploading $success={uploadSuccess}>
+            <Styled.UploadPreview
+              src={imagePreview}
+              className="preview"
+              $progress={uploadProgress}
+            />
+            {uploadError ? (
+              <Styled.UploadError>{uploadError}</Styled.UploadError>
+            ) : (
+              totalFileSize > 1 && (
+                <Styled.UploadProgress $progress={uploadProgress} className="progress" />
+              )
+            )}
+          </Styled.ThumbnailUploading>
+        )}
+        {uploadError && (
+          <Styled.Close
+            icon="close"
+            variant="text"
+            onClick={() => {
+              setUploadError('')
+              setSelectedFiles([])
+            }}
+          />
+        )}
+      </Styled.ThumbnailUploaderWrapper>
+    </>
+  )
+}
+
+export default ThumbnailUploader

--- a/src/components/ThumbnailUploader/ThumbnailUploader.jsx
+++ b/src/components/ThumbnailUploader/ThumbnailUploader.jsx
@@ -12,6 +12,7 @@ const ThumbnailUploader = ({
   onUploading,
   isPortal,
   entities,
+  isButton,
 }) => {
   const [dragHover, setDragHover] = useState(false)
   const [imagePreviews, setImagePreviews] = useState([])
@@ -142,17 +143,30 @@ const ThumbnailUploader = ({
       $existingImage={existingImage}
       $success={uploadSuccess}
       $isPortal={isPortal}
+      $isButton={isButton}
     >
-      <div className="bg" />
-      <Icon icon="cloud_upload" className="upload" />
-      <Styled.ThumbnailInput
-        type="file"
-        onDragEnter={() => setDragHover(true)}
-        onDragLeave={() => setDragHover(false)}
-        onDrop={handleInputDrop}
-        onChange={handleInputChange}
-        accept=".png, .jpeg, .jpg"
-      />
+      {isButton ? (
+        <Styled.UploadButton
+          icon="edit"
+          className="upload-button"
+          iconProps={{ className: 'edit' }}
+        >
+          <Styled.ButtonInput type="file" onChange={handleInputChange} accept=".png, .jpeg, .jpg" />
+        </Styled.UploadButton>
+      ) : (
+        <>
+          <div className="bg" />
+          <Icon icon="cloud_upload" className="upload" />
+          <Styled.ThumbnailInput
+            type="file"
+            onDragEnter={() => setDragHover(true)}
+            onDragLeave={() => setDragHover(false)}
+            onDrop={handleInputDrop}
+            onChange={handleInputChange}
+            accept=".png, .jpeg, .jpg"
+          />
+        </>
+      )}
 
       {!!selectedFiles.length && imagePreviews.length && (
         <Styled.ThumbnailUploading $success={uploadSuccess} $isPortal={isPortal}>

--- a/src/components/ThumbnailUploader/ThumbnailUploader.jsx
+++ b/src/components/ThumbnailUploader/ThumbnailUploader.jsx
@@ -120,7 +120,7 @@ const ThumbnailUploader = ({ entityType, entityId, projectName, existingImage })
           onDragLeave={() => setDragHover(false)}
           onDrop={handleInputDrop}
           onChange={handleInputChange}
-          accept="image/*"
+          accept=".png, .jpeg, .jpg"
         />
 
         {!!selectedFiles.length && imagePreview && (

--- a/src/components/ThumbnailUploader/ThumbnailUploader.jsx
+++ b/src/components/ThumbnailUploader/ThumbnailUploader.jsx
@@ -2,8 +2,6 @@ import React, { useEffect, useState } from 'react'
 import * as Styled from './ThumbnailUploader.styled'
 import { Icon } from '@ynput/ayon-react-components'
 import axios from 'axios'
-import { ayonApi } from '/src/services/ayon'
-import { useDispatch } from 'react-redux'
 
 const ThumbnailUploader = ({
   entityType,
@@ -15,7 +13,6 @@ const ThumbnailUploader = ({
   isPortal,
   entities,
 }) => {
-  const dispatch = useDispatch()
   const [dragHover, setDragHover] = useState(false)
   const [imagePreviews, setImagePreviews] = useState([])
   const [selectedFiles, setSelectedFiles] = useState([])
@@ -87,15 +84,6 @@ const ThumbnailUploader = ({
       }
 
       setUploadSuccess(true)
-
-      // if success then we need to refresh the thumbnail
-      // which means invalidating the entityCache
-      dispatch(
-        ayonApi.util.invalidateTags([
-          { type: entityType, id: entityId },
-          { type: 'kanBanTask', id: entityId },
-        ]),
-      )
     } catch (error) {
       console.error(error)
       setUploadError(error.response?.data.detail)

--- a/src/components/ThumbnailUploader/ThumbnailUploader.jsx
+++ b/src/components/ThumbnailUploader/ThumbnailUploader.jsx
@@ -5,7 +5,7 @@ import axios from 'axios'
 import { ayonApi } from '/src/services/ayon'
 import { useDispatch } from 'react-redux'
 
-const ThumbnailUploader = ({ entityType, entityId, projectName, existingImage }) => {
+const ThumbnailUploader = ({ entityType, entityId, projectName, existingImage, onUpload }) => {
   const dispatch = useDispatch()
   const [dragHover, setDragHover] = useState(false)
   const [imagePreview, setImagePreview] = useState(null)
@@ -44,7 +44,7 @@ const ThumbnailUploader = ({ entityType, entityId, projectName, existingImage })
 
       setUploadSuccess(true)
 
-      console.log({ type: entityType, id: entityId })
+      onUpload && onUpload({ type: entityType, id: entityId })
 
       // if success then we need to refresh the thumbnail
       // which means invalidating the entityCache

--- a/src/components/ThumbnailUploader/ThumbnailUploader.styled.js
+++ b/src/components/ThumbnailUploader/ThumbnailUploader.styled.js
@@ -4,11 +4,16 @@ import styled, { css, keyframes } from 'styled-components'
 export const ThumbnailUploaderWrapper = styled.div`
   position: absolute;
   inset: 0;
+  z-index: 900;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
 
   .bg {
     position: absolute;
     inset: 0;
-    border-radius: var(--md-sys-border-radius);
+    border-radius: var(--md-sys-border-radius-m);
     opacity: 0;
     border: 2px dashed var(--md-sys-color-outline);
     background-color: var(--md-sys-color-surface-container-lowest);
@@ -24,15 +29,29 @@ export const ThumbnailUploaderWrapper = styled.div`
     transition: scale 0.2s, opacity 0.1s;
   }
 
-  &:hover {
-    .bg {
-      opacity: ${({ $existingImage }) => ($existingImage ? 0.95 : 1)};
-    }
-    .icon.upload {
-      scale: 1;
-      opacity: 0;
-    }
-  }
+  ${({ $isPortal }) =>
+    $isPortal
+      ? css`
+          .bg {
+            opacity: ${({ $existingImage }) => ($existingImage ? 0.95 : 1)};
+          }
+          .icon.upload {
+            scale: 1;
+            opacity: 1;
+            font-size: 4rem;
+          }
+        `
+      : css`
+          &:hover {
+            .bg {
+              opacity: ${({ $existingImage }) => ($existingImage ? 0.95 : 1)};
+            }
+            .icon.upload {
+              scale: 1;
+              opacity: 0;
+            }
+          }
+        `}
 
   ${({ $dragHover }) =>
     $dragHover &&
@@ -42,7 +61,7 @@ export const ThumbnailUploaderWrapper = styled.div`
       }
       .icon.upload {
         scale: 1;
-        opacity: 0;
+        /* opacity: 0; */
       }
     `}
 
@@ -98,9 +117,9 @@ export const ThumbnailUploading = styled.div`
     $success &&
     css`
       .preview {
-        scale: 0.7;
-        animation: ${FinishAnimation} 200ms ease forwards;
-        animation-delay: 200ms;
+        scale: 1;
+        opacity: 1;
+        animation ${FinishAnimation} 0.2s ease forwards;
       }
 
       .progress {
@@ -131,13 +150,6 @@ export const UploadPreview = styled.img`
   transform-origin: center;
   animation: ${PopInAnimation} 0.2s ease forwards;
   background-color: var(--md-sys-color-surface-container-lowest);
-
-  /* as $progress goes from 0-1 scale from 0.7 to 0.8 */
-  ${({ $progress }) =>
-    $progress &&
-    css`
-      scale: calc(0.7 + 0.1 * ${$progress});
-    `}
 `
 
 export const UploadError = styled.div`

--- a/src/components/ThumbnailUploader/ThumbnailUploader.styled.js
+++ b/src/components/ThumbnailUploader/ThumbnailUploader.styled.js
@@ -1,0 +1,190 @@
+import { Button } from '@ynput/ayon-react-components'
+import styled, { css, keyframes } from 'styled-components'
+
+export const ThumbnailUploaderWrapper = styled.div`
+  position: absolute;
+  inset: 0;
+
+  .bg {
+    position: absolute;
+    inset: 0;
+    border-radius: var(--md-sys-border-radius);
+    opacity: 0;
+    border: 2px dashed var(--md-sys-color-outline);
+    background-color: var(--md-sys-color-surface-container-lowest);
+  }
+
+  .icon.upload {
+    user-select: none;
+    pointer-events: none;
+    opacity: 0;
+    background-color: unset;
+    scale: 0;
+
+    transition: scale 0.2s, opacity 0.1s;
+  }
+
+  &:hover {
+    .bg {
+      opacity: ${({ $existingImage }) => ($existingImage ? 0.95 : 1)};
+    }
+    .icon.upload {
+      scale: 1;
+      opacity: 0;
+    }
+  }
+
+  ${({ $dragHover }) =>
+    $dragHover &&
+    css`
+      .bg {
+        opacity: ${({ $existingImage }) => ($existingImage ? 0.95 : 1)};
+      }
+      .icon.upload {
+        scale: 1;
+        opacity: 0;
+      }
+    `}
+
+  ${({ $uploading }) =>
+    $uploading &&
+    css`
+      .bg {
+        opacity: 1;
+      }
+      .icon.upload {
+        display: none;
+      }
+    `}
+
+  ${({ $success }) =>
+    $success &&
+    css`
+      .bg {
+        opacity: 1;
+        border: none;
+      }
+      .icon.upload {
+        display: none;
+      }
+
+      &:hover {
+        opacity: 0;
+      }
+    `}
+`
+
+export const ThumbnailInput = styled.input`
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+`
+
+const FinishAnimation = keyframes`
+    0% {
+        scale: 0.8;
+    }
+    100% {
+        scale: 1;
+    }
+`
+
+export const ThumbnailUploading = styled.div`
+  position: absolute;
+  inset: 0;
+
+  ${({ $success }) =>
+    $success &&
+    css`
+      .preview {
+        scale: 0.7;
+        animation: ${FinishAnimation} 200ms ease forwards;
+        animation-delay: 200ms;
+      }
+
+      .progress {
+        opacity: 0;
+      }
+    `}
+`
+
+const PopInAnimation = keyframes`
+    0% {
+        scale: 0.45;
+    }
+    100% {
+        scale: 0.7;
+    }
+    
+`
+
+export const UploadPreview = styled.img`
+  position: absolute;
+  inset: 0;
+  border-radius: var(--border-radius-m);
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  overflow: hidden;
+
+  transform-origin: center;
+  animation: ${PopInAnimation} 0.2s ease forwards;
+  background-color: var(--md-sys-color-surface-container-lowest);
+
+  /* as $progress goes from 0-1 scale from 0.7 to 0.8 */
+  ${({ $progress }) =>
+    $progress &&
+    css`
+      scale: calc(0.7 + 0.1 * ${$progress});
+    `}
+`
+
+export const UploadError = styled.div`
+  background-color: var(--md-sys-color-error-container);
+  color: var(--md-sys-color-on-error-container);
+  border-radius: var(--border-radius-m);
+  text-align: center;
+  position: absolute;
+  bottom: 8px;
+  left: 8px;
+  right: 8px;
+`
+
+export const UploadProgress = styled.div`
+  position: absolute;
+  bottom: 8px;
+  left: 40px;
+  right: 40px;
+  height: 8px;
+  border-radius: var(--border-radius-m);
+  background-color: var(--md-sys-color-surface-container-high);
+
+  /* after is the progress */
+  &::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 100%;
+    border-radius: var(--border-radius-m);
+    background-color: var(--md-sys-color-primary);
+    transform: scaleX(${({ $progress }) => $progress});
+    transform-origin: left;
+    transition: transform 0.1s ease, opacity 0.1s ease;
+  }
+`
+
+export const Close = styled(Button)`
+  position: absolute;
+  right: 4px;
+  top: 4px;
+
+  .icon {
+    display: block;
+    font-size: 1.4285rem;
+    position: relative;
+    background-color: unset;
+  }
+`

--- a/src/components/ThumbnailUploader/ThumbnailUploader.styled.js
+++ b/src/components/ThumbnailUploader/ThumbnailUploader.styled.js
@@ -91,11 +91,48 @@ export const ThumbnailUploaderWrapper = styled.div`
         opacity: 0;
       }
     `}
+
+    ${({ $isButton }) =>
+    $isButton &&
+    css`
+      align-items: flex-start;
+      justify-content: flex-end;
+
+      &:hover {
+        .upload-button {
+          opacity: 1;
+        }
+      }
+    `}
 `
 
 export const ThumbnailInput = styled.input`
   position: absolute;
   inset: 0;
+  opacity: 0;
+  cursor: pointer;
+`
+
+export const UploadButton = styled(Button)`
+  position: relative;
+  height: 32px;
+  width: 32px;
+  margin-right: 4px;
+  margin-top: 4px;
+  overflow: hidden;
+
+  opacity: 0;
+
+  .edit {
+    font-size: 1.4285rem;
+    background-color: unset;
+    cursor: pointer;
+  }
+`
+
+export const ButtonInput = styled.input`
+  position: absolute;
+  inset: -40px;
   opacity: 0;
   cursor: pointer;
 `

--- a/src/containers/thumbnail.jsx
+++ b/src/containers/thumbnail.jsx
@@ -86,6 +86,7 @@ const Thumbnail = ({
   // if portalEl is true, attach an event listener for drag events
   useEffect(() => {
     if (!portalEl) return
+
     const handleDragOver = (e) => {
       e.preventDefault()
       e.stopPropagation()
@@ -115,7 +116,6 @@ const Thumbnail = ({
     existingImage: thumbLoaded,
     onUpload: onUpload,
     portalId,
-    isButton: isUploadButton,
   }
 
   return (
@@ -137,7 +137,7 @@ const Thumbnail = ({
       )}
       {entityType && entityId && !isStacked && projectName && !disableUpload && (
         <>
-          <ThumbnailUploader {...thumbnailProps} />
+          <ThumbnailUploader {...thumbnailProps} isButton={isUploadButton} />
           {portalEl &&
             (showPortal || isUploading) &&
             createPortal(

--- a/src/containers/thumbnail.jsx
+++ b/src/containers/thumbnail.jsx
@@ -65,6 +65,7 @@ const Thumbnail = ({
   src,
   uploadEntities,
   isStacked,
+  onUpload,
   ...props
 }) => {
   // Display image only when loaded to avoid flickering and displaying,
@@ -100,6 +101,7 @@ const Thumbnail = ({
           projectName={projectName}
           key={entityId}
           existingImage={thumbLoaded}
+          onUpload={onUpload}
         />
       )}
     </ThumbnailStyled>

--- a/src/containers/thumbnail.jsx
+++ b/src/containers/thumbnail.jsx
@@ -66,6 +66,7 @@ const Thumbnail = ({
   uploadEntities,
   isStacked,
   onUpload,
+  portalId,
   ...props
 }) => {
   // Display image only when loaded to avoid flickering and displaying,
@@ -102,6 +103,7 @@ const Thumbnail = ({
           key={entityId}
           existingImage={thumbLoaded}
           onUpload={onUpload}
+          portalId={portalId}
         />
       )}
     </ThumbnailStyled>

--- a/src/containers/thumbnail.jsx
+++ b/src/containers/thumbnail.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import styled, { keyframes } from 'styled-components'
 import getShimmerStyles from '../styles/getShimmerStyles'
 import { Icon } from '@ynput/ayon-react-components'
+import ThumbnailUploader from '../components/ThumbnailUploader/ThumbnailUploader'
 
 const fadeIn = keyframes`
   from { opacity: 0; }
@@ -31,7 +32,7 @@ const ThumbnailStyled = styled.div`
     color: var(--md-sys-color-outline);
 
     opacity: 0;
-    /* delay being seen by 1s */
+    /* delay being seen by 0.3s */
     animation: ${fadeIn} 0.1s 0.3s forwards;
   }
 
@@ -62,6 +63,8 @@ const Thumbnail = ({
   className,
   disabled,
   src,
+  uploadEntities,
+  isStacked,
   ...props
 }) => {
   // Display image only when loaded to avoid flickering and displaying,
@@ -70,7 +73,7 @@ const Thumbnail = ({
 
   const url = `/api/projects/${projectName}/${entityType}s/${entityId}/thumbnail`
   const queryArgs = `?updatedAt=${entityUpdatedAt}&token=${localStorage.getItem('accessToken')}`
-  const isWrongEntity = ['task', 'product'].includes(entityType)
+  const isWrongEntity = ['product'].includes(entityType)
 
   return (
     <ThumbnailStyled
@@ -87,6 +90,16 @@ const Thumbnail = ({
           style={{ display: thumbLoaded ? 'block' : 'none' }}
           onError={() => setThumbLoaded(false)}
           onLoad={() => setThumbLoaded(true)}
+        />
+      )}
+      {entityType && entityId && !isStacked && projectName && (
+        <ThumbnailUploader
+          entities={uploadEntities}
+          entityType={entityType}
+          entityId={entityId}
+          projectName={projectName}
+          key={entityId}
+          existingImage={thumbLoaded}
         />
       )}
     </ThumbnailStyled>

--- a/src/containers/thumbnail.jsx
+++ b/src/containers/thumbnail.jsx
@@ -69,6 +69,7 @@ const Thumbnail = ({
   onUpload,
   portalId,
   disableUpload,
+  isUploadButton,
   ...props
 }) => {
   // Display image only when loaded to avoid flickering and displaying,
@@ -114,6 +115,7 @@ const Thumbnail = ({
     existingImage: thumbLoaded,
     onUpload: onUpload,
     portalId,
+    isButton: isUploadButton,
   }
 
   return (

--- a/src/pages/BrowserPage/Detail.jsx
+++ b/src/pages/BrowserPage/Detail.jsx
@@ -89,7 +89,6 @@ const Detail = () => {
             for (const id of ids) {
               draft.forEach((p) => {
                 if (p.versionId === id) {
-                  console.log('here')
                   p.versionStatus = value
                 }
               })
@@ -116,6 +115,70 @@ const Detail = () => {
       if (productsPatch) {
         productsPatch.undo()
       }
+    }
+  }
+
+  // patch in new thumbnail data for both product list and
+  const handleVersionThumbnailUpdate = (value) => {
+    const { id, thumbnailId, type } = value || {}
+
+    // only update if type is version and id and thumbnailId is set
+    if (!id || !thumbnailId) return
+
+    // create a fake updatedAt
+    const updatedAt = new Date().toISOString()
+
+    let success1 = false
+    let success2 = false
+
+    // patch new updatedAt for getEntitiesDetails
+    dispatch(
+      ayonApi.util.updateQueryData(
+        'getEntitiesDetails',
+        { projectName, ids: ids, type },
+        (draft) => {
+          // find the product in the cache that match the ids
+          // and update the updatedAt
+          let item = draft.find((p) => p.node.id === id)
+          if (item) {
+            success2 = true
+            item.node.updatedAt = updatedAt
+          }
+        },
+      ),
+    )
+
+    const invalidate = () => {
+      dispatch(ayonApi.util.invalidateTags([{ type: type, id: id }]))
+    }
+
+    if (type !== 'version') {
+      if (!success1) {
+        // patching failed so lets invalidate the cache
+        invalidate()
+      }
+    }
+
+    // patch in the new updatedAt for version id on getProductList
+    dispatch(
+      ayonApi.util.updateQueryData(
+        'getProductList',
+        { projectName, ids: focusedFolders },
+        (draft) => {
+          // find the product in the cache that match the ids
+          // and update the versionUpdatedAt
+          let item = draft.find((p) => p.versionId === id)
+          if (item) {
+            success1 = true
+            item.versionUpdatedAt = updatedAt
+          }
+        },
+      ),
+    )
+
+    if (!success1 || !success2) {
+      // patching failed so lets invalidate the cache
+      invalidate()
     }
   }
 
@@ -276,6 +339,7 @@ const Detail = () => {
           hideNull={isVersion}
           style={{ height: isVersion ? 'unset' : '100%' }}
           isLoading={showLoading}
+          onThumbnailUpload={handleVersionThumbnailUpdate}
         />
         {isVersion && (
           <RepresentationList representations={representations} projectName={projectName} />

--- a/src/pages/BrowserPage/Detail.jsx
+++ b/src/pages/BrowserPage/Detail.jsx
@@ -106,6 +106,7 @@ const Detail = () => {
         ids: ids,
         data: { [field]: value },
         patches,
+        disabledInvalidation: isVersion,
       }).unwrap()
 
       console.log('fulfilled', payload)

--- a/src/pages/BrowserPage/ProductsGrid.jsx
+++ b/src/pages/BrowserPage/ProductsGrid.jsx
@@ -186,6 +186,7 @@ const ProductsGrid = ({
                         }`}
                         thumbnailEntityId={product.versionId}
                         thumbnailEntityType="version"
+                        updatedAt={product.versionUpdatedAt}
                         onClick={(e) => handleSelection(e, product)}
                         selected={product.id in selection}
                         onContextMenu={(e) => handleContext(e, product.id)}

--- a/src/pages/EditorPage/EditorPage.jsx
+++ b/src/pages/EditorPage/EditorPage.jsx
@@ -1317,6 +1317,24 @@ const EditorPage = () => {
     }
   }
 
+  // when a thumbnail is uploaded, refetch data for that entity
+  const handleThumbnailUpload = (uploaded = {}) => {
+    const { id, type } = uploaded
+
+    if (!id || !type) return
+
+    // refetch data for that entity
+    if (type === 'folder') {
+      loadNewBranches([id], true)
+    } else {
+      // it's a task so we need to find it in data and then refetch it's parent
+      const parent = rootData[id]?.data?.folderId
+      if (parent) {
+        loadNewBranches([parent], true)
+      }
+    }
+  }
+
   let allColumns = useMemo(
     () => [
       <Column
@@ -1581,6 +1599,7 @@ const EditorPage = () => {
               attribs={attribFields}
               projectName={projectName}
               onForceChange={handleForceChange}
+              onThumbnailUpload={handleThumbnailUpload}
             />
           </SplitterPanel>
         </Splitter>

--- a/src/pages/EditorPage/EditorPanel.jsx
+++ b/src/pages/EditorPage/EditorPanel.jsx
@@ -473,7 +473,7 @@ const EditorPanel = ({
   }, [form, nodes, changes])
 
   return (
-    <Section wrap>
+    <Section wrap id="editor-entity-details-container">
       {!noSelection && (
         <>
           <EntityDetailsHeader

--- a/src/pages/EditorPage/EditorPanel.jsx
+++ b/src/pages/EditorPage/EditorPanel.jsx
@@ -41,7 +41,15 @@ const getInputProps = (attrib = {}) => {
   return props
 }
 
-const EditorPanel = ({ onDelete, onChange, onRevert, attribs, projectName, onForceChange }) => {
+const EditorPanel = ({
+  onDelete,
+  onChange,
+  onRevert,
+  attribs,
+  projectName,
+  onForceChange,
+  onThumbnailUpload,
+}) => {
   // SELECTORS
   const selected = useSelector((state) => state.context.focused.editor)
   const editorNodes = useSelector((state) => state.editor.nodes)
@@ -470,6 +478,7 @@ const EditorPanel = ({ onDelete, onChange, onRevert, attribs, projectName, onFor
         <>
           <EntityDetailsHeader
             values={nodeIds.map((id) => nodes[id]?.data)}
+            onThumbnailUpload={onThumbnailUpload}
             tools={
               <>
                 <Button

--- a/src/pages/EditorPage/StackedThumbnails.jsx
+++ b/src/pages/EditorPage/StackedThumbnails.jsx
@@ -41,8 +41,8 @@ const StackedStyled = styled.div`
   height: 100%;
 `
 
-const StackedThumbnails = ({ thumbnails = [], isLoading, className }) => {
-  const projectName = useSelector((state) => state.project.name)
+const StackedThumbnails = ({ thumbnails = [], isLoading, projectName, className }) => {
+  const projectName2 = projectName || useSelector((state) => state.project.name)
   // limit to 5 users
   thumbnails = thumbnails.slice(0, 5)
 
@@ -51,7 +51,7 @@ const StackedThumbnails = ({ thumbnails = [], isLoading, className }) => {
       {thumbnails.map((thumb, i) =>
         thumb ? (
           <Thumbnail
-            projectName={projectName}
+            projectName={projectName2}
             entityType={thumb.type}
             entityId={thumb.id}
             key={thumb.id || thumb.src || i}
@@ -59,6 +59,7 @@ const StackedThumbnails = ({ thumbnails = [], isLoading, className }) => {
             entityUpdatedAt={thumb.updatedAt}
             isLoading={isLoading}
             src={thumb.src}
+            isStacked={thumbnails.length > 1}
             {...thumb}
           />
         ) : null,

--- a/src/pages/EditorPage/StackedThumbnails.jsx
+++ b/src/pages/EditorPage/StackedThumbnails.jsx
@@ -41,7 +41,7 @@ const StackedStyled = styled.div`
   height: 100%;
 `
 
-const StackedThumbnails = ({ thumbnails = [], isLoading, projectName, className, onUpload }) => {
+const StackedThumbnails = ({ thumbnails = [], isLoading, projectName, className, ...props }) => {
   const projectName2 = projectName || useSelector((state) => state.project.name)
   // limit to 5 users
   thumbnails = thumbnails.slice(0, 5)
@@ -61,7 +61,7 @@ const StackedThumbnails = ({ thumbnails = [], isLoading, projectName, className,
             src={thumb.src}
             isStacked={thumbnails.length > 1}
             {...thumb}
-            onUpload={onUpload}
+            {...props}
           />
         ) : null,
       )}

--- a/src/pages/EditorPage/StackedThumbnails.jsx
+++ b/src/pages/EditorPage/StackedThumbnails.jsx
@@ -41,7 +41,7 @@ const StackedStyled = styled.div`
   height: 100%;
 `
 
-const StackedThumbnails = ({ thumbnails = [], isLoading, projectName, className }) => {
+const StackedThumbnails = ({ thumbnails = [], isLoading, projectName, className, onUpload }) => {
   const projectName2 = projectName || useSelector((state) => state.project.name)
   // limit to 5 users
   thumbnails = thumbnails.slice(0, 5)
@@ -61,6 +61,7 @@ const StackedThumbnails = ({ thumbnails = [], isLoading, projectName, className 
             src={thumb.src}
             isStacked={thumbnails.length > 1}
             {...thumb}
+            onUpload={onUpload}
           />
         ) : null,
       )}

--- a/src/pages/UserDashboardPage/UserDashboardTasks/TaskAttributes/TaskAttributes.jsx
+++ b/src/pages/UserDashboardPage/UserDashboardTasks/TaskAttributes/TaskAttributes.jsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react'
 import AttributeTable from '/src/containers/attributeTable'
 import formatAttributesData from './formatAttributesData'
+import { Section } from '@ynput/ayon-react-components'
 
 const TaskAttributes = ({ tasks = [], isLoading }) => {
   // we need to get the attributes of the selected tasks
@@ -10,7 +11,11 @@ const TaskAttributes = ({ tasks = [], isLoading }) => {
     [tasks, isLoading],
   )
 
-  return <AttributeTable entityType={'task'} data={attribsData} isLoading={isLoading} />
+  return (
+    <Section style={{ padding: '0px 8px' }}>
+      <AttributeTable entityType={'task'} data={attribsData} isLoading={isLoading} />
+    </Section>
+  )
 }
 
 export default TaskAttributes

--- a/src/pages/UserDashboardPage/UserDashboardTasks/UserDashDetailsHeader/UserDashDetailsHeader.jsx
+++ b/src/pages/UserDashboardPage/UserDashboardTasks/UserDashDetailsHeader/UserDashDetailsHeader.jsx
@@ -4,14 +4,12 @@ import { useDispatch } from 'react-redux'
 import * as Styled from './UserDashDetailsHeader.styled'
 import copyToClipboard from '/src/helpers/copyToClipboard'
 import StackedThumbnails from '/src/pages/EditorPage/StackedThumbnails'
-import { useGetTasksDetailsQuery } from '/src/services/userDashboard/getUserDashboard'
 
 import { union } from 'lodash'
 import { useUpdateTasksMutation } from '/src/services/userDashboard/updateUserDashboard'
 import { toast } from 'react-toastify'
 import Actions from '/src/components/Actions/Actions'
 import { onAttributesOpenChanged } from '/src/features/dashboard'
-import TaskAttributes from '../TaskAttributes/TaskAttributes'
 
 const UserDashDetailsHeader = ({
   tasks = [],
@@ -23,12 +21,6 @@ const UserDashDetailsHeader = ({
 }) => {
   const dispatch = useDispatch()
   const setAttributesOpen = (value) => dispatch(onAttributesOpenChanged(value))
-
-  // now we get the full details data for selected tasks
-  const { data: tasksDetailsData, isFetching: isLoadingTasksDetails } = useGetTasksDetailsQuery(
-    { tasks: tasks },
-    { skip: !tasks?.length },
-  )
 
   // for selected tasks, get flat list of assignees
   const selectedTasksAssignees = useMemo(() => union(...tasks.map((t) => t.assignees)), [tasks])
@@ -123,10 +115,9 @@ const UserDashDetailsHeader = ({
         padding: 8,
         alignItems: 'flex-start',
         gap: 8,
-        borderBottom: !attributesOpen ? '1px solid var(--md-sys-color-outline-variant)' : 'none',
+        borderBottom: '1px solid var(--md-sys-color-outline-variant)',
         flex: 'none',
         overflow: 'hidden',
-        height: attributesOpen ? '100%' : 'unset',
       }}
       id={portalId}
     >
@@ -185,9 +176,6 @@ const UserDashDetailsHeader = ({
           iconProps={{ style: { transform: !attributesOpen ? 'scaleX(-1)' : '' } }}
         />
       </Styled.Footer>
-      {attributesOpen && (
-        <TaskAttributes tasks={tasksDetailsData} isLoading={isLoadingTasksDetails} />
-      )}
     </Section>
   )
 }

--- a/src/pages/UserDashboardPage/UserDashboardTasks/UserDashDetailsHeader/UserDashDetailsHeader.jsx
+++ b/src/pages/UserDashboardPage/UserDashboardTasks/UserDashDetailsHeader/UserDashDetailsHeader.jsx
@@ -34,6 +34,7 @@ const UserDashDetailsHeader = ({
   const selectedTasksAssignees = useMemo(() => union(...tasks.map((t) => t.assignees)), [tasks])
 
   const singleTask = tasks[0]
+  const projectName = tasks.length > 1 ? null : singleTask.projectName
 
   const thumbnails = useMemo(
     () =>
@@ -42,6 +43,8 @@ const UserDashDetailsHeader = ({
         .map((t) => ({
           src: t.thumbnailUrl,
           icon: t.taskIcon,
+          id: t.id,
+          type: 'task',
         })),
     [tasks],
   )
@@ -131,7 +134,7 @@ const UserDashDetailsHeader = ({
         style={{ zIndex: 100 }}
       />
       <Styled.Header>
-        <StackedThumbnails thumbnails={thumbnails} />
+        <StackedThumbnails thumbnails={thumbnails} projectName={projectName} />
         <Styled.Content>
           <h2>{!isMultiple ? singleTask.folderName : `${tasks.length} tasks selected`}</h2>
           <h3>{!isMultiple ? singleTask.name : tasks.map((t) => t.name).join(', ')}</h3>

--- a/src/pages/UserDashboardPage/UserDashboardTasks/UserDashDetailsHeader/UserDashDetailsHeader.jsx
+++ b/src/pages/UserDashboardPage/UserDashboardTasks/UserDashDetailsHeader/UserDashDetailsHeader.jsx
@@ -113,6 +113,8 @@ const UserDashDetailsHeader = ({
     })
     .map((action) => action.id)
 
+  const portalId = 'dashboard-details-header'
+
   return (
     <Section
       style={{
@@ -124,6 +126,7 @@ const UserDashDetailsHeader = ({
         overflow: 'hidden',
         height: attributesOpen ? '100%' : 'unset',
       }}
+      id={portalId}
     >
       <Styled.Path
         value={pathArray.join(' / ')}
@@ -134,7 +137,7 @@ const UserDashDetailsHeader = ({
         style={{ zIndex: 100 }}
       />
       <Styled.Header>
-        <StackedThumbnails thumbnails={thumbnails} projectName={projectName} />
+        <StackedThumbnails thumbnails={thumbnails} projectName={projectName} portalId={portalId} />
         <Styled.Content>
           <h2>{!isMultiple ? singleTask.folderName : `${tasks.length} tasks selected`}</h2>
           <h3>{!isMultiple ? singleTask.name : tasks.map((t) => t.name).join(', ')}</h3>

--- a/src/pages/UserDashboardPage/UserDashboardTasks/UserDashDetailsHeader/UserDashDetailsHeader.jsx
+++ b/src/pages/UserDashboardPage/UserDashboardTasks/UserDashDetailsHeader/UserDashDetailsHeader.jsx
@@ -58,6 +58,8 @@ const UserDashDetailsHeader = ({
 
   const [updateTasks] = useUpdateTasksMutation()
   const handleUpdate = async (field, value) => {
+    if (value === null || value === undefined) return console.error('value is null or undefined')
+
     try {
       // build tasks operations array
       const tasksOperations = tasks.map((task) => ({
@@ -137,7 +139,12 @@ const UserDashDetailsHeader = ({
         style={{ zIndex: 100 }}
       />
       <Styled.Header>
-        <StackedThumbnails thumbnails={thumbnails} projectName={projectName} portalId={portalId} />
+        <StackedThumbnails
+          thumbnails={thumbnails}
+          projectName={projectName}
+          portalId={portalId}
+          onUpload={({ thumbnailId }) => handleUpdate('thumbnailId', thumbnailId)}
+        />
         <Styled.Content>
           <h2>{!isMultiple ? singleTask.folderName : `${tasks.length} tasks selected`}</h2>
           <h3>{!isMultiple ? singleTask.name : tasks.map((t) => t.name).join(', ')}</h3>

--- a/src/pages/UserDashboardPage/UserDashboardTasks/UserDashboardDetails/UserDashboardDetails.jsx
+++ b/src/pages/UserDashboardPage/UserDashboardTasks/UserDashboardDetails/UserDashboardDetails.jsx
@@ -4,6 +4,8 @@ import UserDashDetailsHeader from '../UserDashDetailsHeader/UserDashDetailsHeade
 import { useSelector } from 'react-redux'
 import Feed from '/src/containers/Feed/Feed'
 import getCommentsForTasks from '/src/containers/Feed/commentsData'
+import { useGetTasksDetailsQuery } from '/src/services/userDashboard/getUserDashboard'
+import TaskAttributes from '../TaskAttributes/TaskAttributes'
 
 const UserDashboardDetails = ({
   tasks = [],
@@ -22,6 +24,12 @@ const UserDashboardDetails = ({
     if (!selectedTasksIds?.length) return []
     return tasks.filter((task) => selectedTasksIds.includes(task.id))
   }, [selectedTasksIds, tasks])
+
+  // now we get the full details data for selected tasks
+  const { data: tasksDetailsData, isFetching: isLoadingTasksDetails } = useGetTasksDetailsQuery(
+    { tasks: tasks },
+    { skip: !tasks?.length },
+  )
 
   const commentsData = useMemo(() => getCommentsForTasks(tasks, projectUsers), [tasks])
 
@@ -42,6 +50,9 @@ const UserDashboardDetails = ({
           selectedTasksProjects={selectedTasksProjects}
           commentsData={commentsData}
         />
+      )}
+      {attributesOpen && (
+        <TaskAttributes tasks={tasksDetailsData} isLoading={isLoadingTasksDetails} />
       )}
     </Panel>
   )

--- a/src/services/entity/entityQueries.js
+++ b/src/services/entity/entityQueries.js
@@ -155,9 +155,7 @@ fragment taskTileFragment on TaskNode {
   name
   status
   icon: taskType
-  thumbnailEntityId: folder {
-    id
-  }
+  thumbnailEntityId: id
   subTitle: folder {
     name
   }

--- a/src/services/entity/updateEntity.js
+++ b/src/services/entity/updateEntity.js
@@ -11,10 +11,10 @@ const updateEntity = ayonApi.injectEndpoints({
           operations: buildOperations(ids || patches.map((p) => p.id), type, data),
         },
       }),
-      invalidatesTags: (result, error, { ids, type }) => [
-        ...ids.map((id) => ({ type, id })),
-        { type: 'kanBanTask', id: 'TASKS' },
-      ],
+      invalidatesTags: (result, error, { ids, type, disabledInvalidation }) =>
+        disabledInvalidation
+          ? []
+          : [...ids.map((id) => ({ type, id })), { type: 'kanBanTask', id: 'TASKS' }],
       async onQueryStarted(
         { projectName, type, patches, data, ids },
         { dispatch, queryFulfilled },

--- a/src/services/product/getProduct.js
+++ b/src/services/product/getProduct.js
@@ -61,6 +61,7 @@ const parseProductData = (data) => {
       versionId: vers && vers.id ? vers.id : null,
       versionName: vers && vers.name ? vers.name : '',
       versionStatus: vers.status || null,
+      versionUpdatedAt: vers.updatedAt || null,
       taskId: vers && vers.taskId ? vers.taskId : null,
       taskName: vers && vers.task ? vers.task.name : null,
       frames: parseProductFrames(product),
@@ -117,6 +118,7 @@ query ProductsList($projectName: String!, $ids: [String!]!) {
                         name
                         author
                         createdAt
+                        updatedAt
                         taskId
                         task {
                           name
@@ -173,7 +175,12 @@ const getProduct = ayonApi.injectEndpoints({
       }),
       transformResponse: (response) => parseProductData(response.data),
       providesTags: (result) =>
-        result ? [...result.map(({ id }) => ({ type: 'product', id }))] : ['product'],
+        result
+          ? [
+              ...result.map(({ id }) => ({ type: 'product', id })),
+              ...result.map(({ versionId }) => ({ type: 'version', id: versionId })),
+            ]
+          : ['product', 'version'],
     }),
     getProductVersion: build.query({
       query: ({ projectName, versionId }) => ({

--- a/src/services/userDashboard/updateUserDashboard.js
+++ b/src/services/userDashboard/updateUserDashboard.js
@@ -25,6 +25,7 @@ const updateUserDashboard = ayonApi.injectEndpoints({
           patchResult.undo()
         }
       },
+      // this triggers a refetch of getKanBan
       invalidatesTags: (result, error, { taskId }) => [{ type: 'task', id: taskId }],
     }),
     updateTasks: build.mutation({

--- a/src/services/userDashboard/userDashboardHelpers.js
+++ b/src/services/userDashboard/userDashboardHelpers.js
@@ -1,6 +1,6 @@
-const getVersionThumbnailUrl = (version, projectName, accessToken) => {
-  return version?.thumbnailId
-    ? `/api/projects/${projectName}/thumbnails/${version?.thumbnailId}?updatedAt=${version.updatedAt}&token=${accessToken}`
+const getThumbnailUrl = (thumbnailId, updatedAt, projectName, accessToken) => {
+  return thumbnailId
+    ? `/api/projects/${projectName}/thumbnails/${thumbnailId}?updatedAt=${updatedAt}&token=${accessToken}`
     : null
 }
 
@@ -10,12 +10,15 @@ export const transformTasksData = ({ projectName, tasks = [], code }) =>
 
     const accessToken = localStorage.getItem('accessToken')
 
-    const thumbnailUrl = getVersionThumbnailUrl(latestVersion, projectName, accessToken)
+    // use task thumbnail if it exists, otherwise use latest version thumbnail
+    const thumbnailId = task?.thumbnailId || latestVersion?.thumbnailId
+    const updatedAt = task?.thumbnailId ? task?.updatedAt : latestVersion?.updatedAt
+    const thumbnailUrl = getThumbnailUrl(thumbnailId, updatedAt, projectName, accessToken)
 
     const allVersions =
       task?.allVersions?.edges.map(({ node }) => ({
         ...node,
-        thumbnailUrl: getVersionThumbnailUrl(node, projectName, accessToken),
+        thumbnailUrl: getThumbnailUrl(node, projectName, accessToken),
       })) || []
 
     // create a short path [code][.../][end of path by depth joined by /][taskName]
@@ -38,7 +41,6 @@ export const transformTasksData = ({ projectName, tasks = [], code }) =>
       path: `${projectName}/${task.folder?.path}`,
       shortPath,
       latestVersionId: latestVersion?.id,
-      latestVersionThumbnailId: latestVersion?.thumbnailId,
       thumbnailUrl,
       allVersions,
       projectName: projectName,

--- a/src/services/userDashboard/userDashboardHelpers.js
+++ b/src/services/userDashboard/userDashboardHelpers.js
@@ -1,25 +1,13 @@
-const getThumbnailUrl = (thumbnailId, updatedAt, projectName, accessToken) => {
-  return thumbnailId
-    ? `/api/projects/${projectName}/thumbnails/${thumbnailId}?updatedAt=${updatedAt}&token=${accessToken}`
-    : null
-}
+// NOTE: THIS DOES NOT RUN WHEN PATCHING THE TASKS
 
 export const transformTasksData = ({ projectName, tasks = [], code }) =>
   tasks?.map((task) => {
     const latestVersion = task.versions?.edges[0]?.node
 
-    const accessToken = localStorage.getItem('accessToken')
-
     // use task thumbnail if it exists, otherwise use latest version thumbnail
     const thumbnailId = task?.thumbnailId || latestVersion?.thumbnailId
-    const updatedAt = task?.thumbnailId ? task?.updatedAt : latestVersion?.updatedAt
-    const thumbnailUrl = getThumbnailUrl(thumbnailId, updatedAt, projectName, accessToken)
 
-    const allVersions =
-      task?.allVersions?.edges.map(({ node }) => ({
-        ...node,
-        thumbnailUrl: getThumbnailUrl(node, projectName, accessToken),
-      })) || []
+    const allVersions = task?.allVersions?.edges.map(({ node }) => node) || []
 
     // create a short path [code][.../][end of path by depth joined by /][taskName]
     const depth = 2
@@ -41,7 +29,9 @@ export const transformTasksData = ({ projectName, tasks = [], code }) =>
       path: `${projectName}/${task.folder?.path}`,
       shortPath,
       latestVersionId: latestVersion?.id,
-      thumbnailUrl,
+      latestVersionThumbnailId: latestVersion?.thumbnailId,
+      latestVersionUpdatedAt: latestVersion?.updatedAt,
+      thumbnailId,
       allVersions,
       projectName: projectName,
       projectCode: code,

--- a/src/services/userDashboard/userDashboardQueries.js
+++ b/src/services/userDashboard/userDashboardQueries.js
@@ -7,6 +7,7 @@ const TASK_FRAGMENT = `
     assignees
     updatedAt
     folderId
+    thumbnailId
     attrib {
       endDate
     }


### PR DESCRIPTION
## Changelog Description

- Click to upload or drag and drop, to add thumbnails to folders, tasks and versions.
- Upload multiple images: if multiple entities are selected and multiple files dropped, matching file to entity names will be uploaded. For example `sh010.png -> sh010, shot020.png -> sh020`.

## Additional Information

![thumbnail_upload_kanban_v001](https://github.com/ynput/ayon-frontend/assets/49156310/a693350a-baeb-44a5-a8b4-705b76d1f627)
![thumbnail_upload_browser_v001](https://github.com/ynput/ayon-frontend/assets/49156310/0fcce82c-b9af-4360-b476-805db8ead348)

#### Uploading multiple images to multiple folders
![thumbnail_upload_browser_multiple_v001](https://github.com/ynput/ayon-frontend/assets/49156310/f76d5338-f605-4183-bc69-cad80b9ad7c5)
