### PR TITLE
Pass settings variant to services

### DIFF
--- a/src/containers/AddonSettings/VariantSelector.jsx
+++ b/src/containers/AddonSettings/VariantSelector.jsx
@@ -94,7 +94,7 @@ const VariantSelector = ({ variant, setVariant, disabled }) => {
   }
 
   return (
-    <>
+    <div style={{ display: 'flex', flexDirection: 'row', gap: 6 }}>
       <Button
         label="Production"
         onClick={() => setVariant('production')}
@@ -107,7 +107,7 @@ const VariantSelector = ({ variant, setVariant, disabled }) => {
         style={variant === 'staging' ? styleHlStag : {}}
         disabled={disabled}
       />
-    </>
+    </div>
   )
 }
 

--- a/src/pages/ServicesPage/NewServiceDialog.jsx
+++ b/src/pages/ServicesPage/NewServiceDialog.jsx
@@ -12,6 +12,7 @@ import {
   Button,
   Toolbar,
 } from '@ynput/ayon-react-components'
+import VariantSelector from '/src/containers/AddonSettings/VariantSelector'
 
 const NewServiceDialog = ({ onHide, onSpawn }) => {
   const [addonData, setAddonData] = useState([])
@@ -21,6 +22,7 @@ const NewServiceDialog = ({ onHide, onSpawn }) => {
   const [selectedVersion, setSelectedVersion] = useState(null)
   const [selectedService, setSelectedService] = useState(null)
   const [selectedHost, setSelectedHost] = useState(null)
+  const [settingsVariant, setSettingsVariant] = useState('production')
 
   useEffect(() => {
     axios.get('/api/addons?details=1').then((response) => {
@@ -65,12 +67,32 @@ const NewServiceDialog = ({ onHide, onSpawn }) => {
   }, [selectedVersion, selectedAddon?.name])
 
   const submit = () => {
+    /*
+    volumes: list[str] | None = Field(None, title="Volumes", example=["/tmp:/tmp"])
+    ports: list[str] | None = Field(None, title="Ports", example=["8080:8080"])
+    mem_limit: str | None = Field(None, title="Memory Limit", example="1g")
+    user: str | None = Field(None, title="User", example="1000")
+    env: dict[str, Any] = Field(default_factory=dict)
+    */
+
+    const serviceConfig = {
+      volumes: [],
+      ports: [],
+      mem_limit: null,
+      user: null,
+      env: {},
+    }
+    if (settingsVariant !== 'production') {
+      serviceConfig.env.AYON_DEFAULT_SETTINGS_VARIANT = settingsVariant
+    }
+
     axios
       .put(`/api/services/${serviceName}`, {
         addonName: selectedAddon.name,
         addonVersion: selectedVersion,
         service: selectedService,
         hostname: selectedHost,
+        config: serviceConfig,
       })
       .then(() => {
         toast.success(`Service spawned`)
@@ -127,6 +149,15 @@ const NewServiceDialog = ({ onHide, onSpawn }) => {
               setSelectedService(e.value)
               setServiceName(e.value)
             }}
+          />
+        </FormRow>
+
+        <FormRow label="Settings variant">
+          <VariantSelector
+            addonName={selectedAddon?.name}
+            addonVersion={selectedVersion}
+            variant={settingsVariant}
+            setVariant={setSettingsVariant}
           />
         </FormRow>
 


### PR DESCRIPTION
Services can now be configured to use a specific settings variant.

Variant selector is now included to "new service" dialog and sets AYON_DEFAULT_SETTINGS_VARIANT environment variable of the container. This is purely UX feature as the logic is already implemented in the API as well as in Ash