### PR TITLE
Show copy settings button in developer mode

### DIFF
--- a/src/containers/AddonSettings/AddonSettings.jsx
+++ b/src/containers/AddonSettings/AddonSettings.jsx
@@ -91,6 +91,7 @@ const AddonSettings = ({ projectName, showSites = false }) => {
   }
 
   const user = useSelector((state) => state.user)
+  const developerMode = user?.attrib?.developerMode
 
   const onSettingsLoad = (addonName, addonVersion, variant, siteId, data) => {
     const key = `${addonName}|${addonVersion}|${variant}|${siteId}|${projectKey}`
@@ -481,30 +482,35 @@ const AddonSettings = ({ projectName, showSites = false }) => {
     // site settings do not have variants
     if (showSites) return
 
+    const copySettingsButton = (
+      <CopyBundleSettingsButton
+        bundleName={bundleName}
+        variant={variant}
+        disabled={canCommit}
+        localData={localData}
+        changedKeys={changedKeys}
+        setLocalData={setLocalData}
+        setChangedKeys={setChangedKeys}
+        setSelectedAddons={setSelectedAddons}
+        originalData={originalData}
+        setOriginalData={setOriginalData}
+        projectName={projectName}
+      />
+    )
+
     return (
       <>
         <Toolbar>
           <VariantSelector variant={variant} setVariant={setVariant} />
+          {copySettingsButton}
         </Toolbar>
-        {!user?.attrib?.developerMode && (
+        {!developerMode && (
           <Toolbar>
             <span style={{ whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
               {bundleName}
             </span>
             <Spacer />
-            <CopyBundleSettingsButton
-              bundleName={bundleName}
-              variant={variant}
-              disabled={canCommit}
-              localData={localData}
-              changedKeys={changedKeys}
-              setLocalData={setLocalData}
-              setChangedKeys={setChangedKeys}
-              setSelectedAddons={setSelectedAddons}
-              originalData={originalData}
-              setOriginalData={setOriginalData}
-              projectName={projectName}
-            />
+            {copySettingsButton}
             <Button
               icon="rocket_launch"
               data-tooltip="Push bundle to production"
@@ -516,7 +522,7 @@ const AddonSettings = ({ projectName, showSites = false }) => {
         )}
       </>
     )
-  }, [variant, changedKeys, bundleName, projectName])
+  }, [variant, changedKeys, bundleName, projectName, developerMode])
 
   const settingsListHeader = useMemo(() => {
     return (


### PR DESCRIPTION
Copy settings button (by bundle) is now available in developer mode

![image](https://github.com/ynput/ayon-frontend/assets/5007200/8b7510cc-b9db-42e4-8ef7-fe21fcefffa2)
