### PR TITLE
Fix: When all projects are inactive make sure they stay visible somewhere.

### DIFF
--- a/src/pages/UserDashboardPage/UserDashboardPage.jsx
+++ b/src/pages/UserDashboardPage/UserDashboardPage.jsx
@@ -47,7 +47,7 @@ const UserDashboardPage = () => {
 
   // get projects list
   const { data: projects = [], isLoading: isLoadingProjects } = useGetAllProjectsQuery({
-    showInactive: false,
+    showInactive: true,
   })
   // attach projects: ['project_name'] to each projectInfo
   const projectsInfoWithProjects = useMemo(() => {

--- a/src/services/project/updateProject.js
+++ b/src/services/project/updateProject.js
@@ -51,8 +51,14 @@ const updateProject = ayonApi.injectEndpoints({
         method: 'PATCH',
         body: update,
       }),
-      invalidatesTags: (result, error, { projectName }) =>
-        error ? [] : [{ type: 'project', id: projectName }],
+      invalidatesTags: (result, error, { projectName, update }) =>
+        error
+          ? []
+          : 'active' in update
+          ? // if active is updated, invalidate all projects
+            [{ type: 'project' }]
+          : // if not, invalidate only the updated project
+            [{ type: 'project', id: projectName }],
     }),
   }),
 })


### PR DESCRIPTION
## Changelog Description

- Fix: Only show "Create new project" button when there are no projects at all (active/inactive)
- Fix: The projects list UI wouldn't update when a project active flag was updated.

## Testing

1. Make all projects inactive
2. Ensure the projects can still be accessed on the dashboard overview page.