### PR TITLE
Fix: handle deletion of project from dashboard overview page

### DIFF
--- a/src/containers/projectList.jsx
+++ b/src/containers/projectList.jsx
@@ -226,13 +226,15 @@ const ProjectList = ({
           icon: 'create_new_folder',
           command: onNewProject,
         },
-        {
+      ]
+
+      if (onDeleteProject)
+        managerMenuItems.push({
           label: 'Delete Project',
           icon: 'delete',
           command: () => onDeleteProject(sel[0]),
           danger: true,
-        },
-      ]
+        })
 
       if (isProjectManager) menuItems.push(...managerMenuItems)
 

--- a/src/pages/UserDashboardPage/UserDashboardPage.jsx
+++ b/src/pages/UserDashboardPage/UserDashboardPage.jsx
@@ -11,6 +11,8 @@ import { useGetAllProjectsQuery } from '/src/services/project/getProject'
 import UserDashboardNoProjects from './UserDashboardNoProjects/UserDashboardNoProjects'
 import ProjectDashboard from '../ProjectDashboard'
 import NewProjectDialog from '../ProjectManagerPage/NewProjectDialog'
+import { useDeleteProjectMutation } from '/src/services/project/updateProject'
+import confirmDelete from '/src/helpers/confirmDelete'
 
 const UserDashboardPage = () => {
   let { module } = useParams()
@@ -59,6 +61,18 @@ const UserDashboardPage = () => {
     return projectsInfoWithProjects
   }, [projectsInfo, isLoadingInfo])
 
+  const [deleteProject] = useDeleteProjectMutation()
+
+  const handleDeleteProject = (sel) => {
+    confirmDelete({
+      label: `Project: ${sel}`,
+      accept: async () => {
+        await deleteProject({ projectName: sel }).unwrap()
+        setSelectedProjects([])
+      },
+    })
+  }
+
   if (isLoadingProjects) return null
 
   if (!projects.length) return <UserDashboardNoProjects />
@@ -87,6 +101,7 @@ const UserDashboardPage = () => {
             onSelectAllDisabled={!isProjectsMultiSelect}
             isProjectManager={module === 'overview'}
             onNewProject={() => setShowNewProject(true)}
+            onDeleteProject={handleDeleteProject}
           />
           {module === 'tasks' && (
             <UserTasksContainer


### PR DESCRIPTION
## Changelog Description

- Fix: trying to delete a project on the dashboard overview page would fail because it was never implemented.
- Fix: hide the deletion context option if no function has been provided to the `onDeleteProject` prop on `ProjectList`.

## Testing

- Right click on a project in Dashboard overviews page and click "delete".