### PR TITLE
Fix: Bundles Form Improvements

### DIFF
--- a/src/pages/SettingsPage/Bundles/BundleDepPackage.jsx
+++ b/src/pages/SettingsPage/Bundles/BundleDepPackage.jsx
@@ -22,15 +22,15 @@ const StyledFormRow = styled(FormRow)`
 const BundleDepPackage = ({ children, label, onEdit }) => {
   return (
     <StyledFormRow label={label}>
-      <span>
-        {children || '(NONE)'}
-        {/* <span> (author)</span> */}
-      </span>
       <Button
         icon={children ? 'edit' : 'add'}
         onClick={onEdit}
         data-tooltip={children ? 'Edit dependency package' : 'Add dependency package'}
       />
+      <span>
+        {children || '(NONE)'}
+        {/* <span> (author)</span> */}
+      </span>
     </StyledFormRow>
   )
 }

--- a/src/pages/SettingsPage/Bundles/BundleDeps.jsx
+++ b/src/pages/SettingsPage/Bundles/BundleDeps.jsx
@@ -35,9 +35,11 @@ const BundleDeps = ({ bundle }) => {
       dependencyPackages: newDeps,
     }
 
+    // HACK: using whole patch data instead of just the dependencyPackages to avoid overwriting other fields
+
     // update bundle on server
     try {
-      await updateBundle({ name: bundle.name, patch, data: { dependencyPackages: newDeps } })
+      await updateBundle({ name: bundle.name, patch, data: patch })
       handleCloseForm()
       toast.success('Bundle Dependency Package updated')
     } catch (error) {

--- a/src/pages/SettingsPage/Bundles/Bundles.jsx
+++ b/src/pages/SettingsPage/Bundles/Bundles.jsx
@@ -157,6 +157,8 @@ const Bundles = () => {
     return result
   }, [bundleList, selectedBundles])
 
+  // takes an array of installer objects (installerList) and groups them by version.
+  // The result is an array of objects, each containing a version number and an array of platforms for that version.
   const installerVersions = useMemo(() => {
     if (!installerList) return []
 
@@ -170,7 +172,7 @@ const Bundles = () => {
     }
 
     return Object.entries(r).map(([version, platforms]) => ({
-      platforms,
+      platforms: platforms.sort(),
       version,
     }))
   }, [installerList])

--- a/src/pages/SettingsPage/Bundles/NewBundle.jsx
+++ b/src/pages/SettingsPage/Bundles/NewBundle.jsx
@@ -56,7 +56,6 @@ const NewBundle = ({ initBundle, onSave, addons, installers, isLoading, isDev, d
 
       const initForm = {
         addons: initAddons,
-        installerVersion: installers?.[0]?.version,
         name: '',
         ...initBundle,
         isDev: developerMode || isDev,

--- a/src/pages/SettingsPage/Bundles/NewBundle.jsx
+++ b/src/pages/SettingsPage/Bundles/NewBundle.jsx
@@ -152,8 +152,10 @@ const NewBundle = ({ initBundle, onSave, addons, installers, isLoading, isDev, d
       changes.addonDevelopment = removeEmptyDevAddons(changes.addonDevelopment)
     }
 
+    // HACK: include whole bundle data as patch is broken
+
     try {
-      await updateBundle({ name: initBundle.name, data: { ...changes } }).unwrap()
+      await updateBundle({ name: initBundle.name, data: { ...formData } }).unwrap()
 
       toast.success('Dev bundle updated')
       setDevChanges(false)


### PR DESCRIPTION
## Changelog Description

- Fix: remove auto selecting installer version in bundle form.
- HotFix: Always provide full bundles data object when patching to avoid data being overwritten. This can be removed when the BE method is fixed.
- Fix: Installer versions dropdown sort using semver and sort platforms tags.
- Fix: Dep packages put edit button before filename for easier access on smaller screens.

![image](https://github.com/ynput/ayon-frontend/assets/49156310/abaaee6f-a52d-4dc6-8000-4d347dbe53c1)
