### PR TITLE
enhancement: deactivate project from context menu

### DIFF
--- a/src/containers/projectList.jsx
+++ b/src/containers/projectList.jsx
@@ -103,6 +103,7 @@ const ProjectList = ({
   autoSelect,
   isProjectManager,
   onDeleteProject,
+  onActivateProject,
   onNewProject,
   isCollapsible = false,
   collapsedId = 'global',
@@ -228,13 +229,27 @@ const ProjectList = ({
         },
       ]
 
-      if (onDeleteProject)
+      const selObject = data.find((project) => project?.name === sel[0])
+      const active = selObject?.active
+
+      // show deactivate button on active projects and activate on inactive projects
+      if (onActivateProject) {
+        managerMenuItems.push({
+          label: active ? 'Deactivate Project' : 'Activate Project',
+          icon: active ? 'archive' : 'unarchive',
+          command: () => onActivateProject(sel[0], !active),
+        })
+      }
+
+      // only show delete button on non-active projects
+      if (onDeleteProject && selObject && !active) {
         managerMenuItems.push({
           label: 'Delete Project',
           icon: 'delete',
           command: () => onDeleteProject(sel[0]),
           danger: true,
         })
+      }
 
       if (isProjectManager) menuItems.push(...managerMenuItems)
 

--- a/src/pages/ProjectManagerPage/ProjectManagerPage.jsx
+++ b/src/pages/ProjectManagerPage/ProjectManagerPage.jsx
@@ -10,7 +10,10 @@ import ProjectRoots from './ProjectRoots'
 import NewProjectDialog from './NewProjectDialog'
 
 import { selectProject } from '/src/features/context'
-import { useDeleteProjectMutation } from '/src/services/project/updateProject'
+import {
+  useDeleteProjectMutation,
+  useUpdateProjectMutation,
+} from '/src/services/project/updateProject'
 import TeamsPage from '../TeamsPage'
 import ProjectManagerPageContainer from './ProjectManagerPageContainer'
 import ProjectManagerPageLayout from './ProjectManagerPageLayout'
@@ -48,6 +51,9 @@ const ProjectManagerPage = () => {
     withDefault(StringParam, projectName),
   )
 
+  // UPDATE DATA
+  const [updateProject] = useUpdateProjectMutation()
+
   useEffect(() => {
     // Update project name in header
     dispatch(selectProject(selectedProject))
@@ -72,6 +78,10 @@ const ProjectManagerPage = () => {
         setSelectedProject(null)
       },
     })
+  }
+
+  const handleActivateProject = async (sel, active) => {
+    await updateProject({ projectName: sel, update: { active } }).unwrap()
   }
 
   let links = [
@@ -129,6 +139,7 @@ const ProjectManagerPage = () => {
         isUser={isUser}
         onNewProject={() => setShowNewProject(true)}
         onDeleteProject={handleDeleteProject}
+        onActivateProject={handleActivateProject}
       >
         {module === 'anatomy' && <ProjectAnatomy />}
         {module === 'projectSettings' && <ProjectSettings />}

--- a/src/pages/ProjectManagerPage/ProjectManagerPageContainer.jsx
+++ b/src/pages/ProjectManagerPage/ProjectManagerPageContainer.jsx
@@ -10,6 +10,7 @@ const ProjectManagerPageContainer = ({
   selection,
   onDeleteProject,
   onNewProject,
+  onActivateProject,
   ...props
 }) => {
   // for each child, add the project list react node with the props
@@ -25,6 +26,7 @@ const ProjectManagerPageContainer = ({
             autoSelect
             selection={selection}
             onDeleteProject={onDeleteProject}
+            onActivateProject={onActivateProject}
             onNewProject={onNewProject}
             isProjectManager
             {...props}
@@ -32,6 +34,7 @@ const ProjectManagerPageContainer = ({
         ),
         onDeleteProject,
         onNewProject,
+        onActivateProject,
       })
     }
     return child


### PR DESCRIPTION
## Changelog Description

- Activate and deactivate projects from the context menu when on the projects manager page.
- Only show "Delete Project" once a project is inactive.

![activate_project_from_context_v001](https://github.com/ynput/ayon-frontend/assets/49156310/0554bbf1-433d-46d7-b57d-11c5aa654d67)

