### PR TITLE
Highlight broken addon versions

### DIFF
--- a/src/hooks/Tooltip/useTooltip.jsx
+++ b/src/hooks/Tooltip/useTooltip.jsx
@@ -35,6 +35,7 @@ const useTooltip = () => {
 
   const [timeoutId, setTimeoutId] = useState(null)
   const [isActive, setIsActive] = useState(false)
+  const delay = 900
 
   // when tooltip changes, update tooltip position using target position
   useEffect(() => {
@@ -68,7 +69,7 @@ const useTooltip = () => {
         setTimeout(() => {
           setIsActive(true)
           setTooltip((t) => ({ ...t, pos: newTooltipPos, hide: false }))
-        }, 900),
+        }, delay),
       )
     }
   }, [tooltip, setTooltip])
@@ -96,6 +97,7 @@ const useTooltip = () => {
 
       const tooltipData = target?.dataset?.tooltip
       const shortcutData = target?.dataset?.shortcut
+      const noDelayData = target?.dataset?.tooltipNoDelay
       // check if data-tooltip attribute exists
       if (!tooltipData && !shortcutData) {
         setTooltip(null)
@@ -125,6 +127,8 @@ const useTooltip = () => {
 
       // check if tooltip is already set to same value
       if (isEqual(tooltip, newTooltip) && isEqual(tooltip?.target, newTargetPos)) return
+
+      if (noDelayData) setIsActive(true)
 
       setTooltip(newTooltip)
     },

--- a/src/pages/SettingsPage/AddonsManager/AddonsManager.jsx
+++ b/src/pages/SettingsPage/AddonsManager/AddonsManager.jsx
@@ -58,7 +58,7 @@ const AddonsManager = () => {
 
     // remove bundles that are not in the selected versions
     const newBundles = selectedBundles.filter((b) =>
-      selectedVersions.some((v) => filteredVersionsMap.get(v)?.has(b)),
+      selectedVersions.some((v) => filteredVersionsMap.get(v)?.bundles?.has(b)),
     )
 
     setSelectedBundles(newBundles)

--- a/src/pages/SettingsPage/AddonsManager/AddonsManagerTable.jsx
+++ b/src/pages/SettingsPage/AddonsManager/AddonsManagerTable.jsx
@@ -77,7 +77,7 @@ const AddonsManagerTable = ({
       contextSelection.length &&
       contextSelection.every((d) => {
         const v = value.find((v) => v[field] === d)
-        if (v) return !v.status.length
+        if (v) return !v.status.filter((s) => s !== 'error').length
         return false
       })
 
@@ -89,7 +89,7 @@ const AddonsManagerTable = ({
       {onDelete && (
         <Button
           icon={deleteIcon}
-          disabled={tableSelection.some((v) => v.status?.length)}
+          disabled={tableSelection.some((v) => v.status?.filter((s) => s !== 'error').length)}
           onClick={(e) => handleDelete(e, selection)}
         >
           {deleteLabel} {title}
@@ -107,7 +107,20 @@ const AddonsManagerTable = ({
           selection={tableSelection}
           onContextMenu={handleContextClick}
         >
-          <Column field={field} header={title} sortable />
+          <Column
+            field={field}
+            header={title}
+            sortable
+            body={(d) => (
+              <span
+                data-tooltip={d?.tooltip}
+                data-tooltip-no-delay={true}
+                style={{ width: '100%' }}
+              >
+                {d[field]} {d?.suffix}
+              </span>
+            )}
+          />
           <Column
             field="status"
             header={'Status'}

--- a/src/pages/SettingsPage/AddonsManager/helpers.js
+++ b/src/pages/SettingsPage/AddonsManager/helpers.js
@@ -123,7 +123,8 @@ export const transformVersionsTable = (data, addons = [], deletedVersions) => {
       if (version.isBroken) {
         status.push('error')
         suffix = '(broken)'
-        tooltip = JSON.stringify(version.reason)
+        tooltip = 'Addon failed to load. Check logs for details' //JSON.stringify(version.reason)
+        // TODO: allow rendering reason in pre or markdown
       }
     }
 


### PR DESCRIPTION
## Changelog Description

- View and delete broken and crashed addons.
- Add `data-tooltip-no-delay` to invoke a tooltip instantly on hover.

![delete_broken_addons_v001](https://github.com/ynput/ayon-frontend/assets/49156310/0e4f901a-c8ed-472b-8261-615f6a0400bd)

## Testing

1. Break an addon somehow.
2. Go to addons page and try to remove it.