### PR TITLE
Improved tooltips

### DIFF
--- a/src/containers/SettingsEditor/fields.jsx
+++ b/src/containers/SettingsEditor/fields.jsx
@@ -434,20 +434,17 @@ function FieldTemplate(props) {
   //   props.errors.props.errors && props.schema.widget !== 'color' ? 'error' : ''
   // }`
 
-  const inlineHelp = useMemo(() => {
-    return (
-      props.rawDescription && (
-        <div>
-          <ReactMarkdown>{props.rawDescription}</ReactMarkdown>
-        </div>
-      )
-    )
-  }, [props.rawDescription])
-
   return (
     <>
       {divider}
-      <div className={className} data-fieldid={props.id} onContextMenu={onContextMenu}>
+      <div
+        className={className}
+        data-fieldid={props.id}
+        onContextMenu={onContextMenu}
+        data-tooltip={props.rawDescription}
+        data-tooltip-delay={300}
+        data-tooltip-as="markdown"
+      >
         {props.label && (
           <div className={`form-inline-field-label ${overrideLevel}`}>
             <span
@@ -463,7 +460,6 @@ function FieldTemplate(props) {
           </div>
         )}
         <div className={`form-inline-field-widget ${widgetClass}`}>{props.children}</div>
-        <div className="form-inline-field-help">{inlineHelp}</div>
       </div>
     </>
   )

--- a/src/hooks/Tooltip/Tooltip.styled.js
+++ b/src/hooks/Tooltip/Tooltip.styled.js
@@ -2,37 +2,41 @@ import styled from 'styled-components'
 
 export const TooltipWidget = styled.div`
   position: fixed;
-  background-color: hsl(0, 0%, 5%);
-  border-radius: var(--border-radius-m);
+  z-index: 10000;
 
   transition: opacity 300ms;
+  /* how far up the tooltip us */
+  padding-bottom: 4px;
+
+  max-width: 400px;
+`
+
+export const TooltipInner = styled.div`
+  background-color: var(--md-sys-color-surface-container-lowest);
+  border-radius: var(--border-radius-m);
+  border: solid 1px var(--md-sys-color-outline-variant);
+  padding: 8px;
+  margin: 0;
+  max-width: 400px;
+  overflow: hidden;
+
+  p {
+    margin: 0;
+  }
+
+  a {
+    color: var(--md-sys-color-primary);
+    text-decoration: underline;
+  }
 
   display: flex;
   align-items: center;
   gap: var(--base-gap-small);
-  white-space: nowrap;
+  white-space: break-spaces;
 
   /* box shadow */
   box-shadow: 0 0 10px 0px rgba(0, 0, 0, 0.4);
-  user-select: none;
-  pointer-events: none;
   z-index: 1200;
-
-  /* tooltip triangle pointer using ::after */
-  &::after {
-    content: '';
-    position: fixed;
-
-    left: ${(props) => props?.$targetPos?.x}px;
-    top: ${(props) => props?.$targetPos?.y}px;
-
-    translate: 0 -100%;
-
-    margin-left: -5px;
-    border-width: 5px;
-    border-style: solid;
-    border-color: hsl(0, 0%, 5%) transparent transparent transparent;
-  }
 `
 
 export const Shortcut = styled.span`

--- a/src/hooks/Tooltip/useTooltip.jsx
+++ b/src/hooks/Tooltip/useTooltip.jsx
@@ -35,7 +35,8 @@ const useTooltip = () => {
 
   const [timeoutId, setTimeoutId] = useState(null)
   const [isActive, setIsActive] = useState(false)
-  const delay = 900
+  const defaultDelay = 900
+  const [delay, setDelay] = useState(defaultDelay)
 
   // when tooltip changes, update tooltip position using target position
   useEffect(() => {
@@ -72,7 +73,7 @@ const useTooltip = () => {
         }, delay),
       )
     }
-  }, [tooltip, setTooltip])
+  }, [tooltip, setTooltip, delay])
 
   // once tooltip has been null for 300ms, set noTimeOut to false
   const [activeTimeoutId, setActiveTimeoutId] = useState(null)
@@ -97,7 +98,7 @@ const useTooltip = () => {
 
       const tooltipData = target?.dataset?.tooltip
       const shortcutData = target?.dataset?.shortcut
-      const noDelayData = target?.dataset?.tooltipNoDelay
+      const delayData = target?.dataset?.tooltipDelay
       // check if data-tooltip attribute exists
       if (!tooltipData && !shortcutData) {
         setTooltip(null)
@@ -128,11 +129,20 @@ const useTooltip = () => {
       // check if tooltip is already set to same value
       if (isEqual(tooltip, newTooltip) && isEqual(tooltip?.target, newTargetPos)) return
 
-      if (noDelayData) setIsActive(true)
+      if (delayData) {
+        const parsedDelay = parseInt(delayData)
+        if (!isNaN(parsedDelay) && parsedDelay !== defaultDelay) {
+          setDelay(parsedDelay)
+        } else {
+          setDelay(defaultDelay) // replace defaultDelay with your default value
+        }
+      } else if (delay !== defaultDelay) {
+        setDelay(defaultDelay) // replace defaultDelay with your default value
+      }
 
       setTooltip(newTooltip)
     },
-    [setTooltip, tooltip, isActive],
+    [setTooltip, tooltip, isActive, delay],
   )
 
   const hideTooltip = !tooltip?.pos || tooltip?.hide

--- a/src/pages/SettingsPage/AddonsManager/AddonsManagerTable.jsx
+++ b/src/pages/SettingsPage/AddonsManager/AddonsManagerTable.jsx
@@ -77,7 +77,7 @@ const AddonsManagerTable = ({
       contextSelection.length &&
       contextSelection.every((d) => {
         const v = value.find((v) => v[field] === d)
-        if (v) return !v.status.length
+        if (v) return !v.status.filter((s) => s !== 'error').length
         return false
       })
 
@@ -89,7 +89,7 @@ const AddonsManagerTable = ({
       {onDelete && (
         <Button
           icon={deleteIcon}
-          disabled={tableSelection.some((v) => v.status?.length)}
+          disabled={tableSelection.some((v) => v.status?.filter((s) => s !== 'error').length)}
           onClick={(e) => handleDelete(e, selection)}
         >
           {deleteLabel} {title}
@@ -107,7 +107,21 @@ const AddonsManagerTable = ({
           selection={tableSelection}
           onContextMenu={handleContextClick}
         >
-          <Column field={field} header={title} sortable />
+          <Column
+            field={field}
+            header={title}
+            sortable
+            body={(d) => (
+              <span
+                data-tooltip={d?.tooltip}
+                data-tooltip-no-delay={true}
+                data-tooltip-as={'pre'}
+                style={{ width: '100%' }}
+              >
+                {d[field]} {d?.suffix}
+              </span>
+            )}
+          />
           <Column
             field="status"
             header={'Status'}

--- a/src/pages/SettingsPage/AddonsManager/AddonsManagerTable.jsx
+++ b/src/pages/SettingsPage/AddonsManager/AddonsManagerTable.jsx
@@ -114,7 +114,7 @@ const AddonsManagerTable = ({
             body={(d) => (
               <span
                 data-tooltip={d?.tooltip}
-                data-tooltip-no-delay={true}
+                data-tooltip-delay={0}
                 data-tooltip-as={'pre'}
                 style={{ width: '100%' }}
               >

--- a/src/pages/SettingsPage/Bundles/BundleDeps.jsx
+++ b/src/pages/SettingsPage/Bundles/BundleDeps.jsx
@@ -7,7 +7,7 @@ import { Dialog } from 'primereact/dialog'
 import { useGetDependencyPackageListQuery } from '/src/services/dependencyPackages'
 import BundleDepsPicker from './BundleDepsPicker'
 
-const BundleDeps = ({ bundle }) => {
+const BundleDeps = ({ bundle, onChange }) => {
   const initPackageForm = {
     platform: null,
     file: null,
@@ -29,6 +29,12 @@ const BundleDeps = ({ bundle }) => {
       [platform]: packageName || null,
     }
 
+    if (onChange) {
+      onChange(newDeps)
+      handleCloseForm()
+      return
+    }
+
     // update bundle
     const patch = {
       ...bundle,
@@ -37,7 +43,7 @@ const BundleDeps = ({ bundle }) => {
 
     // update bundle on server
     try {
-      await updateBundle({ name: bundle.name, patch, data: { dependencyPackages: newDeps } })
+      await updateBundle({ name: bundle.name, patch, data: patch })
       handleCloseForm()
       toast.success('Bundle Dependency Package updated')
     } catch (error) {

--- a/src/pages/SettingsPage/Bundles/NewBundle.jsx
+++ b/src/pages/SettingsPage/Bundles/NewBundle.jsx
@@ -194,6 +194,13 @@ const NewBundle = ({ initBundle, onSave, addons, installers, isLoading, isDev, d
     setFormData(newFormData)
   }
 
+  // when dep packages are changed in dev mode
+  const handleDepPackagesDevChange = (packages) => {
+    setFormData((prev) => {
+      return { ...prev, dependencyPackages: packages }
+    })
+  }
+
   // SHORTCUTS
   const shortcuts = [
     {
@@ -318,7 +325,7 @@ const NewBundle = ({ initBundle, onSave, addons, installers, isLoading, isDev, d
             </>
           )}
         </Styled.AddonTools>
-        {isDev && <BundleDeps bundle={formData} />}
+        {isDev && <BundleDeps bundle={formData} onChange={handleDepPackagesDevChange} />}
       </BundleForm>
     </>
   )


### PR DESCRIPTION
## Changelog Description

- Tooltips can now accept markdown!
- `data-tooltip-delay` to set the delay for a tooltip
- `data-tooltip-as` to set which tag to be used (`pre`, `markdown`, `div`)
- Fix: dev bundle dep packages would overwrite local change
- Settings field descriptions are now displayed as tooltips.

![tooltip_markdown_v001](https://github.com/ynput/ayon-frontend/assets/49156310/d8b9f8ff-be50-4383-bfbb-dffc87c6518f)

