### PR TITLE
Tools Field Dropdown

### DIFF
--- a/src/pages/EditorPage/fields/ToolsField.jsx
+++ b/src/pages/EditorPage/fields/ToolsField.jsx
@@ -1,0 +1,68 @@
+import { DefaultValueTemplate, Dropdown } from '@ynput/ayon-react-components'
+import { useState } from 'react'
+import styled, { css } from 'styled-components'
+
+const StyledDropdown = styled(Dropdown)`
+  width: 100%;
+
+  ${({ $isOpen }) =>
+    !$isOpen &&
+    css`
+      .button:not(:hover) {
+        background-color: unset;
+
+        & > div {
+          border-color: transparent;
+        }
+
+        .control {
+          opacity: 0;
+        }
+      }
+    `}
+
+  &.changed {
+    .button {
+      background-color: var(--color-changed);
+      color: var(--md-sys-color-on-primary);
+    }
+
+    &.inherited {
+      font-style: italic;
+    }
+  }
+`
+
+const ToolsField = ({ value, className, attrib }) => {
+  const [isOpen, setIsOpen] = useState(false)
+
+  if (!value || !value.length) console.log('null')
+
+  const _enum = attrib?.enum
+
+  const labels = _enum
+    ?.filter((item) => value.includes(item.value))
+    .map((item) => item.label || item.value)
+
+  const isInheritedAndChanged = className.includes('inherited') && className.includes('changed')
+
+  return (
+    <StyledDropdown
+      disabled={isInheritedAndChanged}
+      value={labels}
+      className={className}
+      multiSelect
+      itemStyle={{ pointerEvents: 'none', backgroundColor: 'unset' }}
+      onOpen={() => setIsOpen(true)}
+      onClose={() => setIsOpen(false)}
+      valueTemplate={() => (
+        <DefaultValueTemplate value={value}>
+          {isInheritedAndChanged ? '(inherited)' : `(${labels.length}) ${labels.join(', ')}`}
+        </DefaultValueTemplate>
+      )}
+      $isOpen={isOpen}
+    />
+  )
+}
+
+export default ToolsField

--- a/src/pages/EditorPage/utils.jsx
+++ b/src/pages/EditorPage/utils.jsx
@@ -1,8 +1,8 @@
 import ayonClient from '/src/ayon'
 import { AssigneeSelect, Icon } from '@ynput/ayon-react-components'
 import { TimestampField } from '/src/containers/fieldFormat'
+import ToolsField from './fields/ToolsField'
 
-// TODO rename .jsx -> .js
 const formatAttribute = (node, changes, fieldName, styled = true) => {
   const chobj = changes[node.id]
 
@@ -26,7 +26,9 @@ const formatAttribute = (node, changes, fieldName, styled = true) => {
       (attrib) => attrib.name === fieldName,
     ).data
     const fieldType = attribSettings.type
-    if (fieldType === 'datetime') return <TimestampField value={value} ddOnly />
+    if (fieldName === 'tools' && value)
+      return <ToolsField value={value} className={className} attrib={attribSettings} />
+    else if (fieldType === 'datetime') return <TimestampField value={value} ddOnly />
     else if (fieldType === 'boolean')
       return !value ? '' : <Icon icon="check" className={`editor-field ${className}`} />
     else if (fieldType === 'list_of_strings' && typeof value === 'object') {


### PR DESCRIPTION
## Changelog Description

- Tools field in editor now shows a readonly dropdown for better readability.
- It also shows the number of tools at the start in brackets.

![editor_tools_dropdown_v001](https://github.com/ynput/ayon-frontend/assets/49156310/3e5f65e9-f2e2-4e17-8e2d-af95e4a20cee)


