### PR TITLE
Restart server banner triggered using a server event

### DIFF
--- a/src/components/Menu/MenuComponents/Menu.styled.js
+++ b/src/components/Menu/MenuComponents/Menu.styled.js
@@ -165,6 +165,18 @@ export const Item = styled.li`
       background-color: var(--md-sys-color-primary-container-hover);
     }
   }
+
+  &.notification::after {
+    content: '';
+    position: absolute;
+    right: 0;
+    top: 0;
+    transform: translate(25%, -25%);
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background-color: var(--md-sys-color-error);
+  }
 `
 
 export const Footer = styled.footer`

--- a/src/components/Menu/MenuComponents/MenuItem.jsx
+++ b/src/components/Menu/MenuComponents/MenuItem.jsx
@@ -3,10 +3,22 @@ import React, { forwardRef } from 'react'
 import * as Styled from './Menu.styled'
 import { isArray } from 'lodash'
 import { Link } from 'react-router-dom'
+import classNames from 'classnames'
 
 const MenuItem = forwardRef(
   (
-    { label, icon, highlighted, selected, items = [], className, isLink, shortcut, ...props },
+    {
+      label,
+      icon,
+      highlighted,
+      notification,
+      selected,
+      items = [],
+      className,
+      isLink,
+      shortcut,
+      ...props
+    },
     ref,
   ) => {
     const labelsArray = isArray(label) ? label : [label]
@@ -14,9 +26,15 @@ const MenuItem = forwardRef(
     const Item = (
       <Styled.Item
         ref={ref}
-        className={`menu-item ${highlighted ? 'highlighted' : ''} ${
-          selected ? 'selected' : ''
-        } ${className}`}
+        className={classNames(
+          'menu-item',
+          {
+            highlighted: highlighted,
+            selected: selected,
+            notification: notification,
+          },
+          className,
+        )}
         icon={icon}
         {...props}
         label={labelsArray.join(', ')}

--- a/src/components/Menu/Menus/AppMenu.jsx
+++ b/src/components/Menu/Menus/AppMenu.jsx
@@ -1,11 +1,9 @@
 import Menu from '../MenuComponents/Menu'
-import { confirmDialog } from 'primereact/confirmdialog'
-import { useRestartServerMutation } from '/src/services/restartServer'
 import YnputConnector from '/src/components/YnputCloud/YnputConnector'
 import { useRestartOnBoardingMutation } from '/src/services/onBoarding/onBoarding'
 import { toast } from 'react-toastify'
-import useLocalStorage from '/src/hooks/useLocalStorage'
 import ayonClient from '/src/ayon'
+import { useRestart } from '/src/context/restartContext'
 
 export const AppMenu = ({ user, ...props }) => {
   // check if user is logged in and is manager or admin
@@ -13,23 +11,7 @@ export const AppMenu = ({ user, ...props }) => {
   const isAdmin = user?.data?.isAdmin
 
   // restart server
-  const [restartServer] = useRestartServerMutation()
-  /* eslint-disable-next-line */
-  const [restartConfig, setRestartConfig] = useLocalStorage('restart', null)
-
-  const handleServerRestart = async () => {
-    confirmDialog({
-      message: 'Are you sure you want to restart the server?',
-      header: 'Restart Server',
-      icon: 'pi pi-exclamation-triangle',
-      accept: () => {
-        console.log(restartConfig)
-        setRestartConfig(null)
-        restartServer()
-      },
-      reject: () => {},
-    })
-  }
+  const { confirmRestart } = useRestart()
 
   // onboarding restart
   const [restartOnBoarding] = useRestartOnBoardingMutation()
@@ -102,7 +84,7 @@ export const AppMenu = ({ user, ...props }) => {
       id: 'restart',
       label: 'Restart Server',
       icon: 'restart_alt',
-      onClick: handleServerRestart,
+      onClick: confirmRestart,
     },
   ]
 

--- a/src/components/Menu/Menus/AppMenu.jsx
+++ b/src/components/Menu/Menus/AppMenu.jsx
@@ -11,7 +11,7 @@ export const AppMenu = ({ user, ...props }) => {
   const isAdmin = user?.data?.isAdmin
 
   // restart server
-  const { confirmRestart } = useRestart()
+  const { confirmRestart, isRestartRequired } = useRestart()
 
   // onboarding restart
   const [restartOnBoarding] = useRestartOnBoardingMutation()
@@ -82,9 +82,11 @@ export const AppMenu = ({ user, ...props }) => {
     },
     {
       id: 'restart',
-      label: 'Restart Server',
+      label: isRestartRequired ? 'Restart Required' : 'Restart Server',
       icon: 'restart_alt',
       onClick: confirmRestart,
+      highlighted: isRestartRequired,
+      notification: isRestartRequired,
     },
   ]
 

--- a/src/components/RestartBanner/RestartBanner.jsx
+++ b/src/components/RestartBanner/RestartBanner.jsx
@@ -3,13 +3,23 @@ import * as Styled from './RestartBanner.styled'
 import { Button } from '@ynput/ayon-react-components'
 import Type from '/src/theme/typography.module.css'
 
-const RestartBanner = ({ message = 'Restart server to apply changes.', onRestart }) => {
+const RestartBanner = ({ message = 'Restart server to apply changes.', onRestart, onSnooze }) => {
   return (
     <Styled.Banner>
-      <span className={Type.titleMedium}>{message}</span>
-      <Button variant="filled" onClick={onRestart}>
-        Restart
-      </Button>
+      <Styled.Main>
+        <span className={Type.titleMedium}>{message}</span>
+        <Button variant="filled" onClick={onRestart}>
+          Restart
+        </Button>
+      </Styled.Main>
+      <Styled.SnoozeButton
+        variant="text"
+        icon={'snooze'}
+        label="Snooze"
+        data-tooltip="Snoozes banner until 8pm tonight"
+        data-tooltip-delay={300}
+        onClick={onSnooze}
+      />
     </Styled.Banner>
   )
 }

--- a/src/components/RestartBanner/RestartBanner.styled.js
+++ b/src/components/RestartBanner/RestartBanner.styled.js
@@ -1,4 +1,5 @@
 import styled, { keyframes } from 'styled-components'
+import { Button } from '@ynput/ayon-react-components'
 
 // animate slide in from bottom
 export const SlideIn = keyframes`
@@ -19,16 +20,29 @@ export const Banner = styled.div`
 
   background-color: var(--md-sys-color-on-primary);
 
-  display: flex;
-  gap: 32px;
-
-  align-items: center;
-  justify-content: center;
-
-  padding: 8px;
+  padding: 16px;
   margin: 0;
 
   animation: ${SlideIn} 0.5s ease-in-out;
   z-index: 500;
   box-shadow: 0px -5px 10px 0px rgb(0 0 0 / 30%);
+`
+
+export const Main = styled.div`
+  display: flex;
+  gap: 32px;
+
+  align-items: center;
+  justify-content: center;
+`
+
+export const SnoozeButton = styled(Button)`
+  position: absolute;
+  right: 16px;
+  top: 16px;
+
+  &:hover {
+    background-color: var(--md-sys-color-primary);
+    color: var(--md-sys-color-on-primary);
+  }
 `

--- a/src/containers/header/AppHeader.jsx
+++ b/src/containers/header/AppHeader.jsx
@@ -15,6 +15,8 @@ import { useUpdateUserMutation } from '/src/services/user/updateUser'
 import { toast } from 'react-toastify'
 import { onProfileUpdate } from '/src/features/user'
 import styled from 'styled-components'
+import { useRestart } from '/src/context/restartContext'
+import { classNames } from 'primereact/utils'
 
 const DeveloperSwitch = styled.div`
   display: flex;
@@ -68,6 +70,9 @@ const Header = () => {
   const navigate = useNavigate()
   // get user from redux store
   const user = useSelector((state) => state.user)
+
+  // restart server notification
+  const { isSnoozing } = useRestart()
 
   // Get developer states
   const isDeveloper = user?.data?.isDeveloper
@@ -179,6 +184,7 @@ const Header = () => {
         ref={appButtonRef}
         active={menuOpen === 'app'}
         variant="text"
+        className={classNames({ notification: isSnoozing })}
       />
       <MenuContainer id="app" target={appButtonRef.current}>
         <AppMenu user={user} />

--- a/src/containers/header/HeaderButton.jsx
+++ b/src/containers/header/HeaderButton.jsx
@@ -7,6 +7,7 @@ const HeaderButton = styled(Button)`
   justify-content: center;
   font-weight: bold;
   user-select: none;
+  position: relative;
 
   background-color: transparent;
   z-index: 20;
@@ -28,7 +29,34 @@ const HeaderButton = styled(Button)`
     css`
       outline: solid 1px var(--md-sys-color-outline-variant);
       background-color: var(--md-sys-color-background);
-    `}
+    `} {
+    &::after {
+      content: '';
+      position: absolute;
+      right: -4px;
+      top: -4px;
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background-color: var(--md-sys-color-error);
+      user-select: none;
+      pointer-events: none;
+
+      /* closed */
+      opacity: 0;
+      scale: 0;
+
+      transition: opacity 0.1s, scale 0.1s;
+      transition-delay: 0.5s;
+      transition-timing-function: cubic-bezier(0, 0.67, 0.48, 1.47);
+    }
+
+    /* open */
+    &.notification::after {
+      opacity: 1;
+      scale: 1;
+    }
+  }
 `
 
 export default HeaderButton

--- a/src/context/restartContext.jsx
+++ b/src/context/restartContext.jsx
@@ -1,49 +1,51 @@
-import React, { createContext, useContext } from 'react'
-import { useRestartServerMutation } from '../services/restartServer'
+import React, { createContext, useContext, useState } from 'react'
+import {
+  useGetRestartQuery,
+  usePostRestartMutation,
+  useRestartServerMutation,
+} from '../services/restartServer'
 import RestartBanner from '../components/RestartBanner/RestartBanner'
 import { confirmDialog } from 'primereact/confirmdialog'
 import ServerRestartingPage from '../components/ServerRestartingPage'
-import useLocalStorage from '../hooks/useLocalStorage'
+import { useSelector } from 'react-redux'
 
 const RestartContext = createContext()
 
 function RestartProvider(props) {
-  const [restartConfig, setRestartConfig] = useLocalStorage('restart', null)
+  const isAdmin = useSelector((state) => state.user.data.isAdmin)
   const [restartServer] = useRestartServerMutation()
+  const [postRestart] = usePostRestartMutation()
 
+  const { data: restartData = {} } = useGetRestartQuery({ skip: !isAdmin })
+
+  // a function that runs when the server restarts
+  const [callback, setCallback] = useState(null)
   // ask if the user wants to restart the server after saving
-  const confirmRestart = ({ middleware } = {}) =>
+  const confirmRestart = () =>
     confirmDialog({
       // message,
       header: 'Restart Server?',
       // icon: 'pi pi-exclamation-triangle',
       contentStyle: { display: 'none' },
       accept: () => {
-        if (middleware) middleware()
-        setRestartConfig(null)
+        if (callback) callback()
         restartServer()
       },
       reject: () => {},
     })
 
-  const restartRequired = ({ message, middleware } = {}) => {
-    setRestartConfig({
-      message,
-      middleware,
-    })
-  }
-
-  const handleRestart = () => {
-    confirmRestart(restartConfig)
+  // tell the server that a restart is required
+  const restartRequired = async ({ reason, callback } = {}) => {
+    setCallback(callback)
+    // tell the server that a restart is required
+    await postRestart({ required: true, reason })
   }
 
   return (
-    <RestartContext.Provider
-      value={{ restartRequired, confirmRestart, restartConfig, setRestartConfig }}
-    >
+    <RestartContext.Provider value={{ restartRequired, confirmRestart }}>
       {props.children}
-      {restartConfig && (
-        <RestartBanner message={restartConfig?.message} onRestart={handleRestart} />
+      {restartData?.required && isAdmin && (
+        <RestartBanner message={restartData?.reason} onRestart={confirmRestart} />
       )}
       <ServerRestartingPage />
     </RestartContext.Provider>

--- a/src/pages/MarketPage/MarketPage.jsx
+++ b/src/pages/MarketPage/MarketPage.jsx
@@ -110,7 +110,7 @@ const MarketPage = () => {
     setIsUpdatingAll(false)
     if (isUpdatingAll) setIsUpdatingAllFinished(true)
 
-    restartRequired({ middleware: handleRestarted })
+    restartRequired({ callback: handleRestarted })
   }, [finishedInstalling, installingAddons])
 
   // GET SELECTED ADDON

--- a/src/pages/MarketPage/MarketPage.jsx
+++ b/src/pages/MarketPage/MarketPage.jsx
@@ -110,7 +110,7 @@ const MarketPage = () => {
     setIsUpdatingAll(false)
     if (isUpdatingAll) setIsUpdatingAllFinished(true)
 
-    restartRequired({ callback: handleRestarted })
+    restartRequired({ callback: () => handleRestarted })
   }, [finishedInstalling, installingAddons])
 
   // GET SELECTED ADDON

--- a/src/pages/SettingsPage/AddonsManager/AddonsManager.jsx
+++ b/src/pages/SettingsPage/AddonsManager/AddonsManager.jsx
@@ -111,7 +111,7 @@ const AddonsManager = () => {
   const { restartRequired } = useRestart()
   const restartServer = () => {
     // remove deleted versions from deletedVersions state and restart server
-    restartRequired({ middleware: () => setDeletedVersions([]) })
+    restartRequired({ callback: () => setDeletedVersions([]) })
   }
 
   // DELETE SUCCESS HANDLERS vvv

--- a/src/pages/SettingsPage/Attributes.jsx
+++ b/src/pages/SettingsPage/Attributes.jsx
@@ -17,7 +17,6 @@ import { useUpdateAttributesMutation } from '/src/services/attributes/updateAttr
 import useSearchFilter from '/src/hooks/useSearchFilter'
 import useCreateContext from '/src/hooks/useCreateContext'
 import { isEqual } from 'lodash'
-import { useRestart } from '/src/context/restartContext'
 
 const Attributes = () => {
   const [attributes, setAttributes] = useState([])
@@ -53,14 +52,11 @@ const Attributes = () => {
     [attributes],
   )
 
-  const { restartRequired } = useRestart()
-
   const onSave = async () => {
     await updateAttributes({ attributes, deleteMissing: true, patches: attributes })
       .unwrap()
       .then(() => {
         toast.success('Attribute set saved')
-        restartRequired()
       })
       .catch((err) => {
         console.error(err)

--- a/src/pages/SettingsPage/Bundles/Bundles.jsx
+++ b/src/pages/SettingsPage/Bundles/Bundles.jsx
@@ -26,7 +26,6 @@ import useLocalStorage from '/src/hooks/useLocalStorage'
 import confirmDelete from '/src/helpers/confirmDelete'
 import { Splitter, SplitterPanel } from 'primereact/splitter'
 import useShortcuts from '/src/hooks/useShortcuts'
-import { useRestart } from '/src/context/restartContext'
 import { useSearchParams } from 'react-router-dom'
 
 const Bundles = () => {
@@ -288,13 +287,10 @@ const Bundles = () => {
       },
     })
 
-  const { restartRequired: restartRequiredBanner } = useRestart()
-
   const handleAddonInstallFinish = () => {
     setUploadOpen(false)
     if (restartRequired) {
       setRestartRequired(false)
-      restartRequiredBanner()
     }
   }
 

--- a/src/services/restartServer.js
+++ b/src/services/restartServer.js
@@ -21,6 +21,7 @@ const restartServer = ayonApi.injectEndpoints({
           await cacheDataLoaded
 
           const handlePubSub = async (topic, message) => {
+            localStorage.removeItem('restart-snooze')
             updateCachedData((draft) => {
               Object.assign(draft, { reason: message.description, required: true })
             })


### PR DESCRIPTION
## Changelog Description

- Restart requests are now made server side through the events system.
- The client checks `/api/system/restartRequired` and shows restart banner accordingly.
- The client also subscribes to `server.restart_required` topic for live updates.
- The banner can be snoozed for the rest of the day and will reappear at 8pm.
- Snoozed restarts show a little notification dot on the App Menu.

![restart_from_server_v001](https://github.com/ynput/ayon-frontend/assets/49156310/caa52825-ac02-4db1-8549-94a6f3deb3cd)

## Testing

1. Install/Delete an addon and see if banner appears.
2. Update attributes and see if banner appears.
3. Make a POST request to `/api/system/restartRequired` to see `required=true` and see if banner appears.
4. Click 'snooze' and see if banner hides and notification dot appears.