### PR TITLE
Editor: improved keyboard support and folder collapsing

### DIFF
--- a/src/components/Details/EntityDetailsHeader.jsx
+++ b/src/components/Details/EntityDetailsHeader.jsx
@@ -111,7 +111,7 @@ const EntityDetailsHeader = ({
               prefix={`${values[0]?.product?.name}`}
             />
           ) : (
-            <h2>Multiple Selected ({values.length})</h2>
+            <span style={{ whiteSpace: 'nowrap' }}>Multiple Selected ({values.length})</span>
           )}
           <OverflowField
             value={subTitle}

--- a/src/components/ThumbnailUploader/ThumbnailUploader.jsx
+++ b/src/components/ThumbnailUploader/ThumbnailUploader.jsx
@@ -150,6 +150,8 @@ const ThumbnailUploader = ({
           icon="edit"
           className="upload-button"
           iconProps={{ className: 'edit' }}
+          data-tooltip={'Upload thumbnail from file'}
+          tooltip=""
         >
           <Styled.ButtonInput type="file" onChange={handleInputChange} accept=".png, .jpeg, .jpg" />
         </Styled.UploadButton>

--- a/src/context/shortcutsContext.jsx
+++ b/src/context/shortcutsContext.jsx
@@ -84,8 +84,9 @@ function ShortcutsProvider(props) {
       if (e.target.closest('.block-shortcuts')) return
 
       let singleKey = e.key
+      const isMeta = e.metaKey || e.ctrlKey
       // add ctrl_ prefix if ctrl or cmd is pressed
-      if (e.ctrlKey || e.metaKey) singleKey = 'ctrl+' + singleKey
+      if (isMeta) singleKey = 'ctrl+' + singleKey
       // support alt
       if (e.altKey) singleKey = 'alt+' + singleKey
 
@@ -116,7 +117,7 @@ function ShortcutsProvider(props) {
       }
 
       // and run the action
-      shortcut.action(hovered)
+      shortcut.action(hovered, isMeta)
     },
     [lastPressed, shortcuts, hovered, disabled],
   )

--- a/src/context/shortcutsContext.jsx
+++ b/src/context/shortcutsContext.jsx
@@ -112,7 +112,7 @@ function ShortcutsProvider(props) {
       // check if the shortcut has a closest selector
       if (shortcut.closest) {
         // if it does, check if the target matches the selector
-        if (!hovered || !hovered.closest(shortcut.closest)) return
+        if (!hovered?.target || !hovered?.target?.closest(shortcut.closest)) return
       }
 
       // and run the action
@@ -148,13 +148,13 @@ function ShortcutsProvider(props) {
 
   const removeEventListener = () =>
     document.removeEventListener('mouseover', (e) => {
-      setHovered(e.target)
+      setHovered(e)
     })
 
   useEffect(() => {
     if (shortcuts.some((s) => s.closest)) {
       document.addEventListener('mouseover', (e) => {
-        setHovered(e.target)
+        setHovered(e)
       })
     } else {
       removeEventListener()

--- a/src/pages/EditorPage/EditorPage.jsx
+++ b/src/pages/EditorPage/EditorPage.jsx
@@ -1445,6 +1445,28 @@ const EditorPage = () => {
     }
   }
 
+  const tableRef = useRef(null)
+
+  const handleTableFocus = (event) => {
+    // check if target is tr
+    if (event.target.tagName === 'TR') {
+      console.log(event)
+      // get folder id from classname id-[id]
+      const id = Array.from(event.target.classList)
+        .filter((c) => c.startsWith('id-'))[0]
+        .split('-')[1]
+      const type = Array.from(event.target.classList)
+        .filter((c) => c.startsWith('type-'))[0]
+        .split('-')[1]
+
+      if (id && type) {
+        const selection = [id]
+        // based on type update focused state
+        dispatch(editorSelectionChanged({ selection, [type + 's']: selection }))
+      }
+    }
+  }
+
   let allColumns = useMemo(
     () => [
       <Column
@@ -1684,6 +1706,7 @@ const EditorPage = () => {
                 expandedKeys={expandedFolders}
                 onToggle={onToggle}
                 selectionMode="multiple"
+                onFocus={handleTableFocus}
                 selectionKeys={currentSelection}
                 onSelectionChange={(e) => handleSelectionChange(e.value)}
                 onClick={handleDeselect}
@@ -1693,6 +1716,8 @@ const EditorPage = () => {
                     changed: rowData.key in changes,
                     new: rowData.key in newNodes,
                     deleted: rowData.key in changes && changes[rowData.key]?.__action == 'delete',
+                    ['id-' + rowData.key]: true,
+                    ['type-' + rowData.data.__entityType]: true,
                   }
                 }}
                 onContextMenu={onContextMenu}
@@ -1701,6 +1726,7 @@ const EditorPage = () => {
                 onColReorder={handleColumnReorder}
                 rows={20}
                 className={fullPageLoading ? 'table-loading' : undefined}
+                ref={tableRef}
               >
                 {allColumns}
               </TreeTable>

--- a/src/pages/EditorPage/EditorPage.jsx
+++ b/src/pages/EditorPage/EditorPage.jsx
@@ -1447,22 +1447,29 @@ const EditorPage = () => {
 
   const tableRef = useRef(null)
 
-  const handleTableFocus = (event) => {
-    // check if target is tr
+  const handleKeyPress = (event) => {
     if (event.target.tagName === 'TR') {
-      console.log(event)
-      // get folder id from classname id-[id]
-      const id = Array.from(event.target.classList)
-        .filter((c) => c.startsWith('id-'))[0]
-        .split('-')[1]
-      const type = Array.from(event.target.classList)
-        .filter((c) => c.startsWith('type-'))[0]
-        .split('-')[1]
+      if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+        const nextEl =
+          event.key === 'ArrowDown'
+            ? event.target.nextElementSibling
+            : event.target.previousElementSibling
 
-      if (id && type) {
-        const selection = [id]
-        // based on type update focused state
-        dispatch(editorSelectionChanged({ selection, [type + 's']: selection }))
+        if (!nextEl) return
+
+        const nextId = Array.from(nextEl.classList)
+          .filter((c) => c.startsWith('id-'))[0]
+          .split('-')[1]
+
+        const nextType = Array.from(nextEl.classList)
+          .filter((c) => c.startsWith('type-'))[0]
+          .split('-')[1]
+
+        if (nextId && nextType) {
+          let selection = [nextId]
+          // based on type update focused state
+          dispatch(editorSelectionChanged({ selection, [nextType + 's']: selection }))
+        }
       }
     }
   }
@@ -1706,7 +1713,6 @@ const EditorPage = () => {
                 expandedKeys={expandedFolders}
                 onToggle={onToggle}
                 selectionMode="multiple"
-                onFocus={handleTableFocus}
                 selectionKeys={currentSelection}
                 onSelectionChange={(e) => handleSelectionChange(e.value)}
                 onClick={handleDeselect}
@@ -1727,6 +1733,7 @@ const EditorPage = () => {
                 rows={20}
                 className={fullPageLoading ? 'table-loading' : undefined}
                 ref={tableRef}
+                onKeyDown={handleKeyPress}
               >
                 {allColumns}
               </TreeTable>

--- a/src/pages/EditorPage/EditorPage.jsx
+++ b/src/pages/EditorPage/EditorPage.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo } from 'react'
+import { useEffect, useState, useMemo, useRef } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import { toast } from 'react-toastify'
 import { v1 as uuid1 } from 'uuid'
@@ -78,6 +78,8 @@ const EditorPage = () => {
   const attribFields = attribsData.filter((a) =>
     a.scope.some((s) => ['folder', 'task'].includes(s)),
   )
+
+  const pageFocusRef = useRef(null)
 
   // SEARCH STATES
   // object with folderIds, task parentsIds and taskNames
@@ -1008,6 +1010,11 @@ const EditorPage = () => {
 
   const handleCloseNew = () => {
     setNewEntity('')
+
+    const currentFocusEl = pageFocusRef.current
+    if (currentFocusEl) {
+      currentFocusEl.focus()
+    }
   }
 
   const addNodes = (entityType, root, nodesData = [], sequence) => {
@@ -1604,7 +1611,7 @@ const EditorPage = () => {
             taskNames={taskNamesMap}
           />
         ))}
-      <Section>
+      <Section onFocus={(e) => (pageFocusRef.current = e.target)}>
         <Toolbar>
           <Button
             icon="create_new_folder"

--- a/src/pages/EditorPage/NewEntity.jsx
+++ b/src/pages/EditorPage/NewEntity.jsx
@@ -192,6 +192,8 @@ const NewEntity = ({
       } else if (e.shiftKey) {
         handleSubmit(false)
       }
+    } else if (e.key === 'Escape') {
+      onHide()
     }
   }
 

--- a/src/pages/UserDashboardPage/UserDashboardTasks/UserDashboardList/UserDashboardList.jsx
+++ b/src/pages/UserDashboardPage/UserDashboardTasks/UserDashboardList/UserDashboardList.jsx
@@ -189,7 +189,8 @@ const UserDashboardList = ({
   )
 
   // when users presses "c" over a group
-  const handleShortcutCollapse = (target) => {
+  const handleShortcutCollapse = (event) => {
+    const target = event?.target
     if (!target) return
     let id
     // check if target is HEADER or has 'group-header' class


### PR DESCRIPTION
## Changelog Description

- Enhancement: You can now use your keyboard to navigate between folders. Hold shift to selection multiple folders with the keyboard.
- Enhancement: Double click on a folder to  expand/collapse it.
- Enhancement: Hover over a folder with your mouse and press the key `c` to expand/collapse it.
- Enhancement: Hold down `ctrl/cmd` when collapsing a folder to collapse all expanded children.
- Enhancement: When multiple folders are selected, hold down `ctrl/cmd` to expand/collapse all selected.


- Fix: Focus will now return to previously selected folder when open/closing the new folder modal.
- Fix: Hitting esc in the folder modal will now always close it, even when focused on an input.
- Fix: Editor panel height was jumping around.
- Fix: thumbnail upload tooltip.

Depending on how these changes are received, we might do the same in the Browser hierarchy view.


https://github.com/ynput/ayon-frontend/assets/49156310/780888e1-53d6-4396-a16e-c326eb192746

