### PR TITLE
Editor inheriting fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@rjsf/core": "^4.2.0",
     "@rtk-query/graphql-request-base-query": "^2.2.0",
     "@uiw/react-textarea-code-editor": "^2.1.9",
-    "@ynput/ayon-react-components": "^0.5.5",
+    "@ynput/ayon-react-components": "^0.5.6",
     "axios": "^1.6.3",
     "chart.js": "^4.2.0",
     "date-fns": "^2.29.3",

--- a/src/containers/SiteDropdown.jsx
+++ b/src/containers/SiteDropdown.jsx
@@ -29,8 +29,7 @@ const SiteDropdown = ({ value, onChange, disabled, multiselect = false, allowNul
       options={siteOptions}
       multiSelect={multiselect}
       onChange={handleChange}
-      onClear={() => (allowNull ? onChange(null) : undefined)}
-      onClearNullValue={allowNull}
+      onClearNull={allowNull ? () => onChange(null) : null}
       placeholder="Select a site"
       style={{ flexGrow: 1 }}
       disabled={disabled}

--- a/src/pages/EditorPage/EditorPage.jsx
+++ b/src/pages/EditorPage/EditorPage.jsx
@@ -797,7 +797,13 @@ const EditorPage = () => {
               if (index > -1) ownAttrib.splice(index, 1)
               // inherit from parent and add to patchAttrib
               if (parent?.data?.attrib[key]) patchAttrib[key] = parent.data.attrib[key]
-              else patchAttrib[key] = null
+              else {
+                // no parent? it must be root. We need to inherit from project
+                const attrib = attribsData?.find((a) => a.name === key)?.data
+                // get default value or enum values (like tools)
+                const value = attrib?.default || attrib?.enum?.map((e) => e.value)
+                patchAttrib[key] = value || null
+              }
             } else {
               attribChanges[key] = change
               // add to ownAttrib if not already there

--- a/src/pages/EditorPage/EditorPage.jsx
+++ b/src/pages/EditorPage/EditorPage.jsx
@@ -51,6 +51,7 @@ import NewSequence from './NewSequence'
 import useShortcuts from '/src/hooks/useShortcuts'
 import { useGetUsersAssigneeQuery } from '/src/services/user/getUsers'
 import confirmDelete from '/src/helpers/confirmDelete'
+import { useGetProjectAnatomyQuery } from '/src/services/project/getProject'
 
 const EditorPage = () => {
   const project = useSelector((state) => state.project)
@@ -74,6 +75,13 @@ const EditorPage = () => {
 
   // get attrib fields
   let { data: attribsData = [] } = useGetAttributesQuery()
+
+  // get project attribs values (for root inherited attribs)
+  const { data: projectAnatomyData } = useGetProjectAnatomyQuery(
+    { projectName },
+    { skip: !projectName },
+  )
+
   //   filter out scopes
   const attribFields = attribsData.filter((a) =>
     a.scope.some((s) => ['folder', 'task'].includes(s)),
@@ -799,10 +807,9 @@ const EditorPage = () => {
               if (parent?.data?.attrib[key]) patchAttrib[key] = parent.data.attrib[key]
               else {
                 // no parent? it must be root. We need to inherit from project
-                const attrib = attribsData?.find((a) => a.name === key)?.data
-                // get default value or enum values (like tools)
-                const value = attrib?.default || attrib?.enum?.map((e) => e.value)
-                patchAttrib[key] = value || null
+                const attribs = projectAnatomyData?.attributes
+                const attrib = attribs[key]
+                patchAttrib[key] = attrib || null
               }
             } else {
               attribChanges[key] = change

--- a/src/pages/EditorPage/EditorPanel.jsx
+++ b/src/pages/EditorPage/EditorPanel.jsx
@@ -352,7 +352,6 @@ const EditorPanel = ({
 
   // update the local form on changes
   const handleLocalChange = (value, changeKey, field, formState, setFormNew) => {
-    console.log(value)
     // console.log('local change', value, changeKey, field, form)
     let newForm = { ...form }
     if (formState) {

--- a/src/pages/EditorPage/EditorPanel.jsx
+++ b/src/pages/EditorPage/EditorPanel.jsx
@@ -641,8 +641,12 @@ const EditorPanel = ({
                       widthExpand
                       emptyMessage={`Select option${isMultiSelect ? 's' : ''}...`}
                       isMultiple={!!isMultiple}
-                      onClear={(value) => handleLocalChange(value, changeKey, field)}
-                      onClearNullValue
+                      onClear={
+                        field !== 'attrib.tools'
+                          ? (value) => handleLocalChange(value, changeKey, field)
+                          : undefined
+                      }
+                      onClearNull={(value) => handleLocalChange(value, changeKey, field)}
                       nullPlaceholder="(inherited)"
                       search={attrib?.enum?.length > 10}
                     />

--- a/src/pages/EditorPage/fields/ToolsField.jsx
+++ b/src/pages/EditorPage/fields/ToolsField.jsx
@@ -21,14 +21,15 @@ const StyledDropdown = styled(Dropdown)`
       }
     `}
 
+  &.inherited {
+    font-style: italic;
+    color: var(--md-ref-palette-neutral-variant60);
+  }
+
   &.changed {
     .button {
       background-color: var(--color-changed);
       color: var(--md-sys-color-on-primary);
-    }
-
-    &.inherited {
-      font-style: italic;
     }
   }
 `
@@ -46,9 +47,12 @@ const ToolsField = ({ value, className, attrib }) => {
 
   const isInheritedAndChanged = className.includes('inherited') && className.includes('changed')
 
+  if (isInheritedAndChanged) return <span className="editor-field changed">(inherited)</span>
+
+  if (!value?.length) return null
+
   return (
     <StyledDropdown
-      disabled={isInheritedAndChanged}
       value={labels}
       className={className}
       multiSelect
@@ -57,7 +61,7 @@ const ToolsField = ({ value, className, attrib }) => {
       onClose={() => setIsOpen(false)}
       valueTemplate={() => (
         <DefaultValueTemplate value={value}>
-          {isInheritedAndChanged ? '(inherited)' : `(${labels.length}) ${labels.join(', ')}`}
+          {`(${labels?.length}) ${labels?.join(', ')}`}
         </DefaultValueTemplate>
       )}
       $isOpen={isOpen}


### PR DESCRIPTION
## Changelog Description

- **Tool field validation**: Ensured Tools can only be set to null (inherited) or a specific value, preventing empty lists.
- **Tool field dropdown**: Enhanced the dropdown menu to display a clear "Set to Inherit" option.
- **Tools column**: Resolved an issue causing unexpected behavior in the Tools column.
- **Root entity field inheritance**: Fixed a bug where setting a root entity field to null (inherited) wouldn't immediately display the inherited value. A page reload is no longer required.
- **Parent-child field updates**: Optimized the system to update all child entities, not just the first level, when a parent value is changed.