### PR TITLE
Browser grouping and editor enhancements

### DIFF
--- a/src/pages/BrowserPage/Products.jsx
+++ b/src/pages/BrowserPage/Products.jsx
@@ -578,6 +578,7 @@ const Products = () => {
           onChange={setViewMode}
           grouped={grouped || focusedFolders.length > 1}
           setGrouped={setGrouped}
+          disabled={focusedFolders.length > 1 ? ['grid'] : []}
         />
       </Toolbar>
       <TablePanel style={{ overflow: 'hidden' }} onContextMenu={handleTablePanelContext}>

--- a/src/pages/BrowserPage/ProductsGrid.jsx
+++ b/src/pages/BrowserPage/ProductsGrid.jsx
@@ -1,25 +1,57 @@
-import React, { useMemo } from 'react'
+import React, { useMemo, useState } from 'react'
 import PropTypes from 'prop-types'
 import GridLayout from '/src/components/GridLayout'
-import { EntityCard } from '@ynput/ayon-react-components'
+import { Button, EntityCard } from '@ynput/ayon-react-components'
 import styled from 'styled-components'
 import PerfectScrollbar from 'react-perfect-scrollbar'
 import 'react-perfect-scrollbar/dist/css/styles.css'
+import { classNames } from 'primereact/utils'
+import useShortcuts from '/src/hooks/useShortcuts'
 
 const StyledGridLayout = styled(PerfectScrollbar)`
-  padding: 12px;
+  padding: 4px 12px;
   height: 100%;
+  position: relative;
+`
 
-  & > * {
-    margin-bottom: 16px;
+const StyledGroup = styled.div`
+  .icon {
+    transition: rotate 200ms;
+  }
+  &.isCollapsed {
+    /* rotate icon */
+    .icon {
+      rotate: -90deg;
+    }
+  }
+
+  .header-wrapper {
+    padding: 8px 0;
+    position: sticky;
+    top: -8px;
+
+    z-index: 100;
+    background-color: var(--md-sys-color-surface-container-low);
   }
 `
 
-const StyledGroupName = styled.h2`
-  font-size: 1.3em;
-  padding-left: 8px;
-  margin: 0;
-  margin-bottom: 8px;
+const StyledGroupHeader = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: var(--padding-s);
+
+  &:hover {
+    cursor: pointer;
+    background-color: var(--md-sys-color-surface-container-low-hover);
+    border-radius: var(--border-radius-m);
+  }
+
+  h2 {
+    font-size: 1.3em;
+    margin: 0;
+    user-select: none;
+  }
 `
 
 const ProductsGrid = ({
@@ -121,6 +153,44 @@ const ProductsGrid = ({
     })
   }
 
+  const [collapsedGroups, setCollapsedGroups] = useState([])
+
+  const handleCollapseChange = (groupName) => {
+    if (collapsedGroups.includes(groupName)) {
+      setCollapsedGroups(collapsedGroups.filter((group) => group !== groupName))
+    } else {
+      setCollapsedGroups([...collapsedGroups, groupName])
+    }
+  }
+
+  const handleShortcutCollapse = (event) => {
+    const target = event?.target
+    if (!target) return
+
+    // get id of the group
+    let groupName = target.querySelector('.products-group')?.id
+    if (!groupName) {
+      groupName = target.closest('.products-group')?.id
+    }
+
+    if (groupName) {
+      handleCollapseChange(groupName)
+    }
+  }
+
+  const shortcuts = useMemo(
+    () => [
+      {
+        key: 'c',
+        action: handleShortcutCollapse,
+        closest: '.products-group',
+      },
+    ],
+    [collapsedGroups],
+  )
+
+  useShortcuts(shortcuts, [collapsedGroups])
+
   // if groupBy is set, group the data
 
   const groupedData = useMemo(() => {
@@ -152,50 +222,75 @@ const ProductsGrid = ({
       onClick={() => onSelectionChange({ value: {} })}
     >
       {Object.entries(groupedData).map(([groupName, groupData], index) => (
-        <div key={`groupname-${groupName}`}>
-          {groupName && <StyledGroupName>{groupName}</StyledGroupName>}
-          <GridLayout ratio={1.777777} minWidth={200} key={index}>
-            {isLoading
-              ? Array.from({ length: 20 }).map((_, index) => (
-                  <EntityCard
-                    key={index}
-                    isLoading
-                    style={{
-                      minWidth: 'unset',
-                    }}
-                  />
-                ))
-              : groupData.map(
-                  ({ data: product }, index) =>
-                    product && (
-                      <EntityCard
-                        style={{
-                          minWidth: 'unset',
-                        }}
-                        key={index}
-                        title={product.name}
-                        titleIcon={productTypes[product.productType]?.icon || 'inventory_2'}
-                        icon={statuses[product.versionStatus]?.icon || ''}
-                        iconColor={statuses[product.versionStatus]?.color || ''}
-                        imageUrl={`/api/projects/${projectName}/versions/${
-                          product.versionId
-                        }/thumbnail?updatedAt=${
-                          product.versionUpdatedAt
-                        }&token=${localStorage.getItem('accessToken')}`}
-                        subTitle={`${product.versionName}${
-                          multipleFoldersSelected && product.folder ? ' - ' + product.folder : ''
-                        }`}
-                        onClick={(e) => handleSelection(e, product)}
-                        isActive={product.id in selection}
-                        onContextMenu={(e) => handleContext(e, product.id)}
-                        projectName={projectName}
-                        isFullHighlight
-                        // isActiveAnimate
-                      />
-                    ),
-                )}
-          </GridLayout>
-        </div>
+        <StyledGroup
+          key={groupName}
+          id={groupName}
+          className={classNames(
+            { isCollapsed: collapsedGroups.includes(groupName) },
+            'products-group',
+          )}
+        >
+          {groupName && (
+            <div className="header-wrapper">
+              <StyledGroupHeader
+                onClick={() => handleCollapseChange(groupName)}
+                className="products-group-header"
+              >
+                <Button
+                  icon="expand_more"
+                  variant="text"
+                  data-tooltip={'Collapse/Expand'}
+                  data-shortcut={'C'}
+                  data-tooltip-delay={300}
+                />
+                <h2>{groupName}</h2>
+              </StyledGroupHeader>
+            </div>
+          )}
+          {!collapsedGroups.includes(groupName) && (
+            <GridLayout ratio={1.777777} minWidth={200} key={index}>
+              {isLoading
+                ? Array.from({ length: 20 }).map((_, index) => (
+                    <EntityCard
+                      key={index}
+                      isLoading
+                      style={{
+                        minWidth: 'unset',
+                      }}
+                    />
+                  ))
+                : groupData.map(
+                    ({ data: product }, index) =>
+                      product && (
+                        <EntityCard
+                          style={{
+                            minWidth: 'unset',
+                          }}
+                          key={index}
+                          title={product.name}
+                          titleIcon={productTypes[product.productType]?.icon || 'inventory_2'}
+                          icon={statuses[product.versionStatus]?.icon || ''}
+                          iconColor={statuses[product.versionStatus]?.color || ''}
+                          imageUrl={`/api/projects/${projectName}/versions/${
+                            product.versionId
+                          }/thumbnail?updatedAt=${
+                            product.versionUpdatedAt
+                          }&token=${localStorage.getItem('accessToken')}`}
+                          subTitle={`${product.versionName}${
+                            multipleFoldersSelected && product.folder ? ' - ' + product.folder : ''
+                          }`}
+                          onClick={(e) => handleSelection(e, product)}
+                          isActive={product.id in selection}
+                          onContextMenu={(e) => handleContext(e, product.id)}
+                          projectName={projectName}
+                          isFullHighlight
+                          // isActiveAnimate
+                        />
+                      ),
+                  )}
+            </GridLayout>
+          )}
+        </StyledGroup>
       ))}
     </StyledGridLayout>
   )

--- a/src/pages/BrowserPage/ViewModeToggle.jsx
+++ b/src/pages/BrowserPage/ViewModeToggle.jsx
@@ -2,7 +2,7 @@ import React, { Fragment } from 'react'
 import PropTypes from 'prop-types'
 import { Button } from '@ynput/ayon-react-components'
 
-const ViewModeToggle = ({ onChange, value, grouped, setGrouped }) => {
+const ViewModeToggle = ({ onChange, value, grouped, setGrouped, disabled }) => {
   const handleNormalClick = (id) => {
     setGrouped(false)
     onChange(id)
@@ -21,31 +21,35 @@ const ViewModeToggle = ({ onChange, value, grouped, setGrouped }) => {
       icon: 'format_list_bulleted',
       onClick: () => handleNormalClick('list'),
       ['data-tooltip']: 'List View',
+      disabled: disabled.includes('list'),
     },
     {
       id: 'grid',
       icon: 'grid_view',
       onClick: () => handleNormalClick('grid'),
       ['data-tooltip']: 'Card View',
+      disabled: disabled.includes('grid'),
     },
     {
       id: 'layers',
       icon: 'layers',
       onClick: () => handleGroupClick(),
       ['data-tooltip']: 'Grouped View',
+      disabled: disabled.includes('layers'),
     },
   ]
 
-  if (grouped) value = 'layers'
+  if (grouped && value !== 'list') value = 'layers'
 
   return (
     <>
       {items.map((item) => (
         <Button
+          {...item}
+          selected={value === item.id}
           key={item.id}
           className={value === item.id ? 'active' : ''}
-          selected={value === item.id}
-          {...item}
+          data-tooltip={!item.disabled ? item['data-tooltip'] : undefined}
         />
       ))}
     </>

--- a/src/pages/EditorPage/EditorPage.jsx
+++ b/src/pages/EditorPage/EditorPage.jsx
@@ -1709,11 +1709,6 @@ const EditorPage = () => {
       action: (e) => handleToggleFolder(e, true),
       closest: 'tr.type-folder',
     },
-    {
-      key: 'ctrl+c',
-      action: (e) => handleToggleFolder(e, true, true),
-      closest: 'tr.type-folder',
-    },
   ]
 
   useShortcuts(shortcuts, [disableAddNew, expandedFolders])

--- a/src/pages/EditorPage/EditorPage.jsx
+++ b/src/pages/EditorPage/EditorPage.jsx
@@ -1278,8 +1278,6 @@ const EditorPage = () => {
 
       const isMeta = event.metaKey || event.ctrlKey || meta
 
-      console.log(event)
-
       let id
       // id of the folder that was toggled
       const classList = target?.closest('tr')?.classList
@@ -1294,7 +1292,8 @@ const EditorPage = () => {
       const newExpanded = { ...expandedFolders }
       const getNewBranches = []
       // is the folder toggled in the selection
-      const isToggleSelected = !!currentSelection[id]
+      const isToggledFolderInMultipleSel =
+        !!currentSelection[id] && Object.keys(currentSelection).length > 1
 
       // check if the folder is already expanded
       const isExpanded = !!expandedFolders[id]
@@ -1305,7 +1304,7 @@ const EditorPage = () => {
         // keep track of closing parents
         // so we can close any children of the closing parent (if meta)
         const closingParents = []
-        if (isMeta && isToggleSelected) {
+        if (isMeta && isToggledFolderInMultipleSel) {
           // remove all selected
           const newSelection = { ...currentSelection }
           for (const key in newSelection) {
@@ -1337,7 +1336,7 @@ const EditorPage = () => {
           }
         }
       } else {
-        if (isMeta && isToggleSelected) {
+        if (isMeta && isToggledFolderInMultipleSel) {
           // check if there are any other folders selected that are not already expanded (multiple expand)
           const newSelection = { ...currentSelection }
           const selectedFolders = Object.keys(newSelection).filter(
@@ -1356,6 +1355,29 @@ const EditorPage = () => {
           newExpanded[id] = true
           // get new branch
           getNewBranches.push(id)
+
+          if (isMeta) {
+            // expand all children to id and also id
+
+            // because we don't know the children folders until the parent is expanded
+            // we need to use hierarchy to get all the children of the parent
+            // searchable folders is a flat list of all folders and tasks
+
+            const hierarchyParent = searchableFolders.find((f) => f.id === id)
+
+            if (hierarchyParent) {
+              // loop over it's children and add to expandedFolders
+              const queue = [hierarchyParent]
+              while (queue.length > 0) {
+                const folder = queue.shift()
+                newExpanded[folder.id] = true
+                getNewBranches.push(folder.id)
+                if (folder.children?.length) {
+                  queue.push(...folder.children)
+                }
+              }
+            }
+          }
         }
       }
 

--- a/src/services/product/getProduct.js
+++ b/src/services/product/getProduct.js
@@ -69,6 +69,10 @@ const parseProductData = (data) => {
     }
     s.push(sub)
   }
+
+  // sort alphabetically by name
+  s.sort((a, b) => a.name.localeCompare(b.name))
+
   return s
 }
 


### PR DESCRIPTION
## Changelog Description

**Browser**

- Enhancement: Collapsable product groups. Click the group header or hover anywhere over the group and use the shortcut `c`.
- Fix: Disable tile view when multiple folders are selected.
- Fix: sorting products alphabetically by default.

![browser_collapsable_groups_v001](https://github.com/ynput/ayon-frontend/assets/49156310/a6914cbf-17ca-45d1-b2f1-e388b575305d)

**Editor**

- Enhancement: Expand all child folders using `ctrl/cmd + click` (opposite of collapse all children).
- Fix: Remove `cmd/ctrl+c` shortcut.

![editor_expand_all_v001](https://github.com/ynput/ayon-frontend/assets/49156310/e2e10eec-8fdb-4237-816e-efe2db45acda)