### PR TITLE
Projects menu improvements

### DIFF
--- a/src/components/Menu/MenuComponents/MenuList.jsx
+++ b/src/components/Menu/MenuComponents/MenuList.jsx
@@ -74,7 +74,7 @@ const MenuList = ({
         {items.map((item, i) => {
           // if item is a node, return it
           if (item.node) {
-            return <div key={i}>{item.node}</div>
+            return item.node
           }
 
           if (item?.id === 'divider') return <hr key={i} />

--- a/src/components/ProjectButton/ProjectButton.jsx
+++ b/src/components/ProjectButton/ProjectButton.jsx
@@ -11,10 +11,14 @@ const ProjectButton = ({ label, code, onPin, onEdit, className, highlighted, ...
     >
       <span style={{ marginRight: 8 }}>{label}</span>
       {/* code hides on hover */}
-      {code && <span className="code">{code}</span>}
+      {code && (
+        <span className="code" tabIndex={-1}>
+          {code}
+        </span>
+      )}
       {/* hover buttons */}
-      {onEdit && <Button onClick={onEdit} icon="settings_applications" />}
-      <Button onClick={onPin} icon={'push_pin'} className="pin" />
+      {onEdit && <Button onClick={onEdit} icon="settings_applications" tabIndex={-1} />}
+      <Button onClick={onPin} icon={'push_pin'} className="pin" tabIndex={-1} />
     </Styled.Project>
   )
 }

--- a/src/containers/ProjectMenu/projectMenu.jsx
+++ b/src/containers/ProjectMenu/projectMenu.jsx
@@ -199,12 +199,22 @@ const ProjectMenu = ({ isOpen, onHide }) => {
       setSearchOpen(true)
     }
 
+    // close search on escape
+    // close menu on escape (if search is not open)
     if (e.key === 'Escape') {
       if (searchOpen) {
         setSearchOpen(false)
         setSearch('')
       } else {
         handleHide()
+      }
+    }
+
+    // pick top result on enter and search
+    if (e.key === 'Enter' && search) {
+      const topResult = filteredMenuItems[0]
+      if (topResult) {
+        onProjectSelect(topResult.label)
       }
     }
   }

--- a/src/containers/ProjectMenu/projectMenu.jsx
+++ b/src/containers/ProjectMenu/projectMenu.jsx
@@ -59,8 +59,10 @@ const ProjectMenu = ({ isOpen, onHide }) => {
     e.stopPropagation()
     // e.originalEvent.preventDefault()
     if (pinned.includes(projectName)) {
+      // remove from pinned
       setPinned(pinned.filter((p) => p !== projectName))
-    } else if (pinned.length < 5) {
+    } else {
+      // add to pinned
       setPinned([...pinned, projectName])
     }
   }
@@ -140,7 +142,7 @@ const ProjectMenu = ({ isOpen, onHide }) => {
   // now we have a divider index, we can insert a divider
   const menuItemsWithDivider = useMemo(() => {
     const items = [...sortedMenuItems]
-    if (pinned.length) items.splice(dividerIndex, 0, { id: 'divider' })
+    if (pinned.length !== items.length) items.splice(dividerIndex, 0, { id: 'divider' })
     return items
   }, [sortedMenuItems, dividerIndex])
 

--- a/src/containers/ProjectMenu/projectMenu.jsx
+++ b/src/containers/ProjectMenu/projectMenu.jsx
@@ -7,19 +7,33 @@ import { onProjectChange } from '/src/features/editor'
 import { ayonApi } from '/src/services/ayon'
 import MenuList from '/src/components/Menu/MenuComponents/MenuList'
 import { useGetAllProjectsQuery } from '/src/services/project/getProject'
-import { useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { InputText, Section } from '@ynput/ayon-react-components'
 import useCreateContext from '/src/hooks/useCreateContext'
 import useLocalStorage from '/src/hooks/useLocalStorage'
 import ProjectButton from '/src/components/ProjectButton/ProjectButton'
 import { createPortal } from 'react-dom'
+import { useShortcutsContext } from '/src/context/shortcutsContext'
 
-const ProjectMenu = ({ visible, onHide }) => {
+const ProjectMenu = ({ isOpen, onHide }) => {
   const navigate = useNavigate()
   const dispatch = useDispatch()
   const searchRef = useRef(null)
   const [pinned, setPinned] = useLocalStorage('projectMenu-pinned', [])
   const [searchOpen, setSearchOpen] = useState(false)
+
+  // disable
+  const { setAllowed } = useShortcutsContext()
+
+  useEffect(() => {
+    if (isOpen) {
+      // open only allow project menu shortcuts (block all others)
+      setAllowed(['1', '0', '9', '8'])
+    } else {
+      // close allow all shortcuts
+      setAllowed([])
+    }
+  }, [isOpen])
 
   const projectSelected = useSelector((state) => state.project.name)
   const user = useSelector((state) => state.user)
@@ -163,7 +177,7 @@ const ProjectMenu = ({ visible, onHide }) => {
     setSearchOpen(true)
   }
 
-  if (!visible) return null
+  if (!isOpen) return null
 
   return (
     <>

--- a/src/containers/ProjectMenu/projectMenu.jsx
+++ b/src/containers/ProjectMenu/projectMenu.jsx
@@ -21,6 +21,7 @@ const ProjectMenu = ({ isOpen, onHide }) => {
   const searchRef = useRef(null)
   const [pinned, setPinned] = useLocalStorage('projectMenu-pinned', [])
   const [searchOpen, setSearchOpen] = useState(false)
+  const [projectsFilter, setProjectsFilter] = useState('')
 
   // disable
   const { setAllowed } = useShortcutsContext()
@@ -32,14 +33,14 @@ const ProjectMenu = ({ isOpen, onHide }) => {
     } else {
       // close allow all shortcuts
       setAllowed([])
+      // clear search
+      setProjectsFilter('')
     }
   }, [isOpen])
 
   const projectSelected = useSelector((state) => state.project.name)
   const user = useSelector((state) => state.user)
   const isUser = user?.data?.isUser
-
-  const [projectsFilter, setProjectsFilter] = useState('')
 
   const { data: projects = [] } = useGetAllProjectsQuery({ showInactive: false })
 

--- a/src/containers/ProjectMenu/projectMenu.jsx
+++ b/src/containers/ProjectMenu/projectMenu.jsx
@@ -20,6 +20,7 @@ const ProjectMenu = ({ isOpen, onHide }) => {
   const navigate = useNavigate()
   const dispatch = useDispatch()
   const menuRef = useRef(null)
+  const searchRef = useRef(null)
   const [pinned, setPinned] = useLocalStorage('projectMenu-pinned', [])
   const [searchOpen, setSearchOpen] = useState(false)
   const [search, setSearch] = useState('')
@@ -255,6 +256,11 @@ const ProjectMenu = ({ isOpen, onHide }) => {
           onProjectSelect(topResult.label)
         }
       }
+    } else if (e.key === 'Backspace') {
+      if (searchOpen && search.length > 0) {
+        // focus on search input
+        focusElement(searchRef.current)
+      }
     } else handleArrowKeys(e)
   }
   // Add event listeners
@@ -295,6 +301,7 @@ const ProjectMenu = ({ isOpen, onHide }) => {
               value={search}
               onChange={(e) => setSearch(e.target.value)}
               autoFocus
+              ref={searchRef}
             />
           )}
 

--- a/src/containers/header/AppHeader.jsx
+++ b/src/containers/header/AppHeader.jsx
@@ -152,7 +152,7 @@ const Header = () => {
         </Link>
       </Toolbar>
 
-      <ProjectMenu visible={menuOpen === 'project'} onHide={() => handleSetMenu(false)} />
+      <ProjectMenu isOpen={menuOpen === 'project'} onHide={() => handleSetMenu(false)} />
 
       <Breadcrumbs />
       <Spacer />

--- a/src/context/shortcutsContext.jsx
+++ b/src/context/shortcutsContext.jsx
@@ -55,9 +55,9 @@ function ShortcutsProvider(props) {
     () => [
       { key: '1', action: () => dispatch(toggleMenuOpen('project')) },
       { key: '8', action: () => dispatch(toggleMenuOpen('help')) },
-      { key: '9+9', action: () => logout() },
-      { key: '9', action: () => dispatch(toggleMenuOpen('user')) },
-      { key: '0', action: () => dispatch(toggleMenuOpen('app')) },
+      { key: '9', action: () => dispatch(toggleMenuOpen('app')) },
+      { key: '0+0', action: () => logout() },
+      { key: '0', action: () => dispatch(toggleMenuOpen('user')) },
     ],
     [navigate],
   )

--- a/src/context/shortcutsContext.jsx
+++ b/src/context/shortcutsContext.jsx
@@ -18,7 +18,9 @@ function ShortcutsProvider(props) {
   // keep track of the last key pressed
   const [lastPressed, setLastPressed] = useState(null)
   // disable shortcuts
-  const [disabled, setDisabled] = useState(false)
+  const [disabled, setDisabled] = useState([])
+  // allow shortcuts
+  const [allowed, setAllowed] = useState([])
 
   // last key pressed should be reset after 200ms
   useEffect(() => {
@@ -77,7 +79,7 @@ function ShortcutsProvider(props) {
   const handleKeyPress = useCallback(
     (e) => {
       // check target isn't an input
-      if (['INPUT', 'TEXTAREA'].includes(e.target.tagName) || disabled) return
+      if (['INPUT', 'TEXTAREA'].includes(e.target.tagName)) return
       // or has blocked shortcuts className
       if (e.target.classList.contains('block-shortcuts')) return
       // or any of its parents
@@ -90,6 +92,13 @@ function ShortcutsProvider(props) {
       if (e.altKey) singleKey = 'alt+' + singleKey
 
       const combo = lastPressed + '+' + singleKey
+
+      // check if combo is currently disabled or not in allowed list
+      const isDisabled = disabled.includes(combo) || disabled.includes(singleKey)
+      const isAllowed = !allowed.length || allowed.includes(combo) || allowed.includes(singleKey)
+
+      if (isDisabled || !isAllowed) return
+
       // first check if the key pressed is a shortcut
       // const shortcut = shortcuts[e.key] || shortcuts[combo]
       const shortcut = shortcuts.find((s) => s.key === combo || s.key === singleKey)
@@ -118,7 +127,7 @@ function ShortcutsProvider(props) {
       // and run the action
       shortcut.action(hovered)
     },
-    [lastPressed, shortcuts, hovered, disabled],
+    [lastPressed, shortcuts, hovered, disabled, allowed],
   )
 
   // Add event listeners
@@ -168,8 +177,8 @@ function ShortcutsProvider(props) {
       value={{
         addShortcuts,
         removeShortcuts,
-        disableShortcuts: () => setDisabled(true),
-        enableShortcuts: () => setDisabled(false),
+        setDisabled,
+        setAllowed,
       }}
     >
       {props.children}


### PR DESCRIPTION
## Changelog Description

- Enhancement: Full keyboard support using arrows.
- Enhancement: Start typing straight after opening the menu to start searching, there's no need to click the search icon.

- Fix: Search state now clears on close.
- Fix: Block other shortcuts when open, like `s+s`.
- Fix: Ensure the project is always focused when opening. Sometimes it would get stuck on other items.
- Fix: You can now pin **all** projects, if you are a mad man. _[when you pin all the projects](https://www.youtube.com/watch?v=danzsQTDTx4&t=72s)_

![projects_menu_keyboard_v001](https://github.com/ynput/ayon-frontend/assets/49156310/c69c3a8c-1265-409d-ac5b-8624763047ca)

## Notes

I have been thinking about the shortcut to open the projects menu... `1` isn't exactly obvious and maybe something like `m` would be better? This would also have the advantage of freeing up the numbers to be used to select the projects quicker.

You can press `m` then `1` or `2` or `3` etc to pick one of your top pinned projects, which would make project switching extremely quick (if you learnt the combo).