### PR TITLE
Dashboard tasks path slashes fix

### DIFF
--- a/src/components/ListItem/ListItem.jsx
+++ b/src/components/ListItem/ListItem.jsx
@@ -73,11 +73,7 @@ const ListItem = ({
       <Styled.ItemThumbnail src={task.thumbnailUrl} icon={task.taskIcon} />
       <Styled.Path>
         <Styled.PathItem>{task.projectCode}</Styled.PathItem>
-        {
-          <Styled.PathItem style={{ marginLeft: hasMorePaths ? 0 : -4 }}>
-            {hasMorePaths ? '...' : ''}
-          </Styled.PathItem>
-        }
+        {hasMorePaths && <Styled.PathItem>...</Styled.PathItem>}
         {pathEnds.map((pathEnd, i, a) => (
           <Styled.PathItem key={i} className={i === a.length - 1 ? 'last' : undefined}>
             {pathEnd}

--- a/src/components/ListItem/ListItem.styled.js
+++ b/src/components/ListItem/ListItem.styled.js
@@ -157,12 +157,10 @@ export const PathItem = styled.span`
     color: var(--md-sys-color-on-surface);
   }
 
-  &:not(:first-child) {
-    &::after {
-      content: '/';
-      margin-left: var(--base-gap-medium);
-      color: var(--md-sys-color-outline);
-    }
+  &::after {
+    content: '/';
+    margin-left: var(--base-gap-medium);
+    color: var(--md-sys-color-outline);
   }
 `
 

--- a/src/services/userDashboard/userDashboardHelpers.js
+++ b/src/services/userDashboard/userDashboardHelpers.js
@@ -11,9 +11,9 @@ export const transformTasksData = ({ projectName, tasks = [], code }) =>
 
     // create a short path [code][.../][end of path by depth joined by /][taskName]
     const depth = 2
-    const path = task.folder?.path?.split('/')
+    const path = task.folder?.path?.replace(/^\/+|\/+$/g, '').split('/')
     const pathLastItems = path?.slice(-depth)
-    const pathPrefix = path?.length > depth ? '../' : '/'
+    const pathPrefix = path?.length > depth ? '/.../' : '/'
     const shortPath = `${code}${pathPrefix}${pathLastItems?.join('/')}/${task.name}`
 
     return {
@@ -26,7 +26,7 @@ export const transformTasksData = ({ projectName, tasks = [], code }) =>
       endDate: task.attrib?.endDate,
       folderName: task.folder?.name,
       folderId: task.folderId,
-      path: `${projectName}/${task.folder?.path}`,
+      path: `${projectName}${task.folder?.path}`,
       shortPath,
       latestVersionId: latestVersion?.id,
       latestVersionThumbnailId: latestVersion?.thumbnailId,


### PR DESCRIPTION
## Changelog Description

Fix: slashes on the path in three areas.

![dashboard_dashes_fix](https://github.com/ynput/ayon-frontend/assets/49156310/d74add39-aa45-4ed2-a345-f043ceba2a85)
