### PR TITLE
Assignee select mixed not working temp fix

### DIFF
--- a/src/pages/EditorPage/EditorPage.jsx
+++ b/src/pages/EditorPage/EditorPage.jsx
@@ -48,10 +48,10 @@ import { ayonApi } from '/src/services/ayon'
 import { confirmDialog } from 'primereact/confirmdialog'
 import BuildHierarchyButton from '/src/containers/HierarchyBuilder'
 import NewSequence from './NewSequence'
-import useShortcuts from '/src/hooks/useShortcuts'
 import { useGetUsersAssigneeQuery } from '/src/services/user/getUsers'
 import confirmDelete from '/src/helpers/confirmDelete'
 import { useGetProjectAnatomyQuery } from '/src/services/project/getProject'
+import EditorPageShortcuts from './EditorPageShortcuts'
 
 const EditorPage = () => {
   const project = useSelector((state) => state.project)
@@ -1769,34 +1769,18 @@ const EditorPage = () => {
     treeData = loadingTreeData
   }
 
-  const shortcuts = [
-    {
-      key: 'n',
-      action: () => setNewEntity('folder'),
-    },
-    {
-      key: 'm',
-      action: () => setNewEntity('sequence'),
-    },
-    {
-      key: 't',
-      action: () => setNewEntity('task'),
-      disabled: disableAddNew,
-    },
-    {
-      key: 'c',
-      action: (e) => handleToggleFolder(e, true),
-      closest: 'tr.type-folder',
-    },
-  ]
-
-  useShortcuts(shortcuts, [disableAddNew, expandedFolders])
-
   //
   // Render the TreeTable
 
   return (
     <main className="editor-page">
+      <EditorPageShortcuts
+        {...{
+          setNewEntity,
+          disableAddNew,
+          handleToggleFolder,
+        }}
+      />
       {newEntity &&
         (newEntity === 'sequence' ? (
           <NewSequence

--- a/src/pages/EditorPage/EditorPageShortcuts.jsx
+++ b/src/pages/EditorPage/EditorPageShortcuts.jsx
@@ -1,0 +1,29 @@
+import useShortcuts from '/src/hooks/useShortcuts'
+
+const EditorPageShortcuts = ({ setNewEntity, disableAddNew, handleToggleFolder }) => {
+  const shortcuts = [
+    {
+      key: 'n',
+      action: () => setNewEntity('folder'),
+    },
+    {
+      key: 'm',
+      action: () => setNewEntity('sequence'),
+    },
+    {
+      key: 't',
+      action: () => setNewEntity('task'),
+      disabled: disableAddNew,
+    },
+    {
+      key: 'c',
+      action: (e) => handleToggleFolder(e, true),
+      closest: 'tr.type-folder',
+    },
+  ]
+
+  useShortcuts(shortcuts, [disableAddNew, handleToggleFolder])
+  return null
+}
+
+export default EditorPageShortcuts

--- a/src/pages/EditorPage/EditorPanel.jsx
+++ b/src/pages/EditorPage/EditorPanel.jsx
@@ -196,6 +196,8 @@ const EditorPanel = ({
       },
     }
 
+    console.log('create form')
+
     const type = nodes[nodeIds[0]]?.data?.__entityType
 
     if (type) {
@@ -319,6 +321,8 @@ const EditorPanel = ({
       }
 
       if ((finalValue && finalValue !== nodeValue) || isMultiple) {
+        // if value is undefined, skip
+        if (nodeValue === undefined) continue
         // if type arrays check dif
         if (Array.isArray(finalValue)) {
           // if not different skip


### PR DESCRIPTION
## Changelog Description

- Editor task `AssigneeSelect` would prevent you from adding new users when it was `mixed`.
- This was caused by the shortcuts hook re-rendering the whole page every time the mouse moved.

## Additional Information

`/projects/{project}/editor`

Temporary solution was to move the shortcuts into an empty component to prevent the whole editor page component from re-rendering.

I will need to look into the `useShortcut` hook more to optimise this better.

Maybe we can have a `<Shortcut />` comp that just wraps the `useShortcut` hook.