### PR TITLE
Enhancement/ay 3883 add tags to editor panel

### DIFF
--- a/src/components/status/statusField.jsx
+++ b/src/components/status/statusField.jsx
@@ -46,6 +46,23 @@ const StatusStyled = styled.div`
 
   ${defaultStyle}
 
+  /* Styles for highlighting changed status */
+  ${({ $isChanged }) =>
+  $isChanged &&
+  css`
+    background-color: var(--md-sys-color-primary);
+
+    &,
+    span,
+    .icon {
+      color: var(--md-sys-color-on-primary);
+    }
+
+    :hover {
+      background-color: var(--md-sys-color-primary-hover);
+    }
+  `}
+
   /* selecting styles */
   ${({ $isSelecting }) =>
     $isSelecting &&
@@ -136,6 +153,7 @@ const StatusField = ({
   invert,
   className,
   showChevron,
+  isChanged,
   ...props
 }) => {
   const {
@@ -158,6 +176,7 @@ const StatusField = ({
       $isChanging={isChanging}
       $size={size}
       $invert={invert}
+      $isChanged={isChanged}
       placeholder={!value && placeholder ? placeholder : ''}
       className={className + ' status-field'}
     >

--- a/src/components/status/statusSelect.jsx
+++ b/src/components/status/statusSelect.jsx
@@ -27,6 +27,7 @@ const StatusSelect = ({
   widthExpand,
   options,
   invert = false,
+  isChanged,
   ...props
 }) => {
   const statusesObject = options
@@ -85,6 +86,7 @@ const StatusSelect = ({
           invert={invert}
           className={'value'}
           showChevron
+          isChanged={isChanged}
         />
       )}
       dataKey={'name'}

--- a/src/pages/EditorPage/EditorPanel.jsx
+++ b/src/pages/EditorPage/EditorPanel.jsx
@@ -641,6 +641,7 @@ const EditorPanel = ({
                       onChange={(v) => handleLocalChange(v, changeKey, field)}
                       align="right"
                       width={200}
+                      buttonStyle={{ border: '1px solid var(--md-sys-color-outline-variant)'}}
                       isChanged={isChanged}
                     />
                       )

--- a/src/pages/EditorPage/EditorPanel.jsx
+++ b/src/pages/EditorPage/EditorPanel.jsx
@@ -187,7 +187,7 @@ const EditorPanel = ({
         changeKey: '_status',
         label: 'Status',
         field: 'status',
-        placeholder: `Mixed (${statusValues.isMultiple && statusValues.isMultiple.join(', ')})`,
+        placeholder: `Mixed (${statusValues.multipleValues && statusValues.multipleValues.join(', ')})`,
         ...statusValues,
       },
       _assignees: {
@@ -213,20 +213,20 @@ const EditorPanel = ({
       // field = folderType or taskType
       const field = `${type}Type`
       const changeKey = '_' + field
-      const { isMultiple, isChanged, isOwn, value } = getFieldValue(field, changeKey)
+      const { multipleValues, isChanged, isOwn, value } = getFieldValue(field, changeKey)
 
       let placeholder = ''
       if (hasMixedTypes) {
         placeholder = 'Mixed Entity Types...'
-      } else if (isMultiple) {
-        placeholder = `Mixed (${isMultiple.join(', ')})`
+      } else if (multipleValues) {
+        placeholder = `Mixed (${multipleValues.join(', ')})`
       }
 
       initialForm[changeKey] = {
         changeKey,
         field,
         placeholder,
-        isMultiple,
+        multipleValues,
         isChanged,
         isOwn,
         value,
@@ -240,9 +240,9 @@ const EditorPanel = ({
       const { name, scope, data } = attrib
       const changeKey = name
       const field = 'attrib.' + name
-      const { isMultiple, isChanged, isOwn, value } = getFieldValue(field, changeKey)
+      const { multipleValues, isChanged, isOwn, value } = getFieldValue(field, changeKey)
       const disabled = !types.every((t) => scope.includes(t))
-      const placeholder = isMultiple && !disabled ? `Mixed (${isMultiple.join(', ')})` : ''
+      const placeholder = multipleValues && !disabled ? `Mixed (${multipleValues.join(', ')})` : ''
 
       // create object
       const newRow = {
@@ -250,7 +250,7 @@ const EditorPanel = ({
         field,
         disabled,
         placeholder,
-        isMultiple,
+        multipleValues,
         isChanged,
         isOwn,
         value,
@@ -289,7 +289,7 @@ const EditorPanel = ({
   // returns [value, isChanged, isOwn]
   const getFieldValue = (field, changeKey, type = '') => {
     let finalValue = '',
-      isMultiple = false,
+      multipleValues = false,
       isChanged = false,
       isOwn = false
     for (const id of nodeIds) {
@@ -328,7 +328,7 @@ const EditorPanel = ({
         isOwn = true
       }
 
-      if ((finalValue && finalValue !== nodeValue) || isMultiple) {
+      if ((finalValue && finalValue !== nodeValue) || multipleValues) {
         // if type arrays check dif
         if (Array.isArray(finalValue)) {
           // if not different skip
@@ -337,14 +337,14 @@ const EditorPanel = ({
             continue
           }
         }
-        // different values, this is a isMultiple filed
+        // different values, this is a multipleValues filed
         // assign array of those values
-        if (!isMultiple) {
+        if (!multipleValues) {
           // first time there has been a dif value
-          isMultiple = [finalValue, nodeValue]
-        } else if (!isMultiple?.includes(nodeValue)) {
+          multipleValues = [finalValue, nodeValue]
+        } else if (!multipleValues?.includes(nodeValue)) {
           // add any more new diff values
-          isMultiple?.push(nodeValue)
+          multipleValues?.push(nodeValue)
         }
       } else {
         // final value
@@ -352,12 +352,12 @@ const EditorPanel = ({
       }
     }
 
-    if (isMultiple) {
+    if (multipleValues) {
       // values are different
       finalValue = type
     }
 
-    return { value: finalValue, isChanged, isOwn, isMultiple }
+    return { value: finalValue, isChanged, isOwn, multipleValues }
   }
 
   // update the local form on changes
@@ -380,7 +380,7 @@ const EditorPanel = ({
 
       let isChanged = true
 
-      if (!oldValue?.isMultiple && !oldValue?.__new) {
+      if (!oldValue?.multipleValues && !oldValue?.__new) {
         for (const id of nodeIds) {
           const ogValue = getFieldInObject(field, nodes[id]?.data)
 
@@ -388,7 +388,7 @@ const EditorPanel = ({
           // (always changed)
           if (!ogValue || nodes[id]?.__new) break
 
-          // dif value or isMultiple
+          // dif value or multipleValues
           isChanged = ogValue?.toString() !== newValue
 
           // stop looping if isChanged is ever true
@@ -401,7 +401,7 @@ const EditorPanel = ({
         value: newValue,
         isChanged,
         isOwn: true,
-        isMultiple: oldValue?.isMultiple && !isChanged,
+        multipleValues: oldValue?.multipleValues && !isChanged,
       }
 
       setLocalChange(true)
@@ -446,7 +446,7 @@ const EditorPanel = ({
         if (changes[nodeIds[0]] && key in changes[nodeIds[0]]) {
           oldChanges = changes[nodeIds[0]][key]
         }
-        // only update again if old !== new
+        // only update agap: 8in if old !== new
         if (oldChanges !== row.value) {
           // console.log('change')
           handleGlobalChange(row.value, row.changeKey)
@@ -542,7 +542,7 @@ const EditorPanel = ({
                   value,
                   isChanged,
                   isOwn,
-                  isMultiple,
+                  multipleValues,
                 } = row || {}
 
                 // input type, step, max, min
@@ -576,7 +576,7 @@ const EditorPanel = ({
                 } else if (field.includes('Type')) {
                   input = (
                     <TypeEditor
-                      value={isMultiple ? isMultiple : [value]}
+                      value={multipleValues ? multipleValues : [value]}
                       onChange={(v) => handleLocalChange(v, changeKey, field)}
                       options={typeOptions}
                       style={{
@@ -591,7 +591,7 @@ const EditorPanel = ({
                 } else if (field === 'status') {
                   input = (
                     <StatusSelect
-                      value={isMultiple || value}
+                      value={multipleValues || value}
                       multipleSelected={nodeIds.length}
                       onChange={(v) => handleLocalChange(v, changeKey, field)}
                       maxWidth={'100%'}
@@ -610,9 +610,9 @@ const EditorPanel = ({
                 } else if (field === 'assignees') {
                   input = (
                     <AssigneeSelect
-                      value={isMultiple ? union(...isMultiple) : value || []}
+                      value={multipleValues ? union(...multipleValues) : value || []}
                       options={allUsers}
-                      isMultiple={!!isMultiple}
+                      multipleValues={!!multipleValues}
                       placeholder={placeholder}
                       disabled={disabled}
                       emptyMessage={'None Assigned'}
@@ -630,14 +630,19 @@ const EditorPanel = ({
                     } else if (field === 'tags') {
                       input = (
                     <TagsSelect
-                      value={isMultiple ? union(...isMultiple) : value || []}
+                      value={multipleValues ? union(...multipleValues) : value || []}
                       tags={projectTagsObject}
                       tagsOrder={projectTagsOrder}
-                      isMultiple={!!isMultiple}
+                      multipleValues={!!multipleValues}
                       onChange={(v) => handleLocalChange(v, changeKey, field)}
                       align="right"
-                      styleDropdown={{ overflow: 'hidden' }}
+                      buttonStyle={{
+                        border: isChanged
+                          ? '3px solid var(--md-sys-color-primary)'
+                          : '1px solid var(--md-sys-color-outline-variant) ',
+                      }}
                       width={200}
+                      style={{color: 'blue'}}
                     />
                       )
                     
@@ -645,8 +650,8 @@ const EditorPanel = ({
                   // dropdown
                   const isMultiSelect = ['list_of_strings'].includes(attrib?.type)
                   let enumValue = isMultiSelect ? value : [value]
-                  if (isMultiple) {
-                    enumValue = isMultiSelect ? union(...isMultiple) : isMultiple
+                  if (multipleValues) {
+                    enumValue = isMultiSelect ? union(...multipleValues) : multipleValues
                   }
 
                   // never show value when inherited, just show placeholder
@@ -664,7 +669,7 @@ const EditorPanel = ({
                       multiSelect={isMultiSelect}
                       widthExpand
                       emptyMessage={`Select option${isMultiSelect ? 's' : ''}...`}
-                      isMultiple={!!isMultiple}
+                      multipleValues={!!multipleValues}
                       onClear={
                         field !== 'attrib.tools'
                           ? (value) => handleLocalChange(value, changeKey, field)
@@ -745,7 +750,7 @@ const EditorPanel = ({
                     label={label}
                     className={`editor-form ${field} ${disabled ? 'disabled' : ''}${
                       isOwn ? '' : 'inherited'
-                    } ${attrib?.type} ${isMultiple ? 'isMultiple' : ''} ${
+                    } ${attrib?.type} ${multipleValues ? 'multipleValues' : ''} ${
                       isChanged ? 'isChanged' : ''
                     }`}
                     fieldStyle={{

--- a/src/pages/EditorPage/EditorPanel.jsx
+++ b/src/pages/EditorPage/EditorPanel.jsx
@@ -301,7 +301,7 @@ const EditorPanel = ({
 
       let value = data
       let parent = ''
-      for (const key of keys) {       
+      for (const key of keys) {  
         if (value) {
           // get value and set for next loop
           value = value[key]

--- a/src/pages/EditorPage/EditorPanel.jsx
+++ b/src/pages/EditorPage/EditorPanel.jsx
@@ -560,6 +560,12 @@ const EditorPanel = ({
                   color: isChanged ? 'var(--color-on-changed)' : 'initial',
                 }
 
+                const borderDynamicStyles = {
+                  border: isChanged
+                    ? '3px solid var(--md-sys-color-primary)'
+                    : '1px solid var(--md-sys-color-outline-variant)',
+                }
+
                 let disabledStyles = {}
                 if (disabled) {
                   disabledStyles = {
@@ -595,11 +601,7 @@ const EditorPanel = ({
                       multipleSelected={nodeIds.length}
                       onChange={(v) => handleLocalChange(v, changeKey, field)}
                       maxWidth={'100%'}
-                      style={{
-                        border: isChanged
-                          ? '3px solid var(--md-sys-color-primary)'
-                          : '1px solid var(--md-sys-color-outline-variant)',
-                      }}
+                      style={borderDynamicStyles}
                       isChanged={isChanged}
                       height={30}
                       placeholder={placeholder}
@@ -636,13 +638,9 @@ const EditorPanel = ({
                       multipleValues={!!multipleValues}
                       onChange={(v) => handleLocalChange(v, changeKey, field)}
                       align="right"
-                      buttonStyle={{
-                        border: isChanged
-                          ? '3px solid var(--md-sys-color-primary)'
-                          : '1px solid var(--md-sys-color-outline-variant) ',
-                      }}
+                      buttonStyle={borderDynamicStyles}
                       width={200}
-                      style={{color: 'blue'}}
+                      isChanged={isChanged}
                     />
                       )
                     

--- a/src/pages/EditorPage/EditorPanel.jsx
+++ b/src/pages/EditorPage/EditorPanel.jsx
@@ -301,7 +301,7 @@ const EditorPanel = ({
 
       let value = data
       let parent = ''
-      for (const key of keys) {  
+      for (const key of keys) {
         if (value) {
           // get value and set for next loop
           value = value[key]

--- a/src/pages/EditorPage/EditorPanel.jsx
+++ b/src/pages/EditorPage/EditorPanel.jsx
@@ -11,6 +11,7 @@ import {
   AssigneeSelect,
   InputDate,
   InputSwitch,
+  TagsSelect
 } from '@ynput/ayon-react-components'
 
 import { useSelector } from 'react-redux'
@@ -95,6 +96,8 @@ const EditorPanel = ({
   const changes = useSelector((state) => state.editor.changes)
   const tasks = useSelector((state) => state.project.tasks)
   const folders = useSelector((state) => state.project.folders)
+  const projectTagsOrder = useSelector((state) => state.project.tagsOrder)
+  const projectTagsObject = useSelector((state) => state.project.tags)
 
   // STATES
   // used to throttle changes to redux changes state and keep input fast
@@ -148,6 +151,7 @@ const EditorPanel = ({
     const statusValues = getFieldValue('status', '_status')
     const nameValues = getFieldValue('name', '_name')
     const labelValues = getFieldValue('label', '_label')
+    const tagValues = getFieldValue('tags', '_tags')
 
     const assigneesValues = getFieldValue('assignees', '_assignees', [])
 
@@ -193,6 +197,12 @@ const EditorPanel = ({
         disabled: !types.includes('task'),
         placeholder: `Folders Can Not Have Assignees...`,
         ...assigneesValues,
+      },
+      _tags: {
+        changeKey: '_tags',
+        label: 'Tags',
+        field: 'tags',
+        ...tagValues,
       },
     }
 
@@ -291,7 +301,7 @@ const EditorPanel = ({
 
       let value = data
       let parent = ''
-      for (const key of keys) {
+      for (const key of keys) {       
         if (value) {
           // get value and set for next loop
           value = value[key]
@@ -617,6 +627,20 @@ const EditorPanel = ({
                       widthExpand
                     />
                   )
+                    } else if (field === 'tags') {
+                      input = (
+                    <TagsSelect
+                      value={isMultiple ? union(...isMultiple) : value || []}
+                      tags={projectTagsObject}
+                      tagsOrder={projectTagsOrder}
+                      isMultiple={!!isMultiple}
+                      onChange={(v) => handleLocalChange(v, changeKey, field)}
+                      align="right"
+                      styleDropdown={{ overflow: 'hidden' }}
+                      width={200}
+                    />
+                      )
+                    
                 } else if (attrib?.enum) {
                   // dropdown
                   const isMultiSelect = ['list_of_strings'].includes(attrib?.type)

--- a/src/pages/EditorPage/EditorPanel.jsx
+++ b/src/pages/EditorPage/EditorPanel.jsx
@@ -640,7 +640,6 @@ const EditorPanel = ({
                       multipleValues={!!multipleValues}
                       onChange={(v) => handleLocalChange(v, changeKey, field)}
                       align="right"
-                      buttonStyle={borderDynamicStyles}
                       width={200}
                       isChanged={isChanged}
                     />

--- a/src/pages/EditorPage/queries.js
+++ b/src/pages/EditorPage/queries.js
@@ -9,6 +9,7 @@ const BASE_QUERY = `
             id
             name
             label
+            tags
             folderType
             hasChildren
             hasTasks
@@ -28,6 +29,7 @@ const BASE_QUERY = `
           node {
             id
             label
+            tags
             name
             taskType
             ownAttrib


### PR DESCRIPTION
Added Tags input into the Editor Panel. Mixed values are shown when selecting multiple items with different tags (as is expected). 

Minor fix needs to be done in ayon-react-components if we also want to show text information about tags being "mixed" (just like in Type or Assignees field). Separate ticked was created for this issue.


<img width="868" alt="image" src="https://github.com/ynput/ayon-frontend/assets/16327908/38f0eb41-a7f6-40b3-98b4-7a760230492c">
