### PR TITLE
Fix/ay 4015 fix status select chevron

### DIFF
--- a/src/components/status/statusField.jsx
+++ b/src/components/status/statusField.jsx
@@ -30,7 +30,10 @@ const StatusStyled = styled.div`
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
-  padding: 0 4px;
+  padding: 0 8px;
+  justify-content: space-between;
+  max-height: 160px;
+  width: 100%;
 
   /* ICON */
   .material-symbols-outlined {
@@ -43,6 +46,14 @@ const StatusStyled = styled.div`
   /* same height as a row */
   height: 27px;
   min-height: 27px;
+
+  .status-texticon {
+    display: flex;
+  }
+
+  .status-text {
+    margin-left: 8px;
+  }
 
   ${defaultStyle}
 
@@ -161,9 +172,11 @@ const StatusField = ({
       placeholder={!value && placeholder ? placeholder : ''}
       className={className + ' status-field'}
     >
-      {icon && <Icon icon={icon} />}
-      <span>{size !== 'icon' && (size === 'full' ? shownValue : shortName)}</span>
-      {showChevron && <Icon icon="expand_more"  />}
+      <div className='status-texticon'>
+        {icon && <Icon icon={icon} />}
+        <span className='status-text'>{size !== 'icon' && (size === 'full' ? shownValue : shortName)}</span>
+      </div>
+      {showChevron && <Icon icon="expand_more" />}
     </StatusStyled>
   )
 }

--- a/src/components/status/statusSelect.jsx
+++ b/src/components/status/statusSelect.jsx
@@ -9,6 +9,7 @@ const StyledDropdown = styled(Dropdown)`
   button {
     background-color: unset;
   }
+  display: flex;
 `
 
 const StatusSelect = ({

--- a/src/components/status/statusSelect.jsx
+++ b/src/components/status/statusSelect.jsx
@@ -96,11 +96,11 @@ const StatusSelect = ({
           <StatusField
             value={status.name}
             isSelecting
-            isActive={!isMixed && isActive}
+            isActive={isActive}
             align={align}
             height={height}
             statuses={statusesObject}
-            showChevron={isActive}
+            showChevron={isMixed ? false : isActive}
           />
         )
       }

--- a/src/pages/BrowserPage/Detail.jsx
+++ b/src/pages/BrowserPage/Detail.jsx
@@ -239,6 +239,7 @@ const Detail = () => {
           align={'right'}
           onChange={(v) => handleEntityChange('status', v)}
           multipleSelected={values.length}
+          maxWidth={'100%'}
           style={{
             paddingLeft: 8,
           }}

--- a/src/pages/BrowserPage/Products.jsx
+++ b/src/pages/BrowserPage/Products.jsx
@@ -248,21 +248,22 @@ const Products = () => {
       {
         field: 'versionStatus',
         header: 'Version Status',
-        width: 150,
+        width: 180,
         style: { height: 'max-content' },
         body: (node) => {
           if (node.data.isGroup) return ''
           const statusMaxWidth = 120
+          const versionStatusWidth = columnsWidths['versionStatus'];
+          const resolveWidth = (statusWidth) => {
+            if (statusWidth < 60) return 'icon';
+            if (statusWidth < statusMaxWidth) return 'short'
+            return 'full';
+          }
+
           return (
             <StatusSelect
               value={node.data.versionStatus}
-              size={
-                columnsWidths['versionStatus'] < statusMaxWidth
-                  ? columnsWidths['versionStatus'] < 60
-                    ? 'icon'
-                    : 'short'
-                  : 'full'
-              }
+              size={resolveWidth(versionStatusWidth)}
               onChange={(v) => handleStatusChange(v, node.data.id)}
               multipleSelected={focusedProducts.length}
               onOpen={() => handleStatusOpen(node.data.id)}


### PR DESCRIPTION
I have made some smaller adjustments for Status field.

1. Chevron spacing is changed (Text is on left side, chevron on very right) in Both editor and Browser section.
2. If multiple statuses are selected, they are highlighted in dropdown (but no chevron is shown in dropdown menu in this case).


<img width="834" alt="image" src="https://github.com/ynput/ayon-frontend/assets/16327908/8f966b6c-d780-4be3-af79-b6bd0b8931cb">

<img width="833" alt="image" src="https://github.com/ynput/ayon-frontend/assets/16327908/714ed921-75b6-47b9-b51a-fe623baa22c8">


<img width="836" alt="image" src="https://github.com/ynput/ayon-frontend/assets/16327908/9a23648c-7c9d-46ee-985e-ac08661391aa">

