### PR TITLE
fix: throttle websocket overload

### DIFF
--- a/src/components/RefreshToast.jsx
+++ b/src/components/RefreshToast.jsx
@@ -1,0 +1,14 @@
+import { Button } from '@ynput/ayon-react-components'
+
+const RefreshToast = () => {
+  return (
+    <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+      Refresh to see latest changes.
+      <Button onClick={() => window.location.reload()} variant="filled">
+        Refresh
+      </Button>
+    </div>
+  )
+}
+
+export default RefreshToast

--- a/src/context/websocketContext.jsx
+++ b/src/context/websocketContext.jsx
@@ -88,11 +88,12 @@ export const SocketProvider = (props) => {
       }
 
       const data = JSON.parse(message.data)
-      if (data.topic === 'heartbeat') return
+      const { topic, sender, summary } = data || {}
+      if (topic === 'heartbeat') return
 
-      if (data.topic === 'server.restart_requested') setServerRestartingVisible(true)
+      if (topic === 'server.restart_requested') setServerRestartingVisible(true)
 
-      if (data.sender === window.senderId) {
+      if (sender === window.senderId) {
         return // my own message. ignore
       }
 
@@ -105,10 +106,10 @@ export const SocketProvider = (props) => {
 
       lastCall = now
 
-      if (data.topic === 'shout' && data?.summary?.text) toast.info(data.summary.text)
+      if (topic === 'shout' && data?.summary?.text) toast.info(summary.text)
 
       console.log('Event RX', data)
-      PubSub.publish(data.topic, data)
+      PubSub.publish(topic, data)
     }
   })()
 

--- a/src/context/websocketContext.jsx
+++ b/src/context/websocketContext.jsx
@@ -82,7 +82,7 @@ export const SocketProvider = (props) => {
 
     return (message) => {
       // If the function is called more than 10 times per second, return early.
-      if (callCount > 10) {
+      if (callCount > 100) {
         setOverloaded(true)
         return console.log('WS OVERLOAD!!!!')
       }

--- a/src/context/websocketContext.jsx
+++ b/src/context/websocketContext.jsx
@@ -81,10 +81,13 @@ export const SocketProvider = (props) => {
     let lastCall = Date.now()
 
     return (message) => {
-      // If the function is called more than 10 times per second, return early.
-      if (callCount > 100) {
+      // If the function is called more than 100 times per second, return early.
+      const threshold = 100
+      if (callCount > threshold) {
         setOverloaded(true)
-        return console.log('WS OVERLOAD!!!!')
+        return console.log(
+          `Overload: Over ${threshold} messages per second. Ignoring subsequent messages.`,
+        )
       }
 
       const data = JSON.parse(message.data)

--- a/src/context/websocketContext.jsx
+++ b/src/context/websocketContext.jsx
@@ -6,6 +6,7 @@ import arrayEquals from '../helpers/arrayEquals'
 import useWebSocket, { ReadyState } from 'react-use-websocket'
 import { debounce } from 'lodash'
 import { ayonApi } from '../services/ayon'
+import RefreshToast from '../components/RefreshToast'
 
 export const SocketContext = createContext()
 
@@ -54,20 +55,62 @@ export const SocketProvider = (props) => {
 
   PubSub.setOnSubscriptionsChange((newTopics) => updateTopicsDebounce(newTopics))
 
-  const onMessage = (message) => {
-    const data = JSON.parse(message.data)
-    if (data.topic === 'heartbeat') return
+  const [overloaded, setOverloaded] = useState(false)
+  const [toastShown, setToastShown] = useState(false)
 
-    if (data.topic === 'server.restart_requested') setServerRestartingVisible(true)
+  // when overloaded is true, activate toast
+  useEffect(() => {
+    if (overloaded)
+      if (!toastShown) {
+        toast.warning(<RefreshToast />, {
+          autoClose: false,
+          closeButton: false,
+        })
+        setToastShown(true)
+      }
 
-    if (data.sender === window.senderId) {
-      return // my own message. ignore
+    return () => {
+      setOverloaded(false)
     }
-    if (data.topic === 'shout' && data?.summary?.text) toast.info(data.summary.text)
+  }, [overloaded, setOverloaded])
 
-    console.log('Event RX', data)
-    PubSub.publish(data.topic, data)
-  }
+  // onMessage is a function that is called when a message comes in from the websocket
+  // it is a closure that keeps track of the number of calls and the last call time
+  let onMessage = (() => {
+    let callCount = 0
+    let lastCall = Date.now()
+
+    return (message) => {
+      // If the function is called more than 10 times per second, return early.
+      if (callCount > 10) {
+        setOverloaded(true)
+        return console.log('WS OVERLOAD!!!!')
+      }
+
+      const data = JSON.parse(message.data)
+      if (data.topic === 'heartbeat') return
+
+      if (data.topic === 'server.restart_requested') setServerRestartingVisible(true)
+
+      if (data.sender === window.senderId) {
+        return // my own message. ignore
+      }
+
+      const now = Date.now()
+      if (now - lastCall < 1000) {
+        callCount += 1
+      } else {
+        callCount = 0
+      }
+
+      lastCall = now
+
+      if (data.topic === 'shout' && data?.summary?.text) toast.info(data.summary.text)
+
+      console.log('Event RX', data)
+      PubSub.publish(data.topic, data)
+    }
+  })()
 
   useEffect(() => {
     if (readyState === ReadyState.OPEN) {


### PR DESCRIPTION
## Changelog Description

If lots of changes were made at a different site then the websocket messages could overload the client.

- Fix: When there are too many messages to handle they will be ignored and you will be prompted to reload the page.
- Hopefully it solves: #303 

![image](https://github.com/ynput/ayon-frontend/assets/49156310/5cf2e0ee-0db1-4259-a6a3-507e971ad81e)

## Testing

1. Open events viewer page.
2. In a new browser, make loads of changes, like creating 1000 folders.
3. The events viewing will probably show the first 10ish and then the toast should appear.

## Additional Information

We might need to play with the threshold amount, it's currently pretty low, about 15 changes in one go.
