### PR TITLE
fix: fixed chevron - visible only in EditorPanel

### DIFF
--- a/src/components/status/statusField.jsx
+++ b/src/components/status/statusField.jsx
@@ -35,8 +35,8 @@ const StatusStyled = styled.div`
   max-height: 160px;
   width: 100%;
 
-  /* ICON */
-  .material-symbols-outlined {
+  /* STATUS ICON */
+  .status-icon {
     font-variation-settings: 'FILL' 1, 'wght' 300, 'GRAD' 300, 'opsz' 20;
     /* always taks parents color */
     color: inherit;
@@ -123,6 +123,7 @@ const StatusStyled = styled.div`
       }
       [icon="expand_more"] {
         transform: rotate(180deg);
+        ${invertHoverStyle}
       }
     `}
 
@@ -192,7 +193,7 @@ const StatusField = ({
       className={className + ' status-field'}
     >
       <div className='status-texticon'>
-        {icon && <Icon icon={icon} />}
+        {icon && <Icon className='status-icon' icon={icon} />}
         <span className='status-text'>{size !== 'icon' && (size === 'full' ? shownValue : shortName)}</span>
       </div>
       {showChevron && <Icon icon="expand_more" />}

--- a/src/components/status/statusSelect.jsx
+++ b/src/components/status/statusSelect.jsx
@@ -29,6 +29,7 @@ const StatusSelect = ({
   options,
   invert = false,
   isChanged,
+  isChevron = false,
   ...props
 }) => {
   const statusesObject = options
@@ -64,6 +65,13 @@ const StatusSelect = ({
   const dropdownValue = Array.isArray(value) ? uniq(value) : [value]
   const isMixed = dropdownValue.length > 1
 
+  // Hide chevron for mixed values and if isChevron is false
+  const resolveChevronVisibility = (isChevron, isActive) => {
+    if (!isChevron) return false
+    if (isChevron && isMixed) return false
+    return isActive
+  }
+
   return (
     <StyledDropdown
       {...props}
@@ -86,7 +94,7 @@ const StatusSelect = ({
           statuses={statusesObject}
           invert={invert}
           className={'value'}
-          showChevron
+          showChevron={isChevron}
           isChanged={isChanged}
         />
       )}
@@ -101,7 +109,7 @@ const StatusSelect = ({
             align={align}
             height={height}
             statuses={statusesObject}
-            showChevron={isMixed ? false : isActive}
+            showChevron={resolveChevronVisibility(isChevron,isActive)}
           />
         )
       }

--- a/src/pages/BrowserPage/Products.jsx
+++ b/src/pages/BrowserPage/Products.jsx
@@ -255,9 +255,9 @@ const Products = () => {
           const statusMaxWidth = 120
           const versionStatusWidth = columnsWidths['versionStatus'];
           const resolveWidth = (statusWidth) => {
-            if (statusWidth < 60) return 'icon';
+            if (statusWidth < 60) return 'icon'
             if (statusWidth < statusMaxWidth) return 'short'
-            return 'full';
+            return 'full'
           }
 
           return (

--- a/src/pages/EditorPage/EditorPanel.jsx
+++ b/src/pages/EditorPage/EditorPanel.jsx
@@ -609,6 +609,7 @@ const EditorPanel = ({
                       placeholder={placeholder}
                       disableMessage
                       widthExpand
+                      isChevron
                     />
                   )
                 } else if (field === 'assignees') {


### PR DESCRIPTION
## Changelog description

After some discussion it was decided that chevron icon for statuses will only be visible in EditorPanel.
Following changes were implemented:
- chevron visible only for EditorPanel, its possible to add it in other places if property `isChevron` is added (as a `true` bool value)
- chevron itself has `on-surface` (white) color
- font styles of chevron changed to font-variation-settings: `"FILL" 1, "wght" 200, "GRAD" 200, "opsz" 20;`

EditorPanel:
https://github.com/ynput/ayon-frontend/assets/16327908/89f7d071-49f2-4e8a-a139-aa7accec1c10


Browser:
<img width="994" alt="image" src="https://github.com/ynput/ayon-frontend/assets/16327908/5f7286b0-36d2-4ac7-83de-7cfc4c64b608">

