### PR TITLE
fix: fixed props fullName and name passing in UserImage

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@rjsf/core": "^4.2.0",
     "@rtk-query/graphql-request-base-query": "^2.2.0",
     "@uiw/react-textarea-code-editor": "^2.1.9",
-    "@ynput/ayon-react-components": "^0.5.7",
+    "@ynput/ayon-react-components": "^0.5.8",
     "axios": "^1.6.3",
     "chart.js": "^4.2.0",
     "date-fns": "^2.29.3",

--- a/src/components/CommentMentionSelect/CommentMentionSelect.jsx
+++ b/src/components/CommentMentionSelect/CommentMentionSelect.jsx
@@ -31,7 +31,8 @@ const CommentMentionSelect = ({
             onClick={() => onChange(option)}
             $isCircle={config?.isCircle}
           >
-            <UserImage size={20} src={option.image} fullName={option.label} className="image" />
+          {/* //TODO: See if options contain fullName that can be then passed down in UserImage   */}
+            <UserImage size={20} src={option.image} name={option.label} className="image" />
             <Styled.MentionName>{option.label}</Styled.MentionName>
           </Styled.MentionItem>
         ))}

--- a/src/components/Feed/FeedHeader/FeedHeader.jsx
+++ b/src/components/Feed/FeedHeader/FeedHeader.jsx
@@ -21,8 +21,9 @@ const FeedHeader = ({ name, users, date, reference }) => {
   return (
     <Styled.Header>
       <UserImage
-        fullName={user.fullName || user.name}
+        fullName={user.fullName}
         src={user?.avatarUrl || user?.attrib?.avatarUrl}
+        name={user.name}
         size={22}
       />
       <h5>{user.fullName || user.name}</h5>

--- a/src/components/Feed/FeedReferencePopup/FeedReferencePopup.jsx
+++ b/src/components/Feed/FeedReferencePopup/FeedReferencePopup.jsx
@@ -4,11 +4,11 @@ import Thumbnail from '/src/containers/thumbnail'
 
 const FeedReferencePopup = ({ type, label, pos = {} }) => {
   // TODO: get data from id and type
-
+  // TODO: See if label contain fullName or name and passed props down correcty in UserImage
   return (
     <Styled.Popup style={pos || {}}>
       {type === 'user' ? (
-        <UserImage src={''} fullName={label} />
+        <UserImage src={''} name={label} />
       ) : (
         <Thumbnail entityType={type} icon="directions_run" />
       )}

--- a/src/components/Menu/Menus/UserMenu/UserMenuHeader.jsx
+++ b/src/components/Menu/Menus/UserMenu/UserMenuHeader.jsx
@@ -6,7 +6,7 @@ import { NavLink } from 'react-router-dom'
 const UserMenuHeader = ({ user, fullName }) => {
   return (
     <Styled.Header>
-      <UserImage size={30} src={user?.attrib?.avatarUrl} fullName={fullName || user?.name} />
+      <UserImage size={30} src={user?.attrib?.avatarUrl} name={user?.name} fullName={fullName} />
       <Styled.Details className={Font.titleSmall}>
         <span>{user?.name}</span>
         {fullName ? (

--- a/src/components/User/UserDetailsHeader.jsx
+++ b/src/components/User/UserDetailsHeader.jsx
@@ -15,7 +15,8 @@ const UserDetailsHeader = ({ users = [], onClose, subTitle = '', style = {} }) =
     <DetailHeader onClose={onClose} context={users} dialogTitle="User Context" style={style}>
       <UserImagesStacked
         users={users.map((user) => ({
-          fullName: getUserName(user),
+          fullName: user?.attrib?.fullName,
+          name: user?.name,
           avatarUrl: user?.attrib?.avatarUrl,
           self: user?.self,
         }))}

--- a/src/containers/header/AppHeader.jsx
+++ b/src/containers/header/AppHeader.jsx
@@ -202,7 +202,8 @@ const Header = () => {
         <UserImage
           size={26}
           src={user?.attrib?.avatarUrl}
-          fullName={user?.attrib?.fullName || user?.name}
+          fullName={user?.attrib?.fullName}
+          name={user?.name}
         />
       </HeaderButton>
       <MenuContainer id="user" target={userButtonRef.current}>

--- a/src/pages/EditorPage/EditorPanel.jsx
+++ b/src/pages/EditorPage/EditorPanel.jsx
@@ -99,8 +99,6 @@ const EditorPanel = ({
   const projectTagsOrder = useSelector((state) => state.project.tagsOrder)
   const projectTagsObject = useSelector((state) => state.project.tags)
 
-
-  console.log(allUsers,'allUsers')
   // STATES
   // used to throttle changes to redux changes state and keep input fast
   const [localChange, setLocalChange] = useState(false)

--- a/src/pages/EditorPage/EditorPanel.jsx
+++ b/src/pages/EditorPage/EditorPanel.jsx
@@ -99,6 +99,8 @@ const EditorPanel = ({
   const projectTagsOrder = useSelector((state) => state.project.tagsOrder)
   const projectTagsObject = useSelector((state) => state.project.tags)
 
+
+  console.log(allUsers,'allUsers')
   // STATES
   // used to throttle changes to redux changes state and keep input fast
   const [localChange, setLocalChange] = useState(false)

--- a/src/pages/SettingsPage/UsersSettings/UserList.jsx
+++ b/src/pages/SettingsPage/UsersSettings/UserList.jsx
@@ -66,18 +66,22 @@ const UserList = ({
 
   const [ctxMenuTableShow] = useCreateContext(ctxMenuTableItems)
 
-  const ProfileRow = ({ rowData }) => (
+  const ProfileRow = ({ rowData }) => {
+    const { name, attrib: { fullName, avatarUrl } = {}, self } = rowData;
+    return (
     <StyledProfileRow>
       <UserImage
-        fullName={rowData.attrib?.fullName || rowData.name}
+        fullName={fullName}
+        name={name}
         size={25}
         style={{ margin: 'auto', transform: 'scale(0.8)', maxHeight: 25, maxWidth: 25 }}
-        highlight={rowData.self}
-        src={rowData.attrib?.avatarUrl}
+        highlight={self}
+        src={avatarUrl}
       />
-      <span>{rowData.self ? `${rowData.name} (me)` : rowData.name}</span>
+      <span>{self ? `${name} (me)` : name}</span>
     </StyledProfileRow>
-  )
+    )
+  }
 
   // create 10 dummy rows
   const loadingData = useMemo(() => {

--- a/src/pages/SettingsPage/UsersSettings/UserTile.jsx
+++ b/src/pages/SettingsPage/UsersSettings/UserTile.jsx
@@ -134,7 +134,8 @@ const UserTile = ({
     >
       <StyledUserImage
         src={attrib?.avatarUrl}
-        fullName={attrib?.fullName || name}
+        fullName={attrib?.fullName}
+        name={name}
         highlight={isSelf}
         $isLoading={loadingState}
       />

--- a/src/pages/SettingsPage/UsersSettings/newUser.jsx
+++ b/src/pages/SettingsPage/UsersSettings/newUser.jsx
@@ -133,7 +133,8 @@ const NewUser = ({ onHide, open, onSuccess }) => {
       <DetailHeader onClose={handleClose}>
         <UserImage
           src={formData?.avatarUrl}
-          fullName={formData.fullName || formData.Username || '+'}
+          name={formData.Username}
+          fullName={formData.fullName || '+'}
         />
         <div>
           <h2>Create New User</h2>

--- a/src/pages/TeamsPage/UserListTeams.jsx
+++ b/src/pages/TeamsPage/UserListTeams.jsx
@@ -15,10 +15,12 @@ const StyledProfileRow = styled.div`
 `
 
 const ProfileRow = ({ rowData }) => {
+  const { name, attrib: { fullName, avatarUrl } = {}, self, isMissing } = rowData;
   return (
     <StyledProfileRow>
       <UserImage
-        fullName={rowData?.attrib?.fullName || rowData.name}
+        fullName={fullName}
+        name={name}
         size={25}
         style={{
           margin: 'auto',
@@ -28,15 +30,15 @@ const ProfileRow = ({ rowData }) => {
           maxHeight: 25,
           maxWidth: 25,
         }}
-        highlight={rowData.self}
-        src={rowData?.attrib?.avatarUrl}
+        highlight={self}
+        src={avatarUrl}
       />
       <span
         style={{
-          color: rowData.isMissing ? 'var(--color-hl-error)' : 'inherit',
+          color: isMissing ? 'var(--color-hl-error)' : 'inherit',
         }}
       >
-        {rowData.name}
+        {name}
       </span>
     </StyledProfileRow>
   )


### PR DESCRIPTION
## Changelog Description

This is second part of `UserImage` task. I have updated props of parent components to reflect the fact that `UserImage`  has name and `fullName`, and that only `name` is obligatory prop.

First fix from `ayon-react-components`  is working already for images that have just name property and missing `fullName` (green arrows). This PR is more to fix data flow from parent components and not mix two different properties . 

There is an issue though with some of the images for avatars in `UserImage`, path to them returns no image when I test it. (red arrow) There are more of these cases (orange arrow).

I have also updated version of `ayon-react-components` in `package.json`

<img width="1274" alt="image" src="https://github.com/ynput/ayon-frontend/assets/16327908/7f4336d6-4ba3-4e6b-923b-56abe76109ca">
