### PR TITLE
Do not allow "-" or "."

### DIFF
--- a/src/helpers/checkName.js
+++ b/src/helpers/checkName.js
@@ -3,7 +3,7 @@ import { snakeCase } from 'lodash'
 const checkName = (name) => {
   let newName = name
   // check name matches regex
-  const regex = /^[a-zA-Z_][a-zA-Z_]*[a-zA-Z_]$/
+  const regex = /^[a-zA-Z0-9_]+$/
   // if not, convert to snake_case
   if (name && !name.match(regex)) {
     newName = snakeCase(name)

--- a/src/helpers/checkName.js
+++ b/src/helpers/checkName.js
@@ -3,7 +3,7 @@ import { snakeCase } from 'lodash'
 const checkName = (name) => {
   let newName = name
   // check name matches regex
-  const regex = /^[a-zA-Z0-9_][a-zA-Z0-9_.-]*[a-zA-Z0-9_]$/
+  const regex = /^[a-zA-Z_][a-zA-Z_]*[a-zA-Z_]$/
   // if not, convert to snake_case
   if (name && !name.match(regex)) {
     newName = snakeCase(name)


### PR DESCRIPTION
## Changelog Description

- Do not allow `-` or `.` in entity names.
- Only allowed characters are letters (uppercase and lowercase) and underscores `_`.
- Any invalid character/space will replaced with an `_`

## Additional Information

✅ `folder_1`
❌ `folder 1`, `folder-1`, `folder.1`, `folder@1` ➡️ `folder_1`