### PR TITLE
Version NONE button fix

### DIFF
--- a/src/pages/SettingsPage/Bundles/NewBundle.jsx
+++ b/src/pages/SettingsPage/Bundles/NewBundle.jsx
@@ -170,7 +170,7 @@ const NewBundle = ({ initBundle, onSave, addons, installers, isLoading, isDev, d
       const newAddons = { ...newFormData.addons }
       for (const addon of selectedAddons) {
         if (!latest) {
-          newAddons[addon.name] = undefined
+          newAddons[addon.name] = null
           continue
         }
         const versionList = Object.keys(addon.versions || {})


### PR DESCRIPTION
## Changelog Description

**Version NONE** button was fixed in bundles.

## Additional Information

`/settings/bundles`

The bundle was being set to `undefined` and then would not be included in the addons object for the PATCH request. Setting the addon version to `null` ensured it was included in the object.

<img width="642" alt="image" src="https://github.com/ynput/ayon-frontend/assets/49156310/7602f814-aee6-4c43-8177-d99ad05a7a9c">

## Testing

1. Select an addon/s using the mouse or side bar buttons.
2. Click `Version NONE` to set the addon/s version to `NONE`
3. Click save and the version `NONE` should persist.
