### PR TITLE
Unset primary anatomy preset

### DIFF
--- a/src/pages/SettingsPage/AnatomyPresets/AnatomyPresets.jsx
+++ b/src/pages/SettingsPage/AnatomyPresets/AnatomyPresets.jsx
@@ -24,6 +24,7 @@ import {
   useDeletePresetMutation,
   useUpdatePresetMutation,
   useUpdatePrimaryPresetMutation,
+  useUnsetPrimaryPresetMutation,
 } from '/src/services/anatomy/updateAnatomy'
 import confirmDelete from '/src/helpers/confirmDelete'
 
@@ -79,6 +80,7 @@ const AnatomyPresets = () => {
   const [updatePreset, { isLoading: isUpdating }] = useUpdatePresetMutation()
   const [deletePreset] = useDeletePresetMutation()
   const [updatePrimaryPreset] = useUpdatePrimaryPresetMutation()
+  const [unsetPrimaryPreset] = useUnsetPrimaryPresetMutation()
 
   // SAVE PRESET
   const savePreset = (name) => {
@@ -127,8 +129,21 @@ const AnatomyPresets = () => {
       })
   }
 
+  // UNSET PRIMARY PRESET
+  const unsetPrimary = (name) => {
+    unsetPrimaryPreset({ name })
+      .unwrap()
+      .then(() => {
+        toast.info(`Unset primary preset`)
+      })
+      .catch((err) => {
+        toast.error(err.message)
+      })
+  }
+
+
   useEffect(() => {
-    console.log('Bread', breadcrumbs)
+    // TODO
   }, [breadcrumbs])
 
   const onPasteAnatomy = async () => {
@@ -207,7 +222,14 @@ const AnatomyPresets = () => {
           <Button
             label="Set as primary"
             icon="flag"
+            disabled={isSelectedPrimary}
             onClick={() => setPrimaryPreset(selectedPreset)}
+          />
+          <Button
+            label="Unset primary"
+            icon="flag"
+            disabled={!isSelectedPrimary}
+            onClick={() => unsetPrimary(selectedPreset)}
           />
           <Button
             label="Delete preset"

--- a/src/services/anatomy/getAnatomy.js
+++ b/src/services/anatomy/getAnatomy.js
@@ -5,7 +5,7 @@ const transformAnatomyPresets = (data) => {
   let primaryPreset = defaultPreset
   let presets = []
   for (const preset of data) {
-    if (preset.primary) primaryPreset = { name: preset.name, title: `<default (${preset.name})>` }
+    if (preset.primary) primaryPreset = { name: preset.name, title: `<default (${preset.name})>`, primary: 'PRIMARY' }
     presets.push({
       name: preset.name,
       title: preset.name,

--- a/src/services/anatomy/updateAnatomy.js
+++ b/src/services/anatomy/updateAnatomy.js
@@ -18,17 +18,24 @@ const getAnatomy = ayonApi.injectEndpoints({
         url: `/api/anatomy/presets/${name}`,
         method: 'DELETE',
       }),
-      invalidatesTags: (result, error, { name }) => [{ type: 'anatomyPresets', id: name }],
+      invalidatesTags: (result, error, { name }) => [{ type: 'anatomyPresets', id: name }, { type: 'anatomyPresets', id: 'LIST' }],
     }),
     updatePrimaryPreset: build.mutation({
       query: ({ name }) => ({
         url: `/api/anatomy/presets/${name}/primary`,
         method: 'POST',
       }),
-      invalidatesTags: (result, error, { name }) => [{ type: 'anatomyPresets', id: name }],
+      invalidatesTags: (result, error, { name }) => [{ type: 'anatomyPresets', id: name }, { type: 'anatomyPresets', id: 'LIST' }],
+    }),
+    unsetPrimaryPreset: build.mutation({
+      query: ({ name }) => ({
+        url: `/api/anatomy/presets/${name}/primary`,
+        method: 'DELETE',
+      }),
+      invalidatesTags: (result, error, { name }) => [{ type: 'anatomyPresets', id: name }, { type: 'anatomyPresets', id: 'LIST' }],
     }),
   }),
 })
 
-export const { useUpdatePresetMutation, useDeletePresetMutation, useUpdatePrimaryPresetMutation } =
+export const { useUpdatePresetMutation, useDeletePresetMutation, useUpdatePrimaryPresetMutation, useUnsetPrimaryPresetMutation } =
   getAnatomy


### PR DESCRIPTION
Adds a button to unset the primary anatomy preset (revert to built-in).

This PR depends on https://github.com/ynput/ayon-backend/pull/116

