### PR TITLE
fix: added tabindex to skip clearfield when pressing tab

### DIFF
--- a/src/pages/EditorPage/EditorPanel.jsx
+++ b/src/pages/EditorPage/EditorPanel.jsx
@@ -767,6 +767,7 @@ const EditorPanel = ({
                           icon={'backspace'}
                           tooltip="Clear field"
                           className="null"
+                          tabIndex={-1}
                         />
                       )}
                     </SubRow>


### PR DESCRIPTION
## Changelog Description

🛠️ Fixed tab key behaviour in Editor Panel - tabkey now ignores clierfield button and focus skips to next field

Relates to issue https://github.com/ynput/ayon-frontend/issues/336


https://github.com/ynput/ayon-frontend/assets/16327908/4ba10d84-b7d8-4abf-9b52-c96261785698

