### PR TITLE
Editor same entity names handled by server

### DIFF
--- a/src/pages/EditorPage/EditorPage.jsx
+++ b/src/pages/EditorPage/EditorPage.jsx
@@ -1557,6 +1557,13 @@ const EditorPage = () => {
     localStorage.setItem('editor-columns-order', JSON.stringify(localStorageOrder))
   }
 
+  const handleDeselect = (e) => {
+    // target class is p-treetable-scrollable-body
+    if (e.target.classList.contains('p-treetable-scrollable-body')) {
+      handleSelectionChange({})
+    }
+  }
+
   // when a thumbnail is uploaded, refetch data for that entity
   const handleThumbnailUpload = (uploaded = {}) => {
     const { id, type } = uploaded
@@ -1891,6 +1898,7 @@ const EditorPage = () => {
                 selectionMode="multiple"
                 selectionKeys={currentSelection}
                 onSelectionChange={(e) => handleSelectionChange(e.value)}
+                onClick={handleDeselect}
                 onRowClick={onRowClick}
                 rowClassName={(rowData) => {
                   return {

--- a/src/pages/EditorPage/EditorPage.jsx
+++ b/src/pages/EditorPage/EditorPage.jsx
@@ -382,22 +382,6 @@ const EditorPage = () => {
     return data
   }, [rootDataCache, newNodes, changes, projectName])
 
-  // create an array of folder names and a map of task names with parentId as the value
-  const [folderNamesMap, taskNamesMap] = useMemo(() => {
-    const folders = new Map()
-    const tasks = new Map()
-    for (const key in rootData) {
-      const entity = rootData[key].data
-      if (!entity) continue
-      if (entity.__entityType === 'folder') {
-        folders.set(entity.name, entity.id)
-      } else if (entity.__entityType === 'task') {
-        tasks.set(entity.name, entity.__parentId)
-      }
-    }
-    return [folders, tasks]
-  }, [rootData])
-
   // SEARCH FILTER
   // if search results filter out nodes
   const filteredNodeData = useMemo(() => {
@@ -966,7 +950,11 @@ const EditorPage = () => {
             return
           } else {
             for (const msg of messages) {
-              toast.error('Error: ' + msg)
+              if (msg.includes('duplicate key value violates unique constraint')) {
+                toast.error('Error: Duplicate name found in sibling entities')
+              } else {
+                toast.error('Error: ' + msg)
+              }
             }
             setCommitUpdating(false)
             return null
@@ -1809,7 +1797,6 @@ const EditorPage = () => {
             onHide={() => setNewEntity('')}
             onConfirm={addNodes}
             currentSelection={currentSelection}
-            folderNames={folderNamesMap}
           />
         ) : (
           <NewEntity
@@ -1818,8 +1805,6 @@ const EditorPage = () => {
             onHide={handleCloseNew}
             onConfirm={addNodes}
             currentSelection={currentSelection}
-            folderNames={folderNamesMap}
-            taskNames={taskNamesMap}
           />
         ))}
       <Section onFocus={(e) => (pageFocusRef.current = e.target)}>

--- a/src/pages/EditorPage/NewEntity.jsx
+++ b/src/pages/EditorPage/NewEntity.jsx
@@ -10,7 +10,6 @@ import styled from 'styled-components'
 import TypeEditor from './TypeEditor'
 import checkName from '/src/helpers/checkName'
 import { Dialog } from 'primereact/dialog'
-import { toast } from 'react-toastify'
 
 const ContentStyled = styled.div`
   display: flex;
@@ -23,15 +22,7 @@ const ContentStyled = styled.div`
   }
 `
 
-const NewEntity = ({
-  type,
-  currentSelection = {},
-  visible,
-  onConfirm,
-  onHide,
-  folderNames = new Map(),
-  taskNames = new Map(),
-}) => {
+const NewEntity = ({ type, currentSelection = {}, visible, onConfirm, onHide }) => {
   const [nameFocused, setNameFocused] = useState(false)
   const [entityType, setEntityType] = useState(null)
   //   build out form state
@@ -153,14 +144,6 @@ const NewEntity = ({
   const handleSubmit = (hide = false) => {
     // first check name and type valid
     if (!entityData.label || !entityData.type) return
-
-    // check name is unique
-    //if (folderNames.has(entityData.name) && type === 'folder')
-    if (folderNames.get(entityData.name) in currentSelection) {
-      return toast.warning('Sibling Folder names must be unique')
-    } else if (taskNames.get(entityData.name) in currentSelection) {
-      return toast.warning('Sibling Task names must be unique')
-    }
 
     // convert type to correct key
     // convert name to camelCase

--- a/src/pages/EditorPage/NewSequence.jsx
+++ b/src/pages/EditorPage/NewSequence.jsx
@@ -6,15 +6,8 @@ import { Dialog } from 'primereact/dialog'
 import FolderSequence from '/src/components/FolderSequence/FolderSequence'
 import getSequence from '/src/helpers/getSequence'
 import { isEmpty } from 'lodash'
-import { toast } from 'react-toastify'
 
-const NewSequence = ({
-  visible,
-  onConfirm,
-  onHide,
-  currentSelection = {},
-  folderNames = new Map(),
-}) => {
+const NewSequence = ({ visible, onConfirm, onHide, currentSelection = {} }) => {
   const isRoot = isEmpty(currentSelection)
   const multipleSelection = Object.keys(currentSelection).length > 1
   const examplePrefix = isRoot
@@ -70,19 +63,6 @@ const NewSequence = ({
         label: item.replace(/\s/g, '_'),
         __prefix: createSeq.prefix,
       })
-    }
-
-    // check if any of the names are already in use
-    const names = nodes.map((n) => n.name)
-    const duplicateNames = []
-    for (const name of names) {
-      if (folderNames.has(name)) {
-        duplicateNames.push(name)
-      }
-    }
-
-    if (duplicateNames.length > 0) {
-      return toast.warning('Folder names must be unique: ' + duplicateNames.join(', '))
     }
 
     onConfirm('folder', isRoot, nodes, true)


### PR DESCRIPTION
## Changelog Description

- Fix: clicking outside of editor table deselects selection. This is needed in order to add root folders.
- Fix: remove any duplicate name restrictions on the frontend and let the server return an error if there non unique entities.

![image](https://github.com/ynput/ayon-frontend/assets/49156310/f1b00761-f2cc-4382-bf93-0f04a6f10650)

## Testing
1. Create a new entity with a duplicate name to a sibling.
2. The entity is added as an unsaved change.
3. Saving should return an error toast.

1. Create a new entity with a duplicate name but it's in a sub folder.
2. The entity is added as an unsaved change.
3. Saving has no errors.