### PR TITLE
fix: check if projectName is not falsy (undefined, null) for request

### DIFF
--- a/src/components/ThumbnailUploader/ThumbnailUploader.jsx
+++ b/src/components/ThumbnailUploader/ThumbnailUploader.jsx
@@ -76,7 +76,7 @@ const ThumbnailUploader = ({
 
         // for a single file we just use single entityId
         const res = await axios.post(
-          `/api/projects/${projectName}/${entityType}s/${entityId}/thumbnail`,
+          projectName && `/api/projects/${projectName}/${entityType}s/${entityId}/thumbnail`,
           file,
           opts,
         )

--- a/src/containers/ThumbnailSimple.jsx
+++ b/src/containers/ThumbnailSimple.jsx
@@ -49,7 +49,7 @@ const ThumbnailSimple = ({
   src,
   ...props
 }) => {
-  const url = `/api/projects/${projectName}/${entityType}s/${entityId}/thumbnail`
+  const url = projectName && `/api/projects/${projectName}/${entityType}s/${entityId}/thumbnail`
   const queryArgs = `?updatedAt=${entityUpdatedAt}`
   const isWrongEntity = ['product'].includes(entityType)
 

--- a/src/containers/thumbnail.jsx
+++ b/src/containers/thumbnail.jsx
@@ -75,7 +75,7 @@ const Thumbnail = ({
   // ugly border around the image (when it's not loaded yet)
   const [thumbLoaded, setThumbLoaded] = useState(false)
 
-  const url = `/api/projects/${projectName}/${entityType}s/${entityId}/thumbnail`
+  const url = projectName && `/api/projects/${projectName}/${entityType}s/${entityId}/thumbnail`
   const queryArgs = `?updatedAt=${entityUpdatedAt}`
   const isWrongEntity = ['product'].includes(entityType)
   const portalEl = document.getElementById(portalId)
@@ -125,7 +125,7 @@ const Thumbnail = ({
       {...props}
     >
       {(!isLoading || !thumbLoaded) && !disabled && <Icon icon={icon || 'image'} />}
-      {((entityType && !(isWrongEntity || !entityId)) || src) && (
+      {((entityType && projectName && !(isWrongEntity || !entityId)) || src) && (
         <ImageStyled
           alt={`Entity thumbnail ${entityId}`}
           src={src || `${url}${queryArgs}`}

--- a/src/pages/BrowserPage/ProductsGrid.jsx
+++ b/src/pages/BrowserPage/ProductsGrid.jsx
@@ -285,7 +285,7 @@ const ProductsGrid = ({
                           titleIcon={productTypes[product.productType]?.icon || 'inventory_2'}
                           icon={statuses[product.versionStatus]?.icon || ''}
                           iconColor={statuses[product.versionStatus]?.color || ''}
-                          imageUrl={`/api/projects/${projectName}/versions/${
+                          imageUrl={projectName && `/api/projects/${projectName}/versions/${
                             product.versionId
                           }/thumbnail?updatedAt=${product.versionUpdatedAt}`}
                           subTitle={`${product.versionName}${

--- a/src/pages/ProjectDashboard/panels/ProjectLatestRow.jsx
+++ b/src/pages/ProjectDashboard/panels/ProjectLatestRow.jsx
@@ -131,7 +131,7 @@ const ProjectLatestRow = ({
               subTitle={entity.footer}
               className={entity.className}
               imageUrl={
-                !isLoadingData &&
+                !isLoadingData && projectName &&
                 `/api/projects/${projectName}/${entity.thumbnailEntityType}s/${
                   entity.thumbnailEntityId
                 }/thumbnail?updatedAt=${entity.updatedAt}`


### PR DESCRIPTION
## Changelog description

- added check for falsy values of projectName variable.
- this is aimed to solve issue with creating requests that contained projectName with null value and were flooding Event Viewer with error messages

<img width="607" alt="image" src="https://github.com/ynput/ayon-frontend/assets/16327908/38027833-25cc-4448-a28e-5b0df80d7b72">


