### PR TITLE
fix: remove other roles if user is admin/manager

### DIFF
--- a/src/pages/SettingsPage/UsersSettings/userDetail.jsx
+++ b/src/pages/SettingsPage/UsersSettings/userDetail.jsx
@@ -313,10 +313,16 @@ const UserDetail = ({
       )
       .flat()
 
+    // if user is admin or manager, clear other roles
+    function replaceAccessRoles(allRoles, role) {
+      allRoles.length = 0
+      allRoles.push(role)
+    }
+
     // add admin, manager, service
-    if (user.isAdmin) accessGroups.push('admin')
+    if (user.isAdmin) replaceAccessRoles(accessGroups,'admin')
+    if (user.isManager) replaceAccessRoles(accessGroups, 'manager')
     else if (user.isService) accessGroups.push('service')
-    else if (user.isManager) accessGroups.push('manager')
 
     return [...new Set([...acc, ...accessGroups])]
   }, [])

--- a/src/pages/SettingsPage/UsersSettings/userDetail.jsx
+++ b/src/pages/SettingsPage/UsersSettings/userDetail.jsx
@@ -313,15 +313,19 @@ const UserDetail = ({
       )
       .flat()
 
+    // if user is admin, he has also a manager role
+    const isUserManager = user.isManager && !user.isAdmin
+    const isUserAdmin = user.isManager && user.isAdmin
+
     // if user is admin or manager, clear other roles
-    function replaceAccessRoles(allRoles, role) {
-      allRoles.length = 0
-      allRoles.push(role)
+    function replaceAccessRoles(role) {
+      accessGroups.length = 0
+      accessGroups.push(role)
     }
 
     // add admin, manager, service
-    if (user.isAdmin) replaceAccessRoles(accessGroups,'admin')
-    if (user.isManager) replaceAccessRoles(accessGroups, 'manager')
+    if (isUserManager) replaceAccessRoles('manager')
+    if (isUserAdmin) replaceAccessRoles('admin')
     else if (user.isService) accessGroups.push('service')
 
     return [...new Set([...acc, ...accessGroups])]

--- a/src/pages/SettingsPage/UsersSettings/userDetail.jsx
+++ b/src/pages/SettingsPage/UsersSettings/userDetail.jsx
@@ -326,7 +326,7 @@ const UserDetail = ({
     // add admin, manager, service
     if (isUserManager) replaceAccessRoles('manager')
     if (isUserAdmin) replaceAccessRoles('admin')
-    else if (user.isService) accessGroups.push('service')
+    if (user.isService) replaceAccessRoles('service')
 
     return [...new Set([...acc, ...accessGroups])]
   }, [])


### PR DESCRIPTION
## Changelog Description

- I have added a simple function that removes any other roles, if the new role is `manager` or `admin`
- there was small caveat - if user is admin he is also a manager. I believe this might be a feature, not a bug so I have adjusted conditions accordingly.

<img width="714" alt="image" src="https://github.com/ynput/ayon-frontend/assets/16327908/add073a9-5869-43f3-a464-fca787cc1ca4">

https://github.com/ynput/ayon-frontend/assets/16327908/332f72f0-ebd0-4742-aca3-5c57bf8ad386

