### PR TITLE
Representations selection and context menu

### DIFF
--- a/src/components/Details/EntityDetailsPanel.jsx
+++ b/src/components/Details/EntityDetailsPanel.jsx
@@ -79,16 +79,18 @@ const EntityDetailsPanel = ({
 
   return (
     <Panel style={{ height: '100%', overflow: 'hidden', ...style }}>
-      <ThumbnailGallery
-        thumbnails={nodes.map((n) => ({
-          id: n.id,
-          name: n.name,
-          updatedAt: n.updatedAt,
-        }))}
-        type={type}
-        isLoading={isLoading}
-        onUpload={onThumbnailUpload}
-      />
+      {type !== 'representation' && (
+        <ThumbnailGallery
+          thumbnails={nodes.map((n) => ({
+            id: n.id,
+            name: n.name,
+            updatedAt: n.updatedAt,
+          }))}
+          type={type}
+          isLoading={isLoading}
+          onUpload={onThumbnailUpload}
+        />
+      )}
       <AttributeTable
         entityType={type}
         data={attribsData}

--- a/src/components/Details/EntityDetailsPanel.jsx
+++ b/src/components/Details/EntityDetailsPanel.jsx
@@ -104,7 +104,7 @@ const EntityDetailsPanel = ({
 }
 
 EntityDetailsPanel.propTypes = {
-  type: PropTypes.oneOf(['version', 'product', 'folder', 'task']),
+  type: PropTypes.oneOf(['version', 'product', 'folder', 'task', 'representation']),
   nodes: PropTypes.arrayOf(
     PropTypes.shape({
       name: PropTypes.string.isRequired,

--- a/src/features/context.js
+++ b/src/features/context.js
@@ -5,6 +5,7 @@ import { cloneDeep, get, set } from 'lodash'
 const initialState = {
   expandedFolders: {},
   expandedProducts: {},
+  expandedRepresentations: {},
   focused: {
     type: null,
     folders: [],
@@ -32,6 +33,7 @@ const initialState = {
 const localStorageKeys = [
   'expandedFolders',
   'expandedProducts',
+  'expandedRepresentations',
   'focused.type',
   'focused.folders',
   'focused.products',
@@ -103,6 +105,11 @@ const reducers = {
   },
   setExpandedProducts: {
     expandedProducts: {
+      payload: true,
+    },
+  },
+  setExpandedReps: {
+    expandedRepresentations: {
       payload: true,
     },
   },
@@ -232,6 +239,9 @@ const reducers = {
     'focused.products': {
       payload: 'products',
     },
+    'focused.representations': {
+      value: [],
+    },
   },
   setUri: {
     uri: {
@@ -307,6 +317,9 @@ const contextSlice = createSlice({
     },
     setExpandedProducts: (state, action) => {
       updateStateWithReducer(reducers.setExpandedProducts, state, action)
+    },
+    setExpandedReps: (state, action) => {
+      updateStateWithReducer(reducers.setExpandedReps, state, action)
     },
     setFocusedFolders: (state, action) => {
       updateStateWithReducer(reducers.setFocusedFolders, state, action)
@@ -415,6 +428,7 @@ export const {
   setFocusedRepresentations,
   setSelectedVersions,
   setExpandedFolders,
+  setExpandedReps,
   setExpandedProducts,
   setPairing,
   setReload,

--- a/src/pages/BrowserPage/Detail.jsx
+++ b/src/pages/BrowserPage/Detail.jsx
@@ -79,8 +79,6 @@ const Detail = () => {
     [versionsDataForReps, showRepsList],
   )
 
-  console.log(representations)
-
   // PATCH ENTITY DATA
   const [updateEntity] = useUpdateEntitiesDetailsMutation()
 
@@ -135,7 +133,6 @@ const Detail = () => {
         dispatch(ayonApi.util.invalidateTags(ids.map((id) => ({ type: 'productsVersion', id }))))
       }
 
-      console.log('fulfilled', payload)
     } catch (error) {
       console.error(error)
 

--- a/src/services/entity/entityQueries.js
+++ b/src/services/entity/entityQueries.js
@@ -87,6 +87,31 @@ export const VERSION_QUERY = `
     }
 `
 
+export const REP_QUERY = `
+    query Representations($projectName: String!, $ids: [String!]!) {
+      project(name: $projectName) {
+        representations(ids: $ids) {
+          edges {
+            node {
+              id
+              versionId
+              name
+              status
+              tags
+              updatedAt
+              attrib {
+                #ATTRS#
+              }
+              version {
+                name
+              }
+            }
+          }
+        }
+      }
+    }
+`
+
 export const PRODUCT_QUERY = `
 query Product($projectName: String!, $ids: [String!]!, $versionOverrides: [String!]!) {
     project(name: $projectName){

--- a/src/services/entity/getEntity.js
+++ b/src/services/entity/getEntity.js
@@ -8,6 +8,7 @@ import {
   FOLDER_TILE_FRAGMENT,
   VERSION_TILE_FRAGMENT,
   TASK_TILE_FRAGMENT,
+  REP_QUERY,
 } from './entityQueries'
 import ayonClient from '/src/ayon'
 
@@ -47,6 +48,9 @@ export const buildEntitiesQuery = (type, attribs) => {
       break
     case 'product':
       QUERY = PRODUCT_QUERY
+      break
+    case 'representation':
+      QUERY = REP_QUERY
       break
     default:
       break


### PR DESCRIPTION
## Changelog Description

- Fix: representation selection is now stored in the global state and persists across refreshes.
- Enhancement: selecting a representation will show it's details in the panel (like status, tags, etc...).
- Enhancement: you can now right click a representation to see it's full data model.

<img width="900" alt="image" src="https://github.com/ynput/ayon-frontend/assets/49156310/86058204-e4ec-4a5c-8bf6-91b2babd2f22">

## Testing

1. Go to `/browser`.
2. Select a folder.
3. Select a version (in the middle).
4. Select a representation (bottom right).
5. You should see the details for the representation.
6. Right click on the representation and show details modal.