### PR TITLE
enhancement: added toggle for showing/hiding passwords

### DIFF
--- a/src/pages/LoginPage/LoginPage.jsx
+++ b/src/pages/LoginPage/LoginPage.jsx
@@ -148,6 +148,7 @@ const LoginPage = ({ isFirstTime }) => {
                 name="password"
                 aria-label="Password"
                 value={password}
+                canRevealPassword
                 onChange={(e) => setPassword(e.target.value)}
               />
               <Button label={<strong>Login</strong>} type="submit" />

--- a/src/pages/PasswordResetPage.jsx
+++ b/src/pages/PasswordResetPage.jsx
@@ -115,6 +115,7 @@ const ResetPage = ({ token }) => {
           name="password"
           aria-label="Password"
           value={password}
+          canRevealPassword
           onChange={(e) => setPassword(e.target.value)}
         />
 
@@ -123,6 +124,7 @@ const ResetPage = ({ token }) => {
           name="confirmPassword"
           aria-label="Confirm Password"
           value={confirmPassword}
+          canRevealPassword
           onChange={(e) => setConfirmPassword(e.target.value)}
         />
         <Button

--- a/src/pages/SettingsPage/Secrets.jsx
+++ b/src/pages/SettingsPage/Secrets.jsx
@@ -5,7 +5,7 @@ import {
   useDeleteSecretMutation,
 } from '/src/services/secrets'
 import styled from 'styled-components'
-import { InputText, Button, ScrollPanel, Section, SaveButton } from '@ynput/ayon-react-components'
+import { InputText, InputPassword, Button, ScrollPanel, Section, SaveButton } from '@ynput/ayon-react-components'
 import { toast } from 'react-toastify'
 import confirmDelete from '/src/helpers/confirmDelete'
 
@@ -82,10 +82,13 @@ const SecretItem = ({ name: initialName, value: initialValue, stored }) => {
         pattern="^\S+$"
       />
 
-      <InputText
+      <InputPassword
         value={value}
+        name="password"
+        aria-label="Password"
         onChange={(e) => setValue(e.target.value)}
         placeholder="Secret value"
+        canRevealPassword
       />
 
       <SaveButton

--- a/src/pages/SettingsPage/UsersSettings/SetPasswordDialog.jsx
+++ b/src/pages/SettingsPage/UsersSettings/SetPasswordDialog.jsx
@@ -46,6 +46,7 @@ const SetPasswordDialog = ({ onHide, selectedUsers }) => {
           <InputPassword
             value={password}
             onChange={(e) => setPassword(e.target.value)}
+            canRevealPassword
             autoComplete="new-password"
             id="password"
           />
@@ -54,6 +55,7 @@ const SetPasswordDialog = ({ onHide, selectedUsers }) => {
           <InputPassword
             value={passwordConfirm}
             onChange={(e) => setPasswordConfirm(e.target.value)}
+            canRevealPassword
             autoComplete="new-password"
             id="password"
             pattern={`^${password}$`}


### PR DESCRIPTION
## Changelog description

I have added new prop that will allow showing/hiding passwords to these places:

- Secrets
/settings/secrets

- Password reset page
/account/profile -> edit password

- Create new user popup
/settings/users -> add new user

- Login page

Show/Hide icon will be visible after ARC PR will be merged and released