### PR TITLE
fix: icon type and text fix

### DIFF
--- a/src/pages/SettingsPage/Bundles/BundlesAddonList.jsx
+++ b/src/pages/SettingsPage/Bundles/BundlesAddonList.jsx
@@ -42,7 +42,7 @@ const AddonItem = ({currentVersion, latestVersion }) => {
   return (
     <>
       <span>{currentVersion}</span>
-      {!isCurrentLatest && <LatestIcon data-tooltip-delay={0} data-tooltip={latestVersion} icon="upgrade" />}
+      {!isCurrentLatest && <LatestIcon data-tooltip-delay={0} data-tooltip={"Latest installed version: " + latestVersion} icon="info" />}
     </>
   )
 }


### PR DESCRIPTION
## Changelog description

- replaced icon "upgrade" with info and added more detailed description for tooltip
- Solves this issue: https://github.com/ynput/ayon-frontend/issues/379

Result:
<img width="817" alt="image" src="https://github.com/ynput/ayon-frontend/assets/16327908/81f48a82-1bc0-43e0-a65b-65e6c82e3062">
