### PR TITLE
fix: empty strings set to null

### DIFF
--- a/src/pages/EditorPage/EditorPage.jsx
+++ b/src/pages/EditorPage/EditorPage.jsx
@@ -605,7 +605,7 @@ const EditorPage = () => {
   // Commit changes
   //
 
-  const commitNewNodes = (commitChanges, updates, parentPatches) => {
+  const commitNewNodes = (commitChanges, updates) => {
     // Create a map to store the newNodes parentIds.
     const newNodesParentIdsMap = new Map()
     for (const id in newNodes) {

--- a/src/pages/EditorPage/EditorPanel.jsx
+++ b/src/pages/EditorPage/EditorPanel.jsx
@@ -429,7 +429,7 @@ const EditorPanel = ({
       const rowChanges = {
         id,
         ...currentChanges,
-        [changeKey]: value,
+        [changeKey]: value === '' ? null : value,
       }
 
       allChanges.push(rowChanges)


### PR DESCRIPTION
### Changelog Description

Inside editor, when a field is set to an empty string `""` then it should be converted to `null` value.

### Testing

1. Set folder label to something
2. Remove label completely
3. Save changes
4. Check the network tab operations request has label: null