### PR TITLE
Fix: move access groups to under access level

### DIFF
--- a/src/pages/SettingsPage/UsersSettings/UserAccessForm.jsx
+++ b/src/pages/SettingsPage/UsersSettings/UserAccessForm.jsx
@@ -112,16 +112,6 @@ const UserAccessForm = ({ accessGroupsData, formData, onChange, disabled, select
           />
         </FormRowStyled>
 
-        <FormRowStyled label="Access level">
-          <SelectButton
-            unselectable={false}
-            value={formData?.userLevel}
-            onChange={(e) => updateFormData('userLevel', e.value)}
-            options={userLevels}
-            disabled={disabled}
-          />
-        </FormRowStyled>
-
         {(isUser || isManager) && (
           <FormRowStyled label="Guest">
             <InputSwitch
@@ -139,6 +129,16 @@ const UserAccessForm = ({ accessGroupsData, formData, onChange, disabled, select
           <InputSwitch
             checked={formData?.isDeveloper}
             onChange={(e) => updateFormData('isDeveloper', e.target.checked)}
+          />
+        </FormRowStyled>
+
+        <FormRowStyled label="Access level">
+          <SelectButton
+            unselectable={false}
+            value={formData?.userLevel}
+            onChange={(e) => updateFormData('userLevel', e.value)}
+            options={userLevels}
+            disabled={disabled}
           />
         </FormRowStyled>
 

--- a/src/pages/SettingsPage/UsersSettings/UserAccessForm.jsx
+++ b/src/pages/SettingsPage/UsersSettings/UserAccessForm.jsx
@@ -23,7 +23,7 @@ const NoteStyled = styled.span`
 `
 
 const UserAccessForm = ({ accessGroupsData, formData, onChange, disabled, selectedProjects }) => {
-  const isAdmin = useSelector((state) => state.user.data.isAdmin)
+  const isUserAdmin = useSelector((state) => state.user.data.isAdmin)
 
   const userLevels = [
     { label: 'User', value: 'user' },
@@ -31,7 +31,7 @@ const UserAccessForm = ({ accessGroupsData, formData, onChange, disabled, select
   ]
 
   // only admins can
-  if (isAdmin) {
+  if (isUserAdmin) {
     userLevels.push({ label: 'Admin', value: 'admin' })
     userLevels.push({ label: 'Service', value: 'service' })
   }
@@ -46,7 +46,7 @@ const UserAccessForm = ({ accessGroupsData, formData, onChange, disabled, select
   }
 
   const isUser = formData?.userLevel === 'user'
-  const isManager = formData?.userLevel === 'manager'
+  const isAdmin = formData?.userLevel === 'admin'
 
   const defaultAccessGroups = formData?.defaultAccessGroups
 
@@ -123,18 +123,16 @@ const UserAccessForm = ({ accessGroupsData, formData, onChange, disabled, select
           />
         </FormRowStyled>
 
-        {(isUser || isManager) && (
-          <FormRowStyled label="Guest">
-            <InputSwitch
-              checked={formData?.isGuest}
-              onChange={(e) => updateFormData('isGuest', e.target.checked)}
-              disabled={disabled}
-              style={{
-                opacity: disabled ? 0.5 : 1,
-              }}
-            />
-          </FormRowStyled>
-        )}
+        <FormRowStyled label="Guest" data-tooltip={isAdmin ? 'Admins cannot be guests' : null}>
+          <InputSwitch
+            checked={disabled || isAdmin ? false : formData?.isGuest}
+            onChange={(e) => updateFormData('isGuest', e.target.checked)}
+            disabled={disabled || isAdmin}
+            style={{
+              opacity: disabled ? 0.5 : 1,
+            }}
+          />
+        </FormRowStyled>
 
         <FormRowStyled label="Developer">
           <InputSwitch

--- a/src/pages/SettingsPage/UsersSettings/UserAccessForm.jsx
+++ b/src/pages/SettingsPage/UsersSettings/UserAccessForm.jsx
@@ -1,5 +1,5 @@
 import { useSelector } from 'react-redux'
-import { InputSwitch, FormLayout, FormRow } from '@ynput/ayon-react-components'
+import { InputSwitch, FormLayout, FormRow, Icon } from '@ynput/ayon-react-components'
 import { SelectButton } from 'primereact/selectbutton'
 import AccessGroupsDropdown from '/src/containers/AccessGroupsDropdown'
 import { isEqual } from 'lodash'
@@ -9,6 +9,17 @@ const FormRowStyled = styled(FormRow)`
   .label {
     min-width: 160px;
   }
+`
+
+const NoteStyled = styled.span`
+  margin: var(--padding-m) 0;
+  padding: var(--padding-m);
+  border-radius: var(--border-radius-m);
+  background-color: var(--md-sys-color-secondary-container);
+
+  gap: var(--base-gap-small);
+  display: flex;
+  align-items: center;
 `
 
 const UserAccessForm = ({ accessGroupsData, formData, onChange, disabled, selectedProjects }) => {
@@ -142,7 +153,7 @@ const UserAccessForm = ({ accessGroupsData, formData, onChange, disabled, select
           />
         </FormRowStyled>
 
-        {isUser && (
+        {isUser ? (
           <FormRowStyled
             label={'New projects access'}
             data-tooltip={
@@ -158,6 +169,11 @@ const UserAccessForm = ({ accessGroupsData, formData, onChange, disabled, select
               accessGroups={accessGroupsData}
             />
           </FormRowStyled>
+        ) : (
+          <NoteStyled>
+            <Icon icon="info" />
+            Admins, managers and services have full access to all projects.
+          </NoteStyled>
         )}
         {isUser && selectedProjects && (
           <FormRowStyled label={'Selected projects access'}>


### PR DESCRIPTION
### Changelog Description

#### 1. Move **Guest** and **Developer** above **Access level** in order to couple **Access level** and **New project access** together.

<img width="587" alt="image" src="https://github.com/ynput/ayon-frontend/assets/49156310/da74f99d-8599-4bc6-8756-04bd76df556e">

#### 2. Add a small note about admins, managers and services having full project access.
<img width="603" alt="image" src="https://github.com/ynput/ayon-frontend/assets/49156310/33b41b80-6627-4b24-86c9-9d9cee7cd487">

#### 3. Disable (instead of hide) guest switch when a user is an admin and add a tooltip.
<img width="404" alt="image" src="https://github.com/ynput/ayon-frontend/assets/49156310/0edaf252-896c-43cd-a8b9-66e8358021c0">

