### PR TITLE
Activity Feed: Versions show in activity feed

### DIFF
--- a/src/components/Feed/ActivityDate.jsx
+++ b/src/components/Feed/ActivityDate.jsx
@@ -35,7 +35,7 @@ const getFuzzyDate = (date) => {
   return fuzzyDate
 }
 
-const ActivityDate = ({ date }) => {
+const ActivityDate = ({ date, ...props }) => {
   const dateObj = new Date(date)
   if (!isValid(dateObj)) return null
 
@@ -56,7 +56,11 @@ const ActivityDate = ({ date }) => {
   // if less than a minute ago overwrite the date string
   if (sameMin) dateString = 'Just now'
 
-  return <DateStyled className={classNames(Typography.bodySmall, 'date')}>{dateString}</DateStyled>
+  return (
+    <DateStyled className={classNames(Typography.bodySmall, 'date')} {...props}>
+      {dateString}
+    </DateStyled>
+  )
 }
 
 export default ActivityDate

--- a/src/components/Feed/ActivityHeader/ActivityHeader.jsx
+++ b/src/components/Feed/ActivityHeader/ActivityHeader.jsx
@@ -23,8 +23,15 @@ const ActivityHeader = ({
   entityType,
   onReferenceClick,
 }) => {
-  const { referenceType, origin = {}, isOwner } = activity
+  const { referenceType, origin = {}, isOwner, activityType, versions = [] } = activity
   const isMention = referenceType === 'mention'
+
+  const isPublish = activityType === 'version.publish'
+  const isMultipleVersions = versions.length > 1
+  const publishedString = isMultipleVersions ? 'published versions' : 'published a version'
+
+  const boldString = isMention ? `mentioned` : 'commented'
+  const entityTypeString = isMention ? `this ${entityType}` : 'on'
 
   // open menu
   const dispatch = useDispatch()
@@ -39,10 +46,10 @@ const ActivityHeader = ({
         {isRef && (
           <>
             <Styled.Text>
-              <strong>{isMention ? `mentioned` : 'commented'}</strong>
+              <strong>{boldString}</strong>
             </Styled.Text>
             <Styled.Text style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
-              {isMention ? `this ${entityType} in` : 'on'}
+              {entityTypeString}
             </Styled.Text>
             <ActivityReference
               id={origin?.id}
@@ -58,6 +65,7 @@ const ActivityHeader = ({
             </ActivityReference>
           </>
         )}
+        {isPublish && <Styled.Text>{publishedString}</Styled.Text>}
 
         {/* custom children, like status change */}
         {children}

--- a/src/components/Feed/ActivityItem.jsx
+++ b/src/components/Feed/ActivityItem.jsx
@@ -6,6 +6,7 @@ import ActivityGroup from './ActivityGroup/ActivityGroup'
 import styled from 'styled-components'
 import { format } from 'date-fns'
 import { isValid } from 'date-fns'
+import ActivityVersions from './ActivityVersions/ActivityVersions'
 
 const FeedEnd = styled.div`
   padding: 0 10px;
@@ -29,6 +30,8 @@ const ActivityItem = ({
       return <ActivityAssigneeChange activity={activity} {...props} isAdding />
     case 'assignee.remove':
       return <ActivityAssigneeChange activity={activity} {...props} />
+    case 'version.publish':
+      return <ActivityVersions {...{ activity, projectInfo }} {...props} />
     case 'group':
       // fromGroup prevents infinite recursion
       return !fromGroup && <ActivityGroup activities={activity.items} {...props} />

--- a/src/components/Feed/ActivityItem.jsx
+++ b/src/components/Feed/ActivityItem.jsx
@@ -4,14 +4,17 @@ import ActivityStatusChange from './ActivityStatusChange/ActivityStatusChange'
 import ActivityAssigneeChange from './ActivityAssigneeChange/ActivityAssigneeChange'
 import ActivityGroup from './ActivityGroup/ActivityGroup'
 import styled from 'styled-components'
-import { format } from 'date-fns'
-import { isValid } from 'date-fns'
 import ActivityVersions from './ActivityVersions/ActivityVersions'
+import ActivityDate from './ActivityDate'
 
 const FeedEnd = styled.div`
   padding: 0 10px;
   color: var(--md-sys-color-outline);
   font-size: 12px;
+  display: flex;
+  align-items: center;
+  gap: var(--base-gap-small);
+  user-select: none;
 `
 
 const ActivityItem = ({
@@ -38,11 +41,14 @@ const ActivityItem = ({
       return !fromGroup && <ActivityGroup activities={activity.items} {...props} />
     case 'end':
       return (
-        <FeedEnd>{`Task${createdAts.length > 1 ? 's' : ''} created: ${createdAts
-          .map((c) =>
-            isValid(new Date(c)) ? format(new Date(c), 'do MMMM y, H:mm') : 'At some point...',
-          )
-          .join(', ')}`}</FeedEnd>
+        <FeedEnd>
+          <>
+            {`Task${createdAts.length > 1 ? 's' : ''} created:`}
+            {createdAts.map((c, i) => (
+              <ActivityDate date={c} key={i} style={{ margin: 0 }} />
+            ))}
+          </>
+        </FeedEnd>
       )
     default:
       return null

--- a/src/components/Feed/ActivityVersions/ActivityVersions.jsx
+++ b/src/components/Feed/ActivityVersions/ActivityVersions.jsx
@@ -4,22 +4,7 @@ import { productTypes } from '/src/features/project'
 import { useState } from 'react'
 
 const ActivityVersions = ({ activity, projectInfo, projectName, entityType, onReferenceClick }) => {
-  let {
-    authorName,
-    authorFullName,
-    createdAt,
-    updatedAt,
-    activityData = {},
-    origin = {},
-  } = activity
-
-  // v00x
-  const { name: versionName, id: versionId } = origin
-  // get product name and type
-  const { context = {} } = activityData
-  const { productName, productType } = context
-
-  const icon = productTypes[productType]?.icon || 'home_repair_service'
+  let { authorName, authorFullName, createdAt, versions = [] } = activity
 
   const [thumbnailError, setThumbnailError] = useState(false)
 
@@ -35,25 +20,26 @@ const ActivityVersions = ({ activity, projectInfo, projectName, entityType, onRe
         entityType={entityType}
         onReferenceClick={onReferenceClick}
       />
-      <Styled.Card
-        onClick={() =>
-          onReferenceClick({ entityType: 'version', entityId: versionId, projectName })
-        }
-      >
-        <Styled.Content>
-          <Styled.Title>{productName}</Styled.Title>
-          <span className="version">{versionName}</span>
-        </Styled.Content>
-        <Styled.Thumbnail
-          {...{ projectName }}
-          entityId={versionId}
-          entityType="version"
-          onError={() => setThumbnailError(true)}
-          iconOnly={thumbnailError}
-          entityUpdatedAt={updatedAt}
-          icon={icon}
-        />
-      </Styled.Card>
+      {versions.map(({ name, id, productName, productType, updatedAt }) => (
+        <Styled.Card
+          key={id}
+          onClick={() => onReferenceClick({ entityType: 'version', entityId: id, projectName })}
+        >
+          <Styled.Content>
+            <Styled.Title>{productName}</Styled.Title>
+            <span className="version">{name}</span>
+          </Styled.Content>
+          <Styled.Thumbnail
+            {...{ projectName }}
+            entityId={id}
+            entityType="version"
+            onError={() => setThumbnailError(true)}
+            iconOnly={thumbnailError}
+            entityUpdatedAt={updatedAt}
+            icon={productTypes[productType]?.icon || 'home_repair_service'}
+          />
+        </Styled.Card>
+      ))}
     </Styled.Container>
   )
 }

--- a/src/components/Feed/ActivityVersions/ActivityVersions.jsx
+++ b/src/components/Feed/ActivityVersions/ActivityVersions.jsx
@@ -15,7 +15,7 @@ const ActivityVersions = ({ activity, projectInfo, projectName, entityType, onRe
   } = activity
 
   // v00x
-  const { name: versionName } = origin
+  const { name: versionName, id: versionId } = origin
   // get product name and type
   const { context = {} } = activityData
   const { productName, productType } = context
@@ -37,7 +37,9 @@ const ActivityVersions = ({ activity, projectInfo, projectName, entityType, onRe
         onReferenceClick={onReferenceClick}
       />
       <Styled.Card
-        onClick={() => onReferenceClick({ entityType: 'version', entityId, projectName })}
+        onClick={() =>
+          onReferenceClick({ entityType: 'version', entityId: versionId, projectName })
+        }
       >
         <Styled.Content>
           <Styled.Title>{productName}</Styled.Title>

--- a/src/components/Feed/ActivityVersions/ActivityVersions.jsx
+++ b/src/components/Feed/ActivityVersions/ActivityVersions.jsx
@@ -1,0 +1,57 @@
+import ActivityHeader from '../ActivityHeader/ActivityHeader'
+import * as Styled from './ActivityVersions.styled'
+import { productTypes } from '/src/features/project'
+import { useState } from 'react'
+
+const ActivityVersions = ({ activity, projectInfo, projectName, entityType, onReferenceClick }) => {
+  let {
+    authorName,
+    authorFullName,
+    createdAt,
+    updatedAt,
+    activityData = {},
+    origin = {},
+  } = activity
+
+  // v00x
+  const { name: versionName } = origin
+  // get product name and type
+  const { context = {} } = activityData
+  const { productName, productType } = context
+
+  const icon = productTypes[productType]?.icon || 'home_repair_service'
+
+  const [thumbnailError, setThumbnailError] = useState(false)
+
+  return (
+    <Styled.Container>
+      <ActivityHeader
+        name={authorName}
+        fullName={authorFullName || authorName}
+        date={createdAt}
+        activity={activity}
+        projectInfo={projectInfo}
+        projectName={projectName}
+        entityType={entityType}
+        onReferenceClick={onReferenceClick}
+      />
+      <Styled.Card
+        onClick={() => onReferenceClick({ entityType: 'version', entityId, projectName })}
+      >
+        <Styled.Content>
+          <Styled.Title>{productName}</Styled.Title>
+          <span className="version">{versionName}</span>
+        </Styled.Content>
+        <Styled.Thumbnail
+          {...{ projectName, entityId, entityType }}
+          onError={() => setThumbnailError(true)}
+          iconOnly={thumbnailError}
+          entityUpdatedAt={updatedAt}
+          icon={icon}
+        />
+      </Styled.Card>
+    </Styled.Container>
+  )
+}
+
+export default ActivityVersions

--- a/src/components/Feed/ActivityVersions/ActivityVersions.jsx
+++ b/src/components/Feed/ActivityVersions/ActivityVersions.jsx
@@ -9,7 +9,6 @@ const ActivityVersions = ({ activity, projectInfo, projectName, entityType, onRe
     authorFullName,
     createdAt,
     updatedAt,
-    entityId,
     activityData = {},
     origin = {},
   } = activity
@@ -46,7 +45,9 @@ const ActivityVersions = ({ activity, projectInfo, projectName, entityType, onRe
           <span className="version">{versionName}</span>
         </Styled.Content>
         <Styled.Thumbnail
-          {...{ projectName, entityId, entityType }}
+          {...{ projectName }}
+          entityId={versionId}
+          entityType="version"
           onError={() => setThumbnailError(true)}
           iconOnly={thumbnailError}
           entityUpdatedAt={updatedAt}

--- a/src/components/Feed/ActivityVersions/ActivityVersions.jsx
+++ b/src/components/Feed/ActivityVersions/ActivityVersions.jsx
@@ -1,10 +1,22 @@
+import { Icon } from '@ynput/ayon-react-components'
 import ActivityHeader from '../ActivityHeader/ActivityHeader'
 import * as Styled from './ActivityVersions.styled'
 import { productTypes } from '/src/features/project'
 import { useState } from 'react'
+import { More } from '../ActivityGroup/ActivityGroup.styled'
 
-const ActivityVersions = ({ activity, projectInfo, projectName, entityType, onReferenceClick }) => {
+const ActivityVersions = ({
+  activity,
+  projectInfo,
+  projectName,
+  entityType,
+  onReferenceClick,
+  filter,
+}) => {
   let { authorName, authorFullName, createdAt, versions = [] } = activity
+
+  const [showAll, setShowAll] = useState(filter === 'publishes')
+  const limit = 2
 
   const [thumbnailError, setThumbnailError] = useState(false)
 
@@ -20,26 +32,35 @@ const ActivityVersions = ({ activity, projectInfo, projectName, entityType, onRe
         entityType={entityType}
         onReferenceClick={onReferenceClick}
       />
-      {versions.map(({ name, id, productName, productType, updatedAt }) => (
-        <Styled.Card
-          key={id}
-          onClick={() => onReferenceClick({ entityType: 'version', entityId: id, projectName })}
-        >
-          <Styled.Content>
-            <Styled.Title>{productName}</Styled.Title>
-            <span className="version">{name}</span>
-          </Styled.Content>
-          <Styled.Thumbnail
-            {...{ projectName }}
-            entityId={id}
-            entityType="version"
-            onError={() => setThumbnailError(true)}
-            iconOnly={thumbnailError}
-            entityUpdatedAt={updatedAt}
-            icon={productTypes[productType]?.icon || 'home_repair_service'}
-          />
-        </Styled.Card>
-      ))}
+      {versions.flatMap(
+        ({ name, id, productName, productType, updatedAt }, index) =>
+          (index < limit || showAll) && (
+            <Styled.Card
+              key={id}
+              onClick={() => onReferenceClick({ entityType: 'version', entityId: id, projectName })}
+            >
+              <Styled.Content>
+                <Styled.Title>{productName}</Styled.Title>
+                <span className="version">{name}</span>
+              </Styled.Content>
+              <Styled.Thumbnail
+                {...{ projectName }}
+                entityId={id}
+                entityType="version"
+                onError={() => setThumbnailError(true)}
+                iconOnly={thumbnailError}
+                entityUpdatedAt={updatedAt}
+                icon={productTypes[productType]?.icon || 'home_repair_service'}
+              />
+            </Styled.Card>
+          ),
+      )}
+      {filter !== 'publishes' && versions.length > limit && (
+        <More onClick={() => setShowAll(!showAll)}>
+          <Icon name="more" />
+          <span>{showAll ? `Show less` : `Show ${versions.length - limit} more versions`}</span>
+        </More>
+      )}
     </Styled.Container>
   )
 }

--- a/src/components/Feed/ActivityVersions/ActivityVersions.jsx
+++ b/src/components/Feed/ActivityVersions/ActivityVersions.jsx
@@ -9,6 +9,7 @@ const ActivityVersions = ({ activity, projectInfo, projectName, entityType, onRe
     authorFullName,
     createdAt,
     updatedAt,
+    entityId,
     activityData = {},
     origin = {},
   } = activity

--- a/src/components/Feed/ActivityVersions/ActivityVersions.styled.js
+++ b/src/components/Feed/ActivityVersions/ActivityVersions.styled.js
@@ -13,7 +13,6 @@ export const Container = styled.li`
 
   width: 100%;
   padding: 8px;
-  border-radius: var(--border-radius-m);
 `
 
 export const Card = styled.div`
@@ -21,7 +20,7 @@ export const Card = styled.div`
   gap: var(--base-gap-large);
   align-items: center;
   justify-content: space-between;
-  border-radius: var(--border-radius-l);
+  border-radius: var(--border-radius-m);
   padding: var(--padding-m);
 
   background-color: var(--md-sys-color-surface-container);

--- a/src/components/Feed/ActivityVersions/ActivityVersions.styled.js
+++ b/src/components/Feed/ActivityVersions/ActivityVersions.styled.js
@@ -1,0 +1,57 @@
+import styled from 'styled-components'
+import ThumbnailSimple from '/src/containers/ThumbnailSimple'
+
+export const Container = styled.li`
+  /* reset default */
+  list-style: none;
+  margin: 0;
+  padding: 0;
+
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+
+  width: 100%;
+  padding: 8px;
+  border-radius: var(--border-radius-m);
+`
+
+export const Card = styled.div`
+  display: flex;
+  gap: var(--base-gap-large);
+  align-items: center;
+  justify-content: space-between;
+  border-radius: var(--border-radius-l);
+  padding: var(--padding-m);
+
+  background-color: var(--md-sys-color-surface-container);
+
+  cursor: pointer;
+  &:hover {
+    background-color: var(--md-sys-color-surface-container-hover);
+  }
+`
+
+export const Content = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+
+  gap: var(--base-gap-small);
+`
+
+export const Title = styled.div`
+  display: flex;
+  gap: var(--base-gap-small);
+`
+
+export const Thumbnail = styled(ThumbnailSimple)`
+  width: 74px;
+  height: 100%;
+  aspect-ratio: 1.7778;
+  margin: unset;
+
+  img {
+    object-fit: cover;
+  }
+`

--- a/src/components/Feed/ActivityVersions/ActivityVersions.styled.js
+++ b/src/components/Feed/ActivityVersions/ActivityVersions.styled.js
@@ -51,6 +51,10 @@ export const Thumbnail = styled(ThumbnailSimple)`
   aspect-ratio: 1.7778;
   margin: unset;
 
+  .icon {
+    font-size: 24px;
+  }
+
   img {
     object-fit: cover;
   }

--- a/src/components/Feed/ActivityVersions/ActivityVersions.styled.js
+++ b/src/components/Feed/ActivityVersions/ActivityVersions.styled.js
@@ -27,6 +27,7 @@ export const Card = styled.div`
 
   cursor: pointer;
   &:hover {
+    color: var(--md-sys-color-on-surface);
     background-color: var(--md-sys-color-surface-container-hover);
   }
 `

--- a/src/components/Tooltips/EntityTooltip/EntityTooltip.jsx
+++ b/src/components/Tooltips/EntityTooltip/EntityTooltip.jsx
@@ -21,7 +21,13 @@ const EntityTooltip = ({ type, id, pos: { left, top } = {}, projectName, project
 
   const taskIcon = task_types.find((type) => type.name === taskType)?.icon
   const status = statuses.find((status) => status.name === data.status)
-  const thumbnailUrl = getThumbnailUrl(id, thumbnailId, updatedAt, projectName, type)
+  const thumbnailUrl = getThumbnailUrl({
+    entityId: id,
+    entityType: type,
+    thumbnailId,
+    updatedAt,
+    projectName,
+  })
   const productTypeData = productTypes[productType]
   const productIcon = productTypeData?.icon || 'layers'
 

--- a/src/components/Tooltips/EntityTooltip/EntityTooltip.jsx
+++ b/src/components/Tooltips/EntityTooltip/EntityTooltip.jsx
@@ -21,7 +21,7 @@ const EntityTooltip = ({ type, id, pos: { left, top } = {}, projectName, project
 
   const taskIcon = task_types.find((type) => type.name === taskType)?.icon
   const status = statuses.find((status) => status.name === data.status)
-  const thumbnailUrl = getThumbnailUrl(id, thumbnailId, updatedAt, projectName)
+  const thumbnailUrl = getThumbnailUrl(id, thumbnailId, updatedAt, projectName, type)
   const productTypeData = productTypes[productType]
   const productIcon = productTypeData?.icon || 'layers'
 

--- a/src/containers/Feed/Feed.jsx
+++ b/src/containers/Feed/Feed.jsx
@@ -212,6 +212,7 @@ const Feed = ({
                 createdAts={entities.map((e) => e.createdAt)}
                 onFileExpand={handleFileExpand}
                 showOrigin={entities.length > 1}
+                filter={filter}
                 editProps={{
                   activeUsers,
                   projectName,

--- a/src/containers/Feed/Feed.jsx
+++ b/src/containers/Feed/Feed.jsx
@@ -70,7 +70,7 @@ const Feed = ({
   // do any transformation on activities data
   // 1. status change activities, attach status data based on projectName
   // 2. reverse the order
-  const transformedActivitiesData = useTransformActivities(activitiesData, projectInfo)
+  const transformedActivitiesData = useTransformActivities(activitiesData, projectInfo, entityType)
 
   // TODO: merge in the versions data with the activities data
 

--- a/src/containers/Feed/hooks/useTransformActivities.js
+++ b/src/containers/Feed/hooks/useTransformActivities.js
@@ -1,3 +1,4 @@
+import { differenceInMinutes } from 'date-fns'
 import { compareAsc } from 'date-fns'
 import { cloneDeep } from 'lodash'
 import { useMemo } from 'react'
@@ -126,6 +127,86 @@ const filterOutRelations = (activities = [], entityTypes = [], entityType) => {
     : activities.filter((activity) => activity.referenceType !== 'relation')
 }
 
+// transforms a full activity to a version item
+const activityToVersionItem = (activity = {}) => {
+  const {
+    updatedAt,
+    origin: { name, id } = {},
+    activityData: { context: { productName, productType } = {} } = {},
+  } = activity
+
+  return {
+    name,
+    id,
+    productName,
+    productType,
+    updatedAt,
+  }
+}
+
+// groups similar activities together
+// 1. version.publish
+// 2. neighboring index
+// 3. neighbor same author and same type
+// 4. neighbor createdAt is within 30 minutes
+const groupVersions = (activities = []) => {
+  const groupedVersions = []
+  let currentVersion = null
+
+  for (const activity of activities) {
+    // if it's not a version.publish activity, push it to the groupedVersions
+    if (activity.activityType !== 'version.publish') {
+      groupedVersions.push(activity)
+
+      // this also resets the currentVersion and adds it to the groupedVersions
+      if (currentVersion) {
+        groupedVersions.push(currentVersion)
+        currentVersion = null
+      }
+
+      continue
+    }
+
+    // if there's no currentVersion, set the first version
+    if (!currentVersion) {
+      currentVersion = cloneDeep(activity)
+
+      currentVersion.versions = [activityToVersionItem(activity)]
+      continue
+    }
+
+    // here we check if the currentVersion and the activity are similar enough to be grouped together
+    // is same author
+    const isSameAuthor = currentVersion.authorName === activity.authorName
+    // is within 30 minutes of currentVersion
+    const minsDiff = differenceInMinutes(
+      new Date(currentVersion.createdAt),
+      new Date(activity.createdAt),
+    )
+    const isWithin30Mins = minsDiff <= 30
+
+    if (isSameAuthor && isWithin30Mins) {
+      currentVersion.versions.push(activityToVersionItem(activity))
+      continue
+    } else {
+      // if not similar, push the currentVersion to the groupedVersions
+      groupedVersions.push(currentVersion)
+
+      // set the currentVersion to the current activity to start a new group
+      currentVersion = cloneDeep(activity)
+      currentVersion.versions = [activityToVersionItem(activity)]
+      continue
+    }
+  }
+
+  // if there's a currentVersion left, push it to the groupedVersions
+  if (currentVersion) {
+    groupedVersions.push(currentVersion)
+  }
+
+  return groupedVersions
+}
+
 const useTransformActivities = (activities = [], projectInfo = {}, entityType) => {
   // 1. add status icons and data for status change activities
   const activitiesWithIcons = useMemo(
@@ -155,15 +236,21 @@ const useTransformActivities = (activities = [], projectInfo = {}, entityType) =
   )
 
   // Define the types of activities that are considered minor
-  const minorActivityTypes = ['status.change', 'assignee.add', 'assignee.remove']
+  const minorActivityTypes = ['status.change', 'assignee.add', 'assignee.remove', '']
 
-  // 5. Use the useMemo hook to optimize performance by memoizing the groupedActivitiesData
+  // 5. group minor activities together
   const groupedActivitiesData = useMemo(
     () => groupMinorActivities(mergedActivitiesData, minorActivityTypes),
     [mergedActivitiesData],
   )
 
-  return groupedActivitiesData
+  // 6. group version activities together
+  const groupedVersionsData = useMemo(
+    () => groupVersions(groupedActivitiesData),
+    [groupedActivitiesData],
+  )
+
+  return groupedVersionsData
 }
 
 export default useTransformActivities

--- a/src/containers/Feed/hooks/useTransformActivities.js
+++ b/src/containers/Feed/hooks/useTransformActivities.js
@@ -156,13 +156,14 @@ const groupVersions = (activities = []) => {
   for (const activity of activities) {
     // if it's not a version.publish activity, push it to the groupedVersions
     if (activity.activityType !== 'version.publish') {
-      groupedVersions.push(activity)
-
-      // this also resets the currentVersion and adds it to the groupedVersions
+      // resets the currentVersion and adds it to the groupedVersions
       if (currentVersion) {
         groupedVersions.push(currentVersion)
         currentVersion = null
       }
+
+      // adds the activity to the groupedVersions
+      groupedVersions.push(activity)
 
       continue
     }
@@ -197,11 +198,6 @@ const groupVersions = (activities = []) => {
       currentVersion.versions = [activityToVersionItem(activity)]
       continue
     }
-  }
-
-  // if there's a currentVersion left, push it to the groupedVersions
-  if (currentVersion) {
-    groupedVersions.push(currentVersion)
   }
 
   return groupedVersions

--- a/src/containers/ThumbnailSimple.jsx
+++ b/src/containers/ThumbnailSimple.jsx
@@ -47,6 +47,9 @@ const ThumbnailSimple = ({
   className,
   disabled,
   src,
+  onLoad,
+  onError,
+  iconOnly,
   ...props
 }) => {
   const url = projectName && `/api/projects/${projectName}/${entityType}s/${entityId}/thumbnail`
@@ -56,8 +59,13 @@ const ThumbnailSimple = ({
   return (
     <ThumbnailStyled className={className + ' thumbnail'} {...props}>
       {!isLoading && !disabled && <Icon icon={icon || 'image'} />}
-      {((entityType && !(isWrongEntity || !entityId)) || src) && (
-        <ImageStyled alt={`Entity thumbnail ${entityId}`} src={src || `${url}${queryArgs}`} />
+      {((entityType && !(isWrongEntity || !entityId)) || src) && !iconOnly && (
+        <ImageStyled
+          alt={`Entity thumbnail ${entityId}`}
+          src={src || `${url}${queryArgs}`}
+          onLoad={onLoad}
+          onError={onError}
+        />
       )}
     </ThumbnailStyled>
   )

--- a/src/features/dashboard.js
+++ b/src/features/dashboard.js
@@ -2,9 +2,9 @@ import { createSlice } from '@reduxjs/toolkit'
 import getInitialStateLocalStorage from './middleware/getInitialStateLocalStorage'
 
 export const filterActivityTypes = {
-  activity: ['comment', 'status.change', 'assignee.add', 'assignee.remove'],
+  activity: ['comment', 'version.publish', 'status.change', 'assignee.add', 'assignee.remove'],
   comments: ['comment'],
-  versions: ['version'],
+  publishes: ['version.publish'],
   checklists: ['checklist'],
 }
 

--- a/src/pages/UserDashboardPage/UserDashboardTasks/UserDashDetailsFilters/UserDashDetailsFilters.jsx
+++ b/src/pages/UserDashboardPage/UserDashboardTasks/UserDashDetailsFilters/UserDashDetailsFilters.jsx
@@ -24,15 +24,15 @@ const UserDashDetailsFilters = ({ isSlideOut }) => {
       label: 'Comments',
       icon: 'chat',
     },
-    // {
-    //   id: 'versions',
-    //   label: 'Versions',
-    //   icon: 'layers',
-    // },
     {
       id: 'checklists',
       label: 'Checklists',
       icon: 'checklist',
+    },
+    {
+      id: 'publishes',
+      label: 'Published versions',
+      icon: 'layers',
     },
   ]
 

--- a/src/pages/UserDashboardPage/UserDashboardTasks/UserDashDetailsHeader/UserDashDetailsHeader.jsx
+++ b/src/pages/UserDashboardPage/UserDashboardTasks/UserDashDetailsHeader/UserDashDetailsHeader.jsx
@@ -39,6 +39,7 @@ const UserDashDetailsHeader = ({
           icon: entity.icon,
           id: entity.id,
           type: entityType,
+          updatedAt: entity.updatedAt,
         })),
     [entities],
   )

--- a/src/pages/UserDashboardPage/UserDashboardTasks/UserTasksContainer.jsx
+++ b/src/pages/UserDashboardPage/UserDashboardTasks/UserTasksContainer.jsx
@@ -14,15 +14,15 @@ import { Section } from '@ynput/ayon-react-components'
 import { setUri } from '/src/features/context'
 import UserDashboardSlideOut from './UserDashboardSlideOut/UserDashboardSlideOut'
 
-export const getThumbnailUrl = (taskId, thumbnailId, updatedAt, projectName) => {
-  if (!projectName || (!thumbnailId && !taskId)) return null
+export const getThumbnailUrl = ({ entityId, entityType, thumbnailId, updatedAt, projectName }) => {
+  if (!projectName || (!thumbnailId && !entityId)) return null
 
-  // fallback on arbitrary thumbnailId if taskId is not available
+  // fallback on arbitrary thumbnailId if entityId is not available
   // this should never happen, but just in case
   // only admins and managers can see the second endpoint though
   const thumbnailUrl = thumbnailId
     ? `/api/projects/${projectName}/thumbnails/${thumbnailId}?updatedAt=${updatedAt}`
-    : `/api/projects/${projectName}/tasks/${taskId}/thumbnail?updatedAt=${updatedAt}`
+    : `/api/projects/${projectName}/${entityType}s/${entityId}/thumbnail?updatedAt=${updatedAt}`
 
   return thumbnailUrl
 }
@@ -86,7 +86,13 @@ const UserTasksContainer = ({ projectsInfo = {}, isLoadingInfo }) => {
       ? task.updatedAt
       : task.latestVersionUpdatedAt ?? task.updatedAt
 
-    const thumbnailUrl = getThumbnailUrl(task.id, thumbnailId, updatedAt, task.projectName)
+    const thumbnailUrl = getThumbnailUrl({
+      entityId: task.id,
+      entityType: 'task',
+      thumbnailId,
+      updatedAt,
+      projectName: task.projectName,
+    })
 
     const updatedTask = { ...task, thumbnailUrl }
 

--- a/src/pages/UserDashboardPage/UserDashboardTasks/UserTasksContainer.jsx
+++ b/src/pages/UserDashboardPage/UserDashboardTasks/UserTasksContainer.jsx
@@ -14,7 +14,7 @@ import { Section } from '@ynput/ayon-react-components'
 import { setUri } from '/src/features/context'
 import UserDashboardSlideOut from './UserDashboardSlideOut/UserDashboardSlideOut'
 
-export const getThumbnailUrl = (taskId, thumbnailId, updatedAt, projectName, type) => {
+export const getThumbnailUrl = (taskId, thumbnailId, updatedAt, projectName) => {
   if (!projectName || (!thumbnailId && !taskId)) return null
 
   // fallback on arbitrary thumbnailId if taskId is not available

--- a/src/pages/UserDashboardPage/UserDashboardTasks/UserTasksContainer.jsx
+++ b/src/pages/UserDashboardPage/UserDashboardTasks/UserTasksContainer.jsx
@@ -14,14 +14,14 @@ import { Section } from '@ynput/ayon-react-components'
 import { setUri } from '/src/features/context'
 import UserDashboardSlideOut from './UserDashboardSlideOut/UserDashboardSlideOut'
 
-export const getThumbnailUrl = (taskId, thumbnailId, updatedAt, projectName) => {
+export const getThumbnailUrl = (taskId, thumbnailId, updatedAt, projectName, type) => {
   if (!projectName || (!thumbnailId && !taskId)) return null
 
   // fallback on arbitrary thumbnailId if taskId is not available
   // this should never happen, but just in case
   // only admins and managers can see the second endpoint though
   return thumbnailId
-    ? `/api/projects/${projectName}/tasks/${taskId}/thumbnail?updatedAt=${updatedAt}`
+    ? `/api/projects/${projectName}/${type}/${taskId}/thumbnail?updatedAt=${updatedAt}`
     : `/api/projects/${projectName}/thumbnails/${thumbnailId}?updatedAt=${updatedAt}`
 }
 

--- a/src/services/activities/activityQueries.js
+++ b/src/services/activities/activityQueries.js
@@ -8,6 +8,7 @@ fragment ActivityFragment on ActivityNode {
     entityId
     body
     createdAt
+    updatedAt
     author {
       name
       attrib {

--- a/src/services/userDashboard/userDashboardHelpers.js
+++ b/src/services/userDashboard/userDashboardHelpers.js
@@ -76,7 +76,7 @@ export const transformEntityData = ({ entity = {}, entityType, projectName, proj
         ...baseDetailsData,
         title: entity?.product?.name || 'Unknown Product',
         subTitle: entity.name || entity.version,
-        users: [entity.author],
+        users: entity.author ? [entity.author] : [],
         path: path,
         folderId: entity.product?.folder?.id,
         icon: icon || 'layers',


### PR DESCRIPTION
### Changelog Description

- New activity item type `version.publish`.
- New filter **Versions** to show only `version.publish`.
- Versions that are made by the same author and within 30 mins of each other are grouped together.
- In the main feed versions are collapsed with a show more button.

<img width="550" alt="activity_feed_versions_v001" src="https://github.com/ynput/ayon-frontend/assets/49156310/1936a8d7-5add-4074-8f1d-dd7ba7b2a798">


https://github.com/ynput/ayon-frontend/assets/49156310/527bdc40-5f16-4692-bcd7-3f8e25896f08

### Testing

**experimental** viewing **frank stephens** will give some good examples on task **lighting**.




