### PR TITLE
fix: replaced user data source to server for showing developer mode

### DIFF
--- a/src/containers/header/AppHeader.jsx
+++ b/src/containers/header/AppHeader.jsx
@@ -13,7 +13,6 @@ import { toggleMenuOpen, setMenuOpen } from '/src/features/context'
 import { HelpMenu, UserMenu } from '/src/components/Menu'
 import MenuContainer from '/src/components/Menu/MenuComponents/MenuContainer'
 import { useUpdateUserMutation } from '/src/services/user/updateUser'
-import { useGetMeQuery } from '/src/services/user/getUsers'
 import { toast } from 'react-toastify'
 import { onProfileUpdate } from '/src/features/user'
 import styled from 'styled-components'
@@ -70,8 +69,8 @@ const Header = () => {
   const handleSetMenu = (menu) => dispatch(setMenuOpen(menu))
   const location = useLocation()
   const navigate = useNavigate()
-  // get user info from BE instead of redux to have up to date information
-  const { data: user } = useGetMeQuery()
+  // get user from redux store
+  const user = useSelector((state) => state.user)
 
   // restart server notification
   const { isSnoozing } = useRestart()

--- a/src/containers/header/AppHeader.jsx
+++ b/src/containers/header/AppHeader.jsx
@@ -13,6 +13,7 @@ import { toggleMenuOpen, setMenuOpen } from '/src/features/context'
 import { HelpMenu, UserMenu } from '/src/components/Menu'
 import MenuContainer from '/src/components/Menu/MenuComponents/MenuContainer'
 import { useUpdateUserMutation } from '/src/services/user/updateUser'
+import { useGetMeQuery } from '/src/services/user/getUsers'
 import { toast } from 'react-toastify'
 import { onProfileUpdate } from '/src/features/user'
 import styled from 'styled-components'
@@ -69,8 +70,8 @@ const Header = () => {
   const handleSetMenu = (menu) => dispatch(setMenuOpen(menu))
   const location = useLocation()
   const navigate = useNavigate()
-  // get user from redux store
-  const user = useSelector((state) => state.user)
+  // get user info from BE instead of redux to have up to date information
+  const { data: user } = useGetMeQuery()
 
   // restart server notification
   const { isSnoozing } = useRestart()

--- a/src/containers/header/AppHeader.jsx
+++ b/src/containers/header/AppHeader.jsx
@@ -114,18 +114,23 @@ const Header = () => {
   const [updateUser] = useUpdateUserMutation()
   const handleDeveloperMode = async () => {
     try {
+      const newDeveloperMode = !developerMode
+      // optimistic update the switch
+      dispatch(toggleDevMode(newDeveloperMode))
+
       await updateUser({
         name: user.name,
         patch: {
-          attrib: { developerMode: !developerMode },
+          attrib: { developerMode: newDeveloperMode },
         },
       }).unwrap()
 
-      // update redux state with new data
-      dispatch(toggleDevMode(!developerMode))
+      // if the request fails, revert the switch
     } catch (error) {
       console.error(error)
       toast.error('Unable to update developer mode: ' + error.details)
+      // reset switch on error
+      dispatch(toggleDevMode(developerMode))
     }
   }
 

--- a/src/containers/header/AppHeader.jsx
+++ b/src/containers/header/AppHeader.jsx
@@ -14,7 +14,7 @@ import { HelpMenu, UserMenu } from '/src/components/Menu'
 import MenuContainer from '/src/components/Menu/MenuComponents/MenuContainer'
 import { useUpdateUserMutation } from '/src/services/user/updateUser'
 import { toast } from 'react-toastify'
-import { onProfileUpdate } from '/src/features/user'
+import { updateUserAttribs } from '/src/features/user'
 import styled from 'styled-components'
 import { useRestart } from '/src/context/restartContext'
 import { classNames } from 'primereact/utils'
@@ -122,7 +122,7 @@ const Header = () => {
       }).unwrap()
 
       // update redux state with new data
-      dispatch(onProfileUpdate({ developerMode: !developerMode }))
+      dispatch(updateUserAttribs({ developerMode: !developerMode }))
     } catch (error) {
       console.error(error)
       toast.error('Unable to update developer mode: ' + error.details)

--- a/src/containers/header/AppHeader.jsx
+++ b/src/containers/header/AppHeader.jsx
@@ -14,7 +14,7 @@ import { HelpMenu, UserMenu } from '/src/components/Menu'
 import MenuContainer from '/src/components/Menu/MenuComponents/MenuContainer'
 import { useUpdateUserMutation } from '/src/services/user/updateUser'
 import { toast } from 'react-toastify'
-import { updateUserAttribs } from '/src/features/user'
+import { toggleDevMode } from '/src/features/user'
 import styled from 'styled-components'
 import { useRestart } from '/src/context/restartContext'
 import { classNames } from 'primereact/utils'
@@ -122,7 +122,7 @@ const Header = () => {
       }).unwrap()
 
       // update redux state with new data
-      dispatch(updateUserAttribs({ developerMode: !developerMode }))
+      dispatch(toggleDevMode(!developerMode))
     } catch (error) {
       console.error(error)
       toast.error('Unable to update developer mode: ' + error.details)

--- a/src/features/user.js
+++ b/src/features/user.js
@@ -32,12 +32,12 @@ const userSlice = createSlice({
       if (!state.attrib) return
       state.attrib = { ...state.attrib, ...action.payload }
     },
-    setUserData: (state, action) => {
-      if (!state.attrib) return
+    updateUserData: (state, action) => {
+      if (!state.data) return
       state.data = { ...state.data, ...action.payload }
     },
   },
 })
 
-export const { login, logout, onProfileUpdate, setUserData } = userSlice.actions
+export const { login, logout, onProfileUpdate, updateUserData } = userSlice.actions
 export default userSlice.reducer

--- a/src/features/user.js
+++ b/src/features/user.js
@@ -36,8 +36,12 @@ const userSlice = createSlice({
       if (!state.data) return
       state.data = { ...state.data, ...action.payload }
     },
+    toggleDevMode: (state, action) => {
+      if (!state.attrib) return
+      state.attrib.developerMode = action.payload
+    },
   },
 })
 
-export const { login, logout, updateUserAttribs, updateUserData } = userSlice.actions
+export const { login, logout, updateUserAttribs, updateUserData, toggleDevMode } = userSlice.actions
 export default userSlice.reducer

--- a/src/features/user.js
+++ b/src/features/user.js
@@ -32,8 +32,12 @@ const userSlice = createSlice({
       if (!state.attrib) return
       state.attrib = { ...state.attrib, ...action.payload }
     },
+    setUserData: (state, action) => {
+      if (!state.attrib) return
+      state.data = { ...state.data, ...action.payload }
+    },
   },
 })
 
-export const { login, logout, onProfileUpdate } = userSlice.actions
+export const { login, logout, onProfileUpdate, setUserData } = userSlice.actions
 export default userSlice.reducer

--- a/src/features/user.js
+++ b/src/features/user.js
@@ -28,7 +28,7 @@ const userSlice = createSlice({
       state = {}
       return state
     },
-    onProfileUpdate: (state, action) => {
+    updateUserAttribs: (state, action) => {
       if (!state.attrib) return
       state.attrib = { ...state.attrib, ...action.payload }
     },
@@ -39,5 +39,5 @@ const userSlice = createSlice({
   },
 })
 
-export const { login, logout, onProfileUpdate, updateUserData } = userSlice.actions
+export const { login, logout, updateUserAttribs, updateUserData } = userSlice.actions
 export default userSlice.reducer

--- a/src/pages/AccountPage/ProfilePage.jsx
+++ b/src/pages/AccountPage/ProfilePage.jsx
@@ -124,8 +124,6 @@ const ProfilePage = ({ user = {}, isLoading }) => {
     }
   }
 
-  console.log(user, 'USERZZZ')
-
   return (
     <main>
       <Section style={{ paddingTop: 16 }}>

--- a/src/pages/AccountPage/ProfilePage.jsx
+++ b/src/pages/AccountPage/ProfilePage.jsx
@@ -14,7 +14,7 @@ import styled from 'styled-components'
 import UserAttribForm from '../SettingsPage/UsersSettings/UserAttribForm'
 import SetPasswordDialog from '../SettingsPage/UsersSettings/SetPasswordDialog'
 import ayonClient from '../../ayon'
-import { onProfileUpdate } from '../../features/user'
+import { updateUserAttribs } from '../../features/user'
 import { useDispatch } from 'react-redux'
 
 const FormsStyled = styled.section`
@@ -113,7 +113,7 @@ const ProfilePage = ({ user = {}, isLoading }) => {
       toast.success('Profile updated')
 
       // update redux state with new data
-      dispatch(onProfileUpdate(formData))
+      dispatch(updateUserAttribs(formData))
       // reset form
       setInitData(formData)
       setChangesMade(false)
@@ -123,6 +123,8 @@ const ProfilePage = ({ user = {}, isLoading }) => {
       toast.error(error.details)
     }
   }
+
+  console.log(user, 'USERZZZ')
 
   return (
     <main>

--- a/src/pages/SettingsPage/UsersSettings/userDetail.jsx
+++ b/src/pages/SettingsPage/UsersSettings/userDetail.jsx
@@ -275,8 +275,6 @@ const UserDetail = ({
         data,
       }
 
-      console.log(data.isDeveloper,'data.isDeveloper')
-
       try {
         // Apply the patch
         await updateUser({

--- a/src/pages/SettingsPage/UsersSettings/userDetail.jsx
+++ b/src/pages/SettingsPage/UsersSettings/userDetail.jsx
@@ -275,8 +275,6 @@ const UserDetail = ({
         data,
       }
 
-      console.log(attrib,'attribXXX')
-
       try {
         // Apply the patch
         await updateUser({
@@ -285,7 +283,7 @@ const UserDetail = ({
         }).unwrap()
 
         toast.update(toastId.current, { render: `Updated user: ${user.name} ` })
-        user.self && dispatch(updateUserData(data)) && dispatch(updateUserAttribs(data)) 
+        user.self && dispatch(updateUserData(data)) && dispatch(updateUserAttribs(data))
         i += 1
       } catch (error) {
         toast.error(`Unable to update user ${user.name} `)

--- a/src/pages/SettingsPage/UsersSettings/userDetail.jsx
+++ b/src/pages/SettingsPage/UsersSettings/userDetail.jsx
@@ -283,7 +283,10 @@ const UserDetail = ({
         }).unwrap()
 
         toast.update(toastId.current, { render: `Updated user: ${user.name} ` })
-        user.self && dispatch(updateUserData(data)) && dispatch(updateUserAttribs(data))
+        if (user.self) {
+          dispatch(updateUserData(data))
+          dispatch(updateUserAttribs(attrib))
+        }
         i += 1
       } catch (error) {
         toast.error(`Unable to update user ${user.name} `)

--- a/src/pages/SettingsPage/UsersSettings/userDetail.jsx
+++ b/src/pages/SettingsPage/UsersSettings/userDetail.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
 import { toast } from 'react-toastify'
+import { useDispatch } from 'react-redux'
 import {
   Button,
   Section,
@@ -9,6 +10,7 @@ import {
   SaveButton,
 } from '@ynput/ayon-react-components'
 import { useUpdateUserMutation } from '/src/services/user/updateUser'
+import { setUserData } from '/src/features/user'
 import styled from 'styled-components'
 import ayonClient from '/src/ayon'
 import UserAttribForm from './UserAttribForm'
@@ -188,6 +190,7 @@ const UserDetail = ({
   const toastId = useRef(null)
 
   const attributes = ayonClient.getAttribsByScope('user')
+  const dispatch = useDispatch()
 
   useEffect(() => {
     // have the selected users changed?
@@ -272,6 +275,8 @@ const UserDetail = ({
         data,
       }
 
+      console.log(data.isDeveloper,'data.isDeveloper')
+
       try {
         // Apply the patch
         await updateUser({
@@ -280,6 +285,7 @@ const UserDetail = ({
         }).unwrap()
 
         toast.update(toastId.current, { render: `Updated user: ${user.name} ` })
+        dispatch(setUserData({ isDeveloper: data.isDeveloper }))
         i += 1
       } catch (error) {
         toast.error(`Unable to update user ${user.name} `)

--- a/src/pages/SettingsPage/UsersSettings/userDetail.jsx
+++ b/src/pages/SettingsPage/UsersSettings/userDetail.jsx
@@ -10,7 +10,7 @@ import {
   SaveButton,
 } from '@ynput/ayon-react-components'
 import { useUpdateUserMutation } from '/src/services/user/updateUser'
-import { setUserData } from '/src/features/user'
+import { updateUserData } from '/src/features/user'
 import styled from 'styled-components'
 import ayonClient from '/src/ayon'
 import UserAttribForm from './UserAttribForm'
@@ -283,7 +283,7 @@ const UserDetail = ({
         }).unwrap()
 
         toast.update(toastId.current, { render: `Updated user: ${user.name} ` })
-        dispatch(setUserData(data))
+        user.self && dispatch(updateUserData(data))
         i += 1
       } catch (error) {
         toast.error(`Unable to update user ${user.name} `)

--- a/src/pages/SettingsPage/UsersSettings/userDetail.jsx
+++ b/src/pages/SettingsPage/UsersSettings/userDetail.jsx
@@ -283,7 +283,7 @@ const UserDetail = ({
         }).unwrap()
 
         toast.update(toastId.current, { render: `Updated user: ${user.name} ` })
-        dispatch(setUserData({ isDeveloper: data.isDeveloper }))
+        dispatch(setUserData(data))
         i += 1
       } catch (error) {
         toast.error(`Unable to update user ${user.name} `)

--- a/src/pages/SettingsPage/UsersSettings/userDetail.jsx
+++ b/src/pages/SettingsPage/UsersSettings/userDetail.jsx
@@ -10,7 +10,7 @@ import {
   SaveButton,
 } from '@ynput/ayon-react-components'
 import { useUpdateUserMutation } from '/src/services/user/updateUser'
-import { updateUserData } from '/src/features/user'
+import { updateUserData, updateUserAttribs } from '/src/features/user'
 import styled from 'styled-components'
 import ayonClient from '/src/ayon'
 import UserAttribForm from './UserAttribForm'
@@ -275,6 +275,8 @@ const UserDetail = ({
         data,
       }
 
+      console.log(attrib,'attribXXX')
+
       try {
         // Apply the patch
         await updateUser({
@@ -283,7 +285,7 @@ const UserDetail = ({
         }).unwrap()
 
         toast.update(toastId.current, { render: `Updated user: ${user.name} ` })
-        user.self && dispatch(updateUserData(data))
+        user.self && dispatch(updateUserData(data)) && dispatch(updateUserAttribs(data)) 
         i += 1
       } catch (error) {
         toast.error(`Unable to update user ${user.name} `)


### PR DESCRIPTION
## Description of changes

Issue link: https://github.com/ynput/ayon-frontend/issues/335
URL: http://localhost:3000/settings/users

- replaced source of information about user - server instead of redux
- developer mode now appears/disappears without need for refresh

### Additional context

https://github.com/ynput/ayon-frontend/assets/16327908/2b1142e6-9025-4cb2-909f-67f4b7b53c35

close #335



