### PR TITLE
fix(comment): \\ replaced with \\\ so that it renders as \\

### DIFF
--- a/src/components/CommentInput/CommentInput.styled.js
+++ b/src/components/CommentInput/CommentInput.styled.js
@@ -61,32 +61,16 @@ export const Comment = styled.div`
 
   /* check box styles */
   .ql-editor ul {
-    /* checkbox data-checked false or true */
-    &[data-checked] {
-      li {
-        height: 25px;
-        /* tick circle */
-        &::before {
-          margin-right: 12px;
-          font-size: unset;
-          top: -2px;
-          position: relative;
-        }
-
-        /* cursor too height */
-        br {
-          position: relative;
-          top: 15px;
-        }
-      }
-    }
-
     &[data-checked='true'] {
       li {
         display: flex;
         ::before {
           /* tick circle svg */
           content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='24' viewBox='0 -960 960 960' width='24' fill='%2323E0A9'%3E%3Cpath d='m427.462-343.692 233.846-232.846L620-617.846 427.462-426.308l-87-86L299.154-471l128.308 127.308ZM480.134-104q-77.313 0-145.89-29.359-68.577-29.36-120.025-80.762-51.447-51.402-80.833-119.917Q104-402.554 104-479.866q0-78.569 29.418-146.871 29.419-68.303 80.922-119.917 51.503-51.614 119.916-80.48Q402.67-856 479.866-856q78.559 0 146.853 28.839 68.294 28.84 119.922 80.422 51.627 51.582 80.493 119.841Q856-558.639 856-480.05q0 77.589-28.839 145.826-28.84 68.237-80.408 119.786-51.569 51.548-119.81 80.993Q558.702-104 480.134-104Z'/%3E%3C/svg%3E");
+          margin-right: 12px;
+          font-size: unset;
+          top: -3px;
+          position: relative;
         }
       }
     }
@@ -96,6 +80,10 @@ export const Comment = styled.div`
         ::before {
           /* open circle svg */
           content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='24' viewBox='0 -960 960 960' width='24' fill='%23F4F5F5'%3E%3Cpath d='M480.409-104q-77.588 0-146.165-29.359-68.577-29.36-120.025-80.762-51.447-51.402-80.833-119.876Q104-402.471 104-480.325q0-78.11 29.418-146.412 29.419-68.303 80.922-119.917 51.503-51.614 119.875-80.48Q402.587-856 480.325-856q78.1 0 146.394 28.839 68.294 28.84 119.922 80.422 51.627 51.582 80.493 120.065Q856-558.191 856-480.326q0 77.865-28.839 146.102-28.84 68.237-80.408 119.786-51.569 51.548-120.034 80.993Q558.253-104 480.409-104ZM480-162q132.513 0 225.256-92.744Q798-347.487 798-480t-92.744-225.256Q612.513-798 480-798t-225.256 92.744Q162-612.513 162-480t92.744 225.256Q347.487-162 480-162Zm0-318Z'/%3E%3C/svg%3E");
+          margin-right: 12px;
+          font-size: unset;
+          top: -3px;
+          position: relative;
         }
       }
     }

--- a/src/components/CommentInput/CommentInput.styled.js
+++ b/src/components/CommentInput/CommentInput.styled.js
@@ -61,16 +61,32 @@ export const Comment = styled.div`
 
   /* check box styles */
   .ql-editor ul {
+    /* checkbox data-checked false or true */
+    &[data-checked] {
+      li {
+        height: 25px;
+        /* tick circle */
+        &::before {
+          margin-right: 12px;
+          font-size: unset;
+          top: -2px;
+          position: relative;
+        }
+
+        /* cursor too height */
+        br {
+          position: relative;
+          top: 15px;
+        }
+      }
+    }
+
     &[data-checked='true'] {
       li {
         display: flex;
         ::before {
           /* tick circle svg */
           content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='24' viewBox='0 -960 960 960' width='24' fill='%2323E0A9'%3E%3Cpath d='m427.462-343.692 233.846-232.846L620-617.846 427.462-426.308l-87-86L299.154-471l128.308 127.308ZM480.134-104q-77.313 0-145.89-29.359-68.577-29.36-120.025-80.762-51.447-51.402-80.833-119.917Q104-402.554 104-479.866q0-78.569 29.418-146.871 29.419-68.303 80.922-119.917 51.503-51.614 119.916-80.48Q402.67-856 479.866-856q78.559 0 146.853 28.839 68.294 28.84 119.922 80.422 51.627 51.582 80.493 119.841Q856-558.639 856-480.05q0 77.589-28.839 145.826-28.84 68.237-80.408 119.786-51.569 51.548-119.81 80.993Q558.702-104 480.134-104Z'/%3E%3C/svg%3E");
-          margin-right: 12px;
-          font-size: unset;
-          top: -3px;
-          position: relative;
         }
       }
     }
@@ -80,10 +96,6 @@ export const Comment = styled.div`
         ::before {
           /* open circle svg */
           content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='24' viewBox='0 -960 960 960' width='24' fill='%23F4F5F5'%3E%3Cpath d='M480.409-104q-77.588 0-146.165-29.359-68.577-29.36-120.025-80.762-51.447-51.402-80.833-119.876Q104-402.471 104-480.325q0-78.11 29.418-146.412 29.419-68.303 80.922-119.917 51.503-51.614 119.875-80.48Q402.587-856 480.325-856q78.1 0 146.394 28.839 68.294 28.84 119.922 80.422 51.627 51.582 80.493 120.065Q856-558.191 856-480.326q0 77.865-28.839 146.102-28.84 68.237-80.408 119.786-51.569 51.548-120.034 80.993Q558.253-104 480.409-104ZM480-162q132.513 0 225.256-92.744Q798-347.487 798-480t-92.744-225.256Q612.513-798 480-798t-225.256 92.744Q162-612.513 162-480t92.744 225.256Q347.487-162 480-162Zm0-318Z'/%3E%3C/svg%3E");
-          margin-right: 12px;
-          font-size: unset;
-          top: -3px;
-          position: relative;
         }
       }
     }

--- a/src/components/CommentInput/helpers.jsx
+++ b/src/components/CommentInput/helpers.jsx
@@ -35,6 +35,16 @@ turndownService.addRule('taskListItems', {
   },
 })
 
+// if there is a double backslash followed by text, \\text, replace with \\\ so it resolves to \\text
+turndownService.addRule('doubleBackslash', {
+  filter: function (node) {
+    return node.innerText?.includes('\\\\')
+  },
+  replacement: function (content) {
+    return content.replaceAll('\\\\', '\\\\\\')
+  },
+})
+
 // replace <p> with <br> for line breaks
 const replaceLineBreaks = (html) => {
   return html.replaceAll('<p>', '').replaceAll('</p>', '\n').replaceAll('```', '')

--- a/src/components/CommentInput/helpers.jsx
+++ b/src/components/CommentInput/helpers.jsx
@@ -41,7 +41,7 @@ turndownService.addRule('doubleBackslash', {
     return node.innerText?.includes('\\\\')
   },
   replacement: function (content) {
-    return content.replaceAll('\\\\', '\\\\\\')
+    return content.replaceAll('\\\\', '\\\\\\\\')
   },
 })
 


### PR DESCRIPTION
## PR Checklist

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant) -->

-   [ ] Commenting a file path `D:\\file\to\path` renders as `D:\\file\to\path` with preserved double backslash.
-   [ ] Other uses of `\` to escape characters are preserved.

## Description of changes

Comments with `\\` are replaced with `\\\` so that it will render as `\\` when parsed as markdown.

### Attachments

https://github.com/ynput/ayon-frontend/assets/49156310/9b6ed6ad-447f-4d4c-91b0-54617431d24d

### Additional context

Fixes this specific issue with paths but pasting paths could be way more useable. Maybe a path could be "attached" like an image and have actionable features, like copying or even opening file.
