### PR TITLE
Pinning settings using changelist

### DIFF
--- a/src/containers/AddonSettings/AddonSettings.jsx
+++ b/src/containers/AddonSettings/AddonSettings.jsx
@@ -165,7 +165,7 @@ const AddonSettings = ({ projectName, showSites = false }) => {
 
       const payloadData = {
         ...localData[key],
-        "__pinned_fields__": changedKeys[key]
+        __pinned_fields__: changedKeys[key],
       }
 
       try {

--- a/src/containers/AddonSettings/AddonSettings.jsx
+++ b/src/containers/AddonSettings/AddonSettings.jsx
@@ -143,7 +143,6 @@ const AddonSettings = ({ projectName, showSites = false }) => {
   }
 
   const reloadAddons = (keys) => {
-    console.log('reloadAddons', keys)
     setLocalData((localData) => {
       const newData = {}
       for (const key in localData) {
@@ -164,6 +163,11 @@ const AddonSettings = ({ projectName, showSites = false }) => {
       if (!changedKeys[key]?.length) continue
       const [addonName, addonVersion, variant, siteId, projectName] = key.split('|')
 
+      const payloadData = {
+        ...localData[key],
+        "__pinned_fields__": changedKeys[key]
+      }
+
       try {
         const payload = {
           addonName,
@@ -171,7 +175,7 @@ const AddonSettings = ({ projectName, showSites = false }) => {
           projectName,
           siteId,
           variant,
-          data: localData[key],
+          data: payloadData,
         }
         await setAddonSettings(payload).unwrap()
 

--- a/src/containers/AddonSettings/VariantSelector.jsx
+++ b/src/containers/AddonSettings/VariantSelector.jsx
@@ -22,7 +22,7 @@ const DropdownBadge = styled.span`
   margin-left: 8px;
 `
 
-const DevModeSelector = ({ variant, setVariant, disabled }) => {
+const DevModeSelector = ({ variant, setVariant, disabled, style }) => {
   const { data } = useGetBundleListQuery({})
   const userName = useSelector((state) => state.user.name)
 
@@ -41,6 +41,8 @@ const DevModeSelector = ({ variant, setVariant, disabled }) => {
       active: b.activeUser === userName,
     }))
   }, [bundleList])
+
+  const dropdownStyle = style || { flexGrow: 1 }
 
   const formatValue = (value) => {
     if (!bundleOptions.length) return ''
@@ -79,7 +81,7 @@ const DevModeSelector = ({ variant, setVariant, disabled }) => {
       value={[variant]}
       onChange={(e) => setVariant(e[0])}
       disabled={disabled}
-      style={{ flexGrow: 1 }}
+      style={dropdownStyle}
       valueTemplate={formatValue}
       itemTemplate={(option) => (
         <BundleDropdownItem>
@@ -103,7 +105,7 @@ const DevModeSelector = ({ variant, setVariant, disabled }) => {
   )
 }
 
-const VariantSelector = ({ variant, setVariant, disabled }) => {
+const VariantSelector = ({ variant, setVariant, disabled, style }) => {
   const user = useSelector((state) => state.user)
 
   useEffect(() => {
@@ -113,7 +115,7 @@ const VariantSelector = ({ variant, setVariant, disabled }) => {
   }, [user.attrib.developerMode])
 
   if (user.attrib.developerMode) {
-    return <DevModeSelector variant={variant} setVariant={setVariant} disabled={disabled} />
+    return <DevModeSelector variant={variant} setVariant={setVariant} disabled={disabled} style={style} />
   }
 
   const styleHlProd = {

--- a/src/containers/CopySettings/CopySettingsDialog.jsx
+++ b/src/containers/CopySettings/CopySettingsDialog.jsx
@@ -57,7 +57,7 @@ const CopySettingsDialog = ({
     for (const nodeKey in nodes) {
       const node = nodes[nodeKey]
       if (!(node.available && node.enabled)) continue
-      console.log('Migrating node', node.addonName, node.addonVersion)
+      //console.log('Migrating node', node.addonName, node.addonVersion)
 
       // Define the target addon
       const siteId = '_'

--- a/src/containers/CopySettings/CopySettingsDialog.jsx
+++ b/src/containers/CopySettings/CopySettingsDialog.jsx
@@ -1,6 +1,7 @@
 /* eslint-disable */
 
 import { useState, useMemo } from 'react'
+import { useSelector } from 'react-redux'
 import { toast } from 'react-toastify'
 
 import { ScrollPanel, Button, Spacer, Toolbar, Dialog } from '@ynput/ayon-react-components'
@@ -32,17 +33,20 @@ const CopySettingsDialog = ({
 
   const [sourceBundle, setSourceBundle] = useState(null)
   const [sourceVariant, setSourceVariant] = useState(null)
-  const [sourceProjectName, setSourceProjectName] = useState(null)
+  const [sourceProjectName, setSourceProjectName] = useState(projectName)
 
   const {
     data: bundlesData,
     isLoading: bundlesLoading,
     isError: bundlesError,
-  } = useGetBundleListQuery({}, { skip: !pickByBundle })
+  } = useGetBundleListQuery({})
 
   const sourceVersions = useMemo(() => {
-    if (bundlesLoading || bundlesError) return {}
     if (!sourceBundle) return {}
+
+    if (bundlesLoading || bundlesError) return {}
+
+    if (!bundlesData) return {}
 
     const sb = bundlesData.find((i) => i.name === sourceBundle)
     return sb?.addons || {}
@@ -126,29 +130,50 @@ const CopySettingsDialog = ({
     </div>
   )
 
-  const toolbar = pickByBundle && (
+  const dropSize = 270
+  const dropStyle = { maxWidth: dropSize, minWidth: dropSize, marginRight: 8 }
+
+  const toolbar = (
     <Toolbar>
-      Copy settings from
-      <BundleDropdown
-        style={{ flexGrow: 1 }}
-        bundleName={sourceBundle}
-        setBundleName={setSourceBundle}
-      />
-      <VariantSelector variant={sourceVariant} setVariant={setSourceVariant} />
-      {projectName && (
-        <ProjectDropdown projectName={sourceProjectName} setProjectName={setSourceProjectName} />
+      {pickByBundle && (
+        <>
+          Source bundle:
+          <BundleDropdown
+            style={dropStyle}
+            bundleName={sourceBundle}
+            setBundleName={setSourceBundle}
+            setVariant={setSourceVariant}
+          />
+        </>
       )}
+      Source variant:
+      <VariantSelector
+        variant={sourceVariant}
+        style={dropStyle}
+        setVariant={(val) => {
+          setSourceVariant(val)
+        }}
+      />
       <Spacer />
+      {projectName && (
+        <>
+          Source project:
+          <ProjectDropdown
+            projectName={sourceProjectName}
+            setProjectName={setSourceProjectName}
+            style={{ ...dropStyle, marginRight: 0 }}
+          />
+        </>
+      )}
     </Toolbar>
   )
-
 
   return (
     <Dialog
       isOpen
       onClose={onClose}
-      variant='dialog'
-      size='full'
+      variant="dialog"
+      size="full"
       style={{ width: '80vw', height: '80vh', zIndex: 999 }}
       header={`Copy ${variant} settings ${pickByBundle ? 'by bundle' : ''}`}
       footer={footer}
@@ -185,7 +210,7 @@ const CopySettingsDialog = ({
                   }}
                   forcedSourceVariant={sourceVariant}
                   forcedSourceVersion={pickByBundle ? sourceVersions[addon.name] : null}
-                  forcedSourceProjectName={pickByBundle ? sourceProjectName : null}
+                  forcedSourceProjectName={sourceProjectName || null}
                 />
               ))}
           </div>

--- a/src/containers/CopySettings/CopySettingsNode.jsx
+++ b/src/containers/CopySettings/CopySettingsNode.jsx
@@ -93,6 +93,7 @@ const CopySettingsNode = ({
 
   nodeData,
   setNodeData,
+  setNodeState,
 
   forcedSourceVersion,
   forcedSourceVariant,
@@ -135,6 +136,7 @@ const CopySettingsNode = ({
     if (!sourceVersion || !sourceVariant) return
     if (targetProjectName && !sourceProjectName) return
     setLoading(true)
+    setNodeState('loading')
 
     if (
       sourceVersion === targetVersion &&
@@ -143,6 +145,7 @@ const CopySettingsNode = ({
     ) {
       setNodeData({ message: 'cannot copy from itself' })
       setLoading(false)
+      setNodeState('empty')
       return
     }
 
@@ -213,6 +216,7 @@ const CopySettingsNode = ({
     if (!changes.length) {
       setNodeData({ message: 'no overrides to copy', enabled: false })
       setLoading(false)
+      setNodeState('empty')
       return
     }
 
@@ -228,6 +232,7 @@ const CopySettingsNode = ({
     })
 
     setLoading(false)
+    setNodeState('loaded')
   } //loadNodeData
 
   useEffect(() => {

--- a/src/containers/CopySettings/CopySettingsNode.jsx
+++ b/src/containers/CopySettings/CopySettingsNode.jsx
@@ -164,12 +164,9 @@ const CopySettingsNode = ({
       asVersion: targetVersion,
     })
 
-    // TODO: we may use this to display whether there
-    // is an override or we are replacing with a default value
-
     // const targetOverrides = await triggerGetOverrides({
     //   addonName,
-    //   addonVersion: targetBundleData.addons[addonName],
+    //   addonVersion: targetVersion,
     //   variant: targetVariant,
     // })
 
@@ -195,7 +192,9 @@ const CopySettingsNode = ({
       const targetValue = getValueByPath(targetSettings.data, sourceOverride.path)
 
       // do not attempt to copy if the values are the same
-      if (isEqual(sourceValue, targetValue)) continue
+      // ... or rather do copy it. we want to force pinned overrides
+      // if (isEqual(sourceValue, targetValue))
+      //   continue
 
       //const compatible = sameKeysStructure(sourceValue, targetValue)
       const compatible = isCompatibleStructure(sourceValue, targetValue)

--- a/src/containers/CopySettings/CopySettingsNode.jsx
+++ b/src/containers/CopySettings/CopySettingsNode.jsx
@@ -125,7 +125,6 @@ const CopySettingsNode = ({
 
   useEffect(() => {
     if (forcedSourceProjectName && forcedSourceProjectName !== sourceProjectName) {
-      console.log('forcedSourceProjectName', forcedSourceProjectName)
       setSourceProjectName(forcedSourceProjectName)
     } else if (forcedSourceProjectName === null && sourceProjectName === null) {
       setSourceProjectName(null)

--- a/src/containers/ProjectDropdown.jsx
+++ b/src/containers/ProjectDropdown.jsx
@@ -2,7 +2,7 @@ import { useGetAllProjectsQuery } from '/src/services/project/getProject'
 import { useMemo } from 'react'
 import { Dropdown } from '@ynput/ayon-react-components'
 
-const ProjectDropdown = ({ projectName, setProjectName, disabled }) => {
+const ProjectDropdown = ({ projectName, setProjectName, disabled, style }) => {
   const { data, isLoading, isError } = useGetAllProjectsQuery({ showInactive: false })
 
   const projectOptions = useMemo(() => {
@@ -10,13 +10,17 @@ const ProjectDropdown = ({ projectName, setProjectName, disabled }) => {
     return data.map((i) => ({ value: i.name }))
   }, [data])
 
+  let dropwdownStyle = {}
+  if (style) dropwdownStyle = style
+  else dropwdownStyle.flexGrow = 1
+
   return (
     <Dropdown
       value={projectName ? [projectName] : null}
       options={projectOptions}
       onChange={(e) => setProjectName(e[0])}
       placeholder="Select a project"
-      style={{ flexGrow: 1 }}
+      style={dropwdownStyle}
       disabled={disabled}
     />
   )

--- a/src/containers/SettingsEditor/fields.jsx
+++ b/src/containers/SettingsEditor/fields.jsx
@@ -189,7 +189,7 @@ function ObjectFieldTemplate(props) {
       const rmPath = override?.inGroup || path || ['root']
       if (props.formContext.onPinOverride)
         model.push({
-          label: `Pin current ${rmPath[rmPath.length - 1]} value as ${
+          label: `Add current ${rmPath[rmPath.length - 1]} value as ${
             props.formContext.level
           } override`,
           command: () => props.formContext.onPinOverride(rmPath),
@@ -349,7 +349,7 @@ function FieldTemplate(props) {
 
     if (props.formContext.onPinOverride)
       model.push({
-        label: `Pin current ${rmPath[rmPath.length - 1]} value as ${
+        label: `Add current ${rmPath[rmPath.length - 1]} value as ${
           props.formContext.level
         } override`,
         command: () => props.formContext.onPinOverride(rmPath),

--- a/src/containers/SettingsEditor/widgets.jsx
+++ b/src/containers/SettingsEditor/widgets.jsx
@@ -15,7 +15,8 @@ import { isEqual } from 'lodash'
 const updateChangedKeys = (props, changed, path) => {
   if (!props.formContext) return // WARN! (but shouldn't happen)
   if (!path?.length) return // WARN!
-  props.formContext.onSetChangedKeys([{ path, isChanged: changed }])
+  if (!changed) return
+  props.formContext.onSetChangedKeys([{ path, isChanged: true }])
 }
 
 const equiv = (a, b) => {


### PR DESCRIPTION
## PR Checklist

-   [x] This comment contains a description of changes
-   [x] Referenced issue is linked

## Description of changes

To be able to migrate settings including "pinned defaults" we need to have a way how to send "pin information" along with the settings payload without relying on additional endpoints (pinOverride, removeOverride). 

### Technical details

Fortunately for us, set_settings endpoints accept arbitrary dictionaries and not a strict model, so the frontend can send an additional well-known field `__pinned_fields__` along with the payload. This field would be extracted before storing the settings and passed to extract_overrides function on the backend, which will use it to ... do some magic.

Frontend-wise, that **should** be straightforward, we can get this information from the changes table. Existing system of pinning overrides could be replaced by just adding the field to changes. Additionally, changes table should accept a change, once the value changes, but don't remove the change when the value changes back - removing fields from the changes table should be done strictly by clicking the trash icon.

### Steps

- [x] In copy settings dialog, do not filter out fields with the same value on source and target
- [x] Prevent removing items from changes table when value changes to the original value
- [x] include `__pinned_fields__` in the set_settings payload