### PR TITLE
fix(bundles): ensure only addons that are still installed copy across

### DIFF
--- a/src/pages/SettingsPage/Bundles/Bundles.jsx
+++ b/src/pages/SettingsPage/Bundles/Bundles.jsx
@@ -222,9 +222,18 @@ const Bundles = () => {
       newName = getVersionedName(newName)
     }
 
+    const duplicatedAddons = { ...bundle.addons }
+    const installedAddonNames = new Set(addons.map((a) => a.name))
+    // ensure that all addons are installed and delete the ones that are not
+    for (const addonName in duplicatedAddons) {
+      if (!installedAddonNames.has(addonName)) {
+        delete duplicatedAddons[addonName]
+      }
+    }
+
     setNewBundleOpen({
       name: newName,
-      addons: bundle.addons,
+      addons: duplicatedAddons,
       installerVersion: bundle.installerVersion,
       dependencyPackages: bundle.dependencyPackages,
       isArchived: false,


### PR DESCRIPTION
## PR Checklist

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant) -->

-   [ ] Duplicate a bundle that once had a deleted addon (no idea how you know this)
-   [ ] You shouldn't get compatibility error `{addon_name}: {addon_name} {addon_version} is not active`

## Description of changes

When duplicating a bundle, ensure that are addons that are now **not** installed are removed from the new bundle.
