### PR TITLE
fix(dev): ignore switch events to pass event up to button

### DIFF
--- a/src/containers/header/AppHeader.jsx
+++ b/src/containers/header/AppHeader.jsx
@@ -60,6 +60,7 @@ const StyledSwitch = styled(InputSwitch)`
       }
     }
   }
+  pointer-events: none;
 `
 
 const Header = () => {


### PR DESCRIPTION
## PR Checklist

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant) -->

-   [ ] Clicking anywhere on the button (including the switch) should toggle the switch.

![image](https://github.com/ynput/ayon-frontend/assets/49156310/db33dbc2-6055-4925-9436-7885d5201eed)


## Description of changes

<!-- Please state what you've changed and how it might affect the user. -->

Fixes an issue where clicking on the actual switch wouldn't work.

## Technical details

<!-- Please state any technical details such as limitations -->
<!-- reasons for additional dependencies, benchmarks etc. here. -->

The switch was blocking the onClick event from propagating up to the button.
