### PR TITLE
Feed: hide activity tools for versions

### DIFF
--- a/src/components/Feed/ActivityHeader/ActivityHeader.jsx
+++ b/src/components/Feed/ActivityHeader/ActivityHeader.jsx
@@ -72,20 +72,21 @@ const ActivityHeader = ({
 
         {/* custom children, like status change */}
         {children}
-
-        <Styled.Tools className={'tools'} ref={moreRef}>
-          {isOwner && onEdit && (
-            <Styled.ToolButton icon="edit_square" variant="text" onClick={onEdit} />
-          )}
-          {isOwner && (
-            <Styled.ToolButton
-              icon="more_horiz"
-              variant="text"
-              className="more"
-              onClick={() => handleToggleMenu(id)}
-            />
-          )}
-        </Styled.Tools>
+        {!isPublish && (
+          <Styled.Tools className={'tools'} ref={moreRef}>
+            {isOwner && onEdit && (
+              <Styled.ToolButton icon="edit_square" variant="text" onClick={onEdit} />
+            )}
+            {isOwner && (
+              <Styled.ToolButton
+                icon="more_horiz"
+                variant="text"
+                className="more"
+                onClick={() => handleToggleMenu(id)}
+              />
+            )}
+          </Styled.Tools>
+        )}
 
         <MenuContainer id={id} target={moreRef.current}>
           <ActivityCommentMenu onDelete={() => isOwner && onDelete()} />


### PR DESCRIPTION
## Description of changes

Fixes an issue where the tools menu icon would show on published versions in the feed.

Thanks @BigRoy 

### Additional context

![image](https://github.com/ynput/ayon-frontend/assets/49156310/1919c6ae-16d7-4d91-8562-c8381095e343)
