### PR TITLE
Details Panel: Only animate panel once

### DIFF
--- a/src/components/CommentInput/CommentInput.jsx
+++ b/src/components/CommentInput/CommentInput.jsx
@@ -39,6 +39,7 @@ const CommentInput = ({
   isEditing,
   filter,
   disabled,
+  isLoading,
 }) => {
   const currentUser = useSelector((state) => state.user.name)
 
@@ -483,6 +484,7 @@ const CommentInput = ({
             isEditing,
             isDropping,
             disabled,
+            isLoading,
           })}
           onKeyDown={handleKeyDown}
           onClick={handleOpenClick}

--- a/src/components/CommentInput/CommentInput.jsx
+++ b/src/components/CommentInput/CommentInput.jsx
@@ -197,9 +197,6 @@ const CommentInput = ({
       return
     }
 
-    const quill = editorRef.current.getEditor()
-    console.log(quill.getContents())
-
     setEditorValue(content)
 
     const isDelete = delta.ops.length === 2 && delta.ops[1].delete

--- a/src/components/CommentInput/CommentInput.styled.js
+++ b/src/components/CommentInput/CommentInput.styled.js
@@ -240,6 +240,12 @@ export const Comment = styled.div`
     background-color: var(--md-sys-color-surface-container-lowest);
   }
 
+  &.isLoading {
+    cursor: default;
+    pointer-events: none;
+    user-select: none;
+  }
+
   /* toolbar styles */
   .ql-toolbar.ql-snow {
     border: none;

--- a/src/containers/DetailsPanel/DetailsPanel.jsx
+++ b/src/containers/DetailsPanel/DetailsPanel.jsx
@@ -116,7 +116,7 @@ const DetailsPanel = ({
         {selectedTab === 'feed' && !isError && (
           <Feed
             entityType={entityType}
-            entities={entityDetailsData}
+            entities={isFetchingEntitiesDetails ? entitiesToQuery : entityDetailsData}
             activeUsers={activeProjectUsers}
             selectedTasksProjects={selectedTasksProjects}
             projectInfo={firstProjectInfo}

--- a/src/containers/DetailsPanel/DetailsPanelSlideOut/DetailsPanelSlideOut.jsx
+++ b/src/containers/DetailsPanel/DetailsPanelSlideOut/DetailsPanelSlideOut.jsx
@@ -4,38 +4,12 @@ import { closeSlideOut } from '/src/features/details'
 import DetailsPanel from '../DetailsPanel'
 import { useGetUsersAssigneeQuery } from '/src/services/user/getUsers'
 import Shortcuts from '/src/containers/Shortcuts'
-import { useEffect, useState } from 'react'
-import { classNames } from 'primereact/utils'
 
 const DetailsPanelSlideOut = ({ projectsInfo, scope }) => {
   const dispatch = useDispatch()
   const slideOut = useSelector((state) => state.details.slideOut[scope])
   const { entityType, entityId, projectName } = slideOut
   const isSlideOutOpen = entityType && entityId && projectName
-
-  const [previouslyOpen, setPreviouslyOpen] = useState(false)
-  const [slideOutShown, setSlideOutShown] = useState(false)
-
-  useEffect(() => {
-    let slideTimeOut
-    if (isSlideOutOpen) {
-      if (!previouslyOpen) {
-        // show slide out when opening new one
-        setPreviouslyOpen(true)
-        setSlideOutShown(true)
-      } else {
-        // hide slide out when loading new one
-        setSlideOutShown(false)
-        // then show slide out when new one is loaded
-        slideTimeOut = setTimeout(() => setSlideOutShown(true), 500)
-      }
-    }
-
-    return () => {
-      slideTimeOut && clearTimeout(slideTimeOut)
-      setSlideOutShown(false)
-    }
-  }, [isSlideOutOpen, entityId])
 
   const { data: users } = useGetUsersAssigneeQuery({ projectName }, { skip: !projectName })
 
@@ -49,7 +23,7 @@ const DetailsPanelSlideOut = ({ projectsInfo, scope }) => {
   }
 
   return (
-    <Styled.SlideOut className={classNames({ slideOutShown })}>
+    <Styled.SlideOut>
       <DetailsPanel
         entityType={entityType}
         entities={[{ id: entityId, projectName }]}

--- a/src/containers/DetailsPanel/DetailsPanelSlideOut/DetailsPanelSlideOut.styled.js
+++ b/src/containers/DetailsPanel/DetailsPanelSlideOut/DetailsPanelSlideOut.styled.js
@@ -21,5 +21,5 @@ export const SlideOut = styled.div`
 
   z-index: 200;
 
-  animation: ${slideOutFromRight} 0.3s forwards;
+  animation: ${slideOutFromRight} 0.2s ease forwards;
 `

--- a/src/containers/DetailsPanel/DetailsPanelSlideOut/DetailsPanelSlideOut.styled.js
+++ b/src/containers/DetailsPanel/DetailsPanelSlideOut/DetailsPanelSlideOut.styled.js
@@ -21,12 +21,5 @@ export const SlideOut = styled.div`
 
   z-index: 200;
 
-  transition: translate 300ms ease;
-  translate: 0 0;
-
-  &.slideOutShown {
-    translate: calc(-100% - 8px) 0;
-  }
-
-  /* animation: ${slideOutFromRight} 0.3s forwards; */
+  animation: ${slideOutFromRight} 0.3s forwards;
 `

--- a/src/containers/Feed/Feed.styled.js
+++ b/src/containers/Feed/Feed.styled.js
@@ -57,7 +57,7 @@ export const LoadMore = styled.span`
 `
 
 export const Placeholder = styled.div`
-  height: 100px;
+  height: 50px;
   background-color: var(--md-sys-color-surface-container-low);
   border-radius: 8px;
   overflow: hidden;

--- a/src/containers/Feed/Feed.styled.js
+++ b/src/containers/Feed/Feed.styled.js
@@ -39,6 +39,7 @@ export const FeedContent = styled.div`
   gap: var(--base-gap-large);
   overflow-y: auto;
   padding-bottom: 40px;
+  scrollbar-gutter: stable;
 
   display: flex;
   flex-direction: column;

--- a/src/containers/Feed/feedHelpers.jsx
+++ b/src/containers/Feed/feedHelpers.jsx
@@ -23,5 +23,5 @@ export const getLoadingPlaceholders = (amount) =>
   new Array(amount)
     .fill(0)
     .map((_, index) => (
-      <Styled.Placeholder key={index} style={{ minHeight: getRandomNumberBetween(50, 200) }} />
+      <Styled.Placeholder key={index} style={{ minHeight: getRandomNumberBetween(50, 150) }} />
     ))


### PR DESCRIPTION
## Description of changes

- Animate the panel in once rather than everytime it changes.
- Improve the loading placeholders and timing of the feed.
- Fix loading entity and then activities waterfall.

### Additional context



https://github.com/ynput/ayon-frontend/assets/49156310/10ebf03b-194a-457f-ad9f-c2351dac1730

