### PR TITLE
Market: replaced 'install' with 'download'

### DIFF
--- a/src/components/MarketAddonCard/MarketAddonCard.jsx
+++ b/src/components/MarketAddonCard/MarketAddonCard.jsx
@@ -24,11 +24,11 @@ const MarketAddonCard = ({
   onInstall,
   ...props
 }) => {
-  let state = 'install'
-  if (isInstalled && !isOutdated) state = 'installed'
+  let state = 'download'
+  if (isInstalled && !isOutdated) state = 'downloaded'
   if (isInstalled && isOutdated) state = 'update'
   if (isWaiting) state = 'pending'
-  if (isInstalling) state = isInstalled && isOutdated ? 'updating' : 'installing'
+  if (isInstalling) state = isInstalled && isOutdated ? 'updating' : 'downloading'
   if (isFailed) state = 'failed'
   if (isFinished) state = 'finished'
 

--- a/src/components/MarketAddonCard/MarketAddonCard.jsx
+++ b/src/components/MarketAddonCard/MarketAddonCard.jsx
@@ -43,7 +43,7 @@ const MarketAddonCard = ({
   if (state === 'update') stateVariant = 'filled'
 
   const handleActionClick = () => {
-    if (['install', 'update'].includes(state)) {
+    if (['download', 'update'].includes(state)) {
       onInstall(name, latestVersion)
     }
   }

--- a/src/components/MarketAddonCard/MarketAddonCard.styled.js
+++ b/src/components/MarketAddonCard/MarketAddonCard.styled.js
@@ -83,8 +83,8 @@ export const Tag = styled(Button)`
 
   gap: var(--base-gap-small);
 
-  &.installed,
-  &.installing,
+  &.downloaded,
+  &.downloading,
   &.pending,
   &.updating,
   &.finished {
@@ -92,12 +92,12 @@ export const Tag = styled(Button)`
     user-select: none;
   }
 
-  &.installed {
+  &.downloaded {
     opacity: 0.5;
     font-style: italic;
   }
 
-  &.installing,
+  &.downloading,
   &.updating {
     .icon {
       user-select: none;

--- a/src/pages/MarketPage/AddonDetails/AddonDetails.jsx
+++ b/src/pages/MarketPage/AddonDetails/AddonDetails.jsx
@@ -85,7 +85,7 @@ const AddonDetails = ({ addon = {}, isLoading, onInstall, isUpdatingAll }) => {
   if (isInstalling) {
     actionButton = (
       <SaveButton active saving disabled>
-        {isOutdated ? 'Updating' : 'Downloading'}...
+        Downloading...
       </SaveButton>
     )
   } else if (isFinished) {

--- a/src/pages/MarketPage/AddonDetails/AddonDetails.jsx
+++ b/src/pages/MarketPage/AddonDetails/AddonDetails.jsx
@@ -91,7 +91,7 @@ const AddonDetails = ({ addon = {}, isLoading, onInstall, isUpdatingAll }) => {
   } else if (isFinished) {
     actionButton = (
       <Button disabled icon={'check_circle'}>
-        Installed!
+        Downloaded !
       </Button>
     )
   } else if (isUpdatingAll) {
@@ -106,14 +106,14 @@ const AddonDetails = ({ addon = {}, isLoading, onInstall, isUpdatingAll }) => {
     actionButton = (
       <Button
         variant="filled"
-        icon={'upgrade'}
+        icon={'download_for_offline'}
         onClick={handleInstall}
-      >{`Update to v${latestVersion}`}</Button>
+      >{`Download v${latestVersion}`}</Button>
     )
   } else if (latestVersion) {
     actionButton = (
       <Button variant="filled" icon={'download_for_offline'} onClick={handleInstall}>
-        {`Install v${latestVersion}`}
+        {`Download v${latestVersion}`}
       </Button>
     )
   }
@@ -158,10 +158,10 @@ const AddonDetails = ({ addon = {}, isLoading, onInstall, isUpdatingAll }) => {
           <Styled.Right className={classNames(Type.bodyMedium, { isLoading })}>
             {actionButton}
             <Styled.MetaPanel className={classNames({ isPlaceholder: isLoading })}>
-              <MetaPanelRow label="Installed Versions">
+              <MetaPanelRow label="Downloaded Versions">
                 {versionsToShow.length
                   ? versionsToShow.map((version) => <span key={version}>{version}</span>)
-                  : 'Not installed'}
+                  : 'Not downloaded'}
                 {!!nOfMoreVersions && (
                   <span className="more" onClick={() => setShowAllVersions(true)}>
                     +{nOfMoreVersions} more

--- a/src/pages/MarketPage/AddonDetails/AddonDetails.jsx
+++ b/src/pages/MarketPage/AddonDetails/AddonDetails.jsx
@@ -106,7 +106,7 @@ const AddonDetails = ({ addon = {}, isLoading, onInstall, isUpdatingAll }) => {
     actionButton = (
       <Button
         variant="filled"
-        icon={'download_for_offline'}
+        icon={'download'}
         onClick={handleInstall}
       >{`Download v${latestVersion}`}</Button>
     )

--- a/src/pages/MarketPage/AddonDetails/AddonDetails.jsx
+++ b/src/pages/MarketPage/AddonDetails/AddonDetails.jsx
@@ -85,7 +85,7 @@ const AddonDetails = ({ addon = {}, isLoading, onInstall, isUpdatingAll }) => {
   if (isInstalling) {
     actionButton = (
       <SaveButton active saving disabled>
-        {isOutdated ? 'Updating' : 'Installing'}...
+        {isOutdated ? 'Updating' : 'Downloading'}...
       </SaveButton>
     )
   } else if (isFinished) {
@@ -106,13 +106,13 @@ const AddonDetails = ({ addon = {}, isLoading, onInstall, isUpdatingAll }) => {
     actionButton = (
       <Button
         variant="filled"
-        icon={'download'}
+        icon={'download_for_offline'}
         onClick={handleInstall}
       >{`Download v${latestVersion}`}</Button>
     )
   } else if (latestVersion) {
     actionButton = (
-      <Button variant="filled" icon={'download_for_offline'} onClick={handleInstall}>
+      <Button variant="filled" icon={'download'} onClick={handleInstall}>
         {`Download v${latestVersion}`}
       </Button>
     )

--- a/src/pages/MarketPage/AddonFilters.jsx
+++ b/src/pages/MarketPage/AddonFilters.jsx
@@ -42,7 +42,7 @@ const AddonFilters = ({ onSelect, onConnection }) => {
       id: 'all',
       name: 'All',
       filter: [],
-      tooltip: 'All addons, installed or not',
+      tooltip: 'All addons, downloaded or not',
     },
     {
       id: 'updates',
@@ -67,7 +67,7 @@ const AddonFilters = ({ onSelect, onConnection }) => {
 
     {
       id: 'uninstalled',
-      name: 'Not Installed',
+      name: 'Not Downloaded',
       filter: [{ isInstalled: false }],
       tooltip: 'Addons available to install',
     },

--- a/src/pages/MarketPage/AddonFilters.jsx
+++ b/src/pages/MarketPage/AddonFilters.jsx
@@ -67,9 +67,9 @@ const AddonFilters = ({ onSelect, onConnection }) => {
 
     {
       id: 'uninstalled',
-      name: 'Not Downloaded',
+      name: 'Downloads Available',
       filter: [{ isInstalled: false }],
-      tooltip: 'Addons available to install',
+      tooltip: 'Addons available to download',
     },
   ]
 

--- a/src/pages/MarketPage/MarketAddonsList.jsx
+++ b/src/pages/MarketPage/MarketAddonsList.jsx
@@ -130,7 +130,6 @@ const MarketAddonsList = ({
               onInstall={onInstall}
               name={name}
               {...props}
-              x
             />
           )
         })}

--- a/src/pages/MarketPage/MarketAddonsList.jsx
+++ b/src/pages/MarketPage/MarketAddonsList.jsx
@@ -110,7 +110,7 @@ const MarketAddonsList = ({
           <Tag
             icon={isUpdatingAll ? 'sync' : isUpdatingAllFinished ? 'check_circle' : 'upgrade'}
             onClick={onUpdateAll}
-            className={isUpdatingAll ? 'installing' : ''}
+            className={isUpdatingAll ? 'downloading' : ''}
             disabled={isUpdatingAll || isUpdatingAllFinished}
           >
             {isUpdatingAll ? 'Updating...' : isUpdatingAllFinished ? 'All Updated' : 'Update All'}


### PR DESCRIPTION
## Description of changes

- replaced _install_ with _download_ (and respective word variations)
- implemented in multiple places across addons market (not just button)
- replaced "Not installed" section with "Downloads available" ( since we already have "Updates Available")
- replaced icons `upgrade` or `download_for_offline` with `download`

### Additional context



https://github.com/ynput/ayon-frontend/assets/16327908/d8e8f2a0-237f-4458-9af5-41d52819b934





