### PR TITLE
Onboarding: Show addon version when selecting addons

### DIFF
--- a/src/components/AddonCard/AddonCard.jsx
+++ b/src/components/AddonCard/AddonCard.jsx
@@ -10,7 +10,7 @@ const AddonCard = React.forwardRef(
         <Icon icon={icon} />
         <span className={Type.titleSmall}>{title || name}</span>
         {error && <span className="error">{error}</span>}
-        {version && <span>{version}</span>}
+        {version && <span className="version">{version}</span>}
       </Styled.AddonCard>
     )
   },

--- a/src/components/AddonCard/AddonCard.jsx
+++ b/src/components/AddonCard/AddonCard.jsx
@@ -10,7 +10,7 @@ const AddonCard = React.forwardRef(
         <Icon icon={icon} />
         <span className={Type.titleSmall}>{title || name}</span>
         {error && <span className="error">{error}</span>}
-        {version && <span className="error">{version}</span>}
+        {version && <span>{version}</span>}
       </Styled.AddonCard>
     )
   },

--- a/src/components/AddonCard/AddonCard.jsx
+++ b/src/components/AddonCard/AddonCard.jsx
@@ -4,12 +4,14 @@ import { Icon } from '@ynput/ayon-react-components'
 import Type from '/src/theme/typography.module.css'
 
 const AddonCard = React.forwardRef(
-  ({ name, icon = 'check_circle', isSelected, error, ...props }, ref) => {
+  ({ name, icon = 'check_circle', isSelected, error, version, ...props }, ref) => {
+    console.log(version,'version')
     return (
       <Styled.AddonCard ref={ref} $selected={isSelected} $error={!!error} {...props}>
         <Icon icon={icon} />
         <span className={Type.titleSmall}>{name}</span>
         {error && <span className="error">{error}</span>}
+        {version && <span className="error">{version}</span>}
       </Styled.AddonCard>
     )
   },

--- a/src/components/AddonCard/AddonCard.jsx
+++ b/src/components/AddonCard/AddonCard.jsx
@@ -4,12 +4,11 @@ import { Icon } from '@ynput/ayon-react-components'
 import Type from '/src/theme/typography.module.css'
 
 const AddonCard = React.forwardRef(
-  ({ name, icon = 'check_circle', isSelected, error, version, ...props }, ref) => {
-    console.log(version,'version')
+  ({ name, icon = 'check_circle', isSelected, error, version, title, ...props }, ref) => {
     return (
       <Styled.AddonCard ref={ref} $selected={isSelected} $error={!!error} {...props}>
         <Icon icon={icon} />
-        <span className={Type.titleSmall}>{name}</span>
+        <span className={Type.titleSmall}>{title || name}</span>
         {error && <span className="error">{error}</span>}
         {version && <span className="error">{version}</span>}
       </Styled.AddonCard>

--- a/src/components/AddonCard/AddonCard.styled.jsx
+++ b/src/components/AddonCard/AddonCard.styled.jsx
@@ -71,4 +71,8 @@ export const AddonCard = styled.button`
     background-color: unset;
     color: var(--md-sys-color-on-error-container);
   }
+
+  .version {
+    margin-left: auto;
+  }
 `

--- a/src/pages/OnBoarding/Step/AddonSelectStep.jsx
+++ b/src/pages/OnBoarding/Step/AddonSelectStep.jsx
@@ -52,8 +52,8 @@ export const AddonSelectStep = ({
 
   const { data: allAddons = [] } = useGetAddonListQuery()
   const addonsWithVersions = sortedAddons.map((addonName) => {
-    const matchingAddon = allAddons.find((addon) => addon.name === addonName);
-    return matchingAddon ? { ...matchingAddon } : { name: addonName };
+    const matchingAddon = allAddons.find((addon) => addon.name === addonName)
+    return matchingAddon ? { ...matchingAddon } : { name: addonName }
   });
   console.log(addonsWithVersions,'addonsWithVersions')
   console.log(sortedAddons,'sortedAddons')
@@ -63,8 +63,7 @@ export const AddonSelectStep = ({
     <Styled.Section>
       <Header>Pick your Addons</Header>
       <Styled.AddonsContainer>
-        {addonsWithVersions.map(
-          (addon) =>
+        {addonsWithVersions.map((addon) => 
             !mandatory.includes(addon.name) && (
               <AddonCard
                 key={addon.name}

--- a/src/pages/OnBoarding/Step/AddonSelectStep.jsx
+++ b/src/pages/OnBoarding/Step/AddonSelectStep.jsx
@@ -53,7 +53,7 @@ export const AddonSelectStep = ({
     <Styled.Section>
       <Header>Pick your Addons</Header>
       <Styled.AddonsContainer>
-        {!isLoadingAddons
+        {isLoadingAddons
         ? 
           placeholders.map((placeholder) => (
               <Styled.PlaceholderCard

--- a/src/pages/OnBoarding/Step/AddonSelectStep.jsx
+++ b/src/pages/OnBoarding/Step/AddonSelectStep.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react'
 import * as Styled from '../util/OnBoardingStep.styled'
 import AddonCard from '/src/components/AddonCard/AddonCard'
+import { useGetAddonListQuery } from '/src/services/addons/getAddons'
 
 export const AddonSelectStep = ({
   Header,
@@ -48,19 +49,30 @@ export const AddonSelectStep = ({
     }
   }
 
+
+  const { data: allAddons = [] } = useGetAddonListQuery()
+  const addonsWithVersions = sortedAddons.map((addonName) => {
+    const matchingAddon = allAddons.find((addon) => addon.name === addonName);
+    return matchingAddon ? { ...matchingAddon } : { name: addonName };
+  });
+  console.log(addonsWithVersions,'addonsWithVersions')
+  console.log(sortedAddons,'sortedAddons')
+  console.log(selectedAddons,'selectedAddons')
+
   return (
     <Styled.Section>
       <Header>Pick your Addons</Header>
       <Styled.AddonsContainer>
-        {sortedAddons.map(
+        {addonsWithVersions.map(
           (addon) =>
-            !mandatory.includes(addon) && (
+            !mandatory.includes(addon.name) && (
               <AddonCard
-                key={addon}
-                name={addon}
-                icon={selectedAddons.includes(addon) ? 'check_circle' : 'circle'}
-                isSelected={selectedAddons.includes(addon)}
-                onClick={() => handleAddonClick(addon)}
+                key={addon.name}
+                name={addon.name}
+                version={addon.productionVersion}
+                icon={selectedAddons.includes(addon.name) ? 'check_circle' : 'circle'}
+                isSelected={selectedAddons.includes(addon.name)}
+                onClick={() => handleAddonClick(addon.name)}
               />
             ),
         )}

--- a/src/pages/OnBoarding/Step/AddonSelectStep.jsx
+++ b/src/pages/OnBoarding/Step/AddonSelectStep.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react'
 import * as Styled from '../util/OnBoardingStep.styled'
 import AddonCard from '/src/components/AddonCard/AddonCard'
-import { useGetReleaseQuery } from '/src/services/onBoarding/onBoarding'
 
 export const AddonSelectStep = ({
   Header,
@@ -9,26 +8,22 @@ export const AddonSelectStep = ({
   selectedAddons = [],
   selectedPreset,
   releases = [],
+  release = {},
   setSelectedAddons,
   onSubmit,
   isLoadingRelease,
+  isLoadingAddons,
 }) => {
-  // FIX: get release by name from /api/onboarding/release/:name
-  // for now import release.230807.json
 
   const [sortedAddons, setSortedAddons] = useState([])
 
-  const { data: currentRelease = {} } = useGetReleaseQuery(
-    { name: selectedPreset },
-    { skip: !selectedPreset },
-  )
 
-  const release = useMemo(
-    () => releases.find((release) => release.name === selectedPreset),
-    [selectedPreset, releases],
-  )
-  const addons = useMemo(() => currentRelease?.addons || [], [currentRelease])
-  const mandatory = useMemo(() => release?.mandatoryAddons || [], [release])
+   const currentRelease = useMemo(
+     () => releases.find((release) => release.name === selectedPreset),
+     [selectedPreset, releases],
+   )
+  const addons = useMemo(() => release?.addons || [], [release])
+  const mandatory = useMemo(() => currentRelease?.mandatoryAddons || [], [currentRelease])
 
   useEffect(() => {
     const sortedAddons = [...addons]
@@ -38,12 +33,10 @@ export const AddonSelectStep = ({
       const bSelected = selectedAddons.includes(b.name)
       if (aSelected && !bSelected) return -1
       if (!aSelected && bSelected) return 1
-      if (mandatory.includes(a.name) && !mandatory.includes(b.name)) return -1
-      if (!mandatory.includes(a.name) && mandatory.includes(b.name)) return 1
       return 0
     })
     setSortedAddons(sortedAddons)
-  }, [releases, currentRelease])
+  }, [releases, release])
 
   const handleAddonClick = (name) => {
     // if it's already selected, remove it
@@ -57,19 +50,20 @@ export const AddonSelectStep = ({
   return (
     <Styled.Section>
       <Header>Pick your Addons</Header>
+      {isLoadingAddons && <Styled.Spinner />}
       <Styled.AddonsContainer>
-         {sortedAddons.map((addon) => 
-            !mandatory.includes(addon.name) && (
-              <AddonCard
-                key={addon.name}
-                title={addon.title}
-                name={addon.name}
-                version={addon.version}
-                icon={selectedAddons.includes(addon.name) ? 'check_circle' : 'circle'}
-                isSelected={selectedAddons.includes(addon.name)}
-                onClick={() => handleAddonClick(addon.name)}
-              />
-            ),
+        {sortedAddons.map((addon) => 
+          !mandatory.includes(addon.name) && (
+            <AddonCard
+              key={addon.name}
+              title={addon.title}
+              name={addon.name}
+              version={addon.version}
+              icon={selectedAddons.includes(addon.name) ? 'check_circle' : 'circle'}
+              isSelected={selectedAddons.includes(addon.name)}
+              onClick={() => handleAddonClick(addon.name)}
+            />
+          ),
         )}
       </Styled.AddonsContainer>
       <Footer

--- a/src/pages/OnBoarding/Step/AddonSelectStep.jsx
+++ b/src/pages/OnBoarding/Step/AddonSelectStep.jsx
@@ -47,12 +47,22 @@ export const AddonSelectStep = ({
     }
   }
 
+  const placeholders = [...Array(20)].map((_, i) => ({name: `Addon ${i}`}))
+
   return (
     <Styled.Section>
       <Header>Pick your Addons</Header>
-      {isLoadingAddons && <Styled.Spinner />}
       <Styled.AddonsContainer>
-        {sortedAddons.map((addon) => 
+        {!isLoadingAddons
+        ? 
+          placeholders.map((placeholder) => (
+              <Styled.PlaceholderCard
+                key={placeholder.name}
+                icon={''}
+            />
+          ))
+        :
+          sortedAddons.map((addon) => 
           !mandatory.includes(addon.name) && (
             <AddonCard
               key={addon.name}
@@ -63,8 +73,8 @@ export const AddonSelectStep = ({
               isSelected={selectedAddons.includes(addon.name)}
               onClick={() => handleAddonClick(addon.name)}
             />
-          ),
-        )}
+          ))
+        }
       </Styled.AddonsContainer>
       <Footer
         next="Confirm"

--- a/src/pages/OnBoarding/Step/AddonSelectStep.jsx
+++ b/src/pages/OnBoarding/Step/AddonSelectStep.jsx
@@ -18,21 +18,8 @@ export const AddonSelectStep = ({
     () => releases.find((release) => release.name === selectedPreset),
     [selectedPreset, releases],
   )
-  const addons = useMemo(() => release?.addons || [], [release])
-  const mandatory = useMemo(() => currentRelease?.mandatoryAddons || [], [currentRelease])
-
-  const sortedAddons = useMemo(() => {
-    const sortedAddons = [...addons]
-    // order addons by selected
-    sortedAddons.sort((a, b) => {
-      const aSelected = selectedAddons.includes(a.name)
-      const bSelected = selectedAddons.includes(b.name)
-      if (aSelected && !bSelected) return -1
-      if (!aSelected && bSelected) return 1
-      return 0
-    })
-    return sortedAddons
-  }, [releases, release])
+  const { mandatoryAddons: mandatory = [] } = currentRelease || {}
+  const { addons = [] } = release || {}
 
   const handleAddonClick = (name) => {
     // if it's already selected, remove it
@@ -43,17 +30,15 @@ export const AddonSelectStep = ({
     }
   }
 
-  const placeholders = [...Array(20)].map((_, i) => ({ name: `Addon ${i}` }))
-
   return (
     <Styled.Section>
       <Header>Pick your Addons</Header>
       <Styled.AddonsContainer>
         {isLoadingAddons
-          ? placeholders.map((placeholder) => (
+          ? releases.map((placeholder) => (
               <Styled.PlaceholderCard key={placeholder.name} icon={''} />
             ))
-          : sortedAddons.map(
+          : addons.map(
               (addon) =>
                 !mandatory.includes(addon.name) && (
                   <AddonCard

--- a/src/pages/OnBoarding/Step/AddonSelectStep.jsx
+++ b/src/pages/OnBoarding/Step/AddonSelectStep.jsx
@@ -30,13 +30,16 @@ export const AddonSelectStep = ({
     }
   }
 
+  // selected release has addons length, so use that as placeholders
+  const placeholders = currentRelease?.addons || [...Array(20)].map((_, i) => `Addon ${i}`)
+
   return (
     <Styled.Section>
       <Header>Pick your Addons</Header>
       <Styled.AddonsContainer>
         {isLoadingAddons
-          ? releases.map((placeholder) => (
-              <Styled.PlaceholderCard key={placeholder.name} icon={''} />
+          ? placeholders.map((placeholder) => (
+              <Styled.PlaceholderCard key={placeholder} icon={''} />
             ))
           : addons.map(
               (addon) =>

--- a/src/pages/OnBoarding/Step/AddonSelectStep.jsx
+++ b/src/pages/OnBoarding/Step/AddonSelectStep.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useMemo } from 'react'
 import * as Styled from '../util/OnBoardingStep.styled'
 import AddonCard from '/src/components/AddonCard/AddonCard'
 
@@ -14,20 +14,16 @@ export const AddonSelectStep = ({
   isLoadingRelease,
   isLoadingAddons,
 }) => {
-
-  const [sortedAddons, setSortedAddons] = useState([])
-
-
-   const currentRelease = useMemo(
-     () => releases.find((release) => release.name === selectedPreset),
-     [selectedPreset, releases],
-   )
+  const currentRelease = useMemo(
+    () => releases.find((release) => release.name === selectedPreset),
+    [selectedPreset, releases],
+  )
   const addons = useMemo(() => release?.addons || [], [release])
   const mandatory = useMemo(() => currentRelease?.mandatoryAddons || [], [currentRelease])
 
-  useEffect(() => {
+  const sortedAddons = useMemo(() => {
     const sortedAddons = [...addons]
-    // order addons by selected and then by addon.mandatory
+    // order addons by selected
     sortedAddons.sort((a, b) => {
       const aSelected = selectedAddons.includes(a.name)
       const bSelected = selectedAddons.includes(b.name)
@@ -35,7 +31,7 @@ export const AddonSelectStep = ({
       if (!aSelected && bSelected) return 1
       return 0
     })
-    setSortedAddons(sortedAddons)
+    return sortedAddons
   }, [releases, release])
 
   const handleAddonClick = (name) => {
@@ -47,34 +43,30 @@ export const AddonSelectStep = ({
     }
   }
 
-  const placeholders = [...Array(20)].map((_, i) => ({name: `Addon ${i}`}))
+  const placeholders = [...Array(20)].map((_, i) => ({ name: `Addon ${i}` }))
 
   return (
     <Styled.Section>
       <Header>Pick your Addons</Header>
       <Styled.AddonsContainer>
         {isLoadingAddons
-        ? 
-          placeholders.map((placeholder) => (
-              <Styled.PlaceholderCard
-                key={placeholder.name}
-                icon={''}
-            />
-          ))
-        :
-          sortedAddons.map((addon) => 
-          !mandatory.includes(addon.name) && (
-            <AddonCard
-              key={addon.name}
-              title={addon.title}
-              name={addon.name}
-              version={addon.version}
-              icon={selectedAddons.includes(addon.name) ? 'check_circle' : 'circle'}
-              isSelected={selectedAddons.includes(addon.name)}
-              onClick={() => handleAddonClick(addon.name)}
-            />
-          ))
-        }
+          ? placeholders.map((placeholder) => (
+              <Styled.PlaceholderCard key={placeholder.name} icon={''} />
+            ))
+          : sortedAddons.map(
+              (addon) =>
+                !mandatory.includes(addon.name) && (
+                  <AddonCard
+                    key={addon.name}
+                    title={addon.title}
+                    name={addon.name}
+                    version={addon.version}
+                    icon={selectedAddons.includes(addon.name) ? 'check_circle' : 'circle'}
+                    isSelected={selectedAddons.includes(addon.name)}
+                    onClick={() => handleAddonClick(addon.name)}
+                  />
+                ),
+            )}
       </Styled.AddonsContainer>
       <Footer
         next="Confirm"

--- a/src/pages/OnBoarding/Step/AddonSelectStep.jsx
+++ b/src/pages/OnBoarding/Step/AddonSelectStep.jsx
@@ -14,12 +14,18 @@ export const AddonSelectStep = ({
   isLoadingRelease,
   isLoadingAddons,
 }) => {
-  const currentRelease = useMemo(
-    () => releases.find((release) => release.name === selectedPreset),
-    [selectedPreset, releases],
-  )
-  const { mandatoryAddons: mandatory = [] } = currentRelease || {}
   const { addons = [] } = release || {}
+  // filter out mandatory addons
+  const notMandatoryAddons = addons.filter((addon) => !addon.mandatory)
+
+  // get placeholders for loading
+  const placeholders = useMemo(() => {
+    const currentRelease = releases.find((release) => release.name === selectedPreset)
+    const notMandatorAddons = currentRelease?.addons.filter(
+      (addon) => !currentRelease?.mandatoryAddons?.includes(addon),
+    )
+    return notMandatorAddons || [...Array(20)].map((_, i) => `Addon ${i}`)
+  }, [selectedPreset, releases])
 
   const handleAddonClick = (name) => {
     // if it's already selected, remove it
@@ -30,9 +36,6 @@ export const AddonSelectStep = ({
     }
   }
 
-  // selected release has addons length, so use that as placeholders
-  const placeholders = currentRelease?.addons || [...Array(20)].map((_, i) => `Addon ${i}`)
-
   return (
     <Styled.Section>
       <Header>Pick your Addons</Header>
@@ -41,20 +44,17 @@ export const AddonSelectStep = ({
           ? placeholders.map((placeholder) => (
               <Styled.PlaceholderCard key={placeholder} icon={''} />
             ))
-          : addons.map(
-              (addon) =>
-                !mandatory.includes(addon.name) && (
-                  <AddonCard
-                    key={addon.name}
-                    title={addon.title}
-                    name={addon.name}
-                    version={addon.version}
-                    icon={selectedAddons.includes(addon.name) ? 'check_circle' : 'circle'}
-                    isSelected={selectedAddons.includes(addon.name)}
-                    onClick={() => handleAddonClick(addon.name)}
-                  />
-                ),
-            )}
+          : notMandatoryAddons.map((addon) => (
+              <AddonCard
+                key={addon.name}
+                title={addon.title}
+                name={addon.name}
+                version={addon.version}
+                icon={selectedAddons.includes(addon.name) ? 'check_circle' : 'circle'}
+                isSelected={selectedAddons.includes(addon.name)}
+                onClick={() => handleAddonClick(addon.name)}
+              />
+            ))}
       </Styled.AddonsContainer>
       <Footer
         next="Confirm"

--- a/src/pages/OnBoarding/util/OnBoardingContext.jsx
+++ b/src/pages/OnBoarding/util/OnBoardingContext.jsx
@@ -118,9 +118,9 @@ export const OnBoardingProvider = ({ children, initStep, onFinish }) => {
   const [selectedAddons, setSelectedAddons] = useState([])
 
   // get selected release data
-  const { data: release = {} } = useGetReleaseQuery(
+  const { data: release = {}, isLoading: isLoadingAddons } = useGetReleaseQuery(
     { name: selectedPreset },
-    { skip: !selectedPreset || stepIndex !== 7 },
+    { skip: !selectedPreset || stepIndex < 6 },
   )
 
   // // once releases are loaded, set selectedPreset to the first one and pre-cache each release
@@ -265,6 +265,7 @@ export const OnBoardingProvider = ({ children, initStep, onFinish }) => {
     setIsConnecting,
     isConnecting,
     isLoadingRelease,
+    isLoadingAddons,
   }
 
   return <OnBoardingContext.Provider value={contextValue}>{children}</OnBoardingContext.Provider>

--- a/src/pages/OnBoarding/util/OnBoardingContext.jsx
+++ b/src/pages/OnBoarding/util/OnBoardingContext.jsx
@@ -120,7 +120,7 @@ export const OnBoardingProvider = ({ children, initStep, onFinish }) => {
   // get selected release data
   const { data: release = {}, isLoading: isLoadingAddons } = useGetReleaseQuery(
     { name: selectedPreset },
-    { skip: !selectedPreset || stepIndex < 6 },
+    { skip: !selectedPreset || stepIndex < 5 },
   )
 
   // // once releases are loaded, set selectedPreset to the first one and pre-cache each release

--- a/src/pages/OnBoarding/util/OnBoardingContext.jsx
+++ b/src/pages/OnBoarding/util/OnBoardingContext.jsx
@@ -118,7 +118,7 @@ export const OnBoardingProvider = ({ children, initStep, onFinish }) => {
   const [selectedAddons, setSelectedAddons] = useState([])
 
   // get selected release data
-  const { data: release = {}, isLoading: isLoadingAddons } = useGetReleaseQuery(
+  const { data: release = {}, isFetching: isLoadingAddons } = useGetReleaseQuery(
     { name: selectedPreset },
     { skip: !selectedPreset || stepIndex < 5 },
   )

--- a/src/pages/OnBoarding/util/OnBoardingStep.styled.js
+++ b/src/pages/OnBoarding/util/OnBoardingStep.styled.js
@@ -105,7 +105,7 @@ export const PresetsContainer = styled.ul`
 export const AddonsContainer = styled.div`
   /* 3 column grid */
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(2, 1fr);
   gap: var(--base-gap-small);
   width: 470px;
   max-width: 470px;

--- a/src/pages/OnBoarding/util/OnBoardingStep.styled.js
+++ b/src/pages/OnBoarding/util/OnBoardingStep.styled.js
@@ -188,3 +188,13 @@ export const NextButton = styled(SaveButton)`
       }
     `}
 `
+
+export const Spinner = styled.div`
+  display: inline-block;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  border-top-color: #fff;
+  animation: ${spin} 0.8s linear infinite;
+`

--- a/src/pages/OnBoarding/util/OnBoardingStep.styled.js
+++ b/src/pages/OnBoarding/util/OnBoardingStep.styled.js
@@ -1,5 +1,6 @@
-import { Panel, SaveButton, Section as SectionComp } from '@ynput/ayon-react-components'
+import { Panel, SaveButton, getShimmerStyles, Section as SectionComp } from '@ynput/ayon-react-components'
 import styled, { css, keyframes } from 'styled-components'
+import AddonCard from '/src/components/AddonCard/AddonCard'
 
 export const Logo = styled.img`
   width: 100px;
@@ -189,12 +190,11 @@ export const NextButton = styled(SaveButton)`
     `}
 `
 
-export const Spinner = styled.div`
-  display: inline-block;
-  width: 32px;
-  height: 32px;
-  border-radius: 50%;
-  border: 2px solid rgba(255, 255, 255, 0.3);
-  border-top-color: #fff;
-  animation: ${spin} 0.8s linear infinite;
+export const PlaceholderCard = styled(AddonCard)`
+  background: transparent;
+  cursor: default;
+  ${getShimmerStyles()}
+  &:hover {
+    background: transparent;
+  }
 `


### PR DESCRIPTION
## Description of changes

- added information about version for addons selection
- added spinner (it can take up to few seconds to display addons)
- used title instead of name for addons
- changed 3 columns to two

### Additional context


https://github.com/ynput/ayon-frontend/assets/16327908/efa88d59-ffaa-4878-a6e8-924118ffef46


closes #430 


