### PR TITLE
Bundles: fix context selection change for archiving and deleting

### DIFF
--- a/src/pages/SettingsPage/Bundles/BundleForm.jsx
+++ b/src/pages/SettingsPage/Bundles/BundleForm.jsx
@@ -86,8 +86,8 @@ const BundleForm = ({
               <h2 style={{ margin: 0, marginRight: 32 }}>{formData?.installerVersion || 'NONE'}</h2>
               <>
                 {!!installerPlatforms?.length &&
-                  installerPlatforms.map((platform) => (
-                    <Styled.PlatformTag key={platform} $platform={platform}>
+                  installerPlatforms.map((platform, i) => (
+                    <Styled.PlatformTag key={platform + '-' + i} $platform={platform}>
                       {upperFirst(platform === 'darwin' ? 'macOS' : platform)}
                     </Styled.PlatformTag>
                   ))}

--- a/src/pages/SettingsPage/Bundles/Bundles.jsx
+++ b/src/pages/SettingsPage/Bundles/Bundles.jsx
@@ -1,14 +1,10 @@
 import { useState, useMemo, useEffect } from 'react'
 import BundleList from './BundleList'
 import BundleDetail from './BundleDetail'
-
 import { Button, InputSwitch, Section, Dialog } from '@ynput/ayon-react-components'
 import * as Styled from './Bundles.styled'
 import { useGetBundleListQuery } from '/src/services/bundles/getBundles'
-import {
-  useDeleteBundleMutation,
-  useUpdateBundleMutation,
-} from '/src/services/bundles/updateBundles'
+import { useUpdateBundleMutation } from '/src/services/bundles/updateBundles'
 import getNewBundleName from './getNewBundleName'
 import NewBundle from './NewBundle'
 import { useGetInstallerListQuery } from '/src/services/installers'
@@ -21,8 +17,6 @@ import getLatestSemver from './getLatestSemver'
 import { ayonApi } from '/src/services/ayon'
 import { useDispatch, useSelector } from 'react-redux'
 import useLocalStorage from '/src/hooks/useLocalStorage'
-
-import confirmDelete from '/src/helpers/confirmDelete'
 import { Splitter, SplitterPanel } from 'primereact/splitter'
 import { useSearchParams } from 'react-router-dom'
 import Shortcuts from '/src/containers/Shortcuts'
@@ -123,7 +117,6 @@ const Bundles = () => {
   }, [searchParams, isLoading, bundleList])
 
   // REDUX MUTATIONS
-  const [deleteBundle] = useDeleteBundleMutation()
   const [updateBundle] = useUpdateBundleMutation()
 
   // get latest core version
@@ -284,17 +277,6 @@ const Bundles = () => {
     }
   }
 
-  const handleDeleteBundle = async () =>
-    confirmDelete({
-      label: `${selectedBundles.length} bundles`,
-      accept: async () => {
-        setSelectedBundles([])
-        for (const name of selectedBundles) {
-          await deleteBundle({ name }).unwrap()
-        }
-      },
-    })
-
   const handleAddonInstallFinish = () => {
     setUploadOpen(false)
     if (restartRequired) {
@@ -431,7 +413,6 @@ const Bundles = () => {
                 bundleList={bundleList}
                 isLoading={isLoading}
                 onDuplicate={handleDuplicateBundle}
-                onDelete={handleDeleteBundle}
                 toggleBundleStatus={toggleBundleStatus}
                 errorMessage={!isFetching && isError && error?.data?.traceback}
                 developerMode={developerMode}

--- a/src/pages/SettingsPage/Bundles/InstallerSelector.jsx
+++ b/src/pages/SettingsPage/Bundles/InstallerSelector.jsx
@@ -35,8 +35,8 @@ const VersionAndPlatformTemplate = ({ version = [], platforms = [] }) => {
   return (
     <DefaultValueTemplate
       value={version}
-      childrenCustom={platforms?.map((platform) => (
-        <Styled.PlatformTag key={platform} $platform={platform}>
+      childrenCustom={platforms?.map((platform, i) => (
+        <Styled.PlatformTag key={platform + '-' + i} $platform={platform}>
           {platform === 'darwin' ? 'macOS' : platform}
         </Styled.PlatformTag>
       ))}
@@ -61,8 +61,8 @@ const InstallerSelector = ({ value = [], options, onChange, disabled }) => {
       itemTemplate={(option, isActive) => (
         <DefaultItemStyled $isSelected={isActive}>
           <span>{option.version}</span>
-          {option?.platforms?.map((platform) => (
-            <Styled.PlatformTag key={platform} $platform={platform}>
+          {option?.platforms?.map((platform, i) => (
+            <Styled.PlatformTag key={platform + '-' + i} $platform={platform}>
               {platform === 'darwin' ? 'macOS' : platform}
             </Styled.PlatformTag>
           ))}


### PR DESCRIPTION
## Description of changes

<!-- Please state what you've changed and how it might affect the user. -->

Fixes an issue where the selection state could become out of sync with internal state, causing the wrong bundle to be archived or deleted.

You can also now archive or delete multiple bundles are once.

### Testing

1. `/settings/bundles` (s+s shortcut).
2. right click on a bundle and `archive`.
3. right click on an archived bundle and `unarchive`.
4. right click on multiple archived bundles and `delete`.

### Additional context

<!-- Add any other context or screenshots here. -->

https://github.com/ynput/ayon-frontend/assets/49156310/563730ec-78dd-4530-a096-995e83c47838

