### PR TITLE
Web Preview: dialog and state architecture

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -39,6 +39,7 @@ import MarketPage from './pages/MarketPage'
 import { RestartProvider } from './context/restartContext'
 import { PasteProvider, PasteModal } from './context/pasteContext'
 import FileUploadPreview from './containers/FileUploadPreview/FileUploadPreview'
+import PreviewDialog from './containers/Preview/PreviewDialog'
 
 const App = () => {
   const user = useSelector((state) => state.user)
@@ -143,6 +144,7 @@ const App = () => {
                     >
                       <Header />
                       <ShareDialog />
+                      <PreviewDialog />
                       <ConfirmDialog />
                       <FileUploadPreview />
                       <Routes>

--- a/src/components/VersionSelectorTool/VersionSelectorTool.jsx
+++ b/src/components/VersionSelectorTool/VersionSelectorTool.jsx
@@ -1,0 +1,7 @@
+import * as Styled from './VersionSelectorTool.styled'
+
+const VersionSelectorTool = ({ versions, selected, latest, approved, hero, onChange }) => {
+  return <Styled.Tools>VersionSelectorTool</Styled.Tools>
+}
+
+export default VersionSelectorTool

--- a/src/components/VersionSelectorTool/VersionSelectorTool.styled.js
+++ b/src/components/VersionSelectorTool/VersionSelectorTool.styled.js
@@ -1,0 +1,8 @@
+import styled from 'styled-components'
+
+export const Tools = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  flex: 1;
+`

--- a/src/containers/Preview/Preview.jsx
+++ b/src/containers/Preview/Preview.jsx
@@ -1,0 +1,34 @@
+import { Button } from '@ynput/ayon-react-components'
+import * as Styled from './Preview.styled'
+import VersionSelectorTool from '/src/components/VersionSelectorTool/VersionSelectorTool'
+
+const Preview = ({ selected = [], entityType, onClose }) => {
+  // TODO @LudoHolbik: a new services file src/services/preview/getPreview.js should be created for these queries below
+
+  // TODO @Innders: get selected entity data from selected and entityType
+
+  // TODO @LudoHolbik: get selected versions data from selected and entityType
+  // some entity types won't support this
+  // look at getActivities.js getEntityVersions [line 64] and getVersions [line 86] for reference
+  const allVersionsDummyData = [
+    { id: 1, name: 'v001' },
+    { id: 2, name: 'v002' },
+    { id: 3, name: 'v003' },
+    { id: 4, name: 'v004', hero: true },
+    { id: 5, name: 'v005', status: 'approved' },
+  ]
+
+  return (
+    <Styled.Container>
+      <Styled.Header>
+        <VersionSelectorTool versions={allVersionsDummyData} selected={selected} />
+        <Button onClick={onClose} icon={'close'} />
+      </Styled.Header>
+      <Styled.Content>
+        <h2>Selected Version: {selected.join(', ')}</h2>
+      </Styled.Content>
+    </Styled.Container>
+  )
+}
+
+export default Preview

--- a/src/containers/Preview/Preview.styled.js
+++ b/src/containers/Preview/Preview.styled.js
@@ -1,0 +1,22 @@
+import { Toolbar } from '@ynput/ayon-react-components'
+import styled from 'styled-components'
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+`
+
+export const Header = styled(Toolbar)``
+export const Content = styled.div`
+  flex: 1;
+  min-height: 80vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  h2 {
+    font-size: 2rem;
+  }
+`

--- a/src/containers/Preview/PreviewDialog.jsx
+++ b/src/containers/Preview/PreviewDialog.jsx
@@ -1,0 +1,56 @@
+import { Dialog } from '@ynput/ayon-react-components'
+import { useDispatch, useSelector } from 'react-redux'
+import { closePreview, openPreview } from '/src/features/preview'
+import { useSearchParams } from 'react-router-dom'
+import { useEffect } from 'react'
+import Preview from './Preview'
+import { isEqual } from 'lodash'
+import styled from 'styled-components'
+
+const StyledDialog = styled(Dialog)`
+  /* hide header and footer */
+  .header,
+  .footer {
+    display: none;
+  }
+`
+
+const PreviewDialog = () => {
+  const dispatch = useDispatch()
+  // check if dialog is open or not
+  const { selected, entityType } = useSelector((state) => state.preview)
+
+  const [searchParams, setUrlSearchParams] = useSearchParams()
+  //   usually just one id is passed, but multiple ids can be passed
+  const selectedIds = searchParams.getAll('preview_id') || []
+  //   passing undefined to openPreview will default to 'version'
+  const selectedType = searchParams.get('preview_type') || undefined
+  // when url has preview_id and preview_type, open the dialog if not already open
+
+  useEffect(() => {
+    if (!selectedIds.length) return
+    // check if dialog is already open with same ids
+    if (isEqual(selected, selectedIds)) return
+    // open the dialog
+    dispatch(openPreview({ selected: selectedIds, entityType: selectedType }))
+  }, [selectedIds, selectedType])
+
+  if (!selected.length) return null
+
+  const handleClose = () => {
+    // remove query params preview_id and preview_type from url
+    searchParams.delete('preview_id')
+    searchParams.delete('preview_type')
+    setUrlSearchParams(searchParams)
+    // close the dialog
+    dispatch(closePreview())
+  }
+
+  return (
+    <StyledDialog isOpen hideCancelButton size="full">
+      <Preview {...{ selected, entityType }} onClose={handleClose} />
+    </StyledDialog>
+  )
+}
+
+export default PreviewDialog

--- a/src/features/preview.js
+++ b/src/features/preview.js
@@ -1,0 +1,25 @@
+import { createSlice } from '@reduxjs/toolkit'
+
+const previewSlice = createSlice({
+  name: 'preview',
+  initialState: {
+    selected: [],
+    entityType: null,
+  },
+  reducers: {
+    openPreview: (state, { payload: { selected, entityType = 'version' } = {} } = {}) => {
+      state.selected = selected
+      state.entityType = entityType
+    },
+    updateSelection: (state, { payload: { selected } }) => {
+      state.selected = selected
+    },
+    closePreview: (state) => {
+      state.selected = []
+      state.entityType = null
+    },
+  },
+})
+
+export const { openPreview, updateSelection, closePreview } = previewSlice.actions
+export default previewSlice.reducer

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -13,6 +13,7 @@ import editorReducer from './features/editor'
 import dashboardReducer, { dashboardLocalItems } from './features/dashboard'
 import detailsReducer, { detailsLocalItems } from './features/details'
 import addonsManagerReducer from './features/addonsManager'
+import previewReducer from './features/preview'
 
 import App from './app'
 
@@ -40,6 +41,7 @@ const store = configureStore({
     dashboard: dashboardReducer,
     details: detailsReducer,
     addonsManager: addonsManagerReducer,
+    preview: previewReducer,
     [ayonApi.reducerPath]: ayonApi.reducer,
   },
   middleware: (getDefaultMiddleware) =>

--- a/src/services/activities/getActivities.js
+++ b/src/services/activities/getActivities.js
@@ -168,5 +168,4 @@ export const {
   useLazyGetActivitiesQuery,
   useGetVersionsQuery,
   useGetEntityTooltipQuery,
-  u,
 } = getActivities


### PR DESCRIPTION
### Description of changes

Use the URL search params `preview_id: EntityId` and `preview_type: EntityType` to open the basic shell of the preview dialog.

This is a WIP and just the basis for collaborators work on the components that go inside it.

### Additional context

![image](https://github.com/ynput/ayon-frontend/assets/49156310/f791a3e4-5d5b-449b-b849-892a532d53b7)