### PR TITLE
Preview: Details panel header compact mode

### DIFF
--- a/src/components/Actions/Actions.jsx
+++ b/src/components/Actions/Actions.jsx
@@ -11,7 +11,7 @@ const Actions = ({ options = [], pinned = [], isLoading }) => {
   // return empty placeholder until finished
   if (showPlaceholder)
     return (
-      <Styled.Actions className={classNames({ isLoading })}>
+      <Styled.Actions className={classNames('actions', { isLoading })}>
         {showPlaceholder ? (
           <Button icon="manufacturing" disabled data-tooltip="Actions coming soon" />
         ) : (

--- a/src/components/status/statusField.jsx
+++ b/src/components/status/statusField.jsx
@@ -127,18 +127,7 @@ const StatusStyled = styled.div`
       }
     `}
 
-  /* ALIGNMENT */
-  ${({ $align }) =>
-    $align === 'right' &&
-    css`
-      justify-content: end;
-
-      span {
-        order: 2;
-      }
-    `}
-
-    /* ICON ONLY STYLES */
+  /* ICON ONLY STYLES */
       ${({ $size }) =>
     $size === 'icon' &&
     css`
@@ -157,7 +146,6 @@ const StatusField = ({
   isChanging,
   isSelecting,
   size = 'full',
-  align = 'left',
   style,
   height,
   placeholder,
@@ -184,7 +172,6 @@ const StatusField = ({
       $color={color}
       $isActive={isActive}
       $isSelecting={isSelecting}
-      $align={align}
       $isChanging={isChanging}
       $size={size}
       $invert={invert}
@@ -209,7 +196,6 @@ StatusField.propTypes = {
   isChanging: PropTypes.bool,
   isSelecting: PropTypes.bool,
   size: PropTypes.oneOf(['full', 'short', 'icon']),
-  align: PropTypes.oneOf(['left', 'right']),
   onClick: PropTypes.func,
   style: PropTypes.object,
   anatomy: PropTypes.object,

--- a/src/components/status/statusSelect.jsx
+++ b/src/components/status/statusSelect.jsx
@@ -86,7 +86,6 @@ const StatusSelect = ({
       valueTemplate={() => (
         <StatusField
           value={isMixed ? `Mixed Statuses` : dropdownValue[0]}
-          align={align}
           size={size}
           style={{ maxWidth, ...style }}
           height={height}
@@ -106,7 +105,6 @@ const StatusSelect = ({
             value={status.name}
             isSelecting
             isActive={isActive}
-            align={align}
             height={height}
             statuses={statusesObject}
             showChevron={resolveChevronVisibility(isChevron, isActive)}

--- a/src/containers/DetailsPanel/DetailsPanel.jsx
+++ b/src/containers/DetailsPanel/DetailsPanel.jsx
@@ -30,6 +30,7 @@ const DetailsPanel = ({
   isSlideOut = false,
   style = {},
   scope,
+  isCompact = false,
 }) => {
   const path = isSlideOut ? 'slideOut' : 'pinned'
   let selectedTab = useSelector((state) => state.details[path].tab)
@@ -112,6 +113,7 @@ const DetailsPanel = ({
           onClose={onClose}
           isSlideOut={isSlideOut}
           isFetching={isFetchingEntitiesDetails}
+          isCompact={isCompact}
         />
         {selectedTab === 'feed' && !isError && (
           <Feed

--- a/src/containers/DetailsPanel/DetailsPanelHeader/DetailsPanelHeader.jsx
+++ b/src/containers/DetailsPanel/DetailsPanelHeader/DetailsPanelHeader.jsx
@@ -1,5 +1,4 @@
-import { AssigneeSelect, TagsSelect } from '@ynput/ayon-react-components'
-import React, { useMemo } from 'react'
+import { useMemo } from 'react'
 import * as Styled from './DetailsPanelHeader.styled'
 import copyToClipboard from '/src/helpers/copyToClipboard'
 import StackedThumbnails from '/src/pages/EditorPage/StackedThumbnails'
@@ -183,15 +182,7 @@ const DetailsPanelHeader = ({
   }
 
   return (
-    <Styled.SectionWrapper id={portalId} className="details-panel-header">
-      <Styled.Path
-        value={pathArray.join(' / ')}
-        align="left"
-        onClick={handleCopyPath}
-        isCopy
-        icon="content_copy"
-        className={classNames({ onClose, isLoading })}
-      />
+    <Styled.Grid id={portalId} className="details-panel-header">
       {onClose && (
         <Styled.CloseButton
           onClick={onClose}
@@ -201,7 +192,15 @@ const DetailsPanelHeader = ({
           data-tooltip-delay={0}
         />
       )}
-      <Styled.Header>
+      <Styled.Path
+        value={pathArray.join(' / ')}
+        align="left"
+        onClick={handleCopyPath}
+        isCopy
+        icon="content_copy"
+        className={classNames('path', { onClose, isLoading })}
+      />
+      <Styled.Header className="titles">
         <StackedThumbnails
           isLoading={isLoading}
           shimmer={isLoading}
@@ -216,46 +215,45 @@ const DetailsPanelHeader = ({
           <h3>{!isMultiple ? firstEntity?.subTitle : entities.map((t) => t.title).join(', ')}</h3>
         </Styled.Content>
       </Styled.Header>
-      <Styled.Section>
-        <Styled.ContentRow>
-          <Styled.TaskStatusSelect
-            value={statusesValue}
-            options={statusesOptions}
-            disabledValues={disabledStatuses}
-            invert
-            style={{ maxWidth: 'unset' }}
-            onChange={(value) => handleUpdate('status', value)}
-            className={classNames({ isLoading })}
-          />
-          {hasUser && !isLoading && (
-            <AssigneeSelect
-              value={entityAssignees}
-              options={usersOptions}
-              disabledValues={disabledAssignees.map((u) => u.name)}
-              isMultiple={isMultiple && entityAssignees.length > 1 && entityType === 'task'}
-              editor={entityType === 'task'}
-              align="right"
-              onChange={(value) => handleUpdate('assignees', value)}
-            />
-          )}
-        </Styled.ContentRow>
-      </Styled.Section>
-      <Styled.Section>
-        <Styled.ContentRow>
-          <Actions options={actions} pinned={pinned} isLoading={isLoading} />
-          <TagsSelect
-            value={union(...tagsValues)}
-            isMultiple={tagsValues.some((v) => !isEqual(v, tagsValues[0]))}
-            tags={tagsOptionsObject}
-            editable
-            onChange={(value) => handleUpdate('tags', value)}
-            align="right"
-            styleDropdown={{ display: isLoading && 'none' }}
-          />
-        </Styled.ContentRow>
-      </Styled.Section>
-      <FeedFilters isSlideOut={isSlideOut} isLoading={isLoading} entityType={entityType} />
-    </Styled.SectionWrapper>
+      <Styled.StatusSelect
+        value={statusesValue}
+        options={statusesOptions}
+        disabledValues={disabledStatuses}
+        invert
+        style={{ maxWidth: 'unset' }}
+        onChange={(value) => handleUpdate('status', value)}
+        className={classNames('status-select', { isLoading })}
+      />
+      {hasUser && !isLoading && (
+        <Styled.AssigneeSelect
+          value={entityAssignees}
+          options={usersOptions}
+          disabledValues={disabledAssignees.map((u) => u.name)}
+          isMultiple={isMultiple && entityAssignees.length > 1 && entityType === 'task'}
+          editor={entityType === 'task'}
+          align="right"
+          onChange={(value) => handleUpdate('assignees', value)}
+          className="assignee-select"
+        />
+      )}
+      <Actions options={actions} pinned={pinned} isLoading={isLoading} />
+      <Styled.TagsSelect
+        value={union(...tagsValues)}
+        isMultiple={tagsValues.some((v) => !isEqual(v, tagsValues[0]))}
+        tags={tagsOptionsObject}
+        editable
+        onChange={(value) => handleUpdate('tags', value)}
+        align="right"
+        styleDropdown={{ display: isLoading && 'none' }}
+        className="tags-select"
+      />
+      <FeedFilters
+        isSlideOut={isSlideOut}
+        isLoading={isLoading}
+        entityType={entityType}
+        className="filters"
+      />
+    </Styled.Grid>
   )
 }
 

--- a/src/containers/DetailsPanel/DetailsPanelHeader/DetailsPanelHeader.jsx
+++ b/src/containers/DetailsPanel/DetailsPanelHeader/DetailsPanelHeader.jsx
@@ -21,6 +21,7 @@ const DetailsPanelHeader = ({
   onClose,
   isSlideOut,
   isFetching,
+  isCompact = false,
 }) => {
   // for selected entities, get flat list of assignees
   const entityAssignees = useMemo(
@@ -182,7 +183,7 @@ const DetailsPanelHeader = ({
   }
 
   return (
-    <Styled.Grid id={portalId} className="details-panel-header">
+    <Styled.Grid id={portalId} className={classNames('details-panel-header', { isCompact })}>
       {onClose && (
         <Styled.CloseButton
           onClick={onClose}
@@ -200,7 +201,7 @@ const DetailsPanelHeader = ({
         icon="content_copy"
         className={classNames('path', { onClose, isLoading })}
       />
-      <Styled.Header className="titles">
+      <Styled.Header className={classNames('titles', { isCompact })}>
         <StackedThumbnails
           isLoading={isLoading}
           shimmer={isLoading}
@@ -223,8 +224,9 @@ const DetailsPanelHeader = ({
         style={{ maxWidth: 'unset' }}
         onChange={(value) => handleUpdate('status', value)}
         className={classNames('status-select', { isLoading })}
+        align={isCompact ? 'right' : 'left'}
       />
-      {hasUser && !isLoading && (
+      {hasUser && !isLoading && !isCompact && (
         <Styled.AssigneeSelect
           value={entityAssignees}
           options={usersOptions}

--- a/src/containers/DetailsPanel/DetailsPanelHeader/DetailsPanelHeader.styled.js
+++ b/src/containers/DetailsPanel/DetailsPanelHeader/DetailsPanelHeader.styled.js
@@ -1,23 +1,34 @@
 import styled from 'styled-components'
-import StatusSelect from '/src/components/status/statusSelect'
+import StatusSelectComponent from '/src/components/status/statusSelect'
 import {
   Button,
   OverflowField,
-  Section as SectionARC,
   getShimmerStyles,
+  AssigneeSelect as AssigneeSelectComponent,
+  TagsSelect as TagsSelectComponent,
 } from '@ynput/ayon-react-components'
 
 export const Container = styled.div`
   position: relative;
 `
 
-export const SectionWrapper = styled(SectionARC)`
+export const Grid = styled.div`
   padding: 8px;
-  align-items: flex-start;
-  gap: var(--base-gap-large);
   border-bottom: 1px solid var(--md-sys-color-outline-variant);
   flex: none;
   overflow: hidden;
+
+  display: grid;
+  /* two columns */
+  grid-template-columns: 1fr 1fr;
+  gap: var(--base-gap-large);
+
+  /* set full widths for different elements */
+  .path,
+  .titles,
+  .filters {
+    grid-column: span 2;
+  }
 `
 
 export const CloseButton = styled(Button)`
@@ -51,7 +62,7 @@ export const Path = styled(OverflowField)`
   }
 
   & > span {
-    -webkit-transform: translate3d(0, 0, 0);
+    transform: translate3d(0, 0, 0);
   }
 
   &.isLoading {
@@ -97,11 +108,6 @@ export const Content = styled.div`
   }
 `
 
-export const Section = styled.div`
-  display: flex;
-  flex-direction: column;
-`
-
 export const ContentRow = styled.div`
   display: flex;
   justify-content: space-between;
@@ -118,7 +124,7 @@ export const LabelWrapper = styled.div`
   flex-direction: column;
 `
 
-export const TaskStatusSelect = styled(StatusSelect)`
+export const StatusSelect = styled(StatusSelectComponent)`
   .status-field.value {
     position: relative;
     left: 1px;
@@ -136,6 +142,17 @@ export const TaskStatusSelect = styled(StatusSelect)`
       opacity: 0;
     }
   }
+
+  width: fit-content;
+`
+
+export const AssigneeSelect = styled(AssigneeSelectComponent)`
+  width: fit-content;
+  justify-self: end;
+`
+export const TagsSelect = styled(TagsSelectComponent)`
+  width: fit-content;
+  justify-self: end;
 `
 
 export const Footer = styled.footer`

--- a/src/containers/DetailsPanel/DetailsPanelHeader/DetailsPanelHeader.styled.js
+++ b/src/containers/DetailsPanel/DetailsPanelHeader/DetailsPanelHeader.styled.js
@@ -29,6 +29,20 @@ export const Grid = styled.div`
   .filters {
     grid-column: span 2;
   }
+
+  &.isCompact {
+    /* hide fields when compact */
+    .assignee-select,
+    .tags-select,
+    .actions,
+    .filters {
+      display: none;
+    }
+    /* right column auto size */
+    grid-template-columns: 1fr auto;
+    /* align center */
+    align-items: center;
+  }
 `
 
 export const CloseButton = styled(Button)`
@@ -47,6 +61,11 @@ export const Header = styled.header`
 
   .thumbnail {
     width: 48px;
+  }
+
+  &.isCompact {
+    /* only take up one column */
+    grid-column: span 1;
   }
 `
 
@@ -125,6 +144,7 @@ export const LabelWrapper = styled.div`
 `
 
 export const StatusSelect = styled(StatusSelectComponent)`
+  width: fit-content;
   .status-field.value {
     position: relative;
     left: 1px;
@@ -142,8 +162,6 @@ export const StatusSelect = styled(StatusSelectComponent)`
       opacity: 0;
     }
   }
-
-  width: fit-content;
 `
 
 export const AssigneeSelect = styled(AssigneeSelectComponent)`

--- a/src/containers/DetailsPanel/FeedFilters/FeedFilters.jsx
+++ b/src/containers/DetailsPanel/FeedFilters/FeedFilters.jsx
@@ -5,7 +5,7 @@ import { Spacer } from '@ynput/ayon-react-components'
 import { classNames } from 'primereact/utils'
 import { entitiesWithoutFeed } from '../DetailsPanel'
 
-const FeedFilters = ({ isSlideOut, isLoading, entityType }) => {
+const FeedFilters = ({ isSlideOut, isLoading, entityType, className, ...props }) => {
   const dispatch = useDispatch()
   const setFeedFilter = (value) => dispatch(updateFeedFilter({ value, isSlideOut }))
   const setTab = (tab) => dispatch(updateDetailsPanelTab({ isSlideOut, tab }))
@@ -41,7 +41,7 @@ const FeedFilters = ({ isSlideOut, isLoading, entityType }) => {
   const hideActivityFilters = entitiesWithoutFeed.includes(entityType)
 
   return (
-    <Styled.FiltersToolbar className={classNames({ isLoading })}>
+    <Styled.FiltersToolbar {...props} className={classNames(className, { isLoading })}>
       {!hideActivityFilters &&
         filtersLeft.map((filter) => (
           <Styled.FilterButton


### PR DESCRIPTION
### Description of changes

<!-- Please state what you've changed and how it might affect the user. -->

Adds a new prop `isCompact=false` that will hide most of the fields, for a more focused and compact header.

This will be used as part of the preview dialog.

### Additional context

<!-- Add any other context or screenshots here. -->

![image](https://github.com/ynput/ayon-frontend/assets/49156310/29031f59-d163-472d-950e-02c262e3abc8)

