### PR TITLE
Browser: Columns select dropdown

### DIFF
--- a/src/components/ColumnsSelect/ColumnsSelect.jsx
+++ b/src/components/ColumnsSelect/ColumnsSelect.jsx
@@ -1,0 +1,29 @@
+import { DefaultValueTemplate, Dropdown } from '@ynput/ayon-react-components'
+
+const ValueTemplate = ({ selected, options = [], ...props }) => {
+  return (
+    <DefaultValueTemplate {...props} valueStyle={{ display: 'flex' }}>
+      {selected.length > 0 ? (
+        <span>
+          Columns: {selected.length} / {options.length}
+        </span>
+      ) : (
+        <span>Filter columns...</span>
+      )}
+    </DefaultValueTemplate>
+  )
+}
+
+const ColumnsSelect = ({ placeholder = 'Filter columns...', ...props }) => {
+  return (
+    <Dropdown
+      {...props}
+      multiSelect
+      valueTemplate={(value, selected) => (
+        <ValueTemplate selected={selected} {...props} value={value} placeholder={placeholder} />
+      )}
+    />
+  )
+}
+
+export default ColumnsSelect

--- a/src/pages/BrowserPage/Products/Products.jsx
+++ b/src/pages/BrowserPage/Products/Products.jsx
@@ -5,7 +5,6 @@ import EntityDetail from '/src/containers/DetailsDialog'
 import { CellWithIcon } from '/src/components/icons'
 import { TimestampField } from '/src/containers/fieldFormat'
 import usePubSub from '/src/hooks/usePubSub'
-
 import groupResult from '/src/helpers/groupResult'
 import useLocalStorage from '/src/hooks/useLocalStorage'
 import {
@@ -19,13 +18,11 @@ import {
 } from '/src/features/context'
 import VersionList from './VersionList'
 import StatusSelect from '/src/components/status/statusSelect'
-
 import {
   useGetProductListQuery,
   useLazyGetProductsVersionsQuery,
 } from '/src/services/product/getProduct'
 import usePatchProductsListWithVersions from '/src/hooks/usePatchProductsListWithVersions'
-import { MultiSelect } from 'primereact/multiselect'
 import useSearchFilter, { filterByFieldsAndValues } from '/src/hooks/useSearchFilter'
 import useColumnResize from '/src/hooks/useColumnResize'
 import { useUpdateEntitiesMutation } from '/src/services/entity/updateEntity'
@@ -358,16 +355,9 @@ const Products = () => {
     allColumnsNames,
   )
 
-  const handleColumnsFilter = (e) => {
-    e.preventDefault()
-    const newArray = e.target.value || []
-
-    if (newArray.length) {
-      // make sure there's always at least one column
-      isMultiSelected
-        ? setShownColumnsMultiFocused(newArray)
-        : setShownColumnsSingleFocused(newArray)
-    }
+  const handleColumnsFilter = (value = []) => {
+    // if multiple folders are selected, we need to save the columns in a different local storage
+    isMultiSelected ? setShownColumnsMultiFocused(value) : setShownColumnsSingleFocused(value)
   }
 
   // sort columns if localstorage set
@@ -385,8 +375,8 @@ const Products = () => {
 
   const shownColumns = isMultiSelected ? shownColumnsMultiFocused : shownColumnsSingleFocused
 
-  // only filter columns if required
-  if (shownColumns.length < columns.length) {
+  // only filter if above zero otherwise show all columns
+  if (shownColumns.length) {
     columns = columns.filter(({ field }) => shownColumns.includes(field))
   }
 
@@ -553,17 +543,6 @@ const Products = () => {
   //
   // Render
   //
-  const getOutOfString = (value, total) => {
-    if (value.length === total.length) return ''
-
-    return `${value.length}/${total.length}`
-  }
-
-  const placeholder = `Show Columns  ${
-    isMultiSelected
-      ? `${getOutOfString(shownColumnsMultiFocused, filterOptions)} (Multiple)`
-      : `${getOutOfString(shownColumnsSingleFocused, filterOptions)} (Single)`
-  }`
 
   const isNone = filteredBySearchData.length === 0
 
@@ -586,12 +565,12 @@ const Products = () => {
           placeholder="Task types..."
           multiSelect
         />
-        <MultiSelect
+        <Styled.ColumnsFilterSelect
           options={filterOptions}
           value={shownColumns}
           onChange={handleColumnsFilter}
-          placeholder={placeholder}
-          fixedPlaceholder
+          onClear={!!shownColumns.length && handleColumnsFilter}
+          multiSelect
         />
         <Spacer />
         <ViewModeToggle

--- a/src/pages/BrowserPage/Products/Products.styled.js
+++ b/src/pages/BrowserPage/Products/Products.styled.js
@@ -1,7 +1,13 @@
 import styled from 'styled-components'
 import CategorySelect from '/src/components/CategorySelect/CategorySelect'
+import ColumnsSelect from '/src/components/ColumnsSelect/ColumnsSelect'
 
 export const TaskFilterDropdown = styled(CategorySelect)`
   min-width: 160px;
   max-width: 160px;
+`
+
+export const ColumnsFilterSelect = styled(ColumnsSelect)`
+  min-width: 170px;
+  max-width: 170px;
 `


### PR DESCRIPTION
### Description of changes

- Replace Prime react multiselect with arc dropdown.
- Value now defaults to empty array `[]` and will show all columns.
- Fixed issue where clearing would not work.
- Removed "(Single)" and "(Multiple)" as it was just confusing.
- New placeholder "Filter columns..."

### Additional context

https://github.com/ynput/ayon-frontend/assets/49156310/8bec03c2-81da-4237-9493-ad5e73d76fb4

