### PR TITLE
Type Editor: Dropdown order of folders and tasks now respect settings order

### DIFF
--- a/src/pages/EditorPage/NewEntity.jsx
+++ b/src/pages/EditorPage/NewEntity.jsx
@@ -43,7 +43,9 @@ const NewEntity = ({ type, currentSelection = {}, visible, onConfirm, onHide }) 
 
   //   type selector
   const tasks = useSelector((state) => state.project.tasks)
+  const tasksOrder = useSelector((state) => state.project.tasksOrder)
   const folders = useSelector((state) => state.project.folders)
+  const foldersOrder = useSelector((state) => state.project.foldersOrder)
   const typeOptions = type === 'folder' ? folders : tasks
 
   // set entity type
@@ -51,36 +53,27 @@ const NewEntity = ({ type, currentSelection = {}, visible, onConfirm, onHide }) 
     if (type !== entityType && type) {
       setEntityType(type)
       let task = {}
-      if ('Generic' in typeOptions)
+      const firstTask = tasksOrder[0]
+
+      if (firstTask in tasks) {
         task = {
-          name: 'generic',
-          label: 'generic',
-          type: 'Generic',
-        }
-
-      let folder = ''
-      if ('Folder' in typeOptions)
-        folder = {
-          name: 'folder',
-          label: 'folder',
-          type: 'Folder',
-        }
-
-      // fallback to first option
-      if (isEmpty(task) && !isEmpty(typeOptions)) {
-        const firstType = Object.values(typeOptions)[0]
-        if (firstType) {
-          const name = firstType.shortName || firstType.name?.toLowerCase()
-
-          folder = {
-            type: firstType.name,
-            name: name,
-            label: name,
-          }
-
-          task = folder
+          name: tasks[firstTask].name,
+          label: tasks[firstTask].name,
+          type: firstTask,
         }
       }
+
+      let folder = {}
+      const firstFolder = foldersOrder[0]
+      if (firstFolder in folders) {
+        folder = {
+          name: folders[firstFolder].name,
+          label: folders[firstFolder].name,
+          type: firstFolder,
+        }
+      }
+
+      console.log(folder)
 
       // set defaults
       if (type === 'task') setEntityData(task)
@@ -198,6 +191,8 @@ const NewEntity = ({ type, currentSelection = {}, visible, onConfirm, onHide }) 
 
   const addDisabled = !entityData.label || !entityData.type
 
+  console.log(entityType)
+
   return (
     <Dialog
       header={title}
@@ -238,6 +233,7 @@ const NewEntity = ({ type, currentSelection = {}, visible, onConfirm, onHide }) 
           ref={typeSelectRef}
           onFocus={handleTypeSelectFocus}
           onClick={() => setNameFocused(false)}
+          type={entityType}
         />
         <InputText
           value={entityData.label}

--- a/src/pages/EditorPage/NewSequence.jsx
+++ b/src/pages/EditorPage/NewSequence.jsx
@@ -5,8 +5,11 @@ import { Toolbar, Spacer, SaveButton, Button, Dialog } from '@ynput/ayon-react-c
 import FolderSequence from '/src/components/FolderSequence/FolderSequence'
 import getSequence from '/src/helpers/getSequence'
 import { isEmpty } from 'lodash'
+import { useSelector } from 'react-redux'
 
 const NewSequence = ({ visible, onConfirm, onHide, currentSelection = {} }) => {
+  const foldersOrder = useSelector((state) => state.project.foldersOrder)
+
   const isRoot = isEmpty(currentSelection)
   const multipleSelection = Object.keys(currentSelection).length > 1
   const examplePrefix = isRoot
@@ -22,7 +25,7 @@ const NewSequence = ({ visible, onConfirm, onHide, currentSelection = {} }) => {
       base: 'Folder010',
       increment: 'Folder020',
       length: 10,
-      type: 'Folder',
+      type: foldersOrder[0],
       prefix: multipleSelection,
       prefixDepth: !isRoot ? 1 : 0,
       entityType: 'folder',

--- a/src/pages/EditorPage/TypeEditor.jsx
+++ b/src/pages/EditorPage/TypeEditor.jsx
@@ -1,5 +1,6 @@
 import { Dropdown } from '@ynput/ayon-react-components'
 import { forwardRef } from 'react'
+import { useSelector } from 'react-redux'
 
 //eslint-disable-next-line no-unused-vars
 const TypeEditor = forwardRef(
@@ -14,29 +15,34 @@ const TypeEditor = forwardRef(
       placeholder,
       isChanged,
       align,
+      type,
       ...props
     },
     ref,
   ) => {
-    const optionsTypes = Object.values(options).map((t) => ({
-      name: t?.name,
-      label: t?.name,
-      icon: t?.icon,
-    }))
+    const project = useSelector((state) => state.project)
+    const order = project[type + 'sOrder']
 
-    // sort by name alphabetically
-    optionsTypes.sort((a, b) => {
-      const nameA = a.name.toLowerCase()
-      const nameB = b.name.toLowerCase()
-      if (nameA < nameB) {
-        return -1
-      }
-      if (nameA > nameB) {
-        return 1
-      }
+    let optionsTypes = []
+    if (order) {
+      // Create a new object with ordered keys
+      // adding the rest of the keys that are not in order to the end
+      const orderedOptions = [...order, ...Object.keys(options).filter((t) => !order.includes(t))]
 
-      return 0
-    })
+      // Create optionsTypes in one loop
+      optionsTypes = orderedOptions.map((t) => ({
+        name: t,
+        label: options[t]?.name,
+        icon: options[t]?.icon,
+      }))
+    } else {
+      // default ordering
+      optionsTypes = Object.values(options).map((t) => ({
+        name: t?.name,
+        label: t?.name,
+        icon: t?.icon,
+      }))
+    }
 
     return (
       <Dropdown


### PR DESCRIPTION
### Description of changes

<!-- Please state what you've changed and how it might affect the user. -->
When selecting a task or folder from a dropdown, the order now matches the order in the anatomy settings.

### Additional context

<!-- Add any other context or screenshots here. -->
![image](https://github.com/ynput/ayon-frontend/assets/49156310/b529ba79-001f-43c2-90bf-7740a00142b8)
