### PR TITLE
File Preview: Support for text files and PDFs

### DIFF
--- a/src/components/FileUploadCard/FileUploadCard.jsx
+++ b/src/components/FileUploadCard/FileUploadCard.jsx
@@ -85,7 +85,7 @@ const FileUploadCard = ({
   const extension = nameParts.pop()
   const fileName = nameParts.join('.')
 
-  const isPreviewable = isFilePreviewable(mime)
+  const isPreviewable = isFilePreviewable(mime || '.' + extension)
   const isImage = mime?.includes('image/')
 
   const downloadComponent = (
@@ -97,7 +97,7 @@ const FileUploadCard = ({
 
   const handleImageClick = () => {
     if (!isPreviewable || !onExpand || imageError) return
-    onExpand({ name, mime, id, size })
+    onExpand({ name, mime, id, size, extension })
   }
 
   return (

--- a/src/components/FileUploadCard/FileUploadCard.jsx
+++ b/src/components/FileUploadCard/FileUploadCard.jsx
@@ -2,6 +2,7 @@ import { Button, Icon } from '@ynput/ayon-react-components'
 import * as Styled from './FileUploadCard.styled'
 import { classNames } from 'primereact/utils'
 import { useState } from 'react'
+import { isFilePreviewable } from '/src/containers/FileUploadPreview/FileUploadPreview'
 
 const fileIcons = {
   // special cases
@@ -84,7 +85,7 @@ const FileUploadCard = ({
   const extension = nameParts.pop()
   const fileName = nameParts.join('.')
 
-  const isImage = mime?.includes('image')
+  const isPreviewable = isFilePreviewable(mime)
 
   const downloadComponent = (
     <>
@@ -94,16 +95,16 @@ const FileUploadCard = ({
   )
 
   const handleImageClick = () => {
-    if (!isImage || !onExpand || imageError) return
+    if (!isPreviewable || !onExpand || imageError) return
     onExpand({ name, mime, id, size })
   }
 
   const fileComponent = (
-    <Styled.File className={classNames({ compact: isCompact, isDownloadable, isImage })}>
+    <Styled.File className={classNames({ compact: isCompact, isDownloadable, isPreviewable })}>
       <Styled.ContentWrapper className="image-wrapper" onClick={handleImageClick}>
         <Icon icon={getIconForType(mime || '.' + extension)} className="type-icon" />
         <Icon icon="download" className="download-icon" />
-        {isImage && src && (
+        {isPreviewable && src && (
           <Styled.ImageWrapper className={classNames({ isDownloadable })}>
             <img
               src={src + '?preview=true'}
@@ -116,14 +117,14 @@ const FileUploadCard = ({
           </Styled.ImageWrapper>
         )}
       </Styled.ContentWrapper>
-      <Styled.Footer className={classNames({ inProgress, isImage, isDownloadable })}>
+      <Styled.Footer className={classNames({ inProgress, isPreviewable, isDownloadable })}>
         <span className="progress" style={{ right: `${100 - progress}%` }} />
         <div className="name-wrapper">
           <span className="name">{fileName}</span>
         </div>
         <span className="extension">.{extension}</span>
         {isDownloadable &&
-          (isImage && !onRemove ? (
+          (isPreviewable && !onRemove ? (
             <a href={src} download className="download">
               {downloadComponent}
             </a>
@@ -136,7 +137,7 @@ const FileUploadCard = ({
   )
 
   // if the file is an image, return the file component
-  if (isImage || onRemove) return fileComponent
+  if (isPreviewable || onRemove) return fileComponent
   // if it's not then we wrap with a direct link to download the file
   else
     return (

--- a/src/components/FileUploadCard/FileUploadCard.jsx
+++ b/src/components/FileUploadCard/FileUploadCard.jsx
@@ -86,6 +86,7 @@ const FileUploadCard = ({
   const fileName = nameParts.join('.')
 
   const isPreviewable = isFilePreviewable(mime)
+  const isImage = mime?.includes('image/')
 
   const downloadComponent = (
     <>
@@ -99,12 +100,14 @@ const FileUploadCard = ({
     onExpand({ name, mime, id, size })
   }
 
-  const fileComponent = (
+  return (
     <Styled.File className={classNames({ compact: isCompact, isDownloadable, isPreviewable })}>
-      <Styled.ContentWrapper className="image-wrapper" onClick={handleImageClick}>
+      <Styled.ContentWrapper
+        className={classNames('content-wrapper', { isPreviewable })}
+        onClick={handleImageClick}
+      >
         <Icon icon={getIconForType(mime || '.' + extension)} className="type-icon" />
-        <Icon icon="download" className="download-icon" />
-        {isPreviewable && src && (
+        {isImage && src && (
           <Styled.ImageWrapper className={classNames({ isDownloadable })}>
             <img
               src={src + '?preview=true'}
@@ -113,9 +116,9 @@ const FileUploadCard = ({
                 display: imageError ? 'none' : 'block',
               }}
             />
-            <Icon icon="open_in_full" />
           </Styled.ImageWrapper>
         )}
+        {isPreviewable && <Icon icon="open_in_full" className="expand-icon" />}
       </Styled.ContentWrapper>
       <Styled.Footer className={classNames({ inProgress, isPreviewable, isDownloadable })}>
         <span className="progress" style={{ right: `${100 - progress}%` }} />
@@ -124,7 +127,7 @@ const FileUploadCard = ({
         </div>
         <span className="extension">.{extension}</span>
         {isDownloadable &&
-          (isPreviewable && !onRemove ? (
+          (!onRemove ? (
             <a href={src} download className="download">
               {downloadComponent}
             </a>
@@ -135,16 +138,6 @@ const FileUploadCard = ({
       {onRemove && <Button className="remove" onClick={onRemove} icon="close" />}
     </Styled.File>
   )
-
-  // if the file is an image, return the file component
-  if (isPreviewable || onRemove) return fileComponent
-  // if it's not then we wrap with a direct link to download the file
-  else
-    return (
-      <a href={src} download>
-        {fileComponent}
-      </a>
-    )
 }
 
 export default FileUploadCard

--- a/src/components/FileUploadCard/FileUploadCard.styled.js
+++ b/src/components/FileUploadCard/FileUploadCard.styled.js
@@ -35,8 +35,8 @@ export const File = styled.div`
     }
   }
 
-  /* set download default color outline when isImage */
-  &.isImage {
+  /* set download default color outline when isPreviewable */
+  &.isPreviewable {
     .download,
     .download-icon {
       color: var(--md-sys-color-outline);
@@ -47,7 +47,7 @@ export const File = styled.div`
     cursor: pointer;
 
     /* when not an image, hover both */
-    &:not(.isImage):hover {
+    &:not(.isPreviewable):hover {
       /* reveal size and download */
       .download {
         display: flex;
@@ -143,7 +143,7 @@ export const Footer = styled.footer`
     font-size: 20px;
   }
 
-  &.isImage {
+  &.isPreviewable {
     position: absolute;
     bottom: 0;
     left: 0;
@@ -154,7 +154,7 @@ export const Footer = styled.footer`
     &:hover {
       cursor: pointer;
 
-      &.isImage {
+      &.isPreviewable {
         padding: var(--padding-m) var(--padding-s);
       }
 

--- a/src/components/FileUploadCard/FileUploadCard.styled.js
+++ b/src/components/FileUploadCard/FileUploadCard.styled.js
@@ -35,46 +35,26 @@ export const File = styled.div`
     }
   }
 
-  /* set download default color outline when isPreviewable */
-  &.isPreviewable {
-    .download,
-    .download-icon {
-      color: var(--md-sys-color-outline);
-    }
+  /* move icon up slightly to center it */
+  .type-icon {
+    margin-top: -20px;
   }
 
-  &.isDownloadable {
-    cursor: pointer;
+  /* set download default color outline */
+  .download,
+  .download-icon {
+    color: var(--md-sys-color-outline);
+  }
 
-    /* when not an image, hover both */
-    &:not(.isPreviewable):hover {
-      /* reveal size and download */
-      .download {
-        display: flex;
-      }
-      .name-wrapper,
-      .extension {
-        display: none;
-      }
-      .image-wrapper,
-      footer {
-        background-color: var(--md-sys-color-surface-container-low-hover);
+  .expand-icon {
+    pointer-events: none;
+    position: absolute;
+    /* center */
+    left: 50%;
+    bottom: calc(50% - 20px);
+    transform: translate(-50%, -50%);
 
-        .download-icon {
-          display: none;
-        }
-      }
-
-      .image-wrapper {
-        .type-icon {
-          display: none;
-        }
-
-        .download-icon {
-          display: block;
-        }
-      }
-    }
+    display: none;
   }
 `
 
@@ -86,6 +66,11 @@ export const Footer = styled.footer`
   padding: 0 var(--padding-s);
   overflow: hidden;
   color: var(--md-sys-color-on-surface);
+
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
 
   transition: padding 0.2s ease;
 
@@ -143,20 +128,11 @@ export const Footer = styled.footer`
     font-size: 20px;
   }
 
-  &.isPreviewable {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    right: 0;
-  }
-
   &.isDownloadable {
     &:hover {
       cursor: pointer;
 
-      &.isPreviewable {
-        padding: var(--padding-m) var(--padding-s);
-      }
+      padding: var(--padding-m) var(--padding-s);
 
       background-color: var(--md-sys-color-surface-container-low-hover);
 
@@ -193,6 +169,21 @@ export const ContentWrapper = styled.div`
   .download-icon {
     display: none;
   }
+
+  /* previewable styles (it can be expanded) */
+  /* on hover it shows the expand icon */
+  &.isPreviewable {
+    cursor: pointer;
+
+    &:hover {
+      .expand-icon {
+        display: block;
+      }
+      .type-icon {
+        display: none;
+      }
+    }
+  }
 `
 
 export const ImageWrapper = styled.div`
@@ -209,16 +200,6 @@ export const ImageWrapper = styled.div`
     height: calc(100% - 20px);
 
     transition: scale 0.2s ease;
-  }
-
-  .icon {
-    position: absolute;
-    /* center */
-    left: 50%;
-    bottom: calc(50% - 20px);
-    transform: translate(-50%, -50%);
-
-    display: none;
   }
 
   &::after {

--- a/src/components/FileUploadCard/FileUploadCard.styled.js
+++ b/src/components/FileUploadCard/FileUploadCard.styled.js
@@ -199,6 +199,7 @@ export const ImageWrapper = styled.div`
   position: absolute;
   inset: 0;
   display: flex;
+  justify-content: center;
   background-color: var(--md-sys-color-surface-container-lowest);
   img {
     position: absolute;

--- a/src/containers/FileUploadPreview/FileUploadPreview.jsx
+++ b/src/containers/FileUploadPreview/FileUploadPreview.jsx
@@ -3,10 +3,12 @@ import * as Styled from './FileUploadPreview.styled'
 import { onFilePreviewClose } from '/src/features/context'
 import { useEffect, useRef } from 'react'
 
+const fullPreviews = ['png', 'jpg', 'jpeg', 'gif', 'svg']
+
 const FileUploadPreview = () => {
   const dispatch = useDispatch()
   const file = useSelector((state) => state.context.previewFile)
-  const { id, projectName } = file || {}
+  const { id, projectName, mime } = file || {}
 
   // when dialog open, focus on the dialog
   // we do this so that the user can navigate with the keyboard (esc works)
@@ -23,6 +25,11 @@ const FileUploadPreview = () => {
 
   if (!id || !projectName) return null
 
+  let imgURL = `/api/projects/${projectName}/files/${id}`
+  const useFullPreview = fullPreviews.some((ext) => mime.includes(ext))
+  // if the file is NOT png, jpg, jpeg, gif, or svg, we use preview image
+  if (!useFullPreview) imgURL += '?preview=true'
+
   return (
     <Styled.DialogWrapper
       size="full"
@@ -31,7 +38,7 @@ const FileUploadPreview = () => {
       hideCancelButton
       ref={dialogRef}
     >
-      <Styled.Image src={`/api/projects/${projectName}/files/${id}`} autoFocus />
+      <Styled.Image src={imgURL} autoFocus />
     </Styled.DialogWrapper>
   )
 }

--- a/src/containers/FileUploadPreview/FileUploadPreview.jsx
+++ b/src/containers/FileUploadPreview/FileUploadPreview.jsx
@@ -37,7 +37,7 @@ export const getFileURL = (id, projectName) => `/api/projects/${projectName}/fil
 const FileUploadPreview = () => {
   const dispatch = useDispatch()
   const file = useSelector((state) => state.context.previewFile)
-  const { id, projectName, mime, extension } = file || {}
+  const { id, projectName, mime, extension, name } = file || {}
 
   // when dialog open, focus on the dialog
   // we do this so that the user can navigate with the keyboard (esc works)
@@ -80,6 +80,7 @@ const FileUploadPreview = () => {
       hideCancelButton={isImage}
       ref={dialogRef}
       className={classNames({ isImage })}
+      header={isImage ? null : name}
     >
       <MimeComponent file={file} />
     </Styled.DialogWrapper>

--- a/src/containers/FileUploadPreview/FileUploadPreview.jsx
+++ b/src/containers/FileUploadPreview/FileUploadPreview.jsx
@@ -2,8 +2,22 @@ import { useDispatch, useSelector } from 'react-redux'
 import * as Styled from './FileUploadPreview.styled'
 import { onFilePreviewClose } from '/src/features/context'
 import { useEffect, useRef } from 'react'
+import ImageMime from './mimes/ImageMime'
 
-const fullPreviews = ['png', 'jpg', 'jpeg', 'gif', 'svg']
+export const expandableMimeTypes = {
+  image: {
+    component: ImageMime,
+    mimeTypes: ['image/'],
+    fullPreviews: ['png', 'jpg', 'jpeg', 'gif', 'svg', 'webp'],
+  },
+}
+
+export const isFilePreviewable = (mime) =>
+  Object.values(expandableMimeTypes).some(({ mimeTypes }) =>
+    mimeTypes.some((type) => mime.includes(type)),
+  )
+
+export const getFileURL = (id, projectName) => `/api/projects/${projectName}/files/${id}`
 
 const FileUploadPreview = () => {
   const dispatch = useDispatch()
@@ -25,10 +39,12 @@ const FileUploadPreview = () => {
 
   if (!id || !projectName) return null
 
-  let imgURL = `/api/projects/${projectName}/files/${id}`
-  const useFullPreview = fullPreviews.some((ext) => mime.includes(ext))
-  // if the file is NOT png, jpg, jpeg, gif, or svg, we use preview image
-  if (!useFullPreview) imgURL += '?preview=true'
+  // get the correct mime type component based on mimeTypes match
+  const { component: MimeComponent } = Object.values(expandableMimeTypes).find(({ mimeTypes }) =>
+    mimeTypes.some((type) => mime.includes(type)),
+  )
+
+  if (!MimeComponent) return null
 
   return (
     <Styled.DialogWrapper
@@ -38,7 +54,7 @@ const FileUploadPreview = () => {
       hideCancelButton
       ref={dialogRef}
     >
-      <Styled.Image src={imgURL} autoFocus />
+      <MimeComponent file={file} />
     </Styled.DialogWrapper>
   )
 }

--- a/src/containers/FileUploadPreview/FileUploadPreview.jsx
+++ b/src/containers/FileUploadPreview/FileUploadPreview.jsx
@@ -19,6 +19,12 @@ export const expandableMimeTypes = {
     mimeTypes: ['text/', 'application/json', 'scss', 'jsx'],
     id: 'text',
   },
+  pdf: {
+    component: null,
+    mimeTypes: ['pdf'],
+    id: 'pdf',
+    callback: (file) => window.open(getFileURL(file.id, file.projectName), '_blank'),
+  },
 }
 
 export const isFilePreviewable = (mime = '', ext = '') =>
@@ -53,7 +59,14 @@ const FileUploadPreview = () => {
     mimeTypes.some((type) => (mime || extension)?.includes(type)),
   )
 
-  const { component: MimeComponent, id: typeId } = previewable || {}
+  const { component: MimeComponent, id: typeId, callback } = previewable || {}
+
+  // if there is a callback, run it and return null
+  // mainly for pdfs
+  if (callback) {
+    callback(file)
+    return null
+  }
 
   const isImage = typeId === 'image'
 

--- a/src/containers/FileUploadPreview/FileUploadPreview.jsx
+++ b/src/containers/FileUploadPreview/FileUploadPreview.jsx
@@ -3,18 +3,27 @@ import * as Styled from './FileUploadPreview.styled'
 import { onFilePreviewClose } from '/src/features/context'
 import { useEffect, useRef } from 'react'
 import ImageMime from './mimes/ImageMime'
+import TextMime from './mimes/TextMime'
+import { classNames } from 'primereact/utils'
 
+// define expandable mime types and their components
 export const expandableMimeTypes = {
   image: {
     component: ImageMime,
     mimeTypes: ['image/'],
     fullPreviews: ['png', 'jpg', 'jpeg', 'gif', 'svg', 'webp'],
+    id: 'image',
+  },
+  text: {
+    component: TextMime,
+    mimeTypes: ['text/', 'application/json', 'scss', 'jsx'],
+    id: 'text',
   },
 }
 
-export const isFilePreviewable = (mime) =>
-  Object.values(expandableMimeTypes).some(({ mimeTypes }) =>
-    mimeTypes.some((type) => mime.includes(type)),
+export const isFilePreviewable = (mime = '', ext = '') =>
+  Object.values(expandableMimeTypes).some(({ mimeTypes = [] }) =>
+    mimeTypes.some((type) => (mime || ext)?.includes(type)),
   )
 
 export const getFileURL = (id, projectName) => `/api/projects/${projectName}/files/${id}`
@@ -22,14 +31,14 @@ export const getFileURL = (id, projectName) => `/api/projects/${projectName}/fil
 const FileUploadPreview = () => {
   const dispatch = useDispatch()
   const file = useSelector((state) => state.context.previewFile)
-  const { id, projectName, mime } = file || {}
+  const { id, projectName, mime, extension } = file || {}
 
   // when dialog open, focus on the dialog
   // we do this so that the user can navigate with the keyboard (esc works)
   const dialogRef = useRef(null)
   useEffect(() => {
     if (id && projectName) {
-      dialogRef.current.focus()
+      dialogRef.current?.focus()
     }
   }, [id, projectName])
 
@@ -40,9 +49,13 @@ const FileUploadPreview = () => {
   if (!id || !projectName) return null
 
   // get the correct mime type component based on mimeTypes match
-  const { component: MimeComponent } = Object.values(expandableMimeTypes).find(({ mimeTypes }) =>
-    mimeTypes.some((type) => mime.includes(type)),
+  const previewable = Object.values(expandableMimeTypes).find(({ mimeTypes }) =>
+    mimeTypes.some((type) => (mime || extension)?.includes(type)),
   )
+
+  const { component: MimeComponent, id: typeId } = previewable || {}
+
+  const isImage = typeId === 'image'
 
   if (!MimeComponent) return null
 
@@ -51,8 +64,9 @@ const FileUploadPreview = () => {
       size="full"
       isOpen={id && projectName}
       onClose={handleClose}
-      hideCancelButton
+      hideCancelButton={isImage}
       ref={dialogRef}
+      className={classNames({ isImage })}
     >
       <MimeComponent file={file} />
     </Styled.DialogWrapper>

--- a/src/containers/FileUploadPreview/FileUploadPreview.styled.js
+++ b/src/containers/FileUploadPreview/FileUploadPreview.styled.js
@@ -2,44 +2,46 @@ import { Dialog } from '@ynput/ayon-react-components'
 import styled from 'styled-components'
 
 export const DialogWrapper = styled(Dialog)`
-  background-color: unset;
-  overflow: hidden;
-  border-radius: 0;
-
-  width: 0;
-  min-width: fit-content;
-
-  .cancelButton {
-    top: 1px;
-    right: 1px;
-    background-color: var(--md-sys-color-surface-container-highest);
-  }
-
-  /* Backdrop property affects inactive area around modal */
-  &::backdrop {
-    background-color: rgba(0, 0, 0, 0.7);
-  }
-
-  .header {
-    display: none;
-  }
-
-  .body {
-    padding: 0;
-    align-items: center;
-    user-select: none;
+  /* custom image styles */
+  &.isImage {
+    background-color: unset;
     overflow: hidden;
-  }
+    border-radius: 0;
 
-  footer {
-    display: none;
-  }
+    width: 0;
+    min-width: fit-content;
 
-  /* remove focus outline */
-  &:focus {
-    outline: none;
-  }
+    .cancelButton {
+      top: 1px;
+      right: 1px;
+      background-color: var(--md-sys-color-surface-container-highest);
+    }
 
+    /* Backdrop property affects inactive area around modal */
+    &::backdrop {
+      background-color: rgba(0, 0, 0, 0.7);
+    }
+
+    .header {
+      display: none;
+    }
+
+    .body {
+      padding: 0;
+      align-items: center;
+      user-select: none;
+      overflow: hidden;
+    }
+
+    footer {
+      display: none;
+    }
+
+    /* remove focus outline */
+    &:focus {
+      outline: none;
+    }
+  }
   /* remove focus outline */
   &:focus-visible {
     outline: none;

--- a/src/containers/FileUploadPreview/FileUploadPreview.styled.js
+++ b/src/containers/FileUploadPreview/FileUploadPreview.styled.js
@@ -2,6 +2,9 @@ import { Dialog } from '@ynput/ayon-react-components'
 import styled from 'styled-components'
 
 export const DialogWrapper = styled(Dialog)`
+  min-height: 90vh;
+  max-height: 90vh;
+  max-width: 1000px;
   /* custom image styles */
   &.isImage {
     background-color: unset;

--- a/src/containers/FileUploadPreview/FileUploadPreview.styled.js
+++ b/src/containers/FileUploadPreview/FileUploadPreview.styled.js
@@ -5,6 +5,11 @@ export const DialogWrapper = styled(Dialog)`
   min-height: 90vh;
   max-height: 90vh;
   max-width: 1000px;
+
+  .body {
+    padding-top: 0;
+  }
+
   /* custom image styles */
   &.isImage {
     background-color: unset;

--- a/src/containers/FileUploadPreview/mimes/ImageMime.jsx
+++ b/src/containers/FileUploadPreview/mimes/ImageMime.jsx
@@ -1,0 +1,13 @@
+import { expandableMimeTypes, getFileURL } from '../FileUploadPreview'
+import * as Styled from '../FileUploadPreview.styled'
+
+const ImageMime = ({ file: { projectName, id, mime } = {} }) => {
+  let imgURL = getFileURL(id, projectName)
+  const useFullPreview = expandableMimeTypes.image.fullPreviews.some((ext) => mime.includes(ext))
+  // if the file is NOT png, jpg, jpeg, gif, or svg, we use preview image
+  if (!useFullPreview) imgURL += '?preview=true'
+
+  return <Styled.Image src={imgURL} autoFocus />
+}
+
+export default ImageMime

--- a/src/containers/FileUploadPreview/mimes/TextMime.jsx
+++ b/src/containers/FileUploadPreview/mimes/TextMime.jsx
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react'
+import { getFileURL } from '../FileUploadPreview'
+import CodeEditor from '@uiw/react-textarea-code-editor'
+import styled from 'styled-components'
+// markdown
+import Markdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import emoji from 'remark-emoji'
+
+const CodeEditorPreview = styled(CodeEditor)`
+  border-radius: var(--border-radius-m);
+  height: 100%;
+  overflow: auto !important;
+`
+
+const TextMime = ({ file: { projectName, id, mime, extension } = {} }) => {
+  let fileURL = getFileURL(id, projectName)
+  const [fileContent, setFileContent] = useState('')
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    const fetchFile = async () => {
+      try {
+        const response = await fetch(fileURL)
+        if (!response.ok) {
+          throw new Error(`HTTP error! status: ${response.status}`)
+        }
+        const text = await response.text()
+        setFileContent(text)
+      } catch (err) {
+        setError(err.message)
+      }
+    }
+
+    fetchFile()
+  }, [projectName, id])
+
+  if (error) {
+    return <div>Error: {error}</div>
+  }
+
+  // if markdown file, return markdown
+  if (mime?.includes('markdown'))
+    return <Markdown remarkPlugins={[remarkGfm, emoji]}>{fileContent}</Markdown>
+
+  return <CodeEditorPreview value={fileContent} language={extension} readOnly />
+}
+
+export default TextMime

--- a/src/features/context.js
+++ b/src/features/context.js
@@ -38,6 +38,7 @@ const initialState = {
     mime: null,
     size: null,
     projectName: null,
+    extension: null,
   },
 }
 


### PR DESCRIPTION
### Description of changes

- Support all `text/` mime formats and some custom text formats.
- Use code editor in read only mode for syntax highlighting
- Markdown files preview as rendered markdown.
- PDF files now open in a new tab for previewing.
- `UploadFileCard` now has a consistent UX for pre-viewing and downloading files.

### Technical details

It is now a lot easier to add support for new file types using the object `expandableMimeTypes` in `FileUploadPreview.jsx`

```js
// define expandable mime types and their components
export const expandableMimeTypes = {
  image: {
    component: ImageMime,
    mimeTypes: ['image/'],
    fullPreviews: ['png', 'jpg', 'jpeg', 'gif', 'svg', 'webp'],
    id: 'image',
  },
  text: {
    component: TextMime,
    mimeTypes: ['text/', 'application/json', 'scss', 'jsx'],
    id: 'text',
  },
  pdf: {
    component: null,
    mimeTypes: ['pdf'],
    id: 'pdf',
    callback: (file) => window.open(getFileURL(file.id, file.projectName), '_blank'),
  },
// add new file support and their custom rendering component here
}

Adding a new file value to the object will also automatically show the expand icon when hovering over a file card.
```


### Additional context

<!-- Add any other context or screenshots here. -->

![CONTRUBTING_markdown](https://github.com/ynput/ayon-frontend/assets/49156310/58bbf4a5-168b-4e5d-96d7-4c3a36ce921c)
![FileUploadPReview_jsx](https://github.com/ynput/ayon-frontend/assets/49156310/d87c9688-b3dd-4048-a9d9-bb924ddba22e)
![lorem_ipsom](https://github.com/ynput/ayon-frontend/assets/49156310/d7e56bae-2822-451e-9adb-1451e791434f)

