### PR TITLE
URI: Fix wrong URI on different pages

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -40,6 +40,7 @@ import { RestartProvider } from './context/restartContext'
 import { PasteProvider, PasteModal } from './context/pasteContext'
 import FileUploadPreview from './containers/FileUploadPreview/FileUploadPreview'
 import PreviewDialog from './containers/Preview/PreviewDialog'
+import { URIProvider } from './context/uriContext'
 
 const App = () => {
   const user = useSelector((state) => state.user)
@@ -135,78 +136,87 @@ const App = () => {
               <PasteProvider>
                 <PasteModal />
                 <BrowserRouter>
-                  <ShortcutsProvider>
-                    <QueryParamProvider
-                      adapter={ReactRouter6Adapter}
-                      options={{
-                        updateType: 'replaceIn',
-                      }}
-                    >
-                      <Header />
-                      <ShareDialog />
-                      <PreviewDialog />
-                      <ConfirmDialog />
-                      <FileUploadPreview />
-                      <Routes>
-                        <Route
-                          path="/"
-                          exact
-                          element={<Navigate replace to="/dashboard/tasks" />}
-                        />
-                        <Route
-                          path="/manageProjects"
-                          exact
-                          element={<Navigate replace to="/manageProjects/anatomy" />}
-                        />
+                  <URIProvider>
+                    <ShortcutsProvider>
+                      <QueryParamProvider
+                        adapter={ReactRouter6Adapter}
+                        options={{
+                          updateType: 'replaceIn',
+                        }}
+                      >
+                        <Header />
+                        <ShareDialog />
+                        <PreviewDialog />
+                        <ConfirmDialog />
+                        <FileUploadPreview />
+                        <Routes>
+                          <Route
+                            path="/"
+                            exact
+                            element={<Navigate replace to="/dashboard/tasks" />}
+                          />
+                          <Route
+                            path="/manageProjects"
+                            exact
+                            element={<Navigate replace to="/manageProjects/anatomy" />}
+                          />
 
-                        <Route
-                          path="/dashboard"
-                          element={<Navigate replace to="/dashboard/tasks" />}
-                        />
-                        <Route path="/dashboard/:module" exact element={<UserDashboardPage />} />
+                          <Route
+                            path="/dashboard"
+                            element={<Navigate replace to="/dashboard/tasks" />}
+                          />
+                          <Route path="/dashboard/:module" exact element={<UserDashboardPage />} />
 
-                        <Route path="/manageProjects/:module" element={<ProjectManagerPage />} />
-                        <Route path={'/projects/:projectName/:module'} element={<ProjectPage />} />
-                        <Route
-                          path={'/projects/:projectName/addon/:addonName'}
-                          element={<ProjectPage />}
-                        />
-                        <Route
-                          path="/settings"
-                          exact
-                          element={<Navigate replace to="/settings/anatomyPresets" />}
-                        />
-                        <Route path="/settings/:module" exact element={<SettingsPage />} />
-                        <Route path="/settings/addon/:addonName" exact element={<SettingsPage />} />
-                        <Route
-                          path="/services"
-                          element={
-                            <ProtectedRoute isAllowed={!isUser} redirectPath="/">
-                              <ServicesPage />
-                            </ProtectedRoute>
-                          }
-                        />
-                        <Route
-                          path="/market"
-                          element={
-                            <ProtectedRoute isAllowed={!isUser} redirectPath="/">
-                              <MarketPage />
-                            </ProtectedRoute>
-                          }
-                        />
-                        <Route path="/explorer" element={<ExplorerPage />} />
-                        <Route path="/doc/api" element={<APIDocsPage />} />
-                        <Route
-                          path="/account"
-                          exact
-                          element={<Navigate replace to="/account/profile" />}
-                        />
-                        <Route path="/account/:module" exact element={<AccountPage />} />
-                        <Route path="/events" element={<EventsPage />} />
-                        <Route element={<ErrorPage code="404" />} />
-                      </Routes>
-                    </QueryParamProvider>
-                  </ShortcutsProvider>
+                          <Route path="/manageProjects/:module" element={<ProjectManagerPage />} />
+                          <Route
+                            path={'/projects/:projectName/:module'}
+                            element={<ProjectPage />}
+                          />
+                          <Route
+                            path={'/projects/:projectName/addon/:addonName'}
+                            element={<ProjectPage />}
+                          />
+                          <Route
+                            path="/settings"
+                            exact
+                            element={<Navigate replace to="/settings/anatomyPresets" />}
+                          />
+                          <Route path="/settings/:module" exact element={<SettingsPage />} />
+                          <Route
+                            path="/settings/addon/:addonName"
+                            exact
+                            element={<SettingsPage />}
+                          />
+                          <Route
+                            path="/services"
+                            element={
+                              <ProtectedRoute isAllowed={!isUser} redirectPath="/">
+                                <ServicesPage />
+                              </ProtectedRoute>
+                            }
+                          />
+                          <Route
+                            path="/market"
+                            element={
+                              <ProtectedRoute isAllowed={!isUser} redirectPath="/">
+                                <MarketPage />
+                              </ProtectedRoute>
+                            }
+                          />
+                          <Route path="/explorer" element={<ExplorerPage />} />
+                          <Route path="/doc/api" element={<APIDocsPage />} />
+                          <Route
+                            path="/account"
+                            exact
+                            element={<Navigate replace to="/account/profile" />}
+                          />
+                          <Route path="/account/:module" exact element={<AccountPage />} />
+                          <Route path="/events" element={<EventsPage />} />
+                          <Route element={<ErrorPage code="404" />} />
+                        </Routes>
+                      </QueryParamProvider>
+                    </ShortcutsProvider>
+                  </URIProvider>
                 </BrowserRouter>
               </PasteProvider>
             </ContextMenuProvider>

--- a/src/containers/Breadcrumbs/Breadcrumbs.jsx
+++ b/src/containers/Breadcrumbs/Breadcrumbs.jsx
@@ -5,8 +5,8 @@ import { Button, InputText } from '@ynput/ayon-react-components'
 import * as Styled from './Breadcrumbs.styled'
 
 import { upperFirst } from 'lodash'
-import useUriNavigate from '/src/hooks/useUriNavigate'
 import copyToClipboard from '/src/helpers/copyToClipboard'
+import { useURIContext } from '/src/context/uriContext'
 
 const uri2crumbs = (uri = '', pathname) => {
   // parse uri to path and query params
@@ -34,8 +34,8 @@ const uri2crumbs = (uri = '', pathname) => {
 
     if (pageTitle.includes('settings')) pageTitle = 'Studio Settings'
     else if (pageTitle.includes('manageProjects')) pageTitle = 'Projects Manager'
-    // just a regular url
-    crumbs.unshift(upperFirst(pageTitle))
+    // just a regular url (use last part of pathname)
+    crumbs.unshift(upperFirst(pathname.split('/').pop()))
   }
 
   const qp = {}
@@ -63,6 +63,7 @@ const Breadcrumbs = () => {
   const [localUri, setLocalUri] = useState('')
   const [editMode, setEditMode] = useState(false)
   const ctxUri = useSelector((state) => state.context.uri) || ''
+  const { navigate } = useURIContext()
 
   const inputRef = useRef(null)
 
@@ -87,9 +88,6 @@ const Breadcrumbs = () => {
     }
   }, [editMode])
 
-  // NAVIGATE TO URI HOOK
-  const navigateToUri = useUriNavigate()
-
   const goThere = async (e) => {
     e?.preventDefault()
     setEditMode(false)
@@ -97,7 +95,7 @@ const Breadcrumbs = () => {
     inputRef.current.blur()
 
     try {
-      await navigateToUri(localUri)
+      await navigate(localUri)
     } catch (error) {
       console.error(error)
       setLocalUri(ctxUri)

--- a/src/context/uriContext.jsx
+++ b/src/context/uriContext.jsx
@@ -1,13 +1,17 @@
-import { useCallback } from 'react'
-import axios from 'axios'
-import { useDispatch } from 'react-redux'
-import { onUriNavigate, setUri, setUriChanged } from '/src/features/context'
-import { useNavigate } from 'react-router'
+import { createContext, useCallback, useContext, useEffect } from 'react'
 import { toast } from 'react-toastify'
+import { onUriNavigate, setUri, setUriChanged } from '../features/context'
+import axios from 'axios'
+import { useLocation, useNavigate } from 'react-router'
+import { useDispatch } from 'react-redux'
 
-const useUriNavigate = () => {
+const URIContext = createContext()
+
+function URIProvider({ children }) {
   const navigate = useNavigate()
   const dispatch = useDispatch()
+  const location = useLocation()
+  const pathname = location.pathname
 
   const focusEntities = (entities) => {
     const focused = {
@@ -132,7 +136,19 @@ const useUriNavigate = () => {
     [dispatch],
   )
 
-  return navigateToUri
+  //   when the scope is outside settings and project, set uri to null
+  const scopes = ['projects', 'settings', 'dashboard/tasks']
+  useEffect(() => {
+    const matchingScope = scopes.some((scope) => pathname.startsWith(`/${scope}`))
+
+    if (!matchingScope) {
+      dispatch(setUri(null))
+    }
+  }, [pathname])
+
+  return <URIContext.Provider value={{ navigate: navigateToUri }}>{children}</URIContext.Provider>
 }
 
-export default useUriNavigate
+const useURIContext = () => useContext(URIContext)
+
+export { URIProvider, useURIContext }

--- a/src/pages/ProjectDashboard/panels/ProjectLatest.jsx
+++ b/src/pages/ProjectDashboard/panels/ProjectLatest.jsx
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux'
 import DashboardPanelWrapper from './DashboardPanelWrapper'
 import ProjectLatestRow from './ProjectLatestRow'
 import { useGetProjectQuery } from '/src/services/project/getProject'
-import useUriNavigate from '/src/hooks/useUriNavigate'
+import { useURIContext } from '/src/context/uriContext'
 
 const ProjectLatest = ({ projectName }) => {
   // project
@@ -68,7 +68,7 @@ const ProjectLatest = ({ projectName }) => {
     },
   ]
 
-  const navigateToUri = useUriNavigate()
+  const { navigate: navigateToUri } = useURIContext()
 
   const handleEntityClick = (entity = {}) => {
     const path = entity.type === 'folder' ? `${entity.path}/${entity.name}` : entity.path

--- a/src/pages/UserDashboardPage/util/useGetTaskContextMenu.js
+++ b/src/pages/UserDashboardPage/util/useGetTaskContextMenu.js
@@ -1,12 +1,12 @@
 import useCreateContext from '/src/hooks/useCreateContext'
 import copyToClipboard from '/src/helpers/copyToClipboard'
-import useUriNavigate from '/src/hooks/useUriNavigate'
 import { onTaskSelected } from '/src/features/dashboard'
 import { useSelector } from 'react-redux'
+import { useURIContext } from '/src/context/uriContext'
 
 export const useGetTaskContextMenu = (tasks, dispatch) => {
   // URI NAVIGATE ON RIGHT CLICK
-  const navigateToUri = useUriNavigate()
+  const { navigate: navigateToUri } = useURIContext()
   const selectedTasks = useSelector((state) => state.dashboard.tasks.selected)
 
   const getContextMenuItems = (card) => {


### PR DESCRIPTION
## Description of changes

<!-- Please state what you've changed and how it might affect the user. -->
A project or settings URI could be left over causing a mismatch between the breadcrumbs and page.

### Technical details

<!-- Please state any technical details such as limitations -->
<!-- reasons for additional dependencies, benchmarks etc. here. -->
On pages that don't have specific URIs use the last part of the URL pathname.

The logic has also been moved to a context provider.

Original problem
![image](https://github.com/ynput/ayon-frontend/assets/49156310/8bcedc49-a43a-4ecf-9e79-d4ff405c8d05)

Fixed
![image](https://github.com/ynput/ayon-frontend/assets/49156310/2ff20b4b-ea96-477b-aff6-130ad7985d73)
