### PR TITLE
fix(bundles): Order dep packages dropdown alphabetically

### DIFF
--- a/src/pages/SettingsPage/Bundles/BundleDepsPicker.jsx
+++ b/src/pages/SettingsPage/Bundles/BundleDepsPicker.jsx
@@ -12,9 +12,10 @@ const BundleDepsPicker = ({
 }) => {
   const options = useMemo(
     () =>
-      packages
+      [...packages]
         .filter((p) => p.platform === value?.platform)
-        .map((p) => ({ label: p.filename, value: p.filename })),
+        .map((p) => ({ label: p.filename, value: p.filename }))
+        .sort((a, b) => b.label.localeCompare(a.label)),
     [packages],
   )
 


### PR DESCRIPTION
## Description of changes

- Orders dependency packages options alphabetically desc (z-a) so that the latest packages show first.
<!-- Please state what you've changed and how it might affect the user. -->

### Additional context

<!-- Add any other context or screenshots here. -->
![image](https://github.com/ynput/ayon-frontend/assets/49156310/c06de435-b516-4dde-839f-c519373dab96)
