### PR TITLE
Browser: Version select replace prime react with arc dropdown

### DIFF
--- a/src/pages/BrowserPage/Products/Products.jsx
+++ b/src/pages/BrowserPage/Products/Products.jsx
@@ -207,6 +207,30 @@ const Products = () => {
     }
   }
 
+  const onSelectVersion = async (
+    { versionId, productId, folderId, versionName, currentSelected },
+    data,
+  ) => {
+    // load data here and patch into cache
+    const res = await handleVersionChange([[versionId, productId]])
+    if (res) {
+      // copy current selection
+      let newSelection = { ...currentSelected }
+      // update selection
+      newSelection[productId] = { versionId, folderId }
+
+      dispatch(setSelectedVersions(newSelection))
+      // set selected product
+      dispatch(productSelected({ products: [productId], versions: [versionId] }))
+      // update breadcrumbs
+      let uri = `ayon+entity://${projectName}/`
+      uri += `${data.parents.join('/')}/${data.folder}`
+      uri += `?product=${data.name}`
+      uri += `&version=${versionName}`
+      dispatch(setUri(uri))
+    }
+  }
+
   let columns = useMemo(
     () => [
       {
@@ -284,31 +308,13 @@ const Products = () => {
         field: 'versionList',
         header: 'Version',
         width: 70,
-        body: (node) =>
-          VersionList(
-            { ...node.data },
-            async ({ versionId, productId, folderId, versionName, currentSelected }) => {
-              // load data here and patch into cache
-              const res = await handleVersionChange([[versionId, productId]])
-              if (res) {
-                // copy current selection
-                let newSelection = { ...currentSelected }
-                // update selection
-                newSelection[productId] = { versionId, folderId }
-
-                dispatch(setSelectedVersions(newSelection))
-                // set selected product
-                dispatch(productSelected({ products: [productId], versions: [versionId] }))
-                // update breadcrumbs
-                let uri = `ayon+entity://${projectName}/`
-                uri += `${node.data.parents.join('/')}/${node.data.folder}`
-                uri += `?product=${node.data.name}`
-                uri += `&version=${versionName}`
-                dispatch(setUri(uri))
-              }
-            },
-            selectedVersions,
-          ), // end VersionList
+        body: (node) => (
+          <VersionList
+            row={node.data}
+            selectedVersions={selectedVersions}
+            onSelectVersion={(version) => onSelectVersion(version, node.data)}
+          />
+        ),
       },
       {
         field: 'createdAt',


### PR DESCRIPTION
## Description of changes

<!-- Please state what you've changed and how it might affect the user. -->
- Replaces the prime react select component with our own ARC dropdown component.
- Now 16+ versions will provide a search bar.

### Technical details

<!-- Please state any technical details such as limitations -->
<!-- reasons for additional dependencies, benchmarks etc. here. -->

This whole thing is really weirdly written but I haven't had the time to rewrite it yet. It works so....

### Additional context

1. `/projects/demo_Commercial/browser`
2. Select a folder
3. Select a task and change the version

<!-- Add any other context or screenshots here. -->
![image](https://github.com/ynput/ayon-frontend/assets/49156310/cec108ad-651e-45a5-8007-f71a10e174b6)
