### PR TITLE
Comment: reference link styling, deleting and tooltips

### DIFF
--- a/src/components/CommentInput/CommentInput.jsx
+++ b/src/components/CommentInput/CommentInput.jsx
@@ -23,6 +23,7 @@ import FilesGrid from '/src/containers/FilesGrid/FilesGrid'
 import { useGetTeamsQuery } from '/src/services/team/getTeams'
 import { useSelector } from 'react-redux'
 import { getModules, quillFormats } from './modules'
+import useMentionLink from './hooks/useMentionLink'
 
 const mentionTypes = ['@', '@@', '@@@']
 export const mentionTypeOptions = {
@@ -54,6 +55,7 @@ const CommentInput = ({
   filter,
   disabled,
   isLoading,
+  scope,
 }) => {
   const currentUser = useSelector((state) => state.user.name)
 
@@ -76,6 +78,9 @@ const CommentInput = ({
 
   // When editing, set selection to the end of the editor
   useSetCursorEnd({ initHeight, editorRef, isEditing })
+
+  // create a new quill format for mentions and registers it
+  useMentionLink({ projectName, projectInfo, scope })
 
   // for the task (entity), get all folderIds
   const folderIds = entities.flatMap((entity) => entity.folderId || [])

--- a/src/components/CommentInput/CommentInput.jsx
+++ b/src/components/CommentInput/CommentInput.jsx
@@ -291,7 +291,7 @@ const CommentInput = ({
         // just deleting any text
         const quill = editorRef.current.getEditor()
         const currentSelection = quill.getSelection(false)
-        const currentFormat = quill.getFormat(currentSelection.index, currentSelection.length)
+        const currentFormat = quill.getFormat(currentSelection?.index, currentSelection?.length)
         if (currentFormat.mention) {
           // if format is mention, delete the whole mention
           const [lineBlock] = quill.getLine(currentSelection.index - 1) || []
@@ -311,7 +311,7 @@ const CommentInput = ({
     // get editor retain
     const quill = editorRef.current.getEditor()
 
-    let retain = quill.getSelection()?.index || 0
+    let retain = quill.getSelection(true)?.index || 0
 
     // get character at retain
     const currentCharacter = quill.getText(retain - 1, 1)

--- a/src/components/CommentInput/CommentInput.jsx
+++ b/src/components/CommentInput/CommentInput.jsx
@@ -327,6 +327,23 @@ const CommentInput = ({
     typeWithDelay(quill, retain, type)
   }
 
+  const handleMentionButton = (type) => {
+    // first check if mention is already open
+    if (mention) {
+      const { type, retain, search = '' } = mention
+
+      const quill = editorRef.current.getEditor()
+      const selection = quill.getSelection()
+      const length = type.length + search.length
+      const start = retain - type.length + 1
+      console.log(start, length)
+      // delete the mention
+      quill.deleteText(start, length)
+    }
+
+    addTextToEditor(type)
+  }
+
   const handleSubmit = async () => {
     try {
       // convert to markdown
@@ -550,7 +567,7 @@ const CommentInput = ({
               <Button
                 icon="person"
                 variant="text"
-                onClick={() => addTextToEditor('@')}
+                onClick={() => handleMentionButton('@')}
                 data-tooltip={'Mention user'}
                 data-shortcut={'@'}
               />
@@ -558,7 +575,7 @@ const CommentInput = ({
               <Button
                 icon="layers"
                 variant="text"
-                onClick={() => addTextToEditor('@@')}
+                onClick={() => handleMentionButton('@@')}
                 data-tooltip={'Mention version'}
                 data-shortcut={'@@'}
               />
@@ -566,7 +583,7 @@ const CommentInput = ({
               <Button
                 icon="check_circle"
                 variant="text"
-                onClick={() => addTextToEditor('@@@')}
+                onClick={() => handleMentionButton('@@@')}
                 data-tooltip={'Mention task'}
                 data-shortcut={'@@@'}
               />

--- a/src/components/CommentInput/CommentInput.jsx
+++ b/src/components/CommentInput/CommentInput.jsx
@@ -333,10 +333,8 @@ const CommentInput = ({
       const { type, retain, search = '' } = mention
 
       const quill = editorRef.current.getEditor()
-      const selection = quill.getSelection()
       const length = type.length + search.length
       const start = retain - type.length + 1
-      console.log(start, length)
       // delete the mention
       quill.deleteText(start, length)
     }

--- a/src/components/CommentInput/CommentInput.styled.js
+++ b/src/components/CommentInput/CommentInput.styled.js
@@ -58,6 +58,36 @@ export const Comment = styled.div`
     }
   }
 
+  /* custom mention styles */
+  .ql-editor {
+    .mention {
+      border-radius: var(--border-radius-m);
+      user-select: none;
+      padding: 0 4px;
+      /* remove underline */
+      text-decoration: none;
+
+      white-space: nowrap;
+      cursor: pointer;
+
+      color: var(--md-sys-color-primary);
+      background-color: var(--md-sys-color-surface-container-high);
+
+      &:hover {
+        background-color: var(--md-sys-color-surface-container-high-hover);
+      }
+      &:active {
+        background-color: var(--md-sys-color-surface-container-high-active);
+      }
+
+      /* the ::before is where the text is held */
+      &::before {
+        content: 'test';
+        display: inline;
+      }
+    }
+  }
+
   /* list and check box styles */
   .ql-editor ol {
     li {

--- a/src/components/CommentInput/hooks/useMentionLink.js
+++ b/src/components/CommentInput/hooks/useMentionLink.js
@@ -1,0 +1,84 @@
+import { Quill } from 'react-quill-ayon'
+import useReferenceTooltip from '/src/containers/Feed/hooks/useReferenceTooltip'
+import { useDispatch } from 'react-redux'
+import { openSlideOut } from '/src/features/details'
+const Inline = Quill.import('blots/inline')
+
+// custom mention links
+const useMentionLink = ({ projectName, projectInfo, scope }) => {
+  const dispatch = useDispatch()
+  const [, setRefTooltip] = useReferenceTooltip({ dispatch })
+
+  // special link for mentions
+  class MentionLink extends Inline {
+    static blotName = 'mention'
+    static tagName = 'A'
+    static create(value) {
+      if (!value || typeof value !== 'string') return
+
+      const node = super.create(value)
+      // check if this is a mention url
+      const valueMentionType = value.split(':').shift()
+      const valueMentionId = value.split(':').pop()
+
+      //   get label from innerText and removing @ symbols
+      const label = node.innerText.replace('@', '')
+
+      node.classList.add('mention')
+      node.classList.add(valueMentionType)
+      //   set as not editable
+      node.setAttribute('contenteditable', 'false')
+
+      // add data-value attribute
+      node.setAttribute('data-value', value)
+      // set href value
+      node.setAttribute('href', value)
+
+      //   on mouse click open reference
+      node.addEventListener('click', (e) => {
+        e.preventDefault()
+        if (valueMentionType === 'user') return
+        dispatch(
+          openSlideOut({
+            entityId: valueMentionId,
+            entityType: valueMentionType,
+            projectName,
+            scope,
+          }),
+        )
+      })
+
+      // add on mouse enter
+      node.addEventListener('mouseenter', (e) => {
+        const target = e.target || {}
+        // get the center of the reference
+        const { x, y, width } = target.getBoundingClientRect()
+        const pos = { left: x + width / 2, top: y }
+
+        setRefTooltip({
+          id: valueMentionId,
+          name: valueMentionId,
+          type: valueMentionType,
+          label,
+          pos,
+          projectName,
+          projectInfo,
+        })
+      })
+
+      //   on mouse leave
+      node.addEventListener('mouseleave', () => {
+        // Your code here
+        console.log('Mouse left!')
+        setRefTooltip(null)
+      })
+
+      return node
+    }
+  }
+
+  MentionLink.sanitize = (url) => url
+  Quill.register(MentionLink, true)
+}
+
+export default useMentionLink

--- a/src/components/CommentInput/hooks/useMentionLink.js
+++ b/src/components/CommentInput/hooks/useMentionLink.js
@@ -21,9 +21,6 @@ const useMentionLink = ({ projectName, projectInfo, scope }) => {
       const valueMentionType = value.split(':').shift()
       const valueMentionId = value.split(':').pop()
 
-      //   get label from innerText and removing @ symbols
-      const label = node.innerText.replace('@', '')
-
       node.classList.add('mention')
       node.classList.add(valueMentionType)
       //   set as not editable
@@ -51,6 +48,7 @@ const useMentionLink = ({ projectName, projectInfo, scope }) => {
       // add on mouse enter
       node.addEventListener('mouseenter', (e) => {
         const target = e.target || {}
+        const label = target.innerText.replace('@', '')
         // get the center of the reference
         const { x, y, width } = target.getBoundingClientRect()
         const pos = { left: x + width / 2, top: y }
@@ -69,11 +67,10 @@ const useMentionLink = ({ projectName, projectInfo, scope }) => {
       //   on mouse leave
       node.addEventListener('mouseleave', () => {
         // Your code here
-        console.log('Mouse left!')
         setRefTooltip(null)
       })
 
-      return node
+      return node || ''
     }
   }
 

--- a/src/components/CommentInput/modules/index.js
+++ b/src/components/CommentInput/modules/index.js
@@ -1,11 +1,44 @@
 import { Quill } from 'react-quill-ayon'
 import MagicUrl from 'quill-magic-url'
 import ImageUploader from './ImageUploader'
+import { mentionTypeOptions } from '../CommentInput'
 Quill.register('modules/imageUploader', ImageUploader)
 Quill.register('modules/magicUrl', MagicUrl)
 
-const Link = Quill.import('formats/link')
-Link.sanitize = (url) => url
+// custom links
+const Inline = Quill.import('blots/inline')
+
+// special link for mentions
+class MentionLink extends Inline {
+  static blotName = 'mention'
+  static tagName = 'A'
+  static create(value) {
+    const node = super.create(value)
+    // check if this is a mention url
+    const mentionIds = Object.values(mentionTypeOptions).map((option) => option.id)
+    const valueMentionId = value.split(':').shift()
+
+    if (mentionIds.includes(valueMentionId)) {
+      node.classList.add('mention')
+      node.classList.add(valueMentionId)
+
+      // add data-value attribute
+      node.setAttribute('data-value', value)
+      // set href value
+      node.setAttribute('href', value)
+
+      // add on click event
+      node.addEventListener('click', (e) => {
+        e.preventDefault()
+        console.log(e)
+      })
+    }
+
+    return node
+  }
+}
+MentionLink.sanitize = (url) => url
+Quill.register(MentionLink, true)
 
 // override icons with material icons
 const getIcon = (icon) => '<span class="material-symbols-outlined icon">' + icon + '</span>'
@@ -22,7 +55,16 @@ icons['list']['check'] = getIcon('checklist')
 icons['image'] = getIcon('attach_file')
 icons['code-block'] = getIcon('code')
 
-export const quillFormats = ['header', 'bold', 'italic', 'strike', 'list', 'link', 'code-block']
+export const quillFormats = [
+  'header',
+  'bold',
+  'italic',
+  'strike',
+  'list',
+  'link',
+  'code-block',
+  'mention',
+]
 
 export const getModules = ({ imageUploader }) => {
   return {
@@ -33,5 +75,6 @@ export const getModules = ({ imageUploader }) => {
     ],
     imageUploader,
     magicUrl: true,
+    mentionSelect: {},
   }
 }

--- a/src/components/CommentInput/modules/index.js
+++ b/src/components/CommentInput/modules/index.js
@@ -1,44 +1,8 @@
 import { Quill } from 'react-quill-ayon'
 import MagicUrl from 'quill-magic-url'
 import ImageUploader from './ImageUploader'
-import { mentionTypeOptions } from '../CommentInput'
 Quill.register('modules/imageUploader', ImageUploader)
 Quill.register('modules/magicUrl', MagicUrl)
-
-// custom links
-const Inline = Quill.import('blots/inline')
-
-// special link for mentions
-class MentionLink extends Inline {
-  static blotName = 'mention'
-  static tagName = 'A'
-  static create(value) {
-    const node = super.create(value)
-    // check if this is a mention url
-    const mentionIds = Object.values(mentionTypeOptions).map((option) => option.id)
-    const valueMentionId = value.split(':').shift()
-
-    if (mentionIds.includes(valueMentionId)) {
-      node.classList.add('mention')
-      node.classList.add(valueMentionId)
-
-      // add data-value attribute
-      node.setAttribute('data-value', value)
-      // set href value
-      node.setAttribute('href', value)
-
-      // add on click event
-      node.addEventListener('click', (e) => {
-        e.preventDefault()
-        console.log(e)
-      })
-    }
-
-    return node
-  }
-}
-MentionLink.sanitize = (url) => url
-Quill.register(MentionLink, true)
 
 // override icons with material icons
 const getIcon = (icon) => '<span class="material-symbols-outlined icon">' + icon + '</span>'
@@ -75,6 +39,5 @@ export const getModules = ({ imageUploader }) => {
     ],
     imageUploader,
     magicUrl: true,
-    mentionSelect: {},
   }
 }

--- a/src/components/Feed/ActivityComment/ActivityComment.jsx
+++ b/src/components/Feed/ActivityComment/ActivityComment.jsx
@@ -10,6 +10,8 @@ import { useSelector } from 'react-redux'
 import CommentInput from '/src/components/CommentInput/CommentInput'
 import { aTag, codeTag, inputTag } from './activityMarkdownComponents'
 import FilesGrid from '/src/containers/FilesGrid/FilesGrid'
+import ActivityReferenceTooltip from '../ActivityReferenceTooltip/ActivityReferenceTooltip'
+import { hideRefTooltip, showRefTooltip } from '/src/features/details'
 
 const ActivityComment = ({
   activity = {},
@@ -25,6 +27,7 @@ const ActivityComment = ({
   onFileExpand,
   showOrigin,
   isHighlighted,
+  dispatch,
 }) => {
   let {
     body,
@@ -43,6 +46,7 @@ const ActivityComment = ({
   let menuId = 'comment-' + activity.activityId
   if (isSlideOut) menuId += '-slideout'
   const isMenuOpen = useSelector((state) => state.context.menuOpen) === menuId
+  const tooltip = useSelector((state) => state.details.refTooltip)
 
   // EDITING
   const [isEditing, setIsEditing] = useState(false)
@@ -61,73 +65,96 @@ const ActivityComment = ({
     setIsEditing(false)
   }
 
+  const handleRefHover = (refData) => {
+    if (refData && refData.id !== tooltip.id) {
+      // open
+      dispatch(showRefTooltip(refData))
+    }
+
+    if (!refData && tooltip.id) {
+      // close
+      dispatch(hideRefTooltip())
+    }
+  }
+
   return (
-    <Styled.Comment
-      className={classNames('comment', { isOwner, isMenuOpen, isEditing, isHighlighted })}
-    >
-      <ActivityHeader
-        id={menuId}
-        name={authorName}
-        fullName={authorFullName}
-        date={createdAt}
-        isRef={referenceType !== 'origin' || showOrigin}
-        activity={activity}
-        onDelete={() => onDelete && onDelete(activityId)}
-        onEdit={handleEditComment}
-        projectInfo={projectInfo}
-        projectName={projectName}
-        entityType={entityType}
-        onReferenceClick={onReferenceClick}
-      />
-      <Styled.Body className={classNames('comment-body', { isEditing })}>
-        {isEditing ? (
-          <CommentInput
-            isOpen={true}
-            initValue={body}
-            initFiles={files}
-            isEditing
-            onClose={handleEditCancel}
-            onSubmit={handleSave}
-            projectInfo={projectInfo}
-            {...editProps}
-          />
-        ) : (
-          <>
-            <CommentWrapper>
-              <ReactMarkdown
-                remarkPlugins={[remarkGfm, emoji]}
-                urlTransform={(url) => url}
-                components={{
-                  // a links
-                  a: (props) =>
-                    aTag(props, {
-                      entityId,
-                      projectName,
-                      projectInfo,
-                      onReferenceClick,
-                      activityId,
-                    }),
-                  // checkbox inputs
-                  input: (props) => inputTag(props, { activity, onCheckChange }),
-                  // code syntax highlighting
-                  code: (props) => codeTag(props),
-                }}
-              >
-                {body}
-              </ReactMarkdown>
-            </CommentWrapper>
-            {/* file uploads */}
-            <FilesGrid
-              files={files}
-              isCompact={files.length > 6}
-              projectName={projectName}
-              isDownloadable
-              onExpand={onFileExpand}
+    <>
+      <Styled.Comment
+        className={classNames('comment', { isOwner, isMenuOpen, isEditing, isHighlighted })}
+      >
+        <ActivityHeader
+          id={menuId}
+          name={authorName}
+          fullName={authorFullName}
+          date={createdAt}
+          isRef={referenceType !== 'origin' || showOrigin}
+          activity={activity}
+          onDelete={() => onDelete && onDelete(activityId)}
+          onEdit={handleEditComment}
+          projectInfo={projectInfo}
+          projectName={projectName}
+          entityType={entityType}
+          onReferenceClick={onReferenceClick}
+          onReferenceTooltip={handleRefHover}
+        />
+        <Styled.Body className={classNames('comment-body', { isEditing })}>
+          {isEditing ? (
+            <CommentInput
+              isOpen={true}
+              initValue={body}
+              initFiles={files}
+              isEditing
+              onClose={handleEditCancel}
+              onSubmit={handleSave}
+              projectInfo={projectInfo}
+              {...editProps}
             />
-          </>
-        )}
-      </Styled.Body>
-    </Styled.Comment>
+          ) : (
+            <>
+              <CommentWrapper>
+                <ReactMarkdown
+                  remarkPlugins={[remarkGfm, emoji]}
+                  urlTransform={(url) => url}
+                  components={{
+                    // a links
+                    a: (props) =>
+                      aTag(props, {
+                        entityId,
+                        projectName,
+                        projectInfo,
+                        onReferenceClick,
+                        onReferenceTooltip: handleRefHover,
+                        activityId,
+                      }),
+                    // checkbox inputs
+                    input: (props) => inputTag(props, { activity, onCheckChange }),
+                    // code syntax highlighting
+                    code: (props) => codeTag(props),
+                  }}
+                >
+                  {body}
+                </ReactMarkdown>
+              </CommentWrapper>
+              {/* file uploads */}
+              <FilesGrid
+                files={files}
+                isCompact={files.length > 6}
+                projectName={projectName}
+                isDownloadable
+                onExpand={onFileExpand}
+              />
+            </>
+          )}
+        </Styled.Body>
+      </Styled.Comment>
+      {tooltip.id && (
+        <ActivityReferenceTooltip
+          pos={tooltip.pos}
+          {...{ projectName, projectInfo }}
+          {...tooltip}
+        />
+      )}
+    </>
   )
 }
 

--- a/src/components/Feed/ActivityComment/ActivityComment.jsx
+++ b/src/components/Feed/ActivityComment/ActivityComment.jsx
@@ -11,7 +11,7 @@ import CommentInput from '/src/components/CommentInput/CommentInput'
 import { aTag, codeTag, inputTag } from './activityMarkdownComponents'
 import FilesGrid from '/src/containers/FilesGrid/FilesGrid'
 import ActivityReferenceTooltip from '../ActivityReferenceTooltip/ActivityReferenceTooltip'
-import { hideRefTooltip, showRefTooltip } from '/src/features/details'
+import useReferenceTooltip from '/src/containers/Feed/hooks/useReferenceTooltip'
 
 const ActivityComment = ({
   activity = {},
@@ -46,7 +46,6 @@ const ActivityComment = ({
   let menuId = 'comment-' + activity.activityId
   if (isSlideOut) menuId += '-slideout'
   const isMenuOpen = useSelector((state) => state.context.menuOpen) === menuId
-  const tooltip = useSelector((state) => state.details.refTooltip)
 
   // EDITING
   const [isEditing, setIsEditing] = useState(false)
@@ -65,17 +64,7 @@ const ActivityComment = ({
     setIsEditing(false)
   }
 
-  const handleRefHover = (refData) => {
-    if (refData && refData.id !== tooltip.id) {
-      // open
-      dispatch(showRefTooltip(refData))
-    }
-
-    if (!refData && tooltip.id) {
-      // close
-      dispatch(hideRefTooltip())
-    }
-  }
+  const [refTooltip, setRefTooltip] = useReferenceTooltip({ dispatch })
 
   return (
     <>
@@ -95,7 +84,7 @@ const ActivityComment = ({
           projectName={projectName}
           entityType={entityType}
           onReferenceClick={onReferenceClick}
-          onReferenceTooltip={handleRefHover}
+          onReferenceTooltip={setRefTooltip}
         />
         <Styled.Body className={classNames('comment-body', { isEditing })}>
           {isEditing ? (
@@ -123,7 +112,7 @@ const ActivityComment = ({
                         projectName,
                         projectInfo,
                         onReferenceClick,
-                        onReferenceTooltip: handleRefHover,
+                        onReferenceTooltip: setRefTooltip,
                         activityId,
                       }),
                     // checkbox inputs
@@ -147,11 +136,11 @@ const ActivityComment = ({
           )}
         </Styled.Body>
       </Styled.Comment>
-      {tooltip.id && (
+      {refTooltip.id && (
         <ActivityReferenceTooltip
-          pos={tooltip.pos}
+          pos={refTooltip.pos}
           {...{ projectName, projectInfo }}
-          {...tooltip}
+          {...refTooltip}
         />
       )}
     </>

--- a/src/components/Feed/ActivityComment/activityMarkdownComponents.jsx
+++ b/src/components/Feed/ActivityComment/activityMarkdownComponents.jsx
@@ -24,7 +24,7 @@ const sanitizeURL = (url = '') => {
 
 export const aTag = (
   { children, href },
-  { entityId, projectName, projectInfo, onReferenceClick, activityId },
+  { entityId, projectName, onReferenceClick, activityId, onReferenceTooltip },
 ) => {
   const { url, type, id } = sanitizeURL(href)
 
@@ -44,13 +44,14 @@ export const aTag = (
 
   return (
     <ActivityReference
-      name={id}
-      {...{ type, id, label, projectName, projectInfo }}
+      {...{ type }}
       variant={isEntity ? 'filled' : 'primary'}
       onClick={() =>
         type !== 'user' &&
         onReferenceClick({ entityId: id, entityType: type, projectName, activityId })
       }
+      onMouseEnter={(e, pos) => onReferenceTooltip({ type, id, label, name: id, pos })}
+      onMouseLeave={() => onReferenceTooltip(null)}
     >
       {label}
     </ActivityReference>

--- a/src/components/Feed/ActivityHeader/ActivityHeader.jsx
+++ b/src/components/Feed/ActivityHeader/ActivityHeader.jsx
@@ -19,10 +19,10 @@ const ActivityHeader = ({
   onEdit,
   children,
   id,
-  projectInfo,
   projectName,
   entityType,
   onReferenceClick,
+  onReferenceTooltip,
 }) => {
   const { referenceType, origin = {}, isOwner, activityType, versions = [], activityId } = activity
   const isMention = referenceType === 'mention'
@@ -57,9 +57,7 @@ const ActivityHeader = ({
             <ActivityReference
               id={origin?.id}
               type={origin?.type}
-              projectName={projectName}
               variant="text"
-              projectInfo={projectInfo}
               onClick={() =>
                 onReferenceClick({
                   entityId: origin?.id,
@@ -68,6 +66,16 @@ const ActivityHeader = ({
                   activityId,
                 })
               }
+              onMouseEnter={(e, pos) =>
+                onReferenceTooltip({
+                  type: origin?.type,
+                  id: origin?.id,
+                  label: origin?.label,
+                  name: origin?.id,
+                  pos,
+                })
+              }
+              onMouseLeave={() => onReferenceTooltip(null)}
             >
               {origin?.label || origin?.name}
             </ActivityReference>

--- a/src/components/Feed/ActivityReference/ActivityReference.jsx
+++ b/src/components/Feed/ActivityReference/ActivityReference.jsx
@@ -1,5 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
-import ActivityReferenceTooltip from '../ActivityReferenceTooltip/ActivityReferenceTooltip'
+import { useRef } from 'react'
 import * as Styled from './ActivityReference.styled'
 import { Icon } from '@ynput/ayon-react-components'
 import { classNames } from 'primereact/utils'
@@ -8,61 +7,38 @@ import getEntityTypeIcon from '/src/helpers/getEntityTypeIcon'
 // variants = filled, text
 
 const ActivityReference = ({
-  id,
   type,
   variant = 'surface',
-  label,
-  name,
   isEntity,
   disabled,
-  projectName,
-  projectInfo,
-  onClick,
+  onMouseEnter,
   ...props
 }) => {
   const icon = type === 'user' ? 'alternate_email' : getEntityTypeIcon(type, 'link')
-  const [refHover, setRefHover] = useState(false)
-  const [referenceCenterPos, setReferenceCenterPos] = useState(null)
 
   const ref = useRef(null)
 
-  //   find the center of the reference
-  useEffect(() => {
-    if (!ref.current) return
+  const handleMouseEnter = (e) => {
+    // get the center of the reference
     const { x, y, width } = ref.current.getBoundingClientRect()
+    const pos = { left: x + width / 2, top: y }
 
-    setReferenceCenterPos({ left: x + width / 2, top: y })
-  }, [ref.current, refHover])
-
-  const handleClick = () => {
-    onClick && onClick()
-    // close hover
-    setRefHover(false)
+    onMouseEnter && onMouseEnter(e, pos)
   }
 
   return (
-    <>
-      <Styled.Reference
-        {...props}
-        variant={variant}
-        icon={icon}
-        $variant={variant}
-        ref={ref}
-        onMouseEnter={() => !disabled && setRefHover(true)}
-        onMouseLeave={() => setRefHover(false)}
-        onClick={handleClick}
-        className={classNames({ disabled, isEntity }, 'reference')}
-      >
-        <Icon icon={icon} />
-        {props.children}
-      </Styled.Reference>
-      {refHover && (
-        <ActivityReferenceTooltip
-          pos={referenceCenterPos}
-          {...{ type, id, label, name, projectName, projectInfo }}
-        />
-      )}
-    </>
+    <Styled.Reference
+      {...props}
+      variant={variant}
+      icon={icon}
+      $variant={variant}
+      ref={ref}
+      onMouseEnter={handleMouseEnter}
+      className={classNames({ disabled, isEntity }, 'reference')}
+    >
+      <Icon icon={icon} />
+      {props.children}
+    </Styled.Reference>
   )
 }
 

--- a/src/components/Tooltips/EntityTooltip/EntityTooltip.styled.js
+++ b/src/components/Tooltips/EntityTooltip/EntityTooltip.styled.js
@@ -27,5 +27,5 @@ export const TooltipEntityCard = styled(EntityCard)`
   }
 
   /* shadow */
-  box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 0 10px 0 rgba(0, 0, 0, 0.2);
 `

--- a/src/containers/Feed/Feed.jsx
+++ b/src/containers/Feed/Feed.jsx
@@ -278,6 +278,7 @@ const Feed = ({
                   versions: versionsData,
                 }}
                 isHighlighted={highlighted.includes(activity.activityId)}
+                dispatch={dispatch}
               />
             ))}
         {hasPreviousPage && (

--- a/src/containers/Feed/Feed.jsx
+++ b/src/containers/Feed/Feed.jsx
@@ -221,7 +221,7 @@ const Feed = ({
   }
 
   const handleRefClick = (ref = {}) => {
-    const { entityId, entityType, projectName, activityId } = ref
+    const { entityId, entityType, activityId } = ref
     const supportedTypes = ['version', 'task']
 
     if (!supportedTypes.includes(entityType)) return console.log('Entity type not supported yet')
@@ -307,6 +307,7 @@ const Feed = ({
         filter={filter}
         disabled={isMultiProjects}
         isLoading={isLoadingNew || !entities.length}
+        scope={scope}
       />
     </Styled.FeedContainer>
   )

--- a/src/containers/Feed/hooks/useReferenceTooltip.js
+++ b/src/containers/Feed/hooks/useReferenceTooltip.js
@@ -10,7 +10,7 @@ const useReferenceTooltip = ({ dispatch }) => {
       dispatch(showRefTooltip(ref))
     }
 
-    if (!ref && refTooltip.id) {
+    if (!ref) {
       // close
       dispatch(hideRefTooltip())
     }

--- a/src/containers/Feed/hooks/useReferenceTooltip.js
+++ b/src/containers/Feed/hooks/useReferenceTooltip.js
@@ -1,0 +1,22 @@
+import { useSelector } from 'react-redux'
+import { hideRefTooltip, showRefTooltip } from '/src/features/details'
+
+const useReferenceTooltip = ({ dispatch }) => {
+  const refTooltip = useSelector((state) => state.details.refTooltip)
+
+  const setRefTooltip = (ref) => {
+    if (ref && ref.id !== refTooltip.id) {
+      // open
+      dispatch(showRefTooltip(ref))
+    }
+
+    if (!ref && refTooltip.id) {
+      // close
+      dispatch(hideRefTooltip())
+    }
+  }
+
+  return [refTooltip, setRefTooltip]
+}
+
+export default useReferenceTooltip

--- a/src/features/details.js
+++ b/src/features/details.js
@@ -15,6 +15,14 @@ const initialStateSlideOut = {
   projectName: '',
 }
 
+const initialTooltip = {
+  id: null,
+  type: '',
+  name: '',
+  label: '',
+  pos: {},
+}
+
 const scopes = ['dashboard', 'project', 'inbox']
 
 const detailsSlice = createSlice({
@@ -35,6 +43,7 @@ const detailsSlice = createSlice({
       tab: 'feed', // feed | attribs | representations,
       highlighted: [],
     },
+    refTooltip: initialTooltip,
   },
   reducers: {
     updateDetailsPanelTab: (state, { payload }) => {
@@ -71,6 +80,8 @@ const detailsSlice = createSlice({
         // set highlighted activity
         state.slideOut.highlighted = [payload.activityId]
       }
+      // hide tooltip
+      state.refTooltip = initialTooltip
     },
     closeSlideOut: (state) => {
       for (const scope of scopes) {
@@ -85,6 +96,14 @@ const detailsSlice = createSlice({
       const location = isSlideOut ? 'slideOut' : 'pinned'
       state[location].highlighted = []
     },
+    showRefTooltip: (state, { payload }) => {
+      // open tooltip
+      state.refTooltip = payload
+    },
+    hideRefTooltip: (state) => {
+      // hide tooltip
+      state.refTooltip = initialTooltip
+    },
   },
 })
 
@@ -95,6 +114,8 @@ export const {
   closeSlideOut,
   highlightActivity,
   clearHighlights,
+  showRefTooltip,
+  hideRefTooltip,
 } = detailsSlice.actions
 export default detailsSlice.reducer
 


### PR DESCRIPTION
## Description of changes

<!-- Please state what you've changed and how it might affect the user. -->

Reference links inside the comment editor now act the same as they would inside a comment.

- Added reference styling.
- Hover over the reference to see it's tooltip.
- Click on a reference to open the slide out.
- Hitting backspace now delete the whole reference (instead of the just the first character).

### Technical details

<!-- Please state any technical details such as limitations -->
<!-- reasons for additional dependencies, benchmarks etc. here. -->

- This required creating a new Quill format called `mention`.
- Moved the reference tooltip state to redux so it could be mutated from anywhere (inside quill)

### Additional context

<!-- Add any other context or screenshots here. -->

https://github.com/ynput/ayon-frontend/assets/49156310/1139919b-2e52-4ce8-bf17-ad924f09aa96

