### PR TITLE
Attributes: Min and max values

### DIFF
--- a/src/components/MinMaxField/MinMaxField.jsx
+++ b/src/components/MinMaxField/MinMaxField.jsx
@@ -16,8 +16,8 @@ const Field = styled.div`
 
 const MinMaxField = ({ value = {}, isMin, isFloat = false, onChange }) => {
   const { le, lt, ge, gt } = value
-  const min = ge === undefined ? gt : ge
-  const max = le === undefined ? lt : le
+  const min = ge ?? gt
+  const max = le ?? lt
   const inputRef = useRef()
 
   const fieldValue = isMin ? min : max
@@ -25,7 +25,7 @@ const MinMaxField = ({ value = {}, isMin, isFloat = false, onChange }) => {
   const equalsKey = fieldKey + 'e'
   const moreThanKey = fieldKey + 't'
 
-  const [isEqual, setIsEqual] = useState(value[equalsKey] !== undefined || !isFloat)
+  const [isEqual, setIsEqual] = useState(value[equalsKey] != undefined || !isFloat)
 
   //   when changing from float to integer
   //   ensure all values are equals: ge or le

--- a/src/components/MinMaxField/MinMaxField.jsx
+++ b/src/components/MinMaxField/MinMaxField.jsx
@@ -1,0 +1,118 @@
+import { Button, InputNumber } from '@ynput/ayon-react-components'
+import { useEffect, useRef, useState } from 'react'
+import styled from 'styled-components'
+
+const Field = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  gap: var(--base-gap-small);
+
+  input {
+    width: 100%;
+  }
+`
+
+const MinMaxField = ({ value = {}, isMin, isFloat = false, onChange }) => {
+  const { le, lt, ge, gt } = value
+  const min = ge === undefined ? gt : ge
+  const max = le === undefined ? lt : le
+  const inputRef = useRef()
+
+  const fieldValue = isMin ? min : max
+  const otherValue = isMin ? max : min
+  const otherValueIsEqual = isMin ? value['le'] !== undefined : value['ge'] !== undefined
+  const fieldKey = isMin ? 'g' : 'l'
+  const equalsKey = fieldKey + 'e'
+  const moreThanKey = fieldKey + 't'
+
+  const [isEqual, setIsEqual] = useState(value[equalsKey] !== undefined || !isFloat)
+
+  const checkNotSameValue = (v) => {
+    // ensure that the values don't match
+    if (otherValue === v && !otherValueIsEqual && isFloat) {
+      // oh no! two matching values with  < and > make any value impossible
+      // make input invalid
+      inputRef.current.setCustomValidity('Values must be different')
+    } else {
+      // clear custom validity
+      inputRef.current.setCustomValidity('')
+    }
+  }
+
+  //   when changing from float to integer
+  //   ensure all values are equals: ge or le
+  // convert all values to integers
+  useEffect(() => {
+    if (!isFloat) {
+      onChange({ [equalsKey]: parseInt(fieldValue)?.toString(), [moreThanKey]: undefined })
+      setIsEqual(true)
+    } else {
+      setIsEqual(true)
+    }
+
+    checkNotSameValue(fieldValue)
+  }, [isFloat])
+
+  const handleOnChange = (e) => {
+    const value = e.target.value
+    if (isFloat) {
+      if (isEqual) {
+        onChange({ [equalsKey]: value, [moreThanKey]: undefined })
+      } else {
+        onChange({ [equalsKey]: undefined, [moreThanKey]: value })
+      }
+    } else {
+      onChange({ [equalsKey]: value, [moreThanKey]: undefined })
+    }
+
+    checkNotSameValue(value)
+
+    // clear custom validity
+    inputRef.current.setCustomValidity('')
+  }
+
+  const handleEqualsSwitch = () => {
+    const newIsEqual = !isEqual
+    setIsEqual(newIsEqual)
+    if (newIsEqual) {
+      onChange({ [moreThanKey]: undefined, [equalsKey]: fieldValue })
+    } else {
+      onChange({ [moreThanKey]: fieldValue, [equalsKey]: undefined })
+    }
+
+    checkNotSameValue(fieldValue)
+  }
+
+  const greaterOrLess = isMin ? 'greater' : 'less'
+  const greaterOrLessIcon = isMin ? '>' : '<'
+  const greaterOrLessEqualsIcon = isMin ? '≥' : '≤'
+  const equalsToolTip = `Determines if the value should be '${greaterOrLess} than or equal to' (${greaterOrLessEqualsIcon}) or 'strictly ${greaterOrLess} than' (${greaterOrLessIcon}). Currently: ${
+    isEqual ? greaterOrLessEqualsIcon : greaterOrLessIcon
+  }`
+
+  return (
+    <Field>
+      <InputNumber
+        value={fieldValue}
+        onChange={handleOnChange}
+        step={isFloat ? 'any' : 1}
+        min={isMin ? undefined : min}
+        max={isMin ? max : undefined}
+        ref={inputRef}
+      />
+      {isFloat && (
+        <Button
+          label={greaterOrLessEqualsIcon}
+          selected={isEqual}
+          onClick={handleEqualsSwitch}
+          data-tooltip={equalsToolTip}
+          data-tooltip-delay={0}
+        />
+      )}
+    </Field>
+  )
+}
+
+export default MinMaxField

--- a/src/components/MinMaxField/MinMaxField.jsx
+++ b/src/components/MinMaxField/MinMaxField.jsx
@@ -21,25 +21,11 @@ const MinMaxField = ({ value = {}, isMin, isFloat = false, onChange }) => {
   const inputRef = useRef()
 
   const fieldValue = isMin ? min : max
-  const otherValue = isMin ? max : min
-  const otherValueIsEqual = isMin ? value['le'] !== undefined : value['ge'] !== undefined
   const fieldKey = isMin ? 'g' : 'l'
   const equalsKey = fieldKey + 'e'
   const moreThanKey = fieldKey + 't'
 
   const [isEqual, setIsEqual] = useState(value[equalsKey] !== undefined || !isFloat)
-
-  const checkNotSameValue = (v) => {
-    // ensure that the values don't match
-    if (otherValue === v && !otherValueIsEqual && isFloat) {
-      // oh no! two matching values with  < and > make any value impossible
-      // make input invalid
-      inputRef.current.setCustomValidity('Values must be different')
-    } else {
-      // clear custom validity
-      inputRef.current.setCustomValidity('')
-    }
-  }
 
   //   when changing from float to integer
   //   ensure all values are equals: ge or le
@@ -51,8 +37,6 @@ const MinMaxField = ({ value = {}, isMin, isFloat = false, onChange }) => {
     } else {
       setIsEqual(true)
     }
-
-    checkNotSameValue(fieldValue)
   }, [isFloat])
 
   const handleOnChange = (e) => {
@@ -67,8 +51,6 @@ const MinMaxField = ({ value = {}, isMin, isFloat = false, onChange }) => {
       onChange({ [equalsKey]: value, [moreThanKey]: undefined })
     }
 
-    checkNotSameValue(value)
-
     // clear custom validity
     inputRef.current.setCustomValidity('')
   }
@@ -81,8 +63,6 @@ const MinMaxField = ({ value = {}, isMin, isFloat = false, onChange }) => {
     } else {
       onChange({ [moreThanKey]: fieldValue, [equalsKey]: undefined })
     }
-
-    checkNotSameValue(fieldValue)
   }
 
   const greaterOrLess = isMin ? 'greater' : 'less'

--- a/src/containers/attributes/attributeEditor.jsx
+++ b/src/containers/attributes/attributeEditor.jsx
@@ -13,6 +13,7 @@ import {
 } from '@ynput/ayon-react-components'
 import EnumEditor from './enumEditor'
 import { camelCase } from 'lodash'
+import MinMaxField from '/src/components/MinMaxField/MinMaxField'
 
 const SCOPE_OPTIONS = [
   { value: 'project', label: 'Project' },
@@ -136,8 +137,6 @@ const AttributeEditor = ({ attribute, existingNames, onHide, onEdit }) => {
     }
   }
 
-
-
   return (
     <Dialog
       header={formData?.data?.title || formData?.name || 'New attribute'}
@@ -146,7 +145,7 @@ const AttributeEditor = ({ attribute, existingNames, onHide, onEdit }) => {
       isOpen={true}
       style={{ width: 700, zIndex: 999 }}
       size="full"
-      variant='dialog'
+      variant="dialog"
     >
       {formData && (
         <FormLayout>
@@ -191,6 +190,25 @@ const AttributeEditor = ({ attribute, existingNames, onHide, onEdit }) => {
               fieldComp = customFields['booleanDefault'](formData?.data[field], (value) =>
                 setData(field, value),
               )
+            } else if (['ge', 'gt', 'le', 'lt'].includes(field)) {
+              // ignore gt and lt
+              if (['gt', 'lt'].includes(field)) return null
+              fieldComp = (
+                <MinMaxField
+                  value={formData?.data}
+                  isMin={field === 'ge'}
+                  isFloat={formData?.data?.type === 'float'}
+                  onChange={(v) =>
+                    setFormData((d) => {
+                      const dt = { ...d.data, ...v }
+                      return { ...d, data: dt }
+                    })
+                  }
+                />
+              )
+
+              // rewrite field to min or max
+              field = field === 'ge' ? 'min' : 'max'
             } else {
               fieldComp = (
                 <InputText


### PR DESCRIPTION
## Description of changes

<!-- Please state what you've changed and how it might affect the user. -->
Instead of `gt, ge, lt, le` values use `min` and `max`.

When `type=float` give the option to toggle `>, ≥, <, ≤`.

### Technical details

<!-- Please state any technical details such as limitations -->
<!-- reasons for additional dependencies, benchmarks etc. here. -->
The returned attribute can not have both `ge` and `gt` at the same time (same for `lt` and `le`).

### Additional context

<!-- Add any other context or screenshots here. -->
![image](https://github.com/ynput/ayon-frontend/assets/49156310/1348045a-5c00-4f64-9b41-b30fcbda8cb5)

