### PR TITLE
Feed: mentioning another entity invalidates its feed

### DIFF
--- a/src/components/CommentInput/CommentInput.jsx
+++ b/src/components/CommentInput/CommentInput.jsx
@@ -331,13 +331,14 @@ const CommentInput = ({
   const handleSubmit = async () => {
     try {
       // convert to markdown
-      const markdown = convertToMarkdown(editorValue)
+      const [markdown, refs] = convertToMarkdown(editorValue)
+
       // remove img query params
       const markdownParsed = parseImages(markdown)
 
       if ((markdownParsed || files.length) && onSubmit) {
         try {
-          await onSubmit(markdownParsed, files)
+          await onSubmit(markdownParsed, files, refs)
           // only clear if onSubmit is successful
           setEditorValue('')
           setFiles([])

--- a/src/components/CommentInput/CommentInput.jsx
+++ b/src/components/CommentInput/CommentInput.jsx
@@ -69,7 +69,15 @@ const CommentInput = ({
   const markdownRef = useRef(null)
 
   // if there is an initial value, set it so the editor is prefilled
-  useInitialValue({ markdownRef, initValue, setEditorValue, setInitHeight, isOpen, filter })
+  useInitialValue({
+    markdownRef,
+    editorRef,
+    initValue,
+    setEditorValue,
+    setInitHeight,
+    isOpen,
+    filter,
+  })
 
   // When editing, set selection to the end of the editor
   useSetCursorEnd({ initHeight, editorRef, isEditing })

--- a/src/components/CommentInput/CommentInput.styled.js
+++ b/src/components/CommentInput/CommentInput.styled.js
@@ -79,12 +79,6 @@ export const Comment = styled.div`
       &:active {
         background-color: var(--md-sys-color-surface-container-high-active);
       }
-
-      /* the ::before is where the text is held */
-      &::before {
-        content: 'test';
-        display: inline;
-      }
     }
   }
 

--- a/src/components/CommentInput/hooks/useMentionLink.js
+++ b/src/components/CommentInput/hooks/useMentionLink.js
@@ -12,9 +12,9 @@ const useMentionLink = ({ projectName, projectInfo, scope }) => {
   // special link for mentions
   class MentionLink extends Inline {
     static blotName = 'mention'
-    static tagName = 'A'
+    static tagName = 'MENTION'
     static create(value) {
-      if (!value || typeof value !== 'string') return
+      if (!value || typeof value !== 'string') return document.createElement(MentionLink.tagName)
 
       const node = super.create(value)
       // check if this is a mention url
@@ -30,8 +30,6 @@ const useMentionLink = ({ projectName, projectInfo, scope }) => {
 
       // add data-value attribute
       node.setAttribute('data-value', value)
-      // set href value
-      node.setAttribute('href', value)
 
       //   on mouse click open reference
       node.addEventListener('click', (e) => {
@@ -67,6 +65,11 @@ const useMentionLink = ({ projectName, projectInfo, scope }) => {
       })
 
       return node || ''
+    }
+
+    // Added value method to retrieve the value from the DOM node
+    static value(node) {
+      return node.getAttribute('data-value')
     }
   }
 

--- a/src/components/CommentInput/quillToMarkdown.jsx
+++ b/src/components/CommentInput/quillToMarkdown.jsx
@@ -122,8 +122,6 @@ export const convertToMarkdown = (value) => {
 
   let body = markdown
 
-  console.log(body)
-
   // inside the markdown, find characters inside () or [] and replace @ with nothing
   const regex = /\((.*?)\)|\[(.*?)\]/g
   const matches = markdown.match(regex)
@@ -135,9 +133,9 @@ export const convertToMarkdown = (value) => {
     })
   }
 
-  console.log(body)
-
   const entities = getTextRefs(markdown)
 
   return [body, entities]
 }
+
+// "8061b1801dab11ef95ad0242ac180005"

--- a/src/components/CommentInput/quillToMarkdown.jsx
+++ b/src/components/CommentInput/quillToMarkdown.jsx
@@ -78,6 +78,32 @@ const parseCodeBlocks = (value) => {
   return value
 }
 
+export const getTextRefs = (text = '') => {
+  // inside the markdown, find characters inside ()
+  const regex2 = /\((.*?)\)/g
+  const links = text.match(regex2) || []
+  const entities = links.flatMap((link) => {
+    // if https, then it is a link and not an entity
+    if (link.includes('http')) {
+      return []
+    } else {
+      // remove the ()
+      const match = link.match(/\(([^)]+)\)/)
+      let parts = []
+      if (match) {
+        // split by :
+        parts = match[1].split(':')
+      }
+      return {
+        type: parts[0],
+        id: parts[1],
+      }
+    }
+  })
+
+  return entities
+}
+
 export const convertToMarkdown = (value) => {
   const codeBlocksParsed = parseCodeBlocks(value)
 
@@ -86,16 +112,17 @@ export const convertToMarkdown = (value) => {
 
   let body = markdown
 
-  // inside the markdown, find characters inside () or [] and replace @ with nothing
-  const regex = /\((.*?)\)|\[(.*?)\]/g
-  const matches = markdown.match(regex)
-  if (matches) {
-    matches.forEach((match) => {
-      if (match.includes('http')) return
+  // inside the markdown, find characters inside [] and replace @ with nothing
+  const regex = /\[(.*?)\]/g
+  const labels = markdown.match(regex)
+  if (labels) {
+    labels.forEach((match) => {
       const newMatch = match.replaceAll('@', '')
       body = body.replace(match, newMatch)
     })
   }
 
-  return body
+  const entities = getTextRefs(markdown)
+
+  return [body, entities]
 }

--- a/src/components/CommentInput/quillToMarkdown.jsx
+++ b/src/components/CommentInput/quillToMarkdown.jsx
@@ -56,6 +56,16 @@ turndownService.addRule('unOrderedList', {
   },
 })
 
+// convert mention tags to links
+turndownService.addRule('mention', {
+  filter: function (node) {
+    return node.classList.contains('mention') && node.getAttribute('data-value')
+  },
+  replacement: function (content, node) {
+    return `[${content}](${node.getAttribute('data-value')})`
+  },
+})
+
 // replace <p> with <br> for line breaks
 const replaceLineBreaks = (html) => {
   return html.replaceAll('<p>', '').replaceAll('</p>', '\n').replaceAll('```', '')
@@ -112,15 +122,20 @@ export const convertToMarkdown = (value) => {
 
   let body = markdown
 
-  // inside the markdown, find characters inside [] and replace @ with nothing
-  const regex = /\[(.*?)\]/g
-  const labels = markdown.match(regex)
-  if (labels) {
-    labels.forEach((match) => {
+  console.log(body)
+
+  // inside the markdown, find characters inside () or [] and replace @ with nothing
+  const regex = /\((.*?)\)|\[(.*?)\]/g
+  const matches = markdown.match(regex)
+  if (matches) {
+    matches.forEach((match) => {
+      if (match.includes('http')) return
       const newMatch = match.replaceAll('@', '')
       body = body.replace(match, newMatch)
     })
   }
+
+  console.log(body)
 
   const entities = getTextRefs(markdown)
 

--- a/src/components/Feed/ActivityComment/ActivityComment.jsx
+++ b/src/components/Feed/ActivityComment/ActivityComment.jsx
@@ -40,6 +40,7 @@ const ActivityComment = ({
     author,
     isOwner,
     files = [],
+    origin,
   } = activity
   if (!authorName) authorName = author?.name || ''
   if (!authorFullName) authorFullName = author?.fullName || authorName
@@ -64,10 +65,20 @@ const ActivityComment = ({
     setIsEditing(false)
   }
 
+  const isRef = referenceType !== 'origin' || showOrigin
+
   const handleDelete = () => {
     const refs = getTextRefs(body)
 
-    onDelete && onDelete(activityId, entityId, refs)
+    // if the comment is a reference, (it's origin is not the entity)
+    // we need to delete the reference from the origin as well
+    // add it to the refs to delete
+    if (isRef && origin) {
+      refs.push({ id: origin.id, type: origin.type })
+    }
+
+    // note: body is used to match other refs to delete
+    onDelete && onDelete(activityId, entityId, refs, body)
   }
 
   const [, setRefTooltip] = useReferenceTooltip({ dispatch })
@@ -82,7 +93,7 @@ const ActivityComment = ({
           name={authorName}
           fullName={authorFullName}
           date={createdAt}
-          isRef={referenceType !== 'origin' || showOrigin}
+          isRef={isRef}
           activity={activity}
           onDelete={handleDelete}
           onEdit={handleEditComment}

--- a/src/components/Feed/ActivityComment/ActivityComment.jsx
+++ b/src/components/Feed/ActivityComment/ActivityComment.jsx
@@ -11,6 +11,7 @@ import CommentInput from '/src/components/CommentInput/CommentInput'
 import { aTag, codeTag, inputTag } from './activityMarkdownComponents'
 import FilesGrid from '/src/containers/FilesGrid/FilesGrid'
 import useReferenceTooltip from '/src/containers/Feed/hooks/useReferenceTooltip'
+import { getTextRefs } from '../../CommentInput/quillToMarkdown'
 
 const ActivityComment = ({
   activity = {},
@@ -63,6 +64,12 @@ const ActivityComment = ({
     setIsEditing(false)
   }
 
+  const handleDelete = () => {
+    const refs = getTextRefs(body)
+
+    onDelete && onDelete(activityId, entityId, refs)
+  }
+
   const [, setRefTooltip] = useReferenceTooltip({ dispatch })
 
   return (
@@ -77,7 +84,7 @@ const ActivityComment = ({
           date={createdAt}
           isRef={referenceType !== 'origin' || showOrigin}
           activity={activity}
-          onDelete={() => onDelete && onDelete(activityId)}
+          onDelete={handleDelete}
           onEdit={handleEditComment}
           projectInfo={projectInfo}
           projectName={projectName}

--- a/src/containers/Feed/Feed.jsx
+++ b/src/containers/Feed/Feed.jsx
@@ -146,6 +146,7 @@ const Feed = ({
     entities,
     activityTypes,
     filter,
+    dispatch,
   })
 
   // When a checkbox is clicked, update the body to add/remove "x" in [ ] markdown
@@ -237,7 +238,7 @@ const Feed = ({
                   activity={activity}
                   onCheckChange={handleCommentChecked}
                   onDelete={deleteComment}
-                  onUpdate={(value, files) => updateComment(activity, value, files)}
+                  onUpdate={(value, files, refs) => updateComment(activity, value, files, refs)}
                   projectInfo={projectInfo}
                   projectName={projectName}
                   entityType={entityType}
@@ -251,6 +252,7 @@ const Feed = ({
                     activeUsers,
                     projectName,
                     entities: entities,
+                    entityType,
                   }}
                   isHighlighted={highlighted.includes(activity.activityId)}
                   dispatch={dispatch}

--- a/src/containers/Feed/hooks/useCommentMutations.js
+++ b/src/containers/Feed/hooks/useCommentMutations.js
@@ -65,7 +65,7 @@ const useCommentMutations = ({
     return body.includes('* [ ]') || body.includes('* [x]')
   }
 
-  const patchAllRefs = ({ refs = [], value = '', files = [], isDelete = false }) => {
+  const patchAllRefs = ({ refs = [], value = '', files = [], isDelete = false, id }) => {
     const hasChecklist = bodyHasChecklist(value)
     // We need to try and update the cache for all the refs
     refs.forEach((ref) => {
@@ -73,7 +73,7 @@ const useCommentMutations = ({
       const patch = !isDelete
         ? createPatch({
             entityId: ref.id,
-            newId: getActivityId(),
+            newId: id,
             subTitle: '',
             value,
             files,
@@ -105,8 +105,10 @@ const useCommentMutations = ({
 
   const submitComment = async (value, files = [], refs = []) => {
     // map over all the entities and create a new comment for each
+    let patchId = null
     const promises = entities.map(({ id: entityId, subTitle }) => {
       const newId = getActivityId()
+      if (!patchId) patchId = newId
       const fileIds = files.map((file) => file.id)
 
       const newComment = {
@@ -137,7 +139,7 @@ const useCommentMutations = ({
       const results = await Promise.all(promises)
 
       // try and patch any ref caches
-      patchAllRefs({ value, refs, files })
+      patchAllRefs({ value, refs, files, id: patchId })
 
       return results
     } catch (error) {
@@ -174,7 +176,7 @@ const useCommentMutations = ({
       }).unwrap()
 
       // try and patch any ref caches
-      patchAllRefs({ value, refs, files })
+      patchAllRefs({ value, refs, files, id: activity.activityId })
 
       return res
     } catch (error) {

--- a/src/containers/Feed/hooks/useCommentMutations.js
+++ b/src/containers/Feed/hooks/useCommentMutations.js
@@ -25,11 +25,13 @@ const useCommentMutations = ({
   const [updateActivity] = useUpdateActivityMutation()
   const [deleteActivity] = useDeleteActivityMutation()
 
-  // type:"entityActivities"
-  // id:"80528aac1dab11ef95ad0242ac180005"
+  const invalidateRefs = (refs = []) => {
+    const entityIds = refs.filter((v) => v.type !== 'user').map((v) => v.id)
+    const uniqueEntityIds = [...new Set(entityIds)]
+    const tags = uniqueEntityIds.map((id) => ({ type: 'entityActivities', id }))
 
-  // id: "80528aac1dab11ef95ad0242ac180005"
-  // type: "entityActivities"
+    dispatch(ayonApi.util.invalidateTags(tags))
+  }
 
   const createPatch = ({ entityId, newId, subTitle, value, files = [] }) => {
     const patch = {
@@ -178,6 +180,9 @@ const useCommentMutations = ({
       // try and patch any ref caches
       patchAllRefs({ value, refs, files, id: activity.activityId })
 
+      // try invalidating any refs as a backup
+      invalidateRefs(refs)
+
       return res
     } catch (error) {
       console.error(error)
@@ -203,6 +208,9 @@ const useCommentMutations = ({
 
       // try and patch any ref caches
       patchAllRefs({ refs, isDelete: true, value: body })
+
+      // try invalidating any refs as a backup
+      invalidateRefs(refs)
     } catch (error) {
       // error is handled in the mutation
     }

--- a/src/containers/Feed/hooks/useTransformActivities.js
+++ b/src/containers/Feed/hooks/useTransformActivities.js
@@ -74,7 +74,15 @@ const useTransformActivities = (activities = [], projectInfo = {}, entityType) =
     [groupedActivitiesData],
   )
 
-  return groupedVersionsData
+  // 7. ensure there are no duplicate activities
+  const uniqueActivitiesData = useMemo(
+    () => [
+      ...new Map(groupedVersionsData.map((activity) => [activity.activityId, activity])).values(),
+    ],
+    [groupedVersionsData],
+  )
+
+  return uniqueActivitiesData
 }
 
 export default useTransformActivities

--- a/src/services/activities/getActivities.js
+++ b/src/services/activities/getActivities.js
@@ -51,6 +51,9 @@ const getActivities = ayonApi.injectEndpoints({
 
         const uniqueMessages = Array.from(messagesMap.values())
 
+        // sort the messages by date with the newest first
+        uniqueMessages.sort((a, b) => new Date(a.createdAt) - new Date(b.createdAt))
+
         return {
           activities: uniqueMessages,
           pageInfo,

--- a/src/services/activities/getActivities.js
+++ b/src/services/activities/getActivities.js
@@ -43,15 +43,16 @@ const getActivities = ayonApi.injectEndpoints({
         const { activities = [], pageInfo } = newCache
         const { activities: lastActivities = [] } = currentCache
 
-        const newMessages = [
-          ...lastActivities,
-          ...activities.filter(
-            (m) => !lastActivities.some((lm) => lm.referenceId === m.referenceId),
-          ),
-        ]
+        const messagesMap = new Map()
+
+        ;[lastActivities, activities].forEach((arr) =>
+          arr.forEach((m) => messagesMap.set(m.referenceId, m)),
+        )
+
+        const uniqueMessages = Array.from(messagesMap.values())
 
         return {
-          activities: newMessages,
+          activities: uniqueMessages,
           pageInfo,
         }
       },


### PR DESCRIPTION
## Description of changes

<!-- Please state what you've changed and how it might affect the user. -->
When a entity is mentioned in a comment, that entities feed has it's cache updated with the changes. This is most obvious when you have two different feeds up at once and one feed mentions the other one.

Also fixes a critical error when trying to edit comments with references in them.

### Technical details

<!-- Please state any technical details such as limitations -->
<!-- reasons for additional dependencies, benchmarks etc. here. -->
- We can't use `invalidateTags` because sometimes the target feed already has a cursor (from infinite scrolling) and so the refreshed data doesn't get the new comment because it's past the cursor. This is a limitation of RTK Query.
- So instead we need to update the cache manually ourselves. Because we don't know if the target cache exists, which filter it is using then we have to try all the filters.

### Additional context

<!-- Add any other context or screenshots here. -->
