### PR TITLE
Workfiles: fix double slashes when roots are replaced

### DIFF
--- a/src/pages/WorkfilesPage/WorkfileDetail.jsx
+++ b/src/pages/WorkfilesPage/WorkfileDetail.jsx
@@ -28,7 +28,10 @@ const replaceRoot = (inputStr, replacements) => {
     //TODO: fix eslint error
     //eslint-disable-next-line
     if (replacements.hasOwnProperty(p1)) {
-      return replacements[p1]
+      let value = replacements[p1]
+      // strip forward and back slashes from the end of the value
+      value = value.replace(/\/$/, '')
+      return value
     }
     return match
   })


### PR DESCRIPTION
Root specified with a trailing slash no longer produces paths with a slash duplicated:

![image](https://github.com/ynput/ayon-frontend/assets/5007200/1232eebc-9820-47a4-853e-20f4284258d4)

![image](https://github.com/ynput/ayon-frontend/assets/5007200/fc17da9d-c248-457a-8320-fe5e6a3e239b)
