### PR TITLE
Tasks: thumbnail does not always use latest version

### DIFF
--- a/src/components/ListItem/ListItem.jsx
+++ b/src/components/ListItem/ListItem.jsx
@@ -86,7 +86,10 @@ const ListItem = forwardRef(
         ) : (
           <Styled.SimpleStatus icon={task.statusIcon} style={{ color: task.statusColor }} />
         )}
-        <Styled.ItemThumbnail src={task.thumbnailUrl} icon={task.taskIcon} />
+        <Styled.ItemThumbnail
+          src={task.thumbnailUrl?.replace('&placeholder=none', '')}
+          icon={task.taskIcon}
+        />
 
         {/* FOLDER LABEL */}
         <Styled.Folder className="folder" style={{ minWidth: minWidths.folder }}>

--- a/src/containers/Feed/Feed.jsx
+++ b/src/containers/Feed/Feed.jsx
@@ -198,7 +198,7 @@ const Feed = ({
 
   const handleRefClick = (ref = {}) => {
     const { entityId, entityType, activityId } = ref
-    const supportedTypes = ['version', 'task']
+    const supportedTypes = ['version', 'task', 'folder']
 
     if (!supportedTypes.includes(entityType)) return console.log('Entity type not supported yet')
 

--- a/src/services/userDashboard/userDashboardHelpers.js
+++ b/src/services/userDashboard/userDashboardHelpers.js
@@ -7,10 +7,14 @@ import getEntityTypeIcon from '/src/helpers/getEntityTypeIcon'
 export const transformTasksData = ({ projectName, tasks = [], code }) =>
   tasks?.map((task) => {
     const versions = task.versions?.edges?.map((edge) => edge.node) || []
-    const latestVersionWithThumbnail = [...versions]
-      .sort((a, b) => a.name.localeCompare(b.name))
-      .reverse()
-      .find((version) => version.thumbnailId)
+    // get latest version with thumbnail
+    // if there is a version named 'HERO' with a thumbnail, use that always
+    const latestVersionWithThumbnail =
+      versions.find((version) => version.name === 'HERO' && version.thumbnailId) ||
+      [...versions]
+        .sort((a, b) => a.name.localeCompare(b.name))
+        .reverse()
+        .find((version) => version.thumbnailId)
 
     // use task thumbnail if it exists, otherwise use latest version thumbnail
     const thumbnailId = task?.thumbnailId || latestVersionWithThumbnail?.thumbnailId

--- a/src/services/userDashboard/userDashboardHelpers.js
+++ b/src/services/userDashboard/userDashboardHelpers.js
@@ -8,6 +8,7 @@ export const transformTasksData = ({ projectName, tasks = [], code }) =>
   tasks?.map((task) => {
     const versions = task.versions?.edges?.map((edge) => edge.node) || []
     const latestVersionWithThumbnail = [...versions]
+      .sort((a, b) => a.name.localeCompare(b.name))
       .reverse()
       .find((version) => version.thumbnailId)
 

--- a/src/services/userDashboard/userDashboardQueries.js
+++ b/src/services/userDashboard/userDashboardQueries.js
@@ -25,6 +25,7 @@ const TASK_FRAGMENT = () => `
       edges {
         node {
           thumbnailId
+          name
         }
       }
   }


### PR DESCRIPTION
## Description of changes

<!-- Please state what you've changed and how it might affect the user. -->
If no task thumbnail is available then it should use the next latest version thumbnail.

### Technical details

<!-- Please state any technical details such as limitations -->
<!-- reasons for additional dependencies, benchmarks etc. here. -->
I thought versions came sorted from the query but I've added in another sort to be extra sort it's sorting from highest to lowest.

If there is a HERO version with a thumbnail, then that will always be used. 🦸 


