### PR TITLE
Editor: onNewChanges patches rather than overwrites changes

### DIFF
--- a/src/features/editor.js
+++ b/src/features/editor.js
@@ -57,10 +57,8 @@ const editorSlice = createSlice({
       state.projectName = action.payload
     },
     onNewChanges: (state, { payload = [] }) => {
-      for (const node of payload) {
-        const id = node.id
-        delete node.id
-        state.changes[id] = node
+      for (const { id, ...node } of payload) {
+        state.changes[id] = { ...(state.changes[id] || {}), ...node }
       }
     },
     onForceChange: (state, { payload = {} }) => {

--- a/src/pages/EditorPage/EditorPanel.jsx
+++ b/src/pages/EditorPage/EditorPanel.jsx
@@ -422,13 +422,11 @@ const EditorPanel = ({
     let allChanges = []
     for (const id in nodes) {
       const node = nodes[id]
-      const currentChanges = changes[id] || {
-        __entityType: node.data.__entityType,
-        __parentId: node.data.__parentId,
-      }
+
       const rowChanges = {
         id,
-        ...currentChanges,
+        __entityType: node.data.__entityType,
+        __parentId: node.data.__parentId,
         [changeKey]: value === '' ? null : value,
       }
 


### PR DESCRIPTION
### Technical details

This was very hard to debug and the issue seemed to happen randomly. My best guess is that states became out of sync because of the debouncing of the changes.

I'm hoping that this fixes the issue by patching the changes to the state instead of overwriting them with all the changes every time. The bad values came from this overwriting method.
