### PR TITLE
Inbox: Disable notifications button if using http

### DIFF
--- a/src/components/EnableNotifications.jsx
+++ b/src/components/EnableNotifications.jsx
@@ -24,13 +24,19 @@ const EnableNotifications = () => {
     }
   }
 
+  const disabled = window.location.protocol !== 'https' && window.location.hostname !== 'localhost' // disable if not on HTTPS or localhost
+  const tooltip = disabled
+    ? 'Browser notifications only work over HTTPS'
+    : 'Get notifications on your device'
+
   return (
     Notification.permission !== 'granted' && (
       <Button
         icon={'notifications'}
-        data-tooltip="Get notifications on your device"
+        data-tooltip={tooltip}
         onClick={handleEnable}
         variant="filled"
+        disabled={disabled}
       >
         Enable notifications
       </Button>

--- a/src/pages/AccountPage/ProfilePage.jsx
+++ b/src/pages/AccountPage/ProfilePage.jsx
@@ -234,6 +234,12 @@ const ProfilePage = ({ user = {}, isLoading }) => {
     toast.success('Profile updated')
   }
 
+  const notificationsDisabled =
+    window.location.protocol !== 'https' && window.location.hostname !== 'localhost' // disable if not on HTTPS or localhost
+  const notificationsTooltip = notificationsDisabled
+    ? 'Browser notifications only work over HTTPS'
+    : 'Get notifications on your device'
+
   return (
     <main>
       <Section style={{ paddingTop: 16 }}>
@@ -262,15 +268,12 @@ const ProfilePage = ({ user = {}, isLoading }) => {
             </FormRow>
 
             <FormRow label="Desktop Notifications" key="notifications">
-              <div
-                data-tooltip="Keep an 'AYON' important notifications on your device"
-                style={{ width: 'fit-content' }}
-              >
+              <div data-tooltip={notificationsTooltip} style={{ width: 'fit-content' }}>
                 <InputSwitch
                   checked={preferencesData.notifications}
                   id={'notifications'}
                   onChange={handleChangePreferences}
-                  disabled={isUpdatingPreferences || isLoading}
+                  disabled={isUpdatingPreferences || isLoading || notificationsDisabled}
                 />
               </div>
             </FormRow>


### PR DESCRIPTION
## Description of changes

<!-- Please state what you've changed and how it might affect the user. -->
Disable desktop notifications button and switch when AYON is not hosted over `https` or `localhost`.

![image](https://github.com/ynput/ayon-frontend/assets/49156310/c90a6c76-b40a-4ae3-9b39-de85bb8599ca)

