### PR TITLE
Bundles: Comparing latest version takes suffixes into consideration

### DIFF
--- a/src/pages/SettingsPage/Bundles/BundlesAddonList.jsx
+++ b/src/pages/SettingsPage/Bundles/BundlesAddonList.jsx
@@ -173,9 +173,13 @@ const BundlesAddonList = React.forwardRef(
             const isPipeline = addon.addonType === 'pipeline'
             const currentVersion = addon.version
             const allVersions = addon.versions
-            const sortedVersions = Object.keys(allVersions).sort((a, b) =>
-              rcompare(coerce(a), coerce(b)),
-            )
+            const sortedVersions = Object.keys(allVersions).sort((a, b) => {
+              const comparison = rcompare(coerce(a), coerce(b))
+              if (comparison === 0) {
+                return b.localeCompare(a)
+              }
+              return comparison
+            })
             const latestVersion = sortedVersions[0]
 
             if (readOnly && isPipeline)


### PR DESCRIPTION
## Description of changes

<!-- Please state what you've changed and how it might affect the user. -->
Even when versions don't follow traditional semver formating like `0.3.3-dev.2` `0.3.3-dev.1` they should still sort correctly using alphabetical descending.


