### PR TITLE
Editor: Check if indirect child has any parent with ownAttrib

### DIFF
--- a/src/pages/EditorPage/EditorPage.jsx
+++ b/src/pages/EditorPage/EditorPage.jsx
@@ -285,8 +285,6 @@ const EditorPage = () => {
               })
             }
 
-            console.log(newChildData)
-
             // Recursively update the attributes of the child's children
             updateChildren(id, newChildData, childSkipAttribs)
           }

--- a/src/pages/EditorPage/NewEntity.jsx
+++ b/src/pages/EditorPage/NewEntity.jsx
@@ -73,8 +73,6 @@ const NewEntity = ({ type, currentSelection = {}, visible, onConfirm, onHide }) 
         }
       }
 
-      console.log(folder)
-
       // set defaults
       if (type === 'task') setEntityData(task)
       if (type === 'folder') setEntityData(folder)
@@ -190,8 +188,6 @@ const NewEntity = ({ type, currentSelection = {}, visible, onConfirm, onHide }) 
   if (!entityType) return null
 
   const addDisabled = !entityData.label || !entityData.type
-
-  console.log(entityType)
 
   return (
     <Dialog


### PR DESCRIPTION
## Description of changes

<!-- Please state what you've changed and how it might affect the user. -->
This fix ensures that inherited values are not set on children that have some other parent with `ownAttrib`.

https://github.com/ynput/ayon-frontend/assets/49156310/916218a3-dfca-4f85-b4ef-a0622b823038

