### PR TITLE
Dashboard: keep selected projects in sync with open project

### DIFF
--- a/src/containers/ProjectMenu/projectMenu.jsx
+++ b/src/containers/ProjectMenu/projectMenu.jsx
@@ -15,6 +15,7 @@ import ProjectButton from '/src/components/ProjectButton/ProjectButton'
 import { createPortal } from 'react-dom'
 import { useShortcutsContext } from '/src/context/shortcutsContext'
 import { classNames } from 'primereact/utils'
+import { onProjectOpened } from '/src/features/dashboard'
 
 const ProjectMenu = ({ isOpen, onHide }) => {
   const navigate = useNavigate()
@@ -177,6 +178,8 @@ const ProjectMenu = ({ isOpen, onHide }) => {
     dispatch(ayonApi.util.invalidateTags(['branch', 'workfile', 'hierarchy', 'project', 'product']))
     // reset uri
     dispatch(setUri(`ayon+entity://${projectName}`))
+    // set dashboard projects
+    dispatch(onProjectOpened(projectName))
 
     // close search if it was open
     setSearchOpen(false)

--- a/src/features/dashboard.js
+++ b/src/features/dashboard.js
@@ -27,6 +27,11 @@ const dashboardSlice = createSlice({
     onProjectSelected: (state, { payload = [] }) => {
       state.selectedProjects = payload
     },
+    onProjectOpened: (state, { payload }) => {
+      // check if project is already selected
+      if (state.selectedProjects.includes(payload)) return
+      state.selectedProjects = [payload]
+    },
     onTaskSelected: (state, { payload = [] }) => {
       state.tasks.selected = payload
     },
@@ -66,6 +71,7 @@ const dashboardSlice = createSlice({
 
 export const {
   onProjectSelected,
+  onProjectOpened,
   onTaskSelected,
   onTasksSortByChanged,
   onTasksGroupByChanged,


### PR DESCRIPTION
## Description of changes

<!-- Please state what you've changed and how it might affect the user. -->
When opening a project, make sure the project is selected when returning home.

If you project was already in the selection, do nothing.

### Additional context

<!-- Add any other context or screenshots here. -->


https://github.com/ynput/ayon-frontend/assets/49156310/b9c70edd-e23e-4a27-b8d5-416edd71a32e

