### PR TITLE
Browser: you can now properly filter versions with multiple folders selected.

### DIFF
--- a/src/hooks/useSearchFilter.js
+++ b/src/hooks/useSearchFilter.js
@@ -15,13 +15,13 @@ export const filterByFieldsAndValues = ({
         if (typeof v === 'string') {
           return v?.toLowerCase()
         } else if (Array.isArray(v)) {
-          return v?.flatMap((v) => v.toLowerCase())
+          return v?.flatMap((v) => v?.toLowerCase())
         } else if (typeof v === 'boolean' && v) {
-          return k.toLowerCase()
+          return k?.toLowerCase()
         } else return []
       } else if (v && typeof v === 'object') {
         return Object.entries(v).flatMap(([k2, v2]) => {
-          return fields.includes(`${k}.${k2}`) && v2 ? v2.toString().toLowerCase() : []
+          return fields.includes(`${k}.${k2}`) && v2 ? v2.toString()?.toLowerCase() : []
         })
       } else return []
     }),
@@ -33,7 +33,7 @@ export const filterByFieldsAndValues = ({
       const inverseMatchingKeys = []
       item.keywords?.forEach((key) => {
         filters.forEach((filter) => {
-          let lowerFilter = filter.toLowerCase()
+          let lowerFilter = filter?.toLowerCase()
           // if lowerFilter has a ! at the start do opposite
           if (lowerFilter[0] === '!') {
             lowerFilter = lowerFilter.slice(1)
@@ -86,7 +86,10 @@ const useSearchFilter = (fields = [], data = [], id) => {
   }, [])
 
   let filteredData = useMemo(
-    () => filterByFieldsAndValues({ filters: searchArray, data, fields, matchesAll: true }),
+    () =>
+      searchString.length
+        ? filterByFieldsAndValues({ filters: searchArray, data, fields, matchesAll: true })
+        : data,
     [searchString, data],
   )
 

--- a/src/hooks/useSearchFilter.js
+++ b/src/hooks/useSearchFilter.js
@@ -77,9 +77,10 @@ const useSearchFilter = (fields = [], data = [], id) => {
   // separate searchString into array by ,
   // end up with array ['search', 'search2']
   const searchArray = searchString?.split(',').reduce((acc, cur) => {
+    if (!cur) return acc
     if (cur.trim() === '') return acc
     else {
-      acc.push(cur.trim().toLowerCase())
+      acc.push(cur.trim()?.toLowerCase())
       return acc
     }
   }, [])

--- a/src/pages/BrowserPage/Products/Products.jsx
+++ b/src/pages/BrowserPage/Products/Products.jsx
@@ -406,15 +406,6 @@ const Products = () => {
     return productIds
   }, [listData, focusedVersions])
 
-  // filter by task types
-  let tableData = selectedTaskTypes.length
-    ? filterByFieldsAndValues({
-        filters: selectedTaskTypes,
-        data: listData,
-        fields: ['data.taskType'],
-      })
-    : listData
-
   // Transform the product data into a TreeTable compatible format
   // by grouping the data by the product name
 
@@ -426,7 +417,6 @@ const Products = () => {
         fields: ['taskType'],
       })
     : listData
-
 
   const searchableFields = [
     'versionAuthor',
@@ -444,7 +434,7 @@ const Products = () => {
 
   let [search, setSearch, filteredBySearchData] = useSearchFilter(
     searchableFields,
-    tableData,
+    filteredByFieldsData,
     'products',
   )
 

--- a/src/pages/BrowserPage/Products/Products.jsx
+++ b/src/pages/BrowserPage/Products/Products.jsx
@@ -409,31 +409,27 @@ const Products = () => {
   // Transform the product data into a TreeTable compatible format
   // by grouping the data by the product name
 
-  let tableData = useMemo(() => {
-    return groupResult(listData, 'name')
-  }, [listData])
-
   // filter by task types
   const filteredByFieldsData = selectedTaskTypes.length
     ? filterByFieldsAndValues({
         filters: selectedTaskTypes,
-        data: tableData,
-        fields: ['data.taskType'],
+        data: listData,
+        fields: ['taskType'],
       })
-    : tableData
+    : listData
 
   const searchableFields = [
-    'data.versionAuthor',
-    'data.productType',
-    'data.folder',
-    'data.fps',
-    'data.frames',
-    'data.name',
-    'data.resolution',
-    'data.versionStatus',
-    'data.versionName',
-    'data.taskType',
-    'data.taskName',
+    'versionAuthor',
+    'productType',
+    'folder',
+    'fps',
+    'frames',
+    'name',
+    'resolution',
+    'versionStatus',
+    'versionName',
+    'taskType',
+    'taskName',
   ]
 
   let [search, setSearch, filteredBySearchData] = useSearchFilter(
@@ -441,6 +437,10 @@ const Products = () => {
     filteredByFieldsData,
     'products',
   )
+
+  const tableData = useMemo(() => {
+    return groupResult(filteredBySearchData, 'name')
+  }, [filteredBySearchData])
 
   //
   // Handlers
@@ -551,7 +551,7 @@ const Products = () => {
   // Render
   //
 
-  const isNone = filteredBySearchData.length === 0
+  const isNone = tableData.length === 0
 
   return (
     <Section wrap>
@@ -600,7 +600,7 @@ const Products = () => {
         {viewMode !== 'list' && (
           <ProductsGrid
             isLoading={isLoading || isFetching}
-            data={filteredBySearchData}
+            data={tableData}
             onItemClick={onRowClick}
             onSelectionChange={onSelectionChange}
             onContext={ctxMenuShow}
@@ -616,7 +616,7 @@ const Products = () => {
         )}
         {viewMode === 'list' && (
           <ProductsList
-            data={filteredBySearchData}
+            data={tableData}
             selectedRows={selectedRows}
             onSelectionChange={onSelectionChange}
             onRowClick={onRowClick}


### PR DESCRIPTION
## Description of changes

<!-- Please state what you've changed and how it might affect the user. -->
Before: selecting multiple folders in the browser and then filtering using "search" or "task types" was broken.
After: now you can properly filter even when the versions have been grouped.

Also fixes some type errors that would cause the page to crash.

### Technical details

<!-- Please state any technical details such as limitations -->
<!-- reasons for additional dependencies, benchmarks etc. here. -->
Before it was incorrectly filtering **after** the grouping, now it does the filtering before the grouping.

### Testing
1. Go to browser
2. Select multiple folders
3. Search for something like "approved"
4. Filter by task type

![image](https://github.com/ynput/ayon-frontend/assets/49156310/b134a54c-3fbb-4fad-b4ef-478e2abcf5d4)
