### PR TITLE
 feed only merge activities within 1 minute period

### DIFF
--- a/src/containers/Feed/helpers/mergeSimilarActivities.js
+++ b/src/containers/Feed/helpers/mergeSimilarActivities.js
@@ -27,9 +27,11 @@ const mergeSimilarActivities = (activities, type, oldKey = 'oldValue') => {
         intervalToDuration({ start: activityCreatedAt, end: currentCreatedAt })
 
       // If the activity is within 1 min of the current activity
-      const isWithinOneMin = !('minutes' in activityDuration) || activityDuration.minutes <= 1
+      const seconds = 20
+      const isWithinSeconds =
+        !('minutes' in activityDuration) && activityDuration.seconds <= seconds
 
-      if (isSameAuthor && isWithinOneMin) {
+      if (isSameAuthor && isWithinSeconds) {
         // Continue the sequence, update the newValue from the current activity
         currentActivity[oldKey] = activity[oldKey]
         // also update newValue

--- a/src/containers/Feed/helpers/mergeSimilarActivities.js
+++ b/src/containers/Feed/helpers/mergeSimilarActivities.js
@@ -1,6 +1,8 @@
+import { intervalToDuration, isValid } from 'date-fns'
 import { cloneDeep } from 'lodash'
 
 // Takes activities of the same type and author and merges them into one activity
+// activities must be within one min of each other
 // for example, if there are multiple status change activities by the same author
 // they will be merged into one activity, resulting in a single status change activity
 
@@ -13,7 +15,21 @@ const mergeSimilarActivities = (activities, type, oldKey = 'oldValue') => {
       if (!currentActivity) {
         // Start a new sequence of the same type
         currentActivity = cloneDeep(activity)
-      } else if (currentActivity.authorName === activity.authorName) {
+        continue
+      }
+
+      const isSameAuthor = currentActivity.authorName === activity.authorName
+      const currentCreatedAt = new Date(currentActivity.createdAt)
+      const activityCreatedAt = new Date(activity.createdAt)
+      const activityDuration =
+        isValid(currentCreatedAt) &&
+        isValid(activityCreatedAt) &&
+        intervalToDuration({ start: activityCreatedAt, end: currentCreatedAt })
+
+      // If the activity is within 1 min of the current activity
+      const isWithinOneMin = !('minutes' in activityDuration) || activityDuration.minutes <= 1
+
+      if (isSameAuthor && isWithinOneMin) {
         // Continue the sequence, update the newValue from the current activity
         currentActivity[oldKey] = activity[oldKey]
         // also update newValue
@@ -21,7 +37,7 @@ const mergeSimilarActivities = (activities, type, oldKey = 'oldValue') => {
         currentActivity.hasPreviousPage = activity.hasPreviousPage
         currentActivity.cursor = activity.cursor
       } else {
-        // If the author is different, end the current sequence and start a new one
+        // If the author is different, or not within 1 min, end the current sequence and start a new one
         if (currentActivity.activityData.oldValue !== currentActivity.activityData.newValue) {
           mergedActivities.push(currentActivity)
         }


### PR DESCRIPTION
## Description of changes

<!-- Please state what you've changed and how it might affect the user. -->
Activities should only be merged within a 20 second period. This should deduplicate most user mistakes, for example setting the wrong status and then correcting yourself straight away.

Originally there was no time limit.


![image](https://github.com/ynput/ayon-frontend/assets/49156310/d0537576-bd9a-4d15-8581-0e581dc1fb74)


