### PR TITLE
Help menu label: `Graphql Explorer` -> `GraphQL Explorer`

### DIFF
--- a/src/components/Menu/Menus/HelpMenu.jsx
+++ b/src/components/Menu/Menus/HelpMenu.jsx
@@ -36,7 +36,7 @@ export const HelpMenu = ({ user, ...props }) => {
     },
     {
       id: 'graphql',
-      label: 'Graphql Explorer',
+      label: 'GraphQL Explorer',
       link: '/explorer',
       icon: 'hub',
       target: '_blank',


### PR DESCRIPTION
## PR Checklist

<!-- Please fill in the appropriate checklist below (delete whatever is not relevant) -->

-   [x] This comment contains a description of changes
-   [ ] Referenced issue is linked

## Description of changes

<!-- Please state what you've changed and how it might affect the user. -->

Change the help menu entry label `Graphql Explorer` -> `GraphQL Explorer`.

### Technical details

<!-- Please state any technical details such as limitations -->
<!-- reasons for additional dependencies, benchmarks etc. here. -->

![image](https://github.com/ynput/ayon-frontend/assets/2439881/75ffa25a-f1bd-4aa0-bb4b-a08669279b25)

Apparently it's Graph**QL**

### Additional context

<!-- Add any other context or screenshots here. -->

This took me sweat and tears - please accept it[.](https://www.youtube.com/watch?v=N__AkJriaN4)
