### PR TITLE
Settings: Fix copying empty project-level values

### DIFF
--- a/src/containers/CopySettings/CopySettingsDialog.jsx
+++ b/src/containers/CopySettings/CopySettingsDialog.jsx
@@ -209,6 +209,8 @@ const CopySettingsDialog = ({
       )}
     </Toolbar>
   )
+  
+  const dialogHeader = `Copy ${projectName? `${projectName} `:''}${variant} settings from...`
 
   return (
     <Dialog
@@ -217,7 +219,7 @@ const CopySettingsDialog = ({
       variant="dialog"
       size="full"
       style={{ width: '80vw', height: '80vh', zIndex: 999 }}
-      header={`Copy ${projectName? `${projectName} `:''}${variant} settings ${pickByBundle ? 'by bundle' : ''}`}
+      header={dialogHeader}
       footer={footer}
     >
       <div

--- a/src/containers/CopySettings/CopySettingsDialog.jsx
+++ b/src/containers/CopySettings/CopySettingsDialog.jsx
@@ -103,7 +103,7 @@ const CopySettingsDialog = ({
 
       for (const change of node.changes) {
         if (!change.enabled) continue
-        const value = cloneDeep(change.sourceValue)
+        const value = cloneDeep(change.copyValue)
         addonSettings = setValueByPath(addonSettings, change.path, value)
         addonOverrides.push(change.path)
 

--- a/src/containers/CopySettings/CopySettingsDialog.jsx
+++ b/src/containers/CopySettings/CopySettingsDialog.jsx
@@ -217,7 +217,7 @@ const CopySettingsDialog = ({
       variant="dialog"
       size="full"
       style={{ width: '80vw', height: '80vh', zIndex: 999 }}
-      header={`Copy ${variant} settings ${pickByBundle ? 'by bundle' : ''}`}
+      header={`Copy ${projectName? `${projectName} `:''}${variant} settings ${pickByBundle ? 'by bundle' : ''}`}
       footer={footer}
     >
       <div

--- a/src/containers/CopySettings/CopySettingsNode.jsx
+++ b/src/containers/CopySettings/CopySettingsNode.jsx
@@ -239,16 +239,9 @@ const CopySettingsNode = ({
       let targetValue = getValueByPath(targetSettings.data, path)
       let copyValue = sourceValue
 
-      // do not attempt to copy overrides from default or studio
-      // to project level
       if (targetProjectName && ['default', 'studio'].includes(sourceOverride?.level)) {
-        // console.debug('Skipping override', path, "because it's from default or studio")
-        // console.log('source override', sourceOverride)
-        // continue
         sourceValue = sourceParentSettings ? getValueByPath(sourceParentSettings.data, path) : null
-        copyValue = null
       }
-
 
       // do not attempt to copy if the values are the same
       // ... or rather do copy it. we want to force pinned overrides

--- a/src/containers/CopySettings/CopySettingsNode.jsx
+++ b/src/containers/CopySettings/CopySettingsNode.jsx
@@ -206,6 +206,17 @@ const CopySettingsNode = ({
       projectName: targetProjectName,
     })
 
+    let sourceParentSettings = null
+    if (sourceProjectName) {
+      sourceParentSettings = await triggerGetSettings({
+        addonName,
+        addonVersion: sourceVersion,
+        variant: sourceVariant,
+        projectName: null,
+        asVersion: targetVersion,
+      })
+    }
+
     const allIds = [
       ...new Set([...Object.keys(sourceOverrides.data), ...Object.keys(targetOverrides.data)]),
     ]
@@ -224,15 +235,20 @@ const CopySettingsNode = ({
       }
 
 
+      let sourceValue = getValueByPath(sourceSettings.data, path)
+      let targetValue = getValueByPath(targetSettings.data, path)
+      let copyValue = sourceValue
+
       // do not attempt to copy overrides from default or studio
       // to project level
       if (targetProjectName && ['default', 'studio'].includes(sourceOverride?.level)) {
-        console.debug('Skipping override', path, "because it's from default or studio")
-        continue
+        // console.debug('Skipping override', path, "because it's from default or studio")
+        // console.log('source override', sourceOverride)
+        // continue
+        sourceValue = sourceParentSettings ? getValueByPath(sourceParentSettings.data, path) : null
+        copyValue = null
       }
 
-      const sourceValue = getValueByPath(sourceSettings.data, path)
-      const targetValue = getValueByPath(targetSettings.data, path)
 
       // do not attempt to copy if the values are the same
       // ... or rather do copy it. we want to force pinned overrides
@@ -253,6 +269,7 @@ const CopySettingsNode = ({
       const item = {
         key: id,
         path: path,
+        copyValue,
         sourceValue,
         targetValue,
         sourceLevel: sourceOverride?.level || 'default',

--- a/src/containers/CopySettings/CopySettingsNode.jsx
+++ b/src/containers/CopySettings/CopySettingsNode.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, useRef } from 'react'
 import { isEqual } from 'lodash'
 
 import { Icon, InputSwitch } from '@ynput/ayon-react-components'
@@ -128,6 +128,7 @@ const CopySettingsNode = ({
   const [sourceVariant, setSourceVariant] = useState(null)
   const [sourceProjectName, setSourceProjectName] = useState(null)
   const [loading, setLoading] = useState(false)
+  const currentPromiseRef = useRef(null);
 
   const [triggerGetOverrides] = useLazyGetAddonSettingsOverridesQuery()
   const [triggerGetSettings] = useLazyGetAddonSettingsQuery()
@@ -253,10 +254,7 @@ const CopySettingsNode = ({
           continue
         }
       }
-      console.log('source override', sourceOverride)
-      console.log('target override', targetOverride)
 
-      //const compatible = sameKeysStructure(sourceValue, targetValue)
       const compatible = isCompatibleStructure(sourceValue, targetValue)
 
       const item = {
@@ -298,8 +296,26 @@ const CopySettingsNode = ({
   } //loadNodeData
 
   useEffect(() => {
-    //console.log('LOAD', addonName, sourceVersion, sourceVariant, sourceProjectName)
-    loadNodeData()
+    const callLoadNodeData = async () => {
+      // Wait for the current promise to finish if it exists
+      if (currentPromiseRef.current) {
+        await currentPromiseRef.current;
+      }
+      // Create a new promise for the current loadNodeData call
+      const loadPromise = loadNodeData();
+      currentPromiseRef.current = loadPromise;
+
+      try {
+        await loadPromise;
+      } finally {
+        // Clear the reference if the promise is resolved or rejected
+        if (currentPromiseRef.current === loadPromise) {
+          currentPromiseRef.current = null;
+        }
+      }
+    };
+
+    callLoadNodeData();
   }, [sourceVersion, sourceVariant, sourceProjectName])
 
   const expanded = !!(nodeData?.available && nodeData?.enabled)


### PR DESCRIPTION
When project level settings are copied, allow copy "empty values" while displaying the underlying studio-level override

![image](https://github.com/ynput/ayon-frontend/assets/5007200/1c9a8887-c834-4e29-bafc-f2a3dc57d055)

![image](https://github.com/ynput/ayon-frontend/assets/5007200/db084cbb-5077-47df-8a59-8391aee78519)
