### PR TITLE
Feed: patch ALL activity caches

### DIFF
--- a/src/services/activities/updateActivities.js
+++ b/src/services/activities/updateActivities.js
@@ -18,15 +18,27 @@ const updateCache = (activitiesDraft, patch = {}, isDelete) => {
 
 const patchActivities = async (
   { projectName, patch, entityIds, activityTypes = [], filter },
-  { dispatch, queryFulfilled },
+  { dispatch, queryFulfilled, getState },
   method,
 ) => {
-  // patch new data into the cache of a single entities activities
-  const patchResult = dispatch(
-    ayonApi.util.updateQueryData(
-      'getActivities',
-      { projectName, entityIds, activityTypes, filter },
-      (draft) => updateCache(draft.activities, patch, method === 'delete'),
+  // build tags that would be affected by this activity
+  const invalidatingTags = entityIds.map((id) => ({
+    type: 'entityActivities',
+    id: id + '-' + filter,
+  }))
+
+  const state = getState()
+  // get caches that would be affected by this activity
+  const entries = ayonApi.util.selectInvalidatedBy(state, invalidatingTags)
+
+  // now patch all the caches with the update
+  const patches = entries.forEach(({ originalArgs }) =>
+    dispatch(
+      ayonApi.util.updateQueryData(
+        'getActivities',
+        { projectName, entityIds: originalArgs.entityIds, activityTypes, filter },
+        (draft) => updateCache(draft.activities, patch, method === 'delete'),
+      ),
     ),
   )
 
@@ -36,10 +48,13 @@ const patchActivities = async (
     const message = `Error: ${error?.error?.data?.detail || `Failed to ${method} activity`}`
     console.error(message, error)
     toast.error(message)
-    patchResult.undo()
+    for (const patchResult of patches) {
+      patchResult?.undo()
+    }
   }
 }
 
+// get tags for other filter types
 const getTags = ({ entityId, filter }) => {
   const invalidateFilters = Object.keys(filterActivityTypes).filter((key) => key !== filter)
 


### PR DESCRIPTION
## Description of changes

<!-- Please state what you've changed and how it might affect the user. -->
When creating/updating/deleting an activity, now the changes propagate to all "combinations" of selections of that entity.

### Technical details

<!-- Please state any technical details such as limitations -->
<!-- reasons for additional dependencies, benchmarks etc. here. -->
This was a frontend caching issue.

Everytime an entity or selection of entities is selected a `getActivities(entityIds)` query is made to fetch all activity data for all entities at once.

The FE will create a new cache for every unique `getActivities(entityIds)` request. 

Before we were only patching the comment change for the one cache you were looking at. If you selected a different "combination" of entity ids you could end up with a now stale cache.

Now we make sure to patch every single cache that includes that entityId.
