### PR TITLE
Bootstrap: Do not create prod bundle if prod bundle already exists

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@rtk-query/codegen-openapi": "^1.2.0",
     "@rtk-query/graphql-request-base-query": "^2.3.1",
     "@uiw/react-textarea-code-editor": "^2.1.9",
-    "@ynput/ayon-react-components": "^1.3.1",
+    "@ynput/ayon-react-components": "^1.3.5",
     "axios": "^1.6.3",
     "chart.js": "^4.2.0",
     "date-fns": "^3.6.0",

--- a/src/pages/OnBoarding/Step/AddonSelectStep.jsx
+++ b/src/pages/OnBoarding/Step/AddonSelectStep.jsx
@@ -59,7 +59,7 @@ export const AddonSelectStep = ({
       <Footer
         next="Confirm"
         onNext={onSubmit}
-        nextProps={{ saving: isLoadingRelease }}
+        nextProps={{ saving: isLoadingRelease, disabled: isLoadingRelease }}
         showIcon={isLoadingRelease}
       />
     </Styled.Section>

--- a/src/pages/OnBoarding/util/OnBoardingContext.jsx
+++ b/src/pages/OnBoarding/util/OnBoardingContext.jsx
@@ -66,12 +66,15 @@ const createBundleFromRelease = (release, selectedAddons, bundleList) => {
 
   const name = getNewBundleName(release.name, bundleList)
 
+  // check if there is already a production bundles
+  const hasProduction = bundleList.some((bundle) => bundle?.isProduction)
+
   return {
     name,
     addons,
     installerVersion,
     dependencyPackages,
-    isProduction: true,
+    isProduction: !hasProduction,
   }
 }
 


### PR DESCRIPTION
A new bundle is still created, just it won't be set to isProduction.