### PR TITLE
Comment: Exact dates and toolbar position

### DIFF
--- a/src/components/Feed/ActivityComment/ActivityComment.jsx
+++ b/src/components/Feed/ActivityComment/ActivityComment.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useRef, useState } from 'react'
 import * as Styled from './ActivityComment.styled'
 import ActivityHeader from '../ActivityHeader/ActivityHeader'
 import ReactMarkdown from 'react-markdown'
@@ -12,6 +12,9 @@ import { aTag, codeTag, inputTag } from './activityMarkdownComponents'
 import FilesGrid from '@containers/FilesGrid/FilesGrid'
 import useReferenceTooltip from '@containers/Feed/hooks/useReferenceTooltip'
 import { getTextRefs } from '../../CommentInput/quillToMarkdown'
+import MenuContainer from '@/components/Menu/MenuComponents/MenuContainer'
+import ActivityCommentMenu from '../ActivityCommentMenu/ActivityCommentMenu'
+import { toggleMenuOpen } from '@/features/context'
 
 const ActivityComment = ({
   activity = {},
@@ -81,6 +84,9 @@ const ActivityComment = ({
     onDelete && onDelete(activityId, entityId, refs, body)
   }
 
+  const handleToggleMenu = (menu) => dispatch(toggleMenuOpen(menu))
+  const moreRef = useRef()
+
   const [, setRefTooltip] = useReferenceTooltip({ dispatch })
 
   return (
@@ -89,14 +95,11 @@ const ActivityComment = ({
         className={classNames('comment', { isOwner, isMenuOpen, isEditing, isHighlighted })}
       >
         <ActivityHeader
-          id={menuId}
           name={authorName}
           fullName={authorFullName}
           date={createdAt}
           isRef={isRef}
           activity={activity}
-          onDelete={handleDelete}
-          onEdit={handleEditComment}
           projectInfo={projectInfo}
           projectName={projectName}
           entityType={entityType}
@@ -151,6 +154,23 @@ const ActivityComment = ({
               />
             </>
           )}
+
+          <Styled.Tools className={'tools'} ref={moreRef}>
+            {isOwner && handleEditComment && (
+              <Styled.ToolButton icon="edit_square" onClick={handleEditComment} />
+            )}
+            {isOwner && (
+              <Styled.ToolButton
+                icon="more_horiz"
+                className="more"
+                onClick={() => handleToggleMenu(menuId)}
+              />
+            )}
+          </Styled.Tools>
+
+          <MenuContainer id={menuId} target={moreRef.current}>
+            <ActivityCommentMenu onDelete={() => isOwner && handleDelete()} />
+          </MenuContainer>
         </Styled.Body>
       </Styled.Comment>
     </>

--- a/src/components/Feed/ActivityComment/ActivityComment.styled.js
+++ b/src/components/Feed/ActivityComment/ActivityComment.styled.js
@@ -1,3 +1,4 @@
+import { Button } from '@ynput/ayon-react-components'
 import styled, { css } from 'styled-components'
 
 export const CommentWrapper = styled.div`
@@ -37,11 +38,6 @@ export const Comment = styled.li`
       &.isMenuOpen {
         .tools {
           opacity: 1;
-        }
-
-        .date {
-          opacity: 0;
-          visibility: hidden;
         }
       }
     }
@@ -188,4 +184,22 @@ export const BlockCode = styled.pre`
   line-break: anywhere;
   word-break: break-word;
   overflow: hidden;
+`
+
+export const Tools = styled.div`
+  display: flex;
+  position: absolute;
+  right: 4px;
+  top: 4px;
+  background-color: var(--md-sys-color-surface-container-highest);
+  border-radius: var(--border-radius-m);
+`
+
+export const ToolButton = styled(Button)`
+  padding: 4px;
+
+  [icon='edit_square'] {
+    position: relative;
+    top: -1px;
+  }
 `

--- a/src/components/Feed/ActivityDate.jsx
+++ b/src/components/Feed/ActivityDate.jsx
@@ -11,6 +11,7 @@ import {
 import Typography from '@/theme/typography.module.css'
 import { classNames } from 'primereact/utils'
 import styled from 'styled-components'
+import { useState } from 'react'
 
 const DateStyled = styled.span`
   margin-left: auto;
@@ -39,6 +40,7 @@ export const getFuzzyDate = (date) => {
 }
 
 const ActivityDate = ({ date, isExact, ...props }) => {
+  const [isFuzzy, setIsFuzzy] = useState(true)
   const dateObj = new Date(date)
   if (!isValid(dateObj)) return null
 
@@ -52,16 +54,29 @@ const ActivityDate = ({ date, isExact, ...props }) => {
   const dateFormat = yesterday ? '' : sameYear ? (sameWeek ? 'E' : 'MMM d') : 'MMM d yyyy'
   const timeFormat = 'h:mm a'
 
-  let dateString =
-    today && !isExact ? getFuzzyDate(dateObj) : format(dateObj, `${dateFormat}, ${timeFormat}`)
+  let dateString = isFuzzy
+    ? today && !isExact
+      ? getFuzzyDate(dateObj)
+      : format(dateObj, `${dateFormat}, ${timeFormat}`)
+    : format(dateObj, 'EEEE, dd MMM yyyy HH:mm')
 
   if (yesterday) dateString = `Yesterday${dateString}`
 
   // if less than a minute ago overwrite the date string
   if (sameMin) dateString = 'Just now'
 
+  const toggleFuzzy = () => {
+    setIsFuzzy(!isFuzzy)
+  }
+
   return (
-    <DateStyled className={classNames(Typography.bodySmall, 'date')} {...props}>
+    <DateStyled
+      className={classNames(Typography.bodySmall, 'date')}
+      {...props}
+      onClick={toggleFuzzy}
+      onMouseOver={() => setIsFuzzy(false)}
+      onMouseOut={() => setIsFuzzy(true)}
+    >
       {dateString}
     </DateStyled>
   )

--- a/src/components/Feed/ActivityHeader/ActivityHeader.jsx
+++ b/src/components/Feed/ActivityHeader/ActivityHeader.jsx
@@ -1,12 +1,7 @@
-import React, { useRef } from 'react'
 import * as Styled from './ActivityHeader.styled'
 import UserImage from '@components/UserImage'
 import ActivityReference from '../ActivityReference/ActivityReference'
 import ActivityDate from '../ActivityDate'
-import MenuContainer from '@components/Menu/MenuComponents/MenuContainer'
-import ActivityCommentMenu from '../ActivityCommentMenu/ActivityCommentMenu'
-import { toggleMenuOpen } from '@state/context'
-import { useDispatch } from 'react-redux'
 import { Icon } from '@ynput/ayon-react-components'
 
 const ActivityHeader = ({
@@ -15,16 +10,15 @@ const ActivityHeader = ({
   date,
   isRef,
   activity = {},
-  onDelete,
-  onEdit,
+
   children,
-  id,
+
   projectName,
   entityType,
   onReferenceClick,
   onReferenceTooltip,
 }) => {
-  const { referenceType, origin = {}, isOwner, activityType, versions = [], activityId } = activity
+  const { referenceType, origin = {}, activityType, versions = [], activityId } = activity
   const isMention = referenceType === 'mention'
 
   const isPublish = activityType === 'version.publish'
@@ -33,11 +27,6 @@ const ActivityHeader = ({
 
   const boldString = isMention ? `mentioned` : 'commented'
   const entityTypeString = isMention ? ` ${entityType} on` : 'on'
-
-  // open menu
-  const dispatch = useDispatch()
-  const handleToggleMenu = (menu) => dispatch(toggleMenuOpen(menu))
-  const moreRef = useRef()
 
   const noUser = activity.author?.deleted || !activity.author?.active
   return (
@@ -84,25 +73,6 @@ const ActivityHeader = ({
 
         {/* custom children, like status change */}
         {children}
-        {!isPublish && (
-          <Styled.Tools className={'tools'} ref={moreRef}>
-            {isOwner && onEdit && (
-              <Styled.ToolButton icon="edit_square" variant="text" onClick={onEdit} />
-            )}
-            {isOwner && (
-              <Styled.ToolButton
-                icon="more_horiz"
-                variant="text"
-                className="more"
-                onClick={() => handleToggleMenu(id)}
-              />
-            )}
-          </Styled.Tools>
-        )}
-
-        <MenuContainer id={id} target={moreRef.current}>
-          <ActivityCommentMenu onDelete={() => isOwner && onDelete()} />
-        </MenuContainer>
       </Styled.Body>
       <ActivityDate date={date} />
     </Styled.Header>

--- a/src/components/Feed/ActivityHeader/ActivityHeader.styled.js
+++ b/src/components/Feed/ActivityHeader/ActivityHeader.styled.js
@@ -1,5 +1,4 @@
 import styled from 'styled-components'
-import { Button } from '@ynput/ayon-react-components'
 
 export const Header = styled.header`
   display: flex;
@@ -20,23 +19,6 @@ export const Body = styled.div`
   gap: var(--base-gap-small);
   align-items: center;
   flex-wrap: wrap;
-`
-
-export const Tools = styled.div`
-  display: flex;
-  gap: var(--base-gap-small);
-  position: absolute;
-  right: 0;
-  bottom: 0;
-`
-
-export const ToolButton = styled(Button)`
-  padding: 4px;
-
-  [icon='edit_square'] {
-    position: relative;
-    top: -1px;
-  }
 `
 
 export const Reference = styled.li`


### PR DESCRIPTION
## Description of changes

<!-- Please state what you've changed and how it might affect the user. -->
- Hover over a date to see the full exact date and time.
- The toolbar now appears over the comment body and not over the time.


https://github.com/ynput/ayon-frontend/assets/49156310/734ecbfa-42e8-4858-85ff-0d7713aef602



