### PR TITLE
fix(user settings): Only admins can be developers, managers cannot se…

### DIFF
--- a/src/pages/SettingsPage/UsersSettings/UserAccessForm.jsx
+++ b/src/pages/SettingsPage/UsersSettings/UserAccessForm.jsx
@@ -23,7 +23,7 @@ const NoteStyled = styled.span`
 `
 
 const UserAccessForm = ({ accessGroupsData, formData, onChange, disabled, selectedProjects }) => {
-  const isUserAdmin = useSelector((state) => state.user.data.isAdmin)
+  const authenticatedUser = useSelector((state) => state.user.data)
 
   const userLevels = [
     { label: 'User', value: 'user' },
@@ -31,7 +31,7 @@ const UserAccessForm = ({ accessGroupsData, formData, onChange, disabled, select
   ]
 
   // only admins can
-  if (isUserAdmin) {
+  if (authenticatedUser.isAdmin) {
     userLevels.push({ label: 'Admin', value: 'admin' })
     userLevels.push({ label: 'Service', value: 'service' })
   }
@@ -46,6 +46,7 @@ const UserAccessForm = ({ accessGroupsData, formData, onChange, disabled, select
   }
 
   const isUser = formData?.userLevel === 'user'
+  const isManager = formData?.userLevel === 'manager'
   const isAdmin = formData?.userLevel === 'admin'
 
   const defaultAccessGroups = formData?.defaultAccessGroups
@@ -110,6 +111,22 @@ const UserAccessForm = ({ accessGroupsData, formData, onChange, disabled, select
     updateFormData('accessGroups', newUsersAccessGroups)
   }
 
+  const isDeveloperSwitchDisabled = () => isUser || isManager || !authenticatedUser.isAdmin
+
+  const getTooltip = () => {
+    if (isUser) {
+      return 'Users cannot be developers'
+    }
+    if (isManager) {
+      return 'Managers cannot be developers'
+    }
+    if (authenticatedUser.isManager) {
+      return 'Only admins can set developers'
+    }
+
+    return 'Developers have access to enhanced tools and features'
+  }
+
   return (
     <>
       <b>Access Control</b>
@@ -142,18 +159,14 @@ const UserAccessForm = ({ accessGroupsData, formData, onChange, disabled, select
 
         <FormRowStyled label="Developer">
           <div
-            data-tooltip={
-              isUser
-                ? 'Users cannot be developers'
-                : 'Developers have access to enhanced tools and features.'
-            }
+            data-tooltip={getTooltip()}
             data-tooltip-delay={0}
             style={{ width: 'fit-content' }}
           >
             <InputSwitch
               checked={formData?.isDeveloper}
               onChange={(e) => updateFormData('isDeveloper', e.target.checked)}
-              disabled={isUser}
+              disabled={isDeveloperSwitchDisabled()}
               style={{
                 opacity: disabled ? 0.5 : 1,
               }}


### PR DESCRIPTION
Disabling switch if the following conditions are not fulfilled, updating tooltip accordingly:
- Managers cannot set admins as developers
- Only admins can be set as developers

closes #596 
