### PR TITLE
Users: Custom form for a adding service user

### DIFF
--- a/src/components/ApiKeyManager.jsx
+++ b/src/components/ApiKeyManager.jsx
@@ -20,7 +20,7 @@ const PanelStyled = styled(Panel)`
   }
 `
 
-const ApiKeyManager = ({ preview, name }) => {
+const ApiKeyManager = ({ preview, name, autosave = true, onGenerate }) => {
   // temp hold new key
   const [newKey, setNewKey] = useState(null)
   // loading state
@@ -38,6 +38,12 @@ const ApiKeyManager = ({ preview, name }) => {
   const createNewKey = async () => {
     setLoading(true)
     const key = uuidv4().replace(/-/g, '')
+    if (!autosave) {
+      setNewKey({ key, preview: true })
+      setLoading(false)
+      onGenerate && onGenerate(key);
+      return;
+    }
 
     // try catch to update api key using unwrap and toaste results
     try {
@@ -47,6 +53,8 @@ const ApiKeyManager = ({ preview, name }) => {
       }).unwrap()
 
       setNewKey({ key, preview: true })
+
+      onGenerate && onGenerate(key);
 
       toast.success('API Key Created')
     } catch (error) {
@@ -62,6 +70,11 @@ const ApiKeyManager = ({ preview, name }) => {
 
     // check if target is an input and do nothing
     if (e.target.tagName === 'INPUT') return
+
+    if (!autosave) {
+      setNewKey(null)
+      return
+    }
 
     confirmDelete({
       label: 'Service Key',

--- a/src/components/ApiKeyManager.jsx
+++ b/src/components/ApiKeyManager.jsx
@@ -23,7 +23,8 @@ const PanelStyledLightBackground = styled(PanelStyled)`
   background-color: var(--md-sys-color-surface-container-high);
 `
 
-const ApiKeyManager = ({ preview,
+const ApiKeyManager = ({
+  preview,
   name,
   autosave = true,
   onGenerate,

--- a/src/components/ApiKeyManager.jsx
+++ b/src/components/ApiKeyManager.jsx
@@ -19,8 +19,17 @@ const PanelStyled = styled(Panel)`
     margin-left: auto;
   }
 `
+const PanelStyledLightBackground = styled(PanelStyled)`
+  background-color: var(--md-sys-color-surface-container-high);
+`
 
-const ApiKeyManager = ({ preview, name, autosave = true, onGenerate }) => {
+const ApiKeyManager = ({ preview,
+  name,
+  autosave = true,
+  onGenerate,
+  repeatGenerate = true,
+  lightBackground = false,
+}) => {
   // temp hold new key
   const [newKey, setNewKey] = useState(null)
   // loading state
@@ -92,18 +101,21 @@ const ApiKeyManager = ({ preview, name, autosave = true, onGenerate }) => {
   const handleCopyKey = () => {
     copyToClipboard(newKey.key)
   }
+  const Panel = lightBackground ? PanelStyledLightBackground : PanelStyled;
 
   if (preview || newKey?.key)
     return (
       <>
-        <LockedInput
-          value={preview || newKey?.preview}
-          onEdit={handleDelete}
-          editIcon={'delete'}
-          label={'Api Key'}
-        />
+        {repeatGenerate &&
+          <LockedInput
+            value={preview || newKey?.preview}
+            onEdit={handleDelete}
+            editIcon={'delete'}
+            label={'Api Key'}
+          />
+        }
         {newKey && (
-          <PanelStyled>
+          <Panel>
             <div>
               <strong>{newKey.key}</strong>
               <br />
@@ -112,7 +124,7 @@ const ApiKeyManager = ({ preview, name, autosave = true, onGenerate }) => {
               </div>
             </div>
             <Icon onClick={handleCopyKey} icon="content_copy" />
-          </PanelStyled>
+          </Panel>
         )}
       </>
     )

--- a/src/containers/Feed/hooks/useUserMutations.js
+++ b/src/containers/Feed/hooks/useUserMutations.js
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react'
+
+const useUserMutations = ({}) => {
+  const initFormData = {
+    userLevel: 'user',
+    userActive: true,
+    UserImage: '',
+    isGuest: false,
+    accessGroups: {},
+    defaultAccessGroups: [],
+  }
+
+  const initialFormDataCallback = () => initFormData
+
+  const [addedUsers, setAddedUsers] = useState([])
+  const [password, setPassword] = useState('')
+  const [passwordConfirm, setPasswordConfirm] = useState('')
+  const [formData, setFormData] = useState(initialFormDataCallback)
+
+  useEffect(() => {
+    // set initial form data
+    setFormData(initialFormDataCallback())
+  }, [])
+
+  const resetFormData = ({ password, passwordConfirm, formData, addedUsers }) => {
+    // keep reusable data in the form
+    setPassword(password)
+    setPasswordConfirm(passwordConfirm)
+    setFormData(formData != undefined ? formData : initialFormDataCallback)
+    setAddedUsers(addedUsers)
+  }
+
+  return {
+    password, setPassword,
+    passwordConfirm, setPasswordConfirm,
+    formData, setFormData,
+    addedUsers,
+    resetFormData,
+  }
+}
+
+export default useUserMutations

--- a/src/containers/Feed/hooks/useUserMutations.js
+++ b/src/containers/Feed/hooks/useUserMutations.js
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 
-const useUserMutations = ({}) => {
+const useUserMutations = () => {
   const initFormData = {
     userLevel: 'user',
     userActive: true,
@@ -14,6 +14,7 @@ const useUserMutations = ({}) => {
 
   const [addedUsers, setAddedUsers] = useState([])
   const [password, setPassword] = useState('')
+  const [apiKey, setApiKey] = useState('')
   const [passwordConfirm, setPasswordConfirm] = useState('')
   const [formData, setFormData] = useState(initialFormDataCallback)
 
@@ -33,6 +34,7 @@ const useUserMutations = ({}) => {
   return {
     password, setPassword,
     passwordConfirm, setPasswordConfirm,
+    apiKey, setApiKey,
     formData, setFormData,
     addedUsers,
     resetFormData,

--- a/src/containers/Feed/hooks/useUserMutations.js
+++ b/src/containers/Feed/hooks/useUserMutations.js
@@ -10,34 +10,24 @@ const useUserMutations = () => {
     defaultAccessGroups: [],
   }
 
-  const initialFormDataCallback = () => initFormData
-
   const [addedUsers, setAddedUsers] = useState([])
   const [password, setPassword] = useState('')
   const [apiKey, setApiKey] = useState('')
   const [passwordConfirm, setPasswordConfirm] = useState('')
-  const [formData, setFormData] = useState(initialFormDataCallback)
+  const [formData, setFormData] = useState(initFormData)
 
   useEffect(() => {
     // set initial form data
-    setFormData(initialFormDataCallback())
+    setFormData(initFormData)
   }, [])
 
-  const resetFormData = ({ password, passwordConfirm, formData, addedUsers }) => {
-    // keep reusable data in the form
-    setPassword(password)
-    setPasswordConfirm(passwordConfirm)
-    setFormData(formData != undefined ? formData : initialFormDataCallback)
-    setAddedUsers(addedUsers)
-  }
 
   return {
     password, setPassword,
     passwordConfirm, setPasswordConfirm,
     apiKey, setApiKey,
-    formData, setFormData,
-    addedUsers,
-    resetFormData,
+    initFormData, formData, setFormData,
+    addedUsers, setAddedUsers,
   }
 }
 

--- a/src/helpers/callbackOnKeyDown.js
+++ b/src/helpers/callbackOnKeyDown.js
@@ -1,0 +1,9 @@
+  const callbackOnKeyDown = (e, { validationPassed, callback}) => {
+    // if enter then submit
+    if (e.key === 'Enter' && (e.ctrlKey || e.metaKey || e.shiftKey) && validationPassed) {
+      e.preventDefault()
+      const closeOnSubmit = e.ctrlKey || e.metaKey
+      callback(closeOnSubmit)
+    }
+  }
+  export default callbackOnKeyDown

--- a/src/pages/SettingsPage/UsersSettings/UserAccessForm.jsx
+++ b/src/pages/SettingsPage/UsersSettings/UserAccessForm.jsx
@@ -33,7 +33,6 @@ const UserAccessForm = ({ accessGroupsData, formData, onChange, disabled, select
   // only admins can
   if (authenticatedUser.isAdmin) {
     userLevels.push({ label: 'Admin', value: 'admin' })
-    userLevels.push({ label: 'Service', value: 'service' })
   }
 
   const activeOptions = [

--- a/src/pages/SettingsPage/UsersSettings/UserAttribForm.jsx
+++ b/src/pages/SettingsPage/UsersSettings/UserAttribForm.jsx
@@ -23,6 +23,7 @@ const UserAttribForm = ({
   setPassword,
   disabled,
   showAvatarUrl = true,
+  customFormRow,
 }) => {
   // separate custom attrib
   const [builtin, custom] = attributes.reduce(
@@ -43,6 +44,8 @@ const UserAttribForm = ({
     },
     [[], []],
   )
+
+  const CustomFormRow = customFormRow !== undefined ? customFormRow : FormRow;
 
   const buildForms = (attribs) =>
     attribs.map(({ name, data, input }) => {
@@ -112,9 +115,9 @@ const UserAttribForm = ({
         )
       }
       return (
-        <FormRow label={data.title} key={name}>
+        <CustomFormRow label={data.title} key={name}>
           {widget}
-        </FormRow>
+        </CustomFormRow>
       )
     })
 

--- a/src/pages/SettingsPage/UsersSettings/UsersSettings.jsx
+++ b/src/pages/SettingsPage/UsersSettings/UsersSettings.jsx
@@ -86,6 +86,7 @@ const UsersSettings = () => {
   // USE STATE
   const [selectedProjects, setSelectedProjects] = useState(null)
   const [showNewUser, setShowNewUser] = useState(false)
+  const [showNewServiceUser, setShowNewServiceUser] = useState(false)
   const [showRenameUser, setShowRenameUser] = useState(false)
   const [showSetPassword, setShowSetPassword] = useState(false)
   // show users for selected projects
@@ -170,6 +171,9 @@ const UsersSettings = () => {
   const openNewUser = () => {
     setShowNewUser(true)
   }
+  const openNewServiceUser = () => {
+    setShowNewServiceUser(true)
+  }
 
   // use filteredUserList if projectAccessOnly
   // else use userList
@@ -238,6 +242,15 @@ const UsersSettings = () => {
         accessGroupsData={accessGroupsData}
       />
 
+      <NewUser
+        onHide={(newUsers = []) => {
+          setShowNewServiceUser(false)
+          if (newUsers.length) setSelectedUsers(newUsers)
+        }}
+        open={showNewServiceUser}
+        serviceUser={true}
+      />
+
       <main>
         <Section>
           <Toolbar>
@@ -262,6 +275,11 @@ const UsersSettings = () => {
               label="Add New User"
               icon="person_add"
               data-shortcut="n"
+            />
+            <Button
+              onClick={openNewServiceUser}
+              label="Add Service User"
+              icon="person_add"
             />
           </Toolbar>
           <Splitter

--- a/src/pages/SettingsPage/UsersSettings/UsersSettings.jsx
+++ b/src/pages/SettingsPage/UsersSettings/UsersSettings.jsx
@@ -18,6 +18,7 @@ import UsersOverview from './UsersOverview'
 import { useEffect } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import NewUser from './newUser'
+import NewServiceUser from './newServiceUser'
 import confirmDelete from '@helpers/confirmDelete'
 import { useGetAccessGroupsQuery } from '@queries/accessGroups/getAccessGroups'
 import Shortcuts from '@containers/Shortcuts'
@@ -242,13 +243,12 @@ const UsersSettings = () => {
         accessGroupsData={accessGroupsData}
       />
 
-      <NewUser
+      <NewServiceUser
         onHide={(newUsers = []) => {
           setShowNewServiceUser(false)
           if (newUsers.length) setSelectedUsers(newUsers)
         }}
         open={showNewServiceUser}
-        serviceUser={true}
       />
 
       <main>

--- a/src/pages/SettingsPage/UsersSettings/UsersSettings.jsx
+++ b/src/pages/SettingsPage/UsersSettings/UsersSettings.jsx
@@ -270,16 +270,12 @@ const UsersSettings = () => {
               icon="person_remove"
               disabled={!selectedUsers.length || isSelfSelected || managerDisabled}
             />
+            <Button onClick={openNewServiceUser} label="Add Service User" icon="person_add" />
             <Button
               onClick={openNewUser}
               label="Add New User"
               icon="person_add"
               data-shortcut="n"
-            />
-            <Button
-              onClick={openNewServiceUser}
-              label="Add Service User"
-              icon="person_add"
             />
           </Toolbar>
           <Splitter

--- a/src/pages/SettingsPage/UsersSettings/newServiceUser.jsx
+++ b/src/pages/SettingsPage/UsersSettings/newServiceUser.jsx
@@ -4,11 +4,11 @@ import styled from 'styled-components'
 import { SelectButton } from 'primereact/selectbutton'
 
 import { Button, SaveButton, Section, Dialog, FormRow } from '@ynput/ayon-react-components'
-import ApiKeyManager from '@/components/ApiKeyManager'
-import useUserMutations from '@/containers/Feed/hooks/useUserMutations'
+import ApiKeyManager from '@components/ApiKeyManager'
+import useUserMutations from '@containers/Feed/hooks/useUserMutations'
 import { useAddUserMutation } from '@queries/user/updateUser'
-import copyToClipboard from '@/helpers/copyToClipboard'
-import callbackOnKeyDown from '@/helpers/callbackOnKeyDown'
+import copyToClipboard from '@helpers/copyToClipboard'
+import callbackOnKeyDown from '@helpers/callbackOnKeyDown'
 
 import UserAttribForm from './UserAttribForm'
 import { uniqueId } from 'lodash'
@@ -21,32 +21,35 @@ const FormRowStyled = styled(FormRow)`
 
 const NewServiceUser = ({ onHide, open, onSuccess }) => {
   const {
-    password, setPassword,
-    formData, setFormData,
-    apiKey, setApiKey,
-    addedUsers, setAddedUsers,
+    password,
+    setPassword,
+    formData,
+    setFormData,
+    apiKey,
+    setApiKey,
+    addedUsers,
+    setAddedUsers,
   } = useUserMutations({})
-
 
   const [addUser, { isLoading: isCreatingUser }] = useAddUserMutation()
   const usernameRef = useRef()
-  const [keyName, setKeyName] = useState('');
+  const [keyName, setKeyName] = useState('')
 
   const validateFormData = (formData) => {
     if (!formData.Username) {
-      return 'Login name must be provided';
+      return 'Login name must be provided'
     }
     if (apiKey == '') {
       return 'Api key needs to be generated'
     }
 
-    return null;
+    return null
   }
 
   const resetFormData = ({ addedUsers }) => {
     setFormData({
       Username: '',
-      userActive: true
+      userActive: true,
     })
     setAddedUsers(addedUsers)
   }
@@ -56,14 +59,14 @@ const NewServiceUser = ({ onHide, open, onSuccess }) => {
       data: { isService: true },
       active: formData.userActive,
       name: formData.Username,
-      apiKey: apiKey
+      apiKey: apiKey,
     }
 
-    return payload;
+    return payload
   }
 
   const handleSubmit = async (close) => {
-    const validationResult = validateFormData(formData);
+    const validationResult = validateFormData(formData)
     if (validationResult !== null) {
       toast.error(validationResult)
       return
@@ -74,8 +77,8 @@ const NewServiceUser = ({ onHide, open, onSuccess }) => {
       toast.success('Service User created')
 
       resetFormData({
-        addedUsers: [...addedUsers, formData.Username]
-      });
+        addedUsers: [...addedUsers, formData.Username],
+      })
 
       setKeyName(uniqueId())
 
@@ -100,18 +103,20 @@ const NewServiceUser = ({ onHide, open, onSuccess }) => {
   }
 
   const handleApiKeyGeneration = (key) => {
-    copyToClipboard(key);
-    setApiKey(key);
+    copyToClipboard(key)
+    setApiKey(key)
   }
 
   if (!open) return null
 
   return (
     <Dialog
-      onKeyDown={(e) => callbackOnKeyDown(e, {
-        validationPassed: formData.Username && password,
-        callback: handleSubmit,
-      })}
+      onKeyDown={(e) =>
+        callbackOnKeyDown(e, {
+          validationPassed: formData.Username && password,
+          callback: handleSubmit,
+        })
+      }
       isOpen
       size="full"
       style={{
@@ -142,11 +147,13 @@ const NewServiceUser = ({ onHide, open, onSuccess }) => {
         <UserAttribForm
           formData={formData}
           setFormData={setFormData}
-          attributes={[{
-            name: 'Username',
-            data: { title: 'Username' },
-            input: { placeholder: 'No spaces allowed', autoFocus: true, ref: usernameRef },
-          }]}
+          attributes={[
+            {
+              name: 'Username',
+              data: { title: 'Username' },
+              input: { placeholder: 'No spaces allowed', autoFocus: true, ref: usernameRef },
+            },
+          ]}
           customFormRow={FormRowStyled}
           {...{ password, setPassword }}
         />
@@ -155,8 +162,12 @@ const NewServiceUser = ({ onHide, open, onSuccess }) => {
           <SelectButton
             unselectable={false}
             value={formData?.userActive}
-            onChange={(event) => setFormData({ ...formData, 'userActive': event.value })}
-            options={[{ label: 'Active', value: true }, { label: 'Inactive', value: false }]} />
+            onChange={(event) => setFormData({ ...formData, userActive: event.value })}
+            options={[
+              { label: 'Active', value: true },
+              { label: 'Inactive', value: false },
+            ]}
+          />
         </FormRowStyled>
 
         <FormRowStyled label="Service user key" />

--- a/src/pages/SettingsPage/UsersSettings/newServiceUser.jsx
+++ b/src/pages/SettingsPage/UsersSettings/newServiceUser.jsx
@@ -39,6 +39,7 @@ const NewServiceUser = ({ onHide, open, onSuccess }) => {
     if (!formData.Username) {
       return 'Login name must be provided'
     }
+
     if (apiKey == '') {
       return 'Api key needs to be generated'
     }
@@ -51,6 +52,9 @@ const NewServiceUser = ({ onHide, open, onSuccess }) => {
       Username: '',
       userActive: true,
     })
+    // reset the api key
+    setKeyName(uniqueId())
+    setApiKey('')
     setAddedUsers(addedUsers)
   }
 
@@ -79,10 +83,6 @@ const NewServiceUser = ({ onHide, open, onSuccess }) => {
       resetFormData({
         addedUsers: [...addedUsers, formData.Username],
       })
-
-      // reset the api key
-      setKeyName(uniqueId())
-      setApiKey('')
 
       onSuccess && onSuccess(formData.Username)
 
@@ -113,12 +113,10 @@ const NewServiceUser = ({ onHide, open, onSuccess }) => {
 
   return (
     <Dialog
-      onKeyDown={(e) =>
-        callbackOnKeyDown(e, {
-          validationPassed: formData.Username && password,
-          callback: handleSubmit,
-        })
-      }
+      onKeyDown={(e) => callbackOnKeyDown(e, {
+        validationPassed: validateFormData(formData) == null,
+        callback: handleSubmit,
+      })}
       isOpen
       size="full"
       style={{
@@ -157,7 +155,6 @@ const NewServiceUser = ({ onHide, open, onSuccess }) => {
             },
           ]}
           customFormRow={FormRowStyled}
-          {...{ password, setPassword }}
         />
 
         <FormRowStyled label="User active">

--- a/src/pages/SettingsPage/UsersSettings/newServiceUser.jsx
+++ b/src/pages/SettingsPage/UsersSettings/newServiceUser.jsx
@@ -33,7 +33,7 @@ const NewServiceUser = ({ onHide, open, onSuccess }) => {
 
   const [addUser, { isLoading: isCreatingUser }] = useAddUserMutation()
   const usernameRef = useRef()
-  const [keyName, setKeyName] = useState('')
+  const [keyName, setKeyName] = useState(uniqueId())
 
   const validateFormData = (formData) => {
     if (!formData.Username) {
@@ -80,7 +80,9 @@ const NewServiceUser = ({ onHide, open, onSuccess }) => {
         addedUsers: [...addedUsers, formData.Username],
       })
 
+      // reset the api key
       setKeyName(uniqueId())
+      setApiKey('')
 
       onSuccess && onSuccess(formData.Username)
 

--- a/src/pages/SettingsPage/UsersSettings/newServiceUser.jsx
+++ b/src/pages/SettingsPage/UsersSettings/newServiceUser.jsx
@@ -20,16 +20,9 @@ const FormRowStyled = styled(FormRow)`
 `
 
 const NewServiceUser = ({ onHide, open, onSuccess }) => {
-  const {
-    password,
-    setPassword,
-    formData,
-    setFormData,
-    apiKey,
-    setApiKey,
-    addedUsers,
-    setAddedUsers,
-  } = useUserMutations({})
+  const { formData, setFormData, apiKey, setApiKey, addedUsers, setAddedUsers } = useUserMutations(
+    {},
+  )
 
   const [addUser, { isLoading: isCreatingUser }] = useAddUserMutation()
   const usernameRef = useRef()
@@ -113,10 +106,12 @@ const NewServiceUser = ({ onHide, open, onSuccess }) => {
 
   return (
     <Dialog
-      onKeyDown={(e) => callbackOnKeyDown(e, {
-        validationPassed: validateFormData(formData) == null,
-        callback: handleSubmit,
-      })}
+      onKeyDown={(e) =>
+        callbackOnKeyDown(e, {
+          validationPassed: validateFormData(formData) == null,
+          callback: handleSubmit,
+        })
+      }
       isOpen
       size="full"
       style={{

--- a/src/pages/SettingsPage/UsersSettings/newServiceUser.jsx
+++ b/src/pages/SettingsPage/UsersSettings/newServiceUser.jsx
@@ -1,7 +1,6 @@
 import { useRef, useState } from 'react'
 import { toast } from 'react-toastify'
 import styled from 'styled-components'
-import { SelectButton } from 'primereact/selectbutton'
 
 import { Button, SaveButton, Section, Dialog, FormRow } from '@ynput/ayon-react-components'
 import ApiKeyManager from '@components/ApiKeyManager'
@@ -43,7 +42,6 @@ const NewServiceUser = ({ onHide, open, onSuccess }) => {
   const resetFormData = ({ addedUsers }) => {
     setFormData({
       Username: '',
-      userActive: true,
     })
     // reset the api key
     setKeyName(uniqueId())
@@ -54,7 +52,7 @@ const NewServiceUser = ({ onHide, open, onSuccess }) => {
   const preparePayload = (formData, apiKey) => {
     const payload = {
       data: { isService: true },
-      active: formData.userActive,
+      active: true,
       name: formData.Username,
       apiKey: apiKey,
     }
@@ -151,18 +149,6 @@ const NewServiceUser = ({ onHide, open, onSuccess }) => {
           ]}
           customFormRow={FormRowStyled}
         />
-
-        <FormRowStyled label="User active">
-          <SelectButton
-            unselectable={false}
-            value={formData?.userActive}
-            onChange={(event) => setFormData({ ...formData, userActive: event.value })}
-            options={[
-              { label: 'Active', value: true },
-              { label: 'Inactive', value: false },
-            ]}
-          />
-        </FormRowStyled>
 
         <FormRowStyled label="Service user key" />
 

--- a/src/pages/SettingsPage/UsersSettings/newUser.jsx
+++ b/src/pages/SettingsPage/UsersSettings/newUser.jsx
@@ -23,14 +23,20 @@ const NewUser = ({ onHide, open, onSuccess, accessGroupsData }) => {
   const {
     password, setPassword,
     passwordConfirm, setPasswordConfirm,
-    formData, setFormData,
-    addedUsers,
-    resetFormData,
+    initFormData, formData, setFormData,
+    addedUsers, setAddedUsers,
   } = useUserMutations({})
   const [addUser, { isLoading: isCreatingUser }] = useAddUserMutation()
   const usernameRef = useRef()
 
   const attributes = ayonClient.getAttribsByScope('user')
+
+  const resetFormData = ({ password, passwordConfirm, formData, addedUsers }) => {
+    setPassword(password)
+    setPasswordConfirm(passwordConfirm)
+    setFormData(formData != undefined ? formData : initFormData)
+    setAddedUsers(addedUsers)
+  }
 
   const validateFormData = (formData) => {
     if (!formData.Username) {

--- a/src/pages/SettingsPage/UsersSettings/newUser.jsx
+++ b/src/pages/SettingsPage/UsersSettings/newUser.jsx
@@ -8,7 +8,8 @@ import UserAccessForm from './UserAccessForm'
 
 import styled from 'styled-components'
 import UserAccessGroupsForm from './UserAccessGroupsForm/UserAccessGroupsForm'
-import useUserMutations from '@/containers/Feed/hooks/useUserMutations'
+import useUserMutations from '@containers/Feed/hooks/useUserMutations'
+import callbackOnKeyDown from '@helpers/callbackOnKeyDown'
 
 const DividerSmallStyled = styled(Divider)`
   margin: 8px 0;
@@ -21,10 +22,15 @@ const SubTitleStyled = styled.span`
 
 const NewUser = ({ onHide, open, onSuccess, accessGroupsData }) => {
   const {
-    password, setPassword,
-    passwordConfirm, setPasswordConfirm,
-    initFormData, formData, setFormData,
-    addedUsers, setAddedUsers,
+    password,
+    setPassword,
+    passwordConfirm,
+    setPasswordConfirm,
+    initFormData,
+    formData,
+    setFormData,
+    addedUsers,
+    setAddedUsers,
   } = useUserMutations({})
   const [addUser, { isLoading: isCreatingUser }] = useAddUserMutation()
   const usernameRef = useRef()
@@ -40,14 +46,14 @@ const NewUser = ({ onHide, open, onSuccess, accessGroupsData }) => {
 
   const validateFormData = (formData) => {
     if (!formData.Username) {
-      return 'Login name must be provided';
+      return 'Login name must be provided'
     }
 
     if (password !== passwordConfirm) {
-      return 'Passwords do not match';
+      return 'Passwords do not match'
     }
 
-    return null;
+    return null
   }
 
   const preparePayload = (formData, attributes, password) => {
@@ -70,26 +76,31 @@ const NewUser = ({ onHide, open, onSuccess, accessGroupsData }) => {
       payload.data.accessGroups = formData.accessGroups || {}
     }
 
-    return payload;
+    return payload
   }
 
   const handleSubmit = async (close) => {
-    const validationResult = validateFormData(formData);
+    const validationResult = validateFormData(formData)
     if (validationResult !== null) {
       toast.error(validationResult)
       return
     }
 
     try {
-      await addUser({ name: formData.Username, user: preparePayload(formData, attributes, password) }).unwrap()
+      await addUser({
+        name: formData.Username,
+        user: preparePayload(formData, attributes, password),
+      }).unwrap()
       toast.success('User created')
 
       resetFormData({
         password: '',
         passwordConfirm: '',
-        formData: (fd) => { return { accessGroups: fd.accessGroups, userLevel: fd.userLevel } },
-        addedUsers: [...addedUsers, formData.Username]
-      });
+        formData: (fd) => {
+          return { accessGroups: fd.accessGroups, userLevel: fd.userLevel }
+        },
+        addedUsers: [...addedUsers, formData.Username],
+      })
 
       onSuccess && onSuccess(formData.Username)
 
@@ -117,7 +128,9 @@ const NewUser = ({ onHide, open, onSuccess, accessGroupsData }) => {
 
   return (
     <Dialog
-      onKeyDown={(e) => callbackOnKeyDown(e, {validationPassed: formData.Username, callback: handleSubmit}) }
+      onKeyDown={(e) =>
+        callbackOnKeyDown(e, { validationPassed: formData.Username, callback: handleSubmit })
+      }
       isOpen
       size="full"
       style={{

--- a/src/pages/SettingsPage/UsersSettings/newUser.jsx
+++ b/src/pages/SettingsPage/UsersSettings/newUser.jsx
@@ -1,7 +1,6 @@
-import { useEffect, useRef, useState } from 'react'
+import { useRef } from 'react'
 import { toast } from 'react-toastify'
-import { Button, Divider, SaveButton, Section, Dialog, FormRow } from '@ynput/ayon-react-components'
-import { SelectButton } from 'primereact/selectbutton'
+import { Button, Divider, SaveButton, Section, Dialog } from '@ynput/ayon-react-components'
 import { useAddUserMutation } from '@queries/user/updateUser'
 import ayonClient from '@/ayon'
 import UserAttribForm from './UserAttribForm'
@@ -9,14 +8,8 @@ import UserAccessForm from './UserAccessForm'
 
 import styled from 'styled-components'
 import UserAccessGroupsForm from './UserAccessGroupsForm/UserAccessGroupsForm'
-import ApiKeyManager from '@/components/ApiKeyManager'
 import useUserMutations from '@/containers/Feed/hooks/useUserMutations'
 
-const FormRowStyled = styled(FormRow)`
-  .label {
-    min-width: 160px;
-  }
-`
 const DividerSmallStyled = styled(Divider)`
   margin: 8px 0;
 `


### PR DESCRIPTION
Existing non service users cannot be converted to Service Users and vice versa. The following actions were taken to avoid that:
- Custom form for service user creation, only username, active/inactive & generated key form fields are required
- Non service users cannot be converted to Service users, option removed from form 