### PR TITLE
Web viewer snap playhead indicator to frame position

### DIFF
--- a/src/containers/VideoPlayer/VideoPlayer.jsx
+++ b/src/containers/VideoPlayer/VideoPlayer.jsx
@@ -215,7 +215,7 @@ const VideoPlayer = ({ src, frameRate, aspectRatio, autoplay, onPlay }) => {
       const actualTime = Math.min(videoRef.current?.currentTime || 0, actualDuration - frameLength)
       if (isPlaying) {
         setCurrentTime(actualTime)
-        setTimeout(() => requestAnimationFrame(updateTime), 40)
+        setTimeout(() => requestAnimationFrame(updateTime), 10)
       } else {
         setCurrentTime(actualTime)
       }
@@ -271,6 +271,8 @@ const VideoPlayer = ({ src, frameRate, aspectRatio, autoplay, onPlay }) => {
   }
 
   const handleScrub = (newTime) => {
+    if (newTime === videoRef.current?.currentTime) 
+      return
     videoRef.current?.pause()
     seekToTime(newTime)
     initialPosition.current = newTime
@@ -278,18 +280,24 @@ const VideoPlayer = ({ src, frameRate, aspectRatio, autoplay, onPlay }) => {
 
   const handlePause = () => {
     initialPosition.current = videoRef.current?.currentTime
+    seekToTime(initialPosition.current)
     setTimeout(() => {
       if (videoRef.current?.paused) {
         seekToTime(initialPosition.current)
         console.debug('VideoPlayer: Paused')
         setIsPlaying(false)
       }
-    }, 50)
+    }, 10)
   }
 
   const handleEnded = () => {
-    if (loop && isPlaying) {
-      console.debug('VideoPlayer: Ended, looping')
+    if (!isPlaying) {
+      console.debug('ended, but not playing')
+      console.debug("position: ", videoRef.current.currentTime)
+      return
+    }
+    if (loop) {
+      console.debug('VideoPlayer: Ended, looping', videoRef.current.currentTime)
       videoRef.current.currentTime = 0
       videoRef.current.play()
     } else {
@@ -366,8 +374,6 @@ const VideoPlayer = ({ src, frameRate, aspectRatio, autoplay, onPlay }) => {
             setCurrentTime(newFrame)
             initialPosition.current = newFrame
           }}
-          currentTime={currentTime}
-          duration={duration}
           frameRate={frameRate}
           setMuted={handleMuteToggle}
           {...{ showOverlay, setShowOverlay, loop, setLoop, muted }}

--- a/src/containers/VideoPlayer/VideoPlayer.jsx
+++ b/src/containers/VideoPlayer/VideoPlayer.jsx
@@ -280,10 +280,11 @@ const VideoPlayer = ({ src, frameRate, aspectRatio, autoplay, onPlay }) => {
     initialPosition.current = videoRef.current?.currentTime
     setTimeout(() => {
       if (videoRef.current?.paused) {
+        seekToTime(initialPosition.current)
         console.debug('VideoPlayer: Paused')
         setIsPlaying(false)
       }
-    }, 100)
+    }, 50)
   }
 
   const handleEnded = () => {
@@ -353,6 +354,7 @@ const VideoPlayer = ({ src, frameRate, aspectRatio, autoplay, onPlay }) => {
           bufferedRanges={bufferedRanges}
           onScrub={handleScrub}
           frameRate={frameRate}
+          isPlaying={isPlaying}
         />
       </div>
 

--- a/src/containers/VideoPlayer/VideoPlayerControls.jsx
+++ b/src/containers/VideoPlayer/VideoPlayerControls.jsx
@@ -47,7 +47,7 @@ const VideoPlayerControls = ({
     console.debug('VideoPlayerControls: Go back 1')
     const duration = videoRef.current?.duration || 0
     const nextFrame = videoRef.current.currentTime - frameLength
-    const newFrame = nextFrame < 0 ? (loop ? duration : 0) : nextFrame
+    const newFrame = nextFrame < 0 ? (loop ? (duration - 0.001) : 0) : nextFrame
     videoRef.current.currentTime = newFrame
     onFrameChange(newFrame)
   }

--- a/src/containers/VideoPlayer/VideoPlayerControls.jsx
+++ b/src/containers/VideoPlayer/VideoPlayerControls.jsx
@@ -8,8 +8,6 @@ const VideoPlayerControls = ({
   videoRef,
   isPlaying,
   onFrameChange,
-  currentTime,
-  duration,
   frameRate,
   showOverlay,
   setShowOverlay,
@@ -20,7 +18,8 @@ const VideoPlayerControls = ({
 }) => {
   const dispatch = useDispatch()
   const fullscreen = useSelector((state) => state.viewer.fullscreen)
-  const frameLength = 0.04 // TODO
+  const frameLength = 1 / frameRate
+
 
   const handlePlayPause = () => {
     if (videoRef.current.paused) {
@@ -38,6 +37,7 @@ const VideoPlayerControls = ({
   }
   const handleGoToEnd = () => {
     console.debug('VideoPlayerControls: Go to end')
+    const duration = videoRef.current?.duration || 0
     const newFrame = duration
     videoRef.current.currentTime = newFrame
     onFrameChange(newFrame)
@@ -45,6 +45,7 @@ const VideoPlayerControls = ({
 
   const handleGoBack1 = () => {
     console.debug('VideoPlayerControls: Go back 1')
+    const duration = videoRef.current?.duration || 0
     const nextFrame = videoRef.current.currentTime - frameLength
     const newFrame = nextFrame < 0 ? (loop ? duration : 0) : nextFrame
     videoRef.current.currentTime = newFrame
@@ -52,6 +53,7 @@ const VideoPlayerControls = ({
   }
   const handleGoForward1 = () => {
     console.debug('VideoPlayerControls: Go forward 1')
+    const duration = videoRef.current?.duration || 0
     const nextFrame = videoRef.current.currentTime + frameLength
     const newFrame = nextFrame > duration ? (loop ? 0 : duration) : nextFrame
     videoRef.current.currentTime = newFrame
@@ -66,6 +68,7 @@ const VideoPlayerControls = ({
   }
   const handleGoForward5 = () => {
     console.debug('VideoPlayerControls: Go forward 5')
+    const duration = videoRef.current?.duration || 0
     const newFrame = Math.min(duration, videoRef.current.currentTime + 5 * frameLength)
     videoRef.current.currentTime = newFrame
     onFrameChange(newFrame)
@@ -127,9 +130,9 @@ const VideoPlayerControls = ({
   return (
     <>
       <Timecode
-        value={currentTime}
+        value={videoRef.current?.currentTime || 0}
         frameRate={frameRate}
-        maximum={duration}
+        maximum={videoRef.current?.duration || 0}
         onChange={(value) => {
           console.debug('VideoPlayerControls: TC Input Change time to', value)
           videoRef.current.currentTime = value
@@ -218,7 +221,7 @@ const VideoPlayerControls = ({
         data-shortcut="F"
       />
 
-      <Timecode value={duration} frameRate={frameRate} disabled tooltip={'Total frames'} />
+      <Timecode value={videoRef.current?.duration} frameRate={frameRate} disabled tooltip={'Total frames'} />
     </>
   )
 }


### PR DESCRIPTION
The playhead of the video timeline now grows if number of frames is lower than the timeline width. That makes it easier what portion of the timeline is "occupied" by a frame. If the width is sufficient, frame boundaries are also drawn as well as frame indicator.

Additionally this PR fixes some edge cases in the playback (looping and sync between actual and registered position)

https://github.com/user-attachments/assets/e2102eb1-1fce-4532-b943-f0d3c5a58d0a



