### PR TITLE
Browser: keyboard changes selection

### DIFF
--- a/src/components/GridLayout.jsx
+++ b/src/components/GridLayout.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import React from 'react'
+import { classNames } from 'primereact/utils'
 
 const StyledGridLayout = styled.div`
   width: 100%;
@@ -24,6 +25,7 @@ const GridLayout = React.forwardRef(
               aspectRatio: `${ratio} / 1`,
             }}
             key={index}
+            className={classNames('grid-item', child.props.className)}
           >
             {child}
           </div>

--- a/src/containers/DetailsPanel/DetailsPanelHeader/DetailsPanelHeader.jsx
+++ b/src/containers/DetailsPanel/DetailsPanelHeader/DetailsPanelHeader.jsx
@@ -263,7 +263,7 @@ const DetailsPanelHeader = ({
           shimmer={isLoading}
           thumbnails={thumbnails}
           projectName={projectName}
-          onClick={thumbnails.length === 1 && handleThumbnailClick}
+          onClick={thumbnails.length === 1 ? handleThumbnailClick : undefined}
           hoverIcon={'play_circle'}
         />
         <Styled.Content className={classNames({ isLoading })}>

--- a/src/containers/Feed/hooks/useTableKeyboardNavigation.ts
+++ b/src/containers/Feed/hooks/useTableKeyboardNavigation.ts
@@ -2,7 +2,7 @@ import { TreeTable } from 'primereact/treetable'
 import { useMemo, useCallback, RefObject } from 'react'
 
 // Utility function to extract ID from a class list
-const extractIdFromClassList = (classList: DOMTokenList): string | null => {
+export const extractIdFromClassList = (classList: DOMTokenList): string | null => {
   const idClass = Array.from(classList).find((c) => c.startsWith('id-'))
   return idClass ? idClass.split('-')[1] : null
 }

--- a/src/containers/Feed/hooks/useTableKeyboardNavigation.ts
+++ b/src/containers/Feed/hooks/useTableKeyboardNavigation.ts
@@ -1,0 +1,87 @@
+import { TreeTable } from 'primereact/treetable'
+import { useMemo, useCallback, RefObject } from 'react'
+
+// Utility function to extract ID from a class list
+const extractIdFromClassList = (classList: DOMTokenList): string | null => {
+  const idClass = Array.from(classList).find((c) => c.startsWith('id-'))
+  return idClass ? idClass.split('-')[1] : null
+}
+
+// Type definitions for props
+interface UseTableNavigationProps {
+  tableRef: RefObject<TreeTable>
+  treeData: any[]
+  selection: Record<string, boolean>
+  onSelectionChange: (selection: { array: string[]; object: { [key: string]: boolean } }) => void
+}
+
+// Hook to manage table navigation for Arrow keys
+const useTableKeyboardNavigation = ({
+  tableRef,
+  treeData,
+  selection,
+  onSelectionChange,
+}: UseTableNavigationProps) => {
+  // Get all row IDs from the table
+  const tableRowsIds = useMemo(() => {
+    const rows: string[] = []
+    tableRef.current
+      ?.getElement()
+      ?.querySelectorAll('.p-treetable-tbody tr')
+      .forEach((tr) => {
+        const id = extractIdFromClassList(tr.classList)
+        if (id) {
+          rows.push(id)
+        }
+      })
+    return rows
+  }, [tableRef.current, treeData])
+
+  // Handle Arrow keydown event
+  const handleTableKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      const { key, target, shiftKey } = event
+
+      if ((target as HTMLElement).tagName === 'TR' && (key === 'ArrowDown' || key === 'ArrowUp')) {
+        const direction = key === 'ArrowDown' ? 1 : -1
+        const nextElement =
+          direction === 1
+            ? (target as HTMLElement).nextElementSibling
+            : (target as HTMLElement).previousElementSibling
+
+        if (!nextElement) return
+
+        const nextId = extractIdFromClassList(nextElement.classList)
+
+        if (nextId) {
+          let newSelection = [nextId]
+          if (shiftKey) {
+            const previousSelection = Object.keys(selection)
+            newSelection = [...new Set([...newSelection, ...previousSelection])]
+            newSelection = tableRowsIds.filter((id) => newSelection.includes(id))
+            const isInPrevious = previousSelection.includes(nextId)
+            if (isInPrevious) {
+              if (direction === 1) {
+                newSelection.shift()
+              } else {
+                newSelection.pop()
+              }
+            }
+          }
+          const array = newSelection
+          const object = newSelection.reduce((acc: { [key: string]: boolean }, id: string) => {
+            acc[id] = true
+            return acc
+          }, {})
+
+          onSelectionChange({ array, object })
+        }
+      }
+    },
+    [tableRowsIds, selection],
+  )
+
+  return handleTableKeyDown
+}
+
+export default useTableKeyboardNavigation

--- a/src/containers/Feed/hooks/useTransformActivities.js
+++ b/src/containers/Feed/hooks/useTransformActivities.js
@@ -91,7 +91,9 @@ const useTransformActivities = (activities = [], projectInfo = {}, entityType) =
   // 7. ensure there are no duplicate activities
   const uniqueActivitiesData = useMemo(
     () => [
-      ...new Map(groupedVersionsData.map((activity) => [activity?.activityId, activity])).values(),
+      ...new Map(groupedVersionsData.map((activity) => [activity?.activityId, activity]))
+        .values()
+        .filter(Boolean),
     ],
     [groupedVersionsData],
   )

--- a/src/containers/hierarchy.jsx
+++ b/src/containers/hierarchy.jsx
@@ -12,7 +12,9 @@ import { useGetHierarchyQuery } from '@queries/getHierarchy'
 import useCreateContext from '@hooks/useCreateContext'
 import HierarchyExpandFolders from './HierarchyExpandFolders'
 import { openViewer } from '@/features/viewer'
-import useTableKeyboardNavigation from './Feed/hooks/useTableKeyboardNavigation'
+import useTableKeyboardNavigation, {
+  extractIdFromClassList,
+} from './Feed/hooks/useTableKeyboardNavigation'
 
 const filterHierarchy = (text, folder, folders) => {
   let result = []
@@ -203,8 +205,11 @@ const Hierarchy = (props) => {
   // Set breadcrumbs on row click (the latest selected folder,
   // will be the one that is displayed in the breadcrumbs)
 
-  const onRowClick = (event) => {
-    const node = event.node.data
+  const onFocus = (event) => {
+    const id = extractIdFromClassList(event.target.classList)
+    if (!id) return
+    const node = hierarchyObjectData[id]
+    if (!node) return
     dispatch(setUri(`ayon+entity://${projectName}/${node.parents.join('/')}/${node.name}`))
   }
 
@@ -374,7 +379,7 @@ const Hierarchy = (props) => {
         emptyMessage={isError && 'No Folders Found'}
         onSelectionChange={onSelectionChange}
         onToggle={onToggle}
-        onRowClick={onRowClick}
+        onFocus={onFocus}
         onContextMenu={onContextMenu}
         className={isFetching ? 'table-loading' : undefined}
         onKeyDown={handleKeyDown}

--- a/src/pages/BrowserPage/Products/ProductsGrid.jsx
+++ b/src/pages/BrowserPage/Products/ProductsGrid.jsx
@@ -157,11 +157,7 @@ const ProductsGrid = ({
 
     onSelectionChange(newSelection)
     // updates the breadcrumbs
-    onItemClick({
-      node: {
-        data: product,
-      },
-    })
+    onItemClick(product)
   }
 
   const [collapsedGroups, setCollapsedGroups] = useState([])

--- a/src/pages/WorkfilesPage/WorkfileList.jsx
+++ b/src/pages/WorkfilesPage/WorkfileList.jsx
@@ -6,8 +6,11 @@ import { useDispatch, useSelector } from 'react-redux'
 import { useGetWorkfileListQuery } from '@queries/getWorkfiles'
 import NoEntityFound from '@components/NoEntityFound'
 import { setFocusedWorkfiles } from '@state/context'
+import { useRef } from 'react'
+import useTableKeyboardNavigation from '@containers/Feed/hooks/useTableKeyboardNavigation'
 
 const WorkfileList = ({ style }) => {
+  const tableRef = useRef(null)
   const dispatch = useDispatch()
   const taskIds = useSelector((state) => state.context.focused.tasks)
   const pairing = useSelector((state) => state.context.pairing)
@@ -58,6 +61,14 @@ const WorkfileList = ({ style }) => {
   const selectedWorkfile = focusedWorkfiles && focusedWorkfiles[0]
   const selection = data.find((workfile) => workfile.id === selectedWorkfile)
 
+  const handleTableKeyDown = useTableKeyboardNavigation({
+    tableRef,
+    treeData: data,
+    selection: { [selectedWorkfile]: true },
+    onSelectionChange: ({ array }) => handleSelectionChange({ value: { id: array[0] } }),
+    config: { multiSelect: false },
+  })
+
   return (
     <Section style={style}>
       <TablePanel loading={isLoading}>
@@ -65,6 +76,7 @@ const WorkfileList = ({ style }) => {
           <NoEntityFound type="workfile" />
         ) : (
           <DataTable
+            ref={tableRef}
             scrollable="true"
             scrollHeight="flex"
             selectionMode="single"
@@ -73,6 +85,8 @@ const WorkfileList = ({ style }) => {
             value={taskIds.length ? data : []}
             selection={selection}
             onSelectionChange={handleSelectionChange}
+            onKeyDown={handleTableKeyDown}
+            rowClassName={(rowData) => ({ ['id-' + rowData.id]: true })}
           >
             <Column field="name" header="Name" body={formatName} />
           </DataTable>


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
You can now use the up and down arrows to change the selection.


## Technical details
<!-- Please state any technical details such as limitations -->
Before it would only focus the table row and not select it.


## Additional context
<!-- Add any other context or screenshots here. -->
https://github.com/user-attachments/assets/006feb2e-0749-4264-8484-a8413e1f919f

## Testing

1. http://localhost:3000/projects/demo_Commercial/browser
2. Test each table, folders, tasks, products.
3. Using arrows keys should change selection and update URI.
4. Holding down shift should select multiple.

