### PR TITLE
Comment: Cycling through attachments via keyboard or mouse

### DIFF
--- a/src/components/Feed/ActivityComment/ActivityComment.jsx
+++ b/src/components/Feed/ActivityComment/ActivityComment.jsx
@@ -162,6 +162,7 @@ const ActivityComment = ({
               <FilesGrid
                 files={files}
                 isCompact={files.length > 6}
+                activityId={activityId}
                 projectName={projectName}
                 isDownloadable
                 onExpand={onFileExpand}

--- a/src/components/FileUploadCard/FileUploadCard.jsx
+++ b/src/components/FileUploadCard/FileUploadCard.jsx
@@ -65,7 +65,6 @@ const getFileSizeString = (bytes) => {
 }
 
 const FileUploadCard = ({
-  id,
   name,
   mime,
   src,
@@ -97,7 +96,7 @@ const FileUploadCard = ({
 
   const handleImageClick = () => {
     if (!isPreviewable || !onExpand || imageError) return
-    onExpand({ name, mime, id, size, extension })
+    onExpand()
   }
 
   return (

--- a/src/containers/Feed/Feed.jsx
+++ b/src/containers/Feed/Feed.jsx
@@ -18,6 +18,7 @@ import { isEqual, union } from 'lodash'
 import useScrollToHighlighted from './hooks/useScrollToHighlighted'
 import { toast } from 'react-toastify'
 import ActivityReferenceTooltip from '@components/Feed/ActivityReferenceTooltip/ActivityReferenceTooltip'
+import { isFilePreviewable } from '@containers/FileUploadPreview/FileUploadPreview'
 
 // number of activities to get
 export const activitiesLast = 30
@@ -207,8 +208,16 @@ const Feed = ({
     dispatch(openSlideOut({ entityId, entityType, projectName, scope, activityId }))
   }
 
-  const handleFileExpand = ({files, index}) => {
-    dispatch(onCommentImageOpen({ files, index, projectName }))
+  const handleFileExpand = ({ index, activityId }) => {
+    const previewableFiles = Object.values(transformedActivitiesData)
+      .reverse()
+      .filter((a) => a.activityType == 'comment')
+      .map((a) => ({
+        id: a.activityId,
+        files: a.files.filter((file) => isFilePreviewable(file.mime, file.ext)),
+      }))
+      .filter((a) => a.files.length > 0)
+    dispatch(onCommentImageOpen({ files: previewableFiles, activityId, index, projectName }))
   }
 
   const loadingPlaceholders = useMemo(() => getLoadingPlaceholders(10), [])

--- a/src/containers/Feed/Feed.jsx
+++ b/src/containers/Feed/Feed.jsx
@@ -207,8 +207,8 @@ const Feed = ({
     dispatch(openSlideOut({ entityId, entityType, projectName, scope, activityId }))
   }
 
-  const handleFileExpand = (file) => {
-    dispatch(onCommentImageOpen({ ...file, projectName }))
+  const handleFileExpand = ({files, index}) => {
+    dispatch(onCommentImageOpen({ files, index, projectName }))
   }
 
   const loadingPlaceholders = useMemo(() => getLoadingPlaceholders(10), [])

--- a/src/containers/FileUploadPreview/FileUploadPreview.jsx
+++ b/src/containers/FileUploadPreview/FileUploadPreview.jsx
@@ -1,6 +1,6 @@
 import { useDispatch, useSelector } from 'react-redux'
 import * as Styled from './FileUploadPreview.styled'
-import { onFilePreviewClose } from '@state/context'
+import { onFilePreviewClose, onCommentImageIndexChange } from '@state/context'
 import { useEffect, useRef } from 'react'
 import ImageMime from './mimes/ImageMime'
 import TextMime from './mimes/TextMime'
@@ -36,8 +36,9 @@ export const getFileURL = (id, projectName) => `/api/projects/${projectName}/fil
 
 const FileUploadPreview = () => {
   const dispatch = useDispatch()
-  const file = useSelector((state) => state.context.previewFile)
-  const { id, projectName, mime, extension, name } = file || {}
+  const files = useSelector((state) => state.context.previewFiles)
+  const index = useSelector((state) => state.context.previewFilesIndex)
+  const { id, projectName, mime, extension, name } = files[index] || {}
 
   // when dialog open, focus on the dialog
   // we do this so that the user can navigate with the keyboard (esc works)
@@ -64,7 +65,7 @@ const FileUploadPreview = () => {
   // if there is a callback, run it and return null
   // mainly for pdfs
   if (callback) {
-    callback(file)
+    callback(files[index])
     return null
   }
 
@@ -74,6 +75,20 @@ const FileUploadPreview = () => {
 
   return (
     <Styled.DialogWrapper
+      onKeyDown={(e) => {
+        if (e.code == 'ArrowRight') {
+          if (index + 1 == files.length) {
+            return
+          }
+          dispatch(onCommentImageIndexChange({index : index + 1}))
+        }
+        if (e.code == 'ArrowLeft') {
+          if (index == 0 ) {
+            return
+          }
+          dispatch(onCommentImageIndexChange({index : index - 1}))
+        }
+      }}
       size="full"
       isOpen={id && projectName}
       onClose={handleClose}
@@ -82,7 +97,7 @@ const FileUploadPreview = () => {
       className={classNames({ isImage })}
       header={isImage ? null : name}
     >
-      <MimeComponent file={file} />
+      <MimeComponent file={files[index]} />
     </Styled.DialogWrapper>
   )
 }

--- a/src/containers/FileUploadPreview/FileUploadPreview.jsx
+++ b/src/containers/FileUploadPreview/FileUploadPreview.jsx
@@ -5,6 +5,7 @@ import { useEffect, useRef } from 'react'
 import ImageMime from './mimes/ImageMime'
 import TextMime from './mimes/TextMime'
 import { classNames } from 'primereact/utils'
+import { Icon } from '@ynput/ayon-react-components'
 
 // define expandable mime types and their components
 export const expandableMimeTypes = {
@@ -69,6 +70,10 @@ const FileUploadPreview = () => {
     return null
   }
 
+  const handleNavigateToPrevious = () => index > 0  && dispatch(onCommentImageIndexChange({ index: index - 1 }))
+
+  const handleNavigateToNext = () => index < files.length -1 && dispatch(onCommentImageIndexChange({ index: index + 1 }))
+
   const isImage = typeId === 'image'
 
   if (!MimeComponent) return null
@@ -77,16 +82,10 @@ const FileUploadPreview = () => {
     <Styled.DialogWrapper
       onKeyDown={(e) => {
         if (e.code == 'ArrowRight') {
-          if (index + 1 == files.length) {
-            return
-          }
-          dispatch(onCommentImageIndexChange({index : index + 1}))
+          handleNavigateToNext()
         }
         if (e.code == 'ArrowLeft') {
-          if (index == 0 ) {
-            return
-          }
-          dispatch(onCommentImageIndexChange({index : index - 1}))
+          handleNavigateToPrevious()
         }
       }}
       size="full"
@@ -97,7 +96,17 @@ const FileUploadPreview = () => {
       className={classNames({ isImage })}
       header={isImage ? null : name}
     >
+      <Icon
+        icon="chevron_left"
+        className={classNames('navIcon', index == 0 ? 'disabled' : undefined)}
+        onClick={handleNavigateToPrevious}
+      />
       <MimeComponent file={files[index]} />
+      <Icon
+        icon="chevron_right"
+        className={classNames('navIcon', index == files.length - 1 ? 'disabled' : undefined)}
+        onClick={handleNavigateToNext}
+      />
     </Styled.DialogWrapper>
   )
 }

--- a/src/containers/FileUploadPreview/FileUploadPreview.styled.js
+++ b/src/containers/FileUploadPreview/FileUploadPreview.styled.js
@@ -7,7 +7,20 @@ export const DialogWrapper = styled(Dialog)`
   max-width: 1000px;
 
   .body {
+    flex-direction: row;
     padding-top: 0;
+  }
+  .navIcon {
+    font-size: 48px;
+    &:hover {
+      cursor: pointer;
+    }
+    &.disabled {
+      opacity: .5;
+      &:hover {
+        cursor: not-allowed;
+      }
+    }
   }
 
   /* custom image styles */

--- a/src/containers/FileUploadPreview/FileUploadPreview.styled.js
+++ b/src/containers/FileUploadPreview/FileUploadPreview.styled.js
@@ -16,7 +16,7 @@ export const DialogWrapper = styled(Dialog)`
       cursor: pointer;
     }
     &.disabled {
-      opacity: .5;
+      color: var(--md-sys-color-outline-variant);
       &:hover {
         cursor: not-allowed;
       }

--- a/src/containers/FileUploadPreview/hooks/useAttachmentNavigation.js
+++ b/src/containers/FileUploadPreview/hooks/useAttachmentNavigation.js
@@ -1,0 +1,75 @@
+import { onCommentImageActivityAndIndexChange, onCommentImageIndexChange } from '@state/context'
+import { useDispatch } from 'react-redux'
+
+const useAttachmentNavigation = ({ files, index, activityId }) => {
+  const dispatch = useDispatch()
+
+  const _attachments = files
+  const _index = index
+  const _activityId = activityId
+
+  const canNavigateUp = () => _attachments[0].id != _activityId
+  const canNavigateDown = () => _attachments[_attachments.length - 1].id != _activityId
+  const canNavigateLeft = () => _index > 0 || canNavigateUp()
+  const canNavigateRight = () =>
+    _index < _attachments.find((att) => att.id == _activityId).files.length - 1 || canNavigateDown()
+  const getPreviousActivity = () =>
+    _attachments[_attachments.findIndex((el) => el.id == _activityId) - 1]
+  const getNextActivity = () =>
+    _attachments[_attachments.findIndex((el) => el.id == _activityId) + 1]
+  const getPreviousActivityId = () => getPreviousActivity().id
+  const getNextActivityId = () => getNextActivity().id
+
+  const getByIndexActivity = (activityId, index) => {
+    if (!activityId === null || index == null) {
+      return { id: null, projectName: null, mime: null, extension: null }
+    }
+    const activity = _attachments.find((att) => att.id == activityId)
+    return activity.files[index]
+  }
+
+  const navigateUp = () => {
+    dispatch(
+      onCommentImageActivityAndIndexChange({ activityId: getPreviousActivityId(), index: 0 }),
+    )
+  }
+  const navigateDown = () =>
+    dispatch(onCommentImageActivityAndIndexChange({ activityId: getNextActivityId(), index: 0 }))
+
+  const navigateLeft = () => {
+    if (_index > 0) {
+      return dispatch(onCommentImageIndexChange({ delta: -1 }))
+    }
+
+    const prevActivity = getPreviousActivity()
+    dispatch(
+      onCommentImageActivityAndIndexChange({
+        activityId: prevActivity.id,
+        index: prevActivity.files.length - 1,
+      }),
+    )
+  }
+
+  const navigateRight = () => {
+    if (_index < _attachments.find((file) => file.id == _activityId).files.length - 1) {
+      return dispatch(onCommentImageIndexChange({ delta: 1 }))
+    }
+
+    dispatch(onCommentImageActivityAndIndexChange({ activityId: getNextActivityId(), index: 0 }))
+  }
+
+  return {
+    canNavigateDown,
+    canNavigateUp,
+    canNavigateLeft,
+    canNavigateRight,
+    getPreviousActivity,
+    getNextActivityId,
+    getByIndexActivity,
+    navigateUp,
+    navigateDown,
+    navigateLeft,
+    navigateRight,
+  }
+}
+export default useAttachmentNavigation

--- a/src/containers/FilesGrid/FilesGrid.jsx
+++ b/src/containers/FilesGrid/FilesGrid.jsx
@@ -5,6 +5,7 @@ import { isFilePreviewable } from '@containers/FileUploadPreview/FileUploadPrevi
 
 const FilesGrid = ({
   files = [],
+  activityId,
   isCompact,
   onRemove,
   projectName,
@@ -17,7 +18,7 @@ const FilesGrid = ({
   const handleExpand = (index) => () => {
     const filteredFiles = files.filter(file => isFilePreviewable(file.mime, file.ext))
     const updatedIndex = filteredFiles.findIndex(file => file.id === files[index].id)
-    onExpand({ files: filteredFiles, index: updatedIndex })
+    onExpand({ files: filteredFiles, index: updatedIndex, activityId: activityId })
   }
 
   return (

--- a/src/containers/FilesGrid/FilesGrid.jsx
+++ b/src/containers/FilesGrid/FilesGrid.jsx
@@ -13,6 +13,10 @@ const FilesGrid = ({
 }) => {
   if (!files.length) return null
 
+  const handleExpand = (index) => () => {
+    onExpand({ files, index })
+  }
+
   return (
     <Styled.Grid className={classNames({ compact: isCompact })} {...props}>
       {files.map((file, index) => (
@@ -27,7 +31,7 @@ const FilesGrid = ({
           onRemove={onRemove ? () => onRemove(file.id, file.name) : undefined}
           isCompact={isCompact}
           isDownloadable={isDownloadable}
-          onExpand={onExpand}
+          onExpand={handleExpand(index)}
         />
       ))}
     </Styled.Grid>

--- a/src/containers/FilesGrid/FilesGrid.jsx
+++ b/src/containers/FilesGrid/FilesGrid.jsx
@@ -1,6 +1,7 @@
 import * as Styled from './FilesGrid.styled'
 import { classNames } from 'primereact/utils'
 import FileUploadCard from '@components/FileUploadCard/FileUploadCard'
+import { isFilePreviewable } from '@containers/FileUploadPreview/FileUploadPreview'
 
 const FilesGrid = ({
   files = [],
@@ -14,7 +15,9 @@ const FilesGrid = ({
   if (!files.length) return null
 
   const handleExpand = (index) => () => {
-    onExpand({ files, index })
+    const filteredFiles = files.filter(file => isFilePreviewable(file.mime, file.ext))
+    const updatedIndex = filteredFiles.findIndex(file => file.id === files[index].id)
+    onExpand({ files: filteredFiles, index: updatedIndex })
   }
 
   return (

--- a/src/features/context.js
+++ b/src/features/context.js
@@ -34,7 +34,9 @@ const initialState = {
   uploadProgress: 0, // percentage 0 - 100
   menuOpen: false,
   previewFiles: [],
-  previewFilesIndex: 0,
+  previewFilesProjectName: '',
+  previewFilesIndex: null,
+  previewFilesActivityId: null,
 }
 
 // all the keys that are stored in local storage
@@ -466,16 +468,31 @@ const contextSlice = createSlice({
     },
     onCommentImageOpen: (state, action) => {
       // set the preview file
-      state.previewFiles = action.payload.files.map(e => ({...e, projectName: action.payload.projectName}))
+      console.log('inside action:')
+      console.log(action.payload.files)
+      console.log(action.payload.activityId)
+      console.log(action.payload.index)
+      state.previewFiles = action.payload.files
+      state.previewFilesProjectName = action.payload.projectName
+      state.previewFilesActivityId = action.payload.activityId
+      state.previewFilesIndex = action.payload.index
+    },
+    onCommentImageActivityAndIndexChange: (state, action) => {
+      console.log(state, action)
+      state.previewFilesActivityId = action.payload.activityId
       state.previewFilesIndex = action.payload.index
     },
     onCommentImageIndexChange: (state, action) => {
-      state.previewFilesIndex = action.payload.index
+      console.log('on index change: ')
+      console.log(action)
+      state.previewFilesIndex += action.payload.delta
     },
     onFilePreviewClose: (state) => {
       // clear the preview file
       state.previewFiles = initialState.previewFiles
-      state.previewFilesIndex = 0
+      state.previewFilesProjectName = initialState.previewFilesProjectName
+      state.previewFilesActivityId = null
+      state.previewFilesIndex = null
     },
   }, // reducers
 })
@@ -511,6 +528,7 @@ export const {
   updateBrowserFilters,
   onCommentImageOpen,
   onCommentImageIndexChange,
+  onCommentImageActivityAndIndexChange,
   onFilePreviewClose,
 } = contextSlice.actions
 

--- a/src/features/context.js
+++ b/src/features/context.js
@@ -33,14 +33,8 @@ const initialState = {
   uriChanged: 0,
   uploadProgress: 0, // percentage 0 - 100
   menuOpen: false,
-  previewFile: {
-    id: null,
-    name: null,
-    mime: null,
-    size: null,
-    projectName: null,
-    extension: null,
-  },
+  previewFiles: [],
+  previewFilesIndex: 0,
 }
 
 // all the keys that are stored in local storage
@@ -472,11 +466,16 @@ const contextSlice = createSlice({
     },
     onCommentImageOpen: (state, action) => {
       // set the preview file
-      state.previewFile = action.payload
+      state.previewFiles = action.payload.files.map(e => ({...e, projectName: action.payload.projectName}))
+      state.previewFilesIndex = action.payload.index
+    },
+    onCommentImageIndexChange: (state, action) => {
+      state.previewFilesIndex = action.payload.index
     },
     onFilePreviewClose: (state) => {
       // clear the preview file
-      state.previewFile = initialState.previewFile
+      state.previewFiles = initialState.previewFiles
+      state.previewFilesIndex = 0
     },
   }, // reducers
 })
@@ -511,6 +510,7 @@ export const {
   onUriNavigate,
   updateBrowserFilters,
   onCommentImageOpen,
+  onCommentImageIndexChange,
   onFilePreviewClose,
 } = contextSlice.actions
 


### PR DESCRIPTION
Description:
When previewing comment attachments one can navigate through the list via keyboard or mouse.

https://github.com/user-attachments/assets/36672f51-94db-4f43-8da3-5f43bbcb8c6f



closes #604 


## Technical details
<!-- Please state any technical details such as limitations -->


## Additional context
<!-- Add any other context or screenshots here. -->

