### PR TITLE
Global: Bugs cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@rtk-query/codegen-openapi": "^1.2.0",
     "@rtk-query/graphql-request-base-query": "^2.3.1",
     "@uiw/react-textarea-code-editor": "^2.1.9",
-    "@ynput/ayon-react-components": "^1.5.2",
+    "@ynput/ayon-react-components": "^1.5.3",
     "axios": "^1.6.3",
     "chart.js": "^4.2.0",
     "date-fns": "^3.6.0",

--- a/src/components/CommentInput/CommentInput.jsx
+++ b/src/components/CommentInput/CommentInput.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react'
 import * as Styled from './CommentInput.styled'
 import { Button, Icon, SaveButton } from '@ynput/ayon-react-components'
-import 'react-quill-ayon/dist/quill.bubble.css'
 
 import ReactQuill, { Quill } from 'react-quill-ayon'
 var Delta = Quill.import('delta')

--- a/src/components/MeOrUserSwitch/MeOrUserSwitch.jsx
+++ b/src/components/MeOrUserSwitch/MeOrUserSwitch.jsx
@@ -1,7 +1,21 @@
+import { useGetUsersQuery } from '@queries/user/getUsers'
 import * as Styled from './MeOrUserSwitch.styled'
 import { AssigneeSelect, Button } from '@ynput/ayon-react-components'
+import { useMemo } from 'react'
 
-const MeOrUserSwitch = ({ value = [], onChange, options = [], filter, ...props }) => {
+const MeOrUserSwitch = ({ value = [], onChange, filter, ...props }) => {
+  const { data: users = [] } = useGetUsersQuery({})
+
+  const options = useMemo(
+    () =>
+      users.map((user) => ({
+        name: user.name,
+        fullName: user.attrib.fullName,
+        avatarUrl: `/api/users/${user.name}/avatar`,
+      })),
+    [users],
+  )
+
   // this is so that the first click on the dropdown will set isMe false but not open the dropdown
   // a second click will open the dropdown
   // or if the there are no assignees selected already

--- a/src/components/Thumbnail/Thumbnail.tsx
+++ b/src/components/Thumbnail/Thumbnail.tsx
@@ -78,7 +78,7 @@ const Thumbnail = ({
       {(!isLoading || !loaded) && !disabled && (
         <Icon icon={icon || 'image'} className="type-icon" />
       )}
-      {((entityType && projectName && !(isWrongEntity || !entityId)) || url) && (
+      {entityType && projectName && !(isWrongEntity || !entityId) && (
         <Styled.Image alt={`Entity thumbnail ${entityId}`} src={url} />
       )}
       {hoverIcon && <Icon icon={hoverIcon} className="hover-icon" />}

--- a/src/components/status/statusSelect.jsx
+++ b/src/components/status/statusSelect.jsx
@@ -76,6 +76,7 @@ const StatusSelect = ({
     <StyledDropdown
       {...props}
       message={!disableMessage && multipleSelected > 1 && `${multipleSelected} Selected`}
+      messageOverButton
       widthExpand={widthExpand}
       onOpen={onOpen}
       align={align}

--- a/src/containers/DetailsPanel/DetailsPanel.jsx
+++ b/src/containers/DetailsPanel/DetailsPanel.jsx
@@ -139,13 +139,14 @@ const DetailsPanel = ({
             isLoading={isFetchingEntitiesDetails}
           />
           <Watchers entities={entitiesToQuery} entityType={entityType} options={projectUsers} />
-          <Button
-            icon="close"
-            variant={'text'}
-            onClick={() => onClose && onClose()}
-            disabled={!onClose}
-            data-shortcut={onClose ? 'Escape' : undefined}
-          />
+          {onClose && (
+            <Button
+              icon="close"
+              variant={'text'}
+              onClick={() => onClose && onClose()}
+              data-shortcut={onClose ? 'Escape' : undefined}
+            />
+          )}
         </Styled.Toolbar>
 
         <DetailsPanelHeader

--- a/src/containers/DetailsPanel/DetailsPanel.styled.js
+++ b/src/containers/DetailsPanel/DetailsPanel.styled.js
@@ -4,6 +4,7 @@ import { Toolbar as ARCToolbar } from '@ynput/ayon-react-components'
 export const Toolbar = styled(ARCToolbar)`
   display: flex;
   justify-content: space-between;
+  align-items: flex-start;
   padding: var(--padding-m);
   padding-bottom: 0;
 `

--- a/src/containers/DetailsPanel/DetailsPanelFiles/DetailsPanelFiles.tsx
+++ b/src/containers/DetailsPanel/DetailsPanelFiles/DetailsPanelFiles.tsx
@@ -60,7 +60,7 @@ const DetailsPanelFiles: FC<DetailsPanelFilesProps> = ({
       </StyledSection>
       <StyledSection>
         <h4>Representations</h4>
-        <RepresentationsList entities={entities} scope={scope} />
+        <RepresentationsList entities={entities} />
       </StyledSection>
     </StyledContainer>
   )

--- a/src/containers/DetailsPanel/DetailsPanelSlideOut/DetailsPanelSlideOut.jsx
+++ b/src/containers/DetailsPanel/DetailsPanelSlideOut/DetailsPanelSlideOut.jsx
@@ -1,9 +1,11 @@
 import * as Styled from './DetailsPanelSlideOut.styled'
-import { useSelector } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 import DetailsPanel from '../DetailsPanel'
 import { useGetUsersAssigneeQuery } from '@queries/user/getUsers'
+import { closeSlideOut } from '@state/details'
 
 const DetailsPanelSlideOut = ({ projectsInfo, scope }) => {
+  const dispatch = useDispatch()
   const slideOut = useSelector((state) => state.details.slideOut[scope])
   const { entityType, entityId, projectName } = slideOut || {}
   const isSlideOutOpen = entityType && entityId && projectName
@@ -14,6 +16,8 @@ const DetailsPanelSlideOut = ({ projectsInfo, scope }) => {
   const { statuses = [], tags = [] } = projectInfo
 
   if (!isSlideOutOpen) return null
+
+  const handleClose = () => dispatch(closeSlideOut())
 
   return (
     <Styled.SlideOut>
@@ -28,6 +32,7 @@ const DetailsPanelSlideOut = ({ projectsInfo, scope }) => {
         activeProjectUsers={users}
         isSlideOut
         scope={scope}
+        onClose={handleClose}
       />
     </Styled.SlideOut>
   )

--- a/src/containers/RepresentationsList/RepresentationsList.jsx
+++ b/src/containers/RepresentationsList/RepresentationsList.jsx
@@ -10,7 +10,6 @@ import groupResult from '@helpers/groupResult'
 import useCreateContext from '@hooks/useCreateContext'
 import DetailsDialog from '../DetailsDialog'
 import versionsToRepresentations from './versionsToRepresentations'
-import { openSlideOut } from '@state/details'
 
 const columns = [
   {
@@ -36,7 +35,7 @@ const columns = [
   },
 ]
 
-const RepresentationList = ({ entities = [], scope }) => {
+const RepresentationList = ({ entities = [] }) => {
   // merge all entities data into one array of entities
   const representations = useMemo(() => versionsToRepresentations(entities) || [], [entities])
 
@@ -67,17 +66,6 @@ const RepresentationList = ({ entities = [], scope }) => {
     dispatch(setUri(uri))
 
     onRepSelectionChange(e.node.data.id, projectName)
-
-    // open slide out panel
-    dispatch(
-      openSlideOut({
-        entityId: e.node.data.id,
-        entityType: 'representation',
-        projectName,
-        tab: 'attribs',
-        scope,
-      }),
-    )
   }
 
   const ctxMenuItems = (id) => [

--- a/src/pages/ProjectDashboard/panels/ProjectDetails/ProjectDetails.jsx
+++ b/src/pages/ProjectDashboard/panels/ProjectDetails/ProjectDetails.jsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { useGetProjectQuery } from '@queries/project/getProject'
 import DashboardPanelWrapper from '../DashboardPanelWrapper'
-import Thumbnail from '@components/Thumbnail'
 import AttributeTable from '@containers/attributeTable'
 import { format } from 'date-fns'
 import { Button, SaveButton, Toolbar } from '@ynput/ayon-react-components'
@@ -195,9 +194,6 @@ const ProjectDetails = ({ projectName }) => {
       stylePanel={{ height: 'calc(100% - 8px)', flex: 1, overflow: 'hidden' }}
       style={{ height: '100%', overflow: 'hidden' }}
     >
-      <Styled.Thumbnail>
-        <Thumbnail projectName={projectName} isLoading={isFetching} shimmer />
-      </Styled.Thumbnail>
       {editing ? (
         <AttribForm
           form={projectForm}

--- a/src/pages/ProjectDashboard/panels/ProjectDetails/ProjectDetails.styled.js
+++ b/src/pages/ProjectDashboard/panels/ProjectDetails/ProjectDetails.styled.js
@@ -2,24 +2,6 @@ import styled, { css } from 'styled-components'
 import getShimmerStyles from '@/styles/getShimmerStyles'
 import { Toolbar } from '@ynput/ayon-react-components'
 
-export const Thumbnail = styled.div`
-  width: 100%;
-  height: auto;
-  position: relative;
-  aspect-ratio: 16 / 9;
-  min-height: auto;
-  & > div {
-    width: 100%;
-    height: 100%;
-    max-width: unset;
-    aspect-ratio: 16 / 9;
-
-    img {
-      object-fit: cover;
-    }
-  }
-`
-
 export const Code = styled.span`
   background-color: var(--md-sys-color-surface-container-lowest);
   padding: 2px 8px;

--- a/src/pages/UserDashboardPage/UserDashboardTasks/DashboardTasksToolbar/DashboardTasksToolbar.jsx
+++ b/src/pages/UserDashboardPage/UserDashboardTasks/DashboardTasksToolbar/DashboardTasksToolbar.jsx
@@ -11,7 +11,7 @@ import MeOrUserSwitch from '@components/MeOrUserSwitch/MeOrUserSwitch'
 import * as Styled from './DashboardTasksToolbar.styled'
 import sortByOptions from './KanBanSortByOptions'
 
-const DashboardTasksToolbar = ({ allUsers = [], isLoading, view, setView }) => {
+const DashboardTasksToolbar = ({ isLoading, view, setView }) => {
   const dispatch = useDispatch()
 
   const user = useSelector((state) => state.user)
@@ -81,7 +81,6 @@ const DashboardTasksToolbar = ({ allUsers = [], isLoading, view, setView }) => {
         <MeOrUserSwitch
           value={assignees}
           onChange={(state, v) => handleAssigneesChange(state, v)}
-          options={allUsers}
           filter={assigneesFilter}
           align={'right'}
           placeholder="Assignees"

--- a/src/pages/UserDashboardPage/UserDashboardTasks/UserDashboardKanBan.jsx
+++ b/src/pages/UserDashboardPage/UserDashboardTasks/UserDashboardKanBan.jsx
@@ -261,10 +261,7 @@ const UserDashboardKanBan = ({
   return (
     <>
       <Section style={{ height: '100%', zIndex: 10, padding: 0, overflow: 'hidden' }}>
-        <DashboardTasksToolbar
-          {...{ view, setView, isLoadingProjectUsers }}
-          allUsers={projectUsers}
-        />
+        <DashboardTasksToolbar {...{ view, setView, isLoadingProjectUsers }} />
         {view === 'kanban' && (
           <DndContext
             sensors={sensors}

--- a/src/services/activities/updateActivities.js
+++ b/src/services/activities/updateActivities.js
@@ -65,6 +65,8 @@ const getTags = ({ entityId, filter }) => {
 
   tags.push({ type: 'activity', id: 'LIST' })
 
+  tags.push({ type: 'watchers', id: entityId })
+
   return tags
 }
 


### PR DESCRIPTION
## Description of changes 
- Watchers: invalidate cache when new comment created so that bell icon is updated to show you are a new watcher.
- Panel: Close button now works on slide out and is hidden when not enabled.
- Representations: disable the slide out until there is a better solution.
- Status Select: Selecting multiple statuses now has the correct position for message `x Selected`.
- Overview: Remove project thumbnail image.
- Tasks: me or assignees now uses all assignees to avoid issues moving across projects.



