### PR TITLE
Launcher authentication

### DIFF
--- a/src/api/rest.ts
+++ b/src/api/rest.ts
@@ -401,6 +401,13 @@ const injectedRtkApi = api.injectEndpoints({
     listActiveSessions: build.query<ListActiveSessionsApiResponse, ListActiveSessionsApiArg>({
       query: () => ({ url: `/api/auth/sessions` }),
     }),
+    createSession: build.mutation<CreateSessionApiResponse, CreateSessionApiArg>({
+      query: (queryArg) => ({
+        url: `/api/auth/sessions`,
+        method: 'POST',
+        body: queryArg.createSessionRequest,
+      }),
+    }),
     listBundles: build.query<ListBundlesApiResponse, ListBundlesApiArg>({
       query: (queryArg) => ({ url: `/api/bundles`, params: { archived: queryArg.archived } }),
     }),
@@ -1289,10 +1296,15 @@ const injectedRtkApi = api.injectEndpoints({
         url: `/api/users/${queryArg.userName}`,
         method: 'PUT',
         body: queryArg.newUserModel,
+        headers: { 'x-sender': queryArg['x-sender'] },
       }),
     }),
     deleteUser: build.mutation<DeleteUserApiResponse, DeleteUserApiArg>({
-      query: (queryArg) => ({ url: `/api/users/${queryArg.userName}`, method: 'DELETE' }),
+      query: (queryArg) => ({
+        url: `/api/users/${queryArg.userName}`,
+        method: 'DELETE',
+        headers: { 'x-sender': queryArg['x-sender'] },
+      }),
     }),
     patchUser: build.mutation<PatchUserApiResponse, PatchUserApiArg>({
       query: (queryArg) => ({
@@ -1320,6 +1332,7 @@ const injectedRtkApi = api.injectEndpoints({
         url: `/api/users/${queryArg.userName}/rename`,
         method: 'PATCH',
         body: queryArg.changeUserNameRequestModel,
+        headers: { 'x-sender': queryArg['x-sender'] },
       }),
     }),
     getUserSessions: build.query<GetUserSessionsApiResponse, GetUserSessionsApiArg>({
@@ -1724,6 +1737,10 @@ export type LogoutApiResponse = /** status 200 Successful Response */ LogoutResp
 export type LogoutApiArg = void
 export type ListActiveSessionsApiResponse = /** status 200 Successful Response */ SessionModel[]
 export type ListActiveSessionsApiArg = void
+export type CreateSessionApiResponse = /** status 200 Successful Response */ SessionModel
+export type CreateSessionApiArg = {
+  createSessionRequest: CreateSessionRequest
+}
 export type ListBundlesApiResponse = /** status 200 Successful Response */ ListBundleModel
 export type ListBundlesApiArg = {
   /** Include archived bundles */
@@ -2445,7 +2462,8 @@ export type PasswordResetApiArg = {
 }
 export type GetCurrentUserApiResponse = /** status 200 Successful Response */ UserModel
 export type GetCurrentUserApiArg = void
-export type GetUserApiResponse = /** status 200 Successful Response */
+export type GetUserApiResponse =
+  /** status 200 Successful Response */
   | UserModel
   | {
       [key: string]: string
@@ -2456,11 +2474,13 @@ export type GetUserApiArg = {
 export type CreateUserApiResponse = /** status 200 Successful Response */ any
 export type CreateUserApiArg = {
   userName: string
+  'x-sender'?: string
   newUserModel: NewUserModel
 }
 export type DeleteUserApiResponse = /** status 200 Successful Response */ any
 export type DeleteUserApiArg = {
   userName: string
+  'x-sender'?: string
 }
 export type PatchUserApiResponse = /** status 200 Successful Response */ any
 export type PatchUserApiArg = {
@@ -2480,6 +2500,7 @@ export type CheckPasswordApiArg = {
 export type ChangeUserNameApiResponse = /** status 200 Successful Response */ any
 export type ChangeUserNameApiArg = {
   userName: string
+  'x-sender'?: string
   changeUserNameRequestModel: ChangeUserNameRequestModel
 }
 export type GetUserSessionsApiResponse =
@@ -3110,6 +3131,12 @@ export type SessionModel = {
   lastUsed?: number
   isService?: boolean
   clientInfo?: ClientInfo
+}
+export type CreateSessionRequest = {
+  /** User name to create session for */
+  userName?: string
+  /** Message to log in event stream */
+  message?: string
 }
 export type AddonDevelopmentItem = {
   /** Enable/disable addon development */
@@ -4603,6 +4630,7 @@ export type VersionAttribModel = {
   site?: string
   families?: string[]
   colorSpace?: string
+  productTypes?: string[]
   /** Textual description of the entity */
   description?: string
   ftrackId?: string

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -77,6 +77,11 @@ const App = () => {
 
   useEffect(() => {
     setLoading(true)
+
+    // Get authorize_url from query params
+    const urlParams = new URLSearchParams(window.location.search)
+    const authorizeRedirect = urlParams.get('auth_redirect')
+
     getInfo()
       .unwrap()
       .then((response) => {
@@ -89,6 +94,12 @@ const App = () => {
         }
 
         if (response.user) {
+
+          if (authorizeRedirect) {
+            const redirectUrl = `${authorizeRedirect}?access_token=${storedAccessToken}`
+            window.location.href = redirectUrl
+          }
+
           dispatch(
             login({
               user: response.user,

--- a/src/pages/LauncherAuthPage/LauncherAuthPage.tsx
+++ b/src/pages/LauncherAuthPage/LauncherAuthPage.tsx
@@ -1,0 +1,113 @@
+import LoginPage from '@pages/LoginPage'
+import { useCreateSessionMutation, useLogOutMutation } from '@queries/auth/getAuth'
+import { Button, Panel, SaveButton, theme, Toolbar } from '@ynput/ayon-react-components'
+import { FC } from 'react'
+import { toast } from 'react-toastify'
+import styled from 'styled-components'
+
+const Container = styled(Panel)`
+  position: fixed;
+  padding: 32px;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -100%);
+  gap: 16px;
+  justify-content: center;
+
+  h1 {
+    ${theme.titleLarge}
+    margin: 0;
+  }
+
+  img {
+    height: 50px;
+  }
+
+  button.hasIcon {
+    width: fit-content;
+    padding: 8px 16px;
+    margin-left: auto;
+  }
+`
+
+const UserDetails = styled(Panel)`
+  background-color: var(--md-sys-color-surface-container);
+
+  span {
+    ${theme.labelLarge}
+  }
+`
+
+const Error = styled(Panel)`
+  background-color: var(--md-sys-color-error-container);
+  color: var(--md-sys-color-on-error-container);
+`
+
+interface LauncherAuthPageProps {
+  user: {
+    name?: string
+  }
+  redirect: string
+}
+
+const LauncherAuthPage: FC<LauncherAuthPageProps> = ({ user, redirect }) => {
+  const [createSession, { isLoading, error }] = useCreateSessionMutation()
+
+  const handleConfirm = async () => {
+    try {
+      // get access token
+      const response = await createSession({
+        createSessionRequest: {
+          message: 'Connect to AYON launcher',
+        },
+      }).unwrap()
+
+      if (response.token) {
+        // redirect to redirect with token as query param
+        window.location.href = `${redirect}?token=${response.token}`
+      }
+    } catch (error) {
+      console.error(error)
+      toast.error('Failed to connect to AYON launcher')
+    }
+  }
+
+  const [logout] = useLogOutMutation()
+
+  const handleSwitch = () => {
+    try {
+      logout({ redirect: window.location.href })
+    } catch (error) {
+      console.error(error)
+      toast.error('Failed to switch account')
+    }
+  }
+
+  //   if not on '/' redirect to '/'
+  if (window.location.pathname !== '/') {
+    window.location.href = `/${window.location.search}`
+  }
+
+  if (!user.name) return <LoginPage />
+
+  return (
+    <Container>
+      <img src="/AYON.svg" />
+      <h1>Connect account to AYON launcher?</h1>
+      <UserDetails>
+        <span>Username: {user.name}</span>
+      </UserDetails>
+      <Toolbar>
+        <Button variant="text" onClick={handleSwitch}>
+          Use a different account
+        </Button>
+        <SaveButton active onClick={handleConfirm} saving={isLoading}>
+          Confirm
+        </SaveButton>
+      </Toolbar>
+      {error && <Error>{JSON.stringify(error)}</Error>}
+    </Container>
+  )
+}
+
+export default LauncherAuthPage

--- a/src/pages/LauncherAuthPage/index.ts
+++ b/src/pages/LauncherAuthPage/index.ts
@@ -1,0 +1,3 @@
+import LauncherAuthPage from './LauncherAuthPage'
+
+export default LauncherAuthPage

--- a/src/pages/LoginPage/LoginPage.jsx
+++ b/src/pages/LoginPage/LoginPage.jsx
@@ -10,6 +10,8 @@ import { useGetInfoQuery } from '@queries/auth/getAuth'
 import ReactMarkdown from 'react-markdown'
 import LoadingPage from '../LoadingPage'
 import * as Styled from './LoginPage.styled'
+import useLocalStorage from '@hooks/useLocalStorage'
+import { isEmpty, isEqual } from 'lodash'
 
 const clearQueryParams = () => {
   const url = new URL(window.location)
@@ -18,7 +20,9 @@ const clearQueryParams = () => {
   history.pushState({}, '', url.href)
 }
 
-const LoginPage = ({ isFirstTime }) => {
+const LoginPage = ({ isFirstTime = false }) => {
+  // get query params from url
+  const search = new URLSearchParams(window.location.search)
   const dispatch = useDispatch()
   const [name, setName] = useState('')
   const [password, setPassword] = useState('')
@@ -27,6 +31,29 @@ const LoginPage = ({ isFirstTime }) => {
 
   const { data: info = {}, isLoading: isLoadingInfo } = useGetInfoQuery()
   const { motd, loginPageBrand = '', loginPageBackground = '' } = info
+
+  // we need to store the redirect in local storage to persist it across auth flows
+  const [redirectQueryParams, setRedirectQueryParams] = useLocalStorage(
+    'auth-redirect-params',
+    null,
+  )
+
+  const allowedParams = ['auth_redirect']
+  // preserve the redirect query params across auth flows
+  useEffect(() => {
+    // convert search params to object
+    const searchParams = search.entries().reduce((acc, [key, value]) => {
+      if (allowedParams.includes(key)) {
+        acc[key] = value
+      }
+      return acc
+    }, {})
+
+    if (isEmpty(searchParams) || isEqual(searchParams, redirectQueryParams)) return
+
+    // store the redirect in local storage
+    setRedirectQueryParams(searchParams)
+  }, [search, setRedirectQueryParams, redirectQueryParams])
 
   // OAuth2 handler after redirect from provider
   useEffect(() => {
@@ -79,6 +106,13 @@ const LoginPage = ({ isFirstTime }) => {
         .finally(() => {
           // clear the query string
           clearQueryParams()
+          // replace with redirect query params
+          if (redirectQueryParams) {
+            const redirect = new URLSearchParams(redirectQueryParams)
+            // clear local storage
+            localStorage.removeItem('auth-redirect-params')
+            window.location.search = redirect.toString()
+          }
           setIsLoading(false)
         })
     }
@@ -93,6 +127,8 @@ const LoginPage = ({ isFirstTime }) => {
       .post('/api/auth/login', { name, password })
       .then((response) => {
         if (response.data.user) {
+          // clear local storage
+          localStorage.removeItem('auth-redirect-params')
           toast.info(response.data.detail)
           dispatch(
             login({

--- a/src/services/auth/getAuth.js
+++ b/src/services/auth/getAuth.js
@@ -30,8 +30,9 @@ const getAuth = api.injectEndpoints({
         localStorage.removeItem('dashboard-tasks-selected')
         // clear dashboard state
         dispatch(onClearDashboard())
+        const redirect = arg?.redirect || '/login'
         // redirect to login
-        window.location.href = '/login'
+        window.location.href = redirect
       },
     }),
   }),
@@ -40,4 +41,5 @@ const getAuth = api.injectEndpoints({
 
 //
 
-export const { useGetInfoQuery, useLazyGetInfoQuery, useLogOutMutation } = getAuth
+export const { useGetInfoQuery, useLazyGetInfoQuery, useLogOutMutation, useCreateSessionMutation } =
+  getAuth


### PR DESCRIPTION
- [x] detect `auth_redirect=` query parameter in URL

### User is already logged in

- [x] if user is logged in, show a confirmation dialog "authorize app?"
- [x] when user confirms, redirect to provided URL with `?access_token=`
 
 ### User is not logged in
 
 - [x] store auth redirect URL temporarily somewhere
 - [x] let the user authenticate via username/password or SSO
 - [x] take the redirect URL, clear it from the temporary storage and continue the flow (ask and redirect)