### PR TITLE
Activities: feed cannot identify status changes for multiple selected folders/tasks/versions

### DIFF
--- a/src/components/Feed/ActivityGroup/ActivityGroup.jsx
+++ b/src/components/Feed/ActivityGroup/ActivityGroup.jsx
@@ -3,7 +3,7 @@ import * as Styled from './ActivityGroup.styled'
 import ActivityItem from '../ActivityItem'
 import { Icon } from '@ynput/ayon-react-components'
 
-const ActivityGroup = ({ activities, ...props }) => {
+const ActivityGroup = ({ activities, editProps, ...props }) => {
   const [isOpen, setIsOpen] = useState(false)
 
   return (
@@ -16,7 +16,7 @@ const ActivityGroup = ({ activities, ...props }) => {
       </Styled.Wrapper>
       {isOpen &&
         activities.map((activity) => (
-          <ActivityItem key={activity.activityId} activity={activity} fromGroup {...props} />
+          <ActivityItem key={activity.activityId} editProps={editProps} activity={activity} fromGroup {...props} />
         ))}
     </>
   )

--- a/src/components/Feed/ActivityItem.jsx
+++ b/src/components/Feed/ActivityItem.jsx
@@ -42,7 +42,7 @@ const ActivityItem = ({
       return <ActivityVersions {...{ activity, projectInfo }} {...props} />
     case 'group':
       // fromGroup prevents infinite recursion
-      return !fromGroup && <ActivityGroup activities={activity.items} {...props} />
+      return !fromGroup && <ActivityGroup editProps={editProps} activities={activity.items} {...props} />
     case 'end':
       return (
         <FeedEnd>

--- a/src/components/Feed/ActivityStatusChange/ActivityStatusChange.jsx
+++ b/src/components/Feed/ActivityStatusChange/ActivityStatusChange.jsx
@@ -11,13 +11,12 @@ const ActivityStatusChange = ({ entityType, activity = {} }) => {
     <Styled.StatusChange>
       <Styled.Body>
         <Styled.Text>{authorFullName}</Styled.Text>
-        <Styled.Text>changed status</Styled.Text>
+        <Styled.Text>- {tagList.join(' / ')} -</Styled.Text>
         {newStatus.icon && <Icon icon={oldStatus.icon} style={{ color: oldStatus.color }} />}
         <Styled.Text>{oldStatus.name}</Styled.Text>
         <Icon icon="trending_flat" />
         {newStatus.icon && <Icon icon={newStatus.icon} style={{ color: newStatus.color }} />}
         <Styled.Text>{newStatus.name}</Styled.Text>
-        <Styled.Text>( {tagList.join(' | ')} )</Styled.Text>
       </Styled.Body>
       <ActivityDate date={createdAt} />
     </Styled.StatusChange>

--- a/src/components/Feed/ActivityStatusChange/ActivityStatusChange.jsx
+++ b/src/components/Feed/ActivityStatusChange/ActivityStatusChange.jsx
@@ -1,9 +1,11 @@
 import * as Styled from './ActivityStatusChange.styled'
 import ActivityDate from '../ActivityDate'
 import { Icon } from '@ynput/ayon-react-components'
+import useGetContextParents from './hooks/getContextParents'
 
-const ActivityStatusChange = ({ activity = {} }) => {
+const ActivityStatusChange = ({ entityType, activity = {} }) => {
   const { authorFullName, createdAt, oldStatus = {}, newStatus = {} } = activity
+  const tagList = useGetContextParents(activity, entityType)
 
   return (
     <Styled.StatusChange>
@@ -15,6 +17,7 @@ const ActivityStatusChange = ({ activity = {} }) => {
         <Icon icon="trending_flat" />
         {newStatus.icon && <Icon icon={newStatus.icon} style={{ color: newStatus.color }} />}
         <Styled.Text>{newStatus.name}</Styled.Text>
+        <Styled.Text>( {tagList.join(' | ')} )</Styled.Text>
       </Styled.Body>
       <ActivityDate date={createdAt} />
     </Styled.StatusChange>

--- a/src/components/Feed/ActivityStatusChange/hooks/getContextParents.js
+++ b/src/components/Feed/ActivityStatusChange/hooks/getContextParents.js
@@ -13,7 +13,7 @@ const useGetContextParents = (activity, entityType) => {
 
   if (focusedFolders?.length > 1 && !tagTypes.folder) {
     tagTypes.folder = true
-    tag.push(activity.activityData.parents.find((p) => p.type == 'folder')?.name)
+    tag.push(activity.activityData.parents?.find((p) => p.type == 'folder')?.name)
   }
 
   if (activity.activityData.origin.type == 'task' && !tagTypes.task) {
@@ -29,7 +29,7 @@ const useGetContextParents = (activity, entityType) => {
   if (entityType == 'version' || activity.activityData.origin.type == 'version') {
     if (!tagTypes.product) {
       tagTypes.product = true
-      tag.push(activity.activityData.parents.find((p) => p.type == 'product')?.name)
+      tag.push(activity.activityData.parents?.find((p) => p.type == 'product')?.name)
     }
     if (!tagTypes.version) {
       tagTypes.version = true

--- a/src/components/Feed/ActivityStatusChange/hooks/getContextParents.js
+++ b/src/components/Feed/ActivityStatusChange/hooks/getContextParents.js
@@ -1,0 +1,44 @@
+import { useSelector } from "react-redux"
+
+const useGetContextParents = (activity, entityType) => {
+  const focusedFolders = useSelector((state) => state.context.focused.folders)
+  let tag = []
+  let tagTypes = {}
+
+
+  if (activity.activityData.origin.type == 'folder' && !tagTypes.folder) {
+    tagTypes.folder = true
+    tag.push(activity.activityData.origin.name)
+  }
+
+  if (focusedFolders?.length > 1 && !tagTypes.folder) {
+    tagTypes.folder = true
+    tag.push(activity.activityData.parents.find((p) => p.type == 'folder')?.name)
+  }
+
+  if (activity.activityData.origin.type == 'task' && !tagTypes.task) {
+    tagTypes.task = true
+    tag.push(activity.activityData.origin.name)
+  }
+
+  if (activity.activityData.origin.type == 'folder' && !tagTypes.folder) {
+    tagTypes.folder = true
+    tag.push(activity.activityData.origin.name)
+  }
+
+  if (entityType == 'version' || activity.activityData.origin.type == 'version') {
+    if (!tagTypes.product) {
+      tagTypes.product = true
+      tag.push(activity.activityData.parents.find((p) => p.type == 'product')?.name)
+    }
+    if (!tagTypes.version) {
+      tagTypes.version = true
+      tag.push(activity.activityData.origin.name)
+    }
+  }
+
+  tag.filter((a) => !!a)
+  return tag
+}
+
+export default useGetContextParents

--- a/src/containers/Feed/helpers/mergeSimilarActivities.js
+++ b/src/containers/Feed/helpers/mergeSimilarActivities.js
@@ -19,7 +19,7 @@ const mergeSimilarActivities = (activities, type, oldKey = 'oldValue') => {
       }
 
       const isSameAuthor = currentActivity.authorName === activity.authorName
-      const isSameEntity = currentActivity.entityId === activity.entityId
+      const isSameEntity = currentActivity.origin.id=== activity.entityId
       const currentCreatedAt = new Date(currentActivity.createdAt)
       const activityCreatedAt = new Date(activity.createdAt)
       const activityDuration =

--- a/src/containers/Feed/hooks/useTransformActivities.js
+++ b/src/containers/Feed/hooks/useTransformActivities.js
@@ -7,7 +7,7 @@ import mergeSimilarActivities from '../helpers/mergeSimilarActivities'
 // Define the types of activities that are considered minor
 const minorActivityTypes = [ 'status.change', 'assignee.add', 'assignee.remove']
 
-const getStatusActivityIcon = (activities = [], usersDemographics, projectInfo = {}) => {
+const getStatusActivityIcon = (activities = [], projectInfo = {}) => {
   return activities.map((activity) => {
     const newActivity = { ...activity, origin: { ...activity.origin } }
 


### PR DESCRIPTION
Showing detailed version info in status change activities depending on selection context
* displaying folder/task name on activity status change items when focused 
* product name included on version selection
* folder name included if multiple selected
* reverted change  that introduced bug which removed activity status icons

https://github.com/user-attachments/assets/f55c1513-42c1-4224-9cfe-3467d2942e60

closed #665 
