### PR TITLE
Market: Show addon links

### DIFF
--- a/src/helpers/url.ts
+++ b/src/helpers/url.ts
@@ -1,0 +1,6 @@
+const getSimplifiedUrl = (urlSring: string): string => {
+  const url = new URL(urlSring)
+  return url.hostname + url.pathname
+}
+
+export { getSimplifiedUrl }

--- a/src/pages/MarketPage/AddonDetails/AddonDetails.jsx
+++ b/src/pages/MarketPage/AddonDetails/AddonDetails.jsx
@@ -257,8 +257,8 @@ const AddonDetails = ({ addon = {}, isLoading, onDownload, isUpdatingAll }) => {
             <Styled.MetaPanel className={clsx({ isPlaceholder: isLoading })}>
               <MetaPanelRow label="Author">{orgTitle}</MetaPanelRow>
               <MetaPanelRow label="Latest Version">
-                {latestVersion && <p>{latestVersion}</p>}
-                {warning && <p>{warning}</p>}
+                {latestVersion && <span>{latestVersion}</span>}
+                {warning && <span>{warning}</span>}
               </MetaPanelRow>
             </Styled.MetaPanel>
 
@@ -271,11 +271,14 @@ const AddonDetails = ({ addon = {}, isLoading, onDownload, isUpdatingAll }) => {
                     label={capitalize(group.type)}
                   >
                     {group.links.map((link) => (
-                      <Styled.UseButton key={link.label} variant="text" onClick={() => window.open(link.url, '_blank').focus()}>
-                          <span> {link.label || getSimplifiedUrl(link.url)} </span>
-                          <Icon icon="open_in_new" />
+                      <Styled.UseButton
+                        key={link.label}
+                        variant="text"
+                        onClick={() => window.open(link.url, '_blank').focus()}
+                      >
+                        <span className="label"> {link.label || getSimplifiedUrl(link.url)} </span>
+                        <Icon icon="open_in_new" />
                       </Styled.UseButton>
-
                     ))}
                   </MetaPanelRow>
                 ))}

--- a/src/pages/MarketPage/AddonDetails/AddonDetails.jsx
+++ b/src/pages/MarketPage/AddonDetails/AddonDetails.jsx
@@ -3,7 +3,7 @@ import React, { useEffect, useMemo, useState } from 'react'
 import * as Styled from './AddonDetails.styled'
 import Type from '@/theme/typography.module.css'
 import clsx from 'clsx'
-import { isEmpty } from 'lodash'
+import { capitalize, isEmpty } from 'lodash'
 import AddonIcon from '@components/AddonIcon/AddonIcon'
 import { rcompare } from 'semver'
 import useUninstall from './useUninstall'
@@ -33,6 +33,7 @@ const AddonDetails = ({ addon = {}, isLoading, onDownload, isUpdatingAll }) => {
     title,
     description,
     icon,
+    links,
     isDownloaded,
     isDownloading,
     isFinished,
@@ -92,6 +93,19 @@ const AddonDetails = ({ addon = {}, isLoading, onDownload, isUpdatingAll }) => {
     if (!downloaded.includes(version)) {
       setDownloadedByAddon((v) => ({ ...v, [name]: [...(v[name] || []), version] }))
     }
+  }
+
+  let groupedLinks = []
+  if (links !== undefined) {
+    links.forEach((link) => {
+      let group = groupedLinks.find((el) => el.type == link.type)
+      if (group != undefined) {
+        group.links.push(link)
+        return
+      }
+
+      groupedLinks.push({ type: link.type, links: [link] })
+    })
   }
 
   let actionButton = null
@@ -238,6 +252,7 @@ const AddonDetails = ({ addon = {}, isLoading, onDownload, isUpdatingAll }) => {
                   ))}
               </MetaPanelRow>
             </Styled.MetaPanel>
+
             <Styled.MetaPanel className={clsx({ isPlaceholder: isLoading })}>
               <MetaPanelRow label="Author">{orgTitle}</MetaPanelRow>
               <MetaPanelRow label="Latest Version">
@@ -245,6 +260,24 @@ const AddonDetails = ({ addon = {}, isLoading, onDownload, isUpdatingAll }) => {
                 {warning && <p>{warning}</p>}
               </MetaPanelRow>
             </Styled.MetaPanel>
+
+            {groupedLinks && (
+              <Styled.MetaPanel className={clsx({ isPlaceholder: isLoading })}>
+                {groupedLinks.map((group) => (
+                  <MetaPanelRow
+                    className="capitalized"
+                    key={group.type}
+                    label={capitalize(group.type)}
+                  >
+                    {group.links.map((link) => (
+                      <a className="link" target="_blank" rel="noreferrer noopener" href={link.url} key={link.label}>
+                        {link.label}
+                      </a>
+                    ))}
+                  </MetaPanelRow>
+                ))}
+              </Styled.MetaPanel>
+            )}
           </Styled.Right>
         </>
       )}

--- a/src/pages/MarketPage/AddonDetails/AddonDetails.jsx
+++ b/src/pages/MarketPage/AddonDetails/AddonDetails.jsx
@@ -8,6 +8,7 @@ import AddonIcon from '@components/AddonIcon/AddonIcon'
 import { rcompare } from 'semver'
 import useUninstall from './useUninstall'
 import { Link } from 'react-router-dom'
+import { getSimplifiedUrl } from '@helpers/url'
 
 const MetaPanelRow = ({ label, children, valueDirection = 'column', ...props }) => (
   <Styled.MetaPanelRow {...props}>
@@ -96,7 +97,7 @@ const AddonDetails = ({ addon = {}, isLoading, onDownload, isUpdatingAll }) => {
   }
 
   let groupedLinks = []
-  if (links !== undefined) {
+  if (links) {
     links.forEach((link) => {
       let group = groupedLinks.find((el) => el.type == link.type)
       if (group != undefined) {
@@ -261,7 +262,7 @@ const AddonDetails = ({ addon = {}, isLoading, onDownload, isUpdatingAll }) => {
               </MetaPanelRow>
             </Styled.MetaPanel>
 
-            {groupedLinks && (
+            {groupedLinks.length > 0 && (
               <Styled.MetaPanel className={clsx({ isPlaceholder: isLoading })}>
                 {groupedLinks.map((group) => (
                   <MetaPanelRow
@@ -270,9 +271,11 @@ const AddonDetails = ({ addon = {}, isLoading, onDownload, isUpdatingAll }) => {
                     label={capitalize(group.type)}
                   >
                     {group.links.map((link) => (
-                      <a className="link" target="_blank" rel="noreferrer noopener" href={link.url} key={link.label}>
-                        {link.label}
-                      </a>
+                      <Styled.UseButton key={link.label} variant="text" onClick={() => window.open(link.url, '_blank').focus()}>
+                          <span> {link.label || getSimplifiedUrl(link.url)} </span>
+                          <Icon icon="open_in_new" />
+                      </Styled.UseButton>
+
                     ))}
                   </MetaPanelRow>
                 ))}

--- a/src/pages/MarketPage/AddonDetails/AddonDetails.styled.js
+++ b/src/pages/MarketPage/AddonDetails/AddonDetails.styled.js
@@ -175,6 +175,10 @@ export const MetaPanelRow = styled.div`
   flex-direction: column;
   gap: var(--base-gap-small);
 
+  .link {
+    text-decoration: underline;
+  }
+
   .value {
     display: flex;
     flex-direction: column;

--- a/src/pages/MarketPage/AddonDetails/AddonDetails.styled.js
+++ b/src/pages/MarketPage/AddonDetails/AddonDetails.styled.js
@@ -143,6 +143,7 @@ export const Description = styled(ReactMarkdown)`
     )}
     border-radius: var(--border-radius);
     min-height: 80px;
+    overflow: hidden;
   }
 `
 
@@ -183,6 +184,7 @@ export const MetaPanelRow = styled.div`
   .value {
     display: flex;
     flex-direction: column;
+    min-height: 24px;
   }
 
   .more:hover {
@@ -203,6 +205,10 @@ export const UseButton = styled(Button)`
     white-space: nowrap;
     display: block;
     text-overflow: ellipsis;
+  }
+
+  .label {
+    flex: 1;
   }
 `
 

--- a/src/pages/MarketPage/AddonDetails/AddonDetails.styled.js
+++ b/src/pages/MarketPage/AddonDetails/AddonDetails.styled.js
@@ -194,6 +194,7 @@ export const MetaPanelRow = styled.div`
 export const UseButton = styled(Button)`
   padding: 2px 6px;
   width: 100%;
+  max-width: fit-content;
   justify-content: start;
   gap: var(--base-gap-small);
   span {

--- a/src/pages/MarketPage/AddonDetails/AddonDetails.styled.js
+++ b/src/pages/MarketPage/AddonDetails/AddonDetails.styled.js
@@ -172,6 +172,7 @@ export const MetaPanel = styled.div`
 
 export const MetaPanelRow = styled.div`
   display: flex;
+  width: 100%;
   flex-direction: column;
   gap: var(--base-gap-small);
 
@@ -192,9 +193,16 @@ export const MetaPanelRow = styled.div`
 
 export const UseButton = styled(Button)`
   padding: 2px 6px;
-  width: fit-content;
-  margin-left: auto;
+  width: 100%;
+  justify-content: start;
   gap: var(--base-gap-small);
+  span {
+    width: auto;
+    overflow: hidden;
+    white-space: nowrap;
+    display: block;
+    text-overflow: ellipsis;
+  }
 `
 
 export const ErrorCard = styled(Panel)`


### PR DESCRIPTION
Adding links tag to addon details section in Addon Market page

![Screenshot 2024-08-05 at 18 16 01](https://github.com/user-attachments/assets/e108aa5a-e1bf-47ba-b312-6ac1b2bc9820)

Closes #704 