### PR TITLE
Hierarchy: Fix conflicting selection events

### DIFF
--- a/src/containers/hierarchy.jsx
+++ b/src/containers/hierarchy.jsx
@@ -84,6 +84,7 @@ const Hierarchy = (props) => {
 
   const dispatch = useDispatch()
   const [query, setQuery] = useState('')
+  const [newUri, setNewUri] = useState('')
   const [selectedFolderTypes, setSelectedFolderTypes] = useState([])
   const [showDetail, setShowDetail] = useState(false)
 
@@ -217,7 +218,7 @@ const Hierarchy = (props) => {
     if (!id) return
     const node = hierarchyObjectData[id]
     if (!node) return
-    dispatch(setUri(`ayon+entity://${projectName}/${node.parents.join('/')}/${node.name}`))
+    setNewUri(`ayon+entity://${projectName}/${node.parents.join('/')}/${node.name}`)
   }
 
   // Update the folder selection in the project context
@@ -249,6 +250,9 @@ const Hierarchy = (props) => {
 
     // update redux
     dispatch(setExpandedFolders(mergedExpandedFolders))
+
+    //updating uri after expanded folder to avoid race condition
+    dispatch(setUri(newUri))
   }
 
   const onToggle = (event) => {


### PR DESCRIPTION
Multiple components depending on setUri context change call their own dispatches which created a race condition issue, where expanding folders cancel the selection changed callback.
To fix it we're enqueuing the setUri dispatch within the onSelectionChange callback.

https://github.com/user-attachments/assets/304c081c-2d87-47f0-8913-84d8ad376164

Closes #716 