### PR TITLE
fix(users) Showing 'none' access users at the bottom of the table whe…

### DIFF
--- a/src/helpers/user.ts
+++ b/src/helpers/user.ts
@@ -1,0 +1,59 @@
+import { UserModel } from "@api/rest"
+import { ColumnSortEvent } from "primereact/column";
+
+type EnrichedUserModel = UserModel &  {
+  isAdmin: boolean;
+  isService: boolean;
+  isManager: boolean;
+  accessGroupList: string[];
+}
+
+const accessGroupsSortFunction = (sortEvent: ColumnSortEvent) => {
+  // Early return while data is still loading
+  if (sortEvent.data[0].isLoading) {
+    return sortEvent.data
+  }
+  const adminFilter = (user: EnrichedUserModel) => user.isAdmin && !user.isService
+  const managerFilter = (user: EnrichedUserModel) => user.isManager && !user.isAdmin && !user.isService
+  const serviceFilter = (user: EnrichedUserModel) => user.isService
+  const othersFilter = (user: EnrichedUserModel) => !user.isAdmin && !user.isManager && !user.isService
+
+  const adminUsers = sortEvent.data.filter((user: EnrichedUserModel) => user.active && adminFilter(user))
+  const managerUsers = sortEvent.data.filter((user: EnrichedUserModel) => user.active && managerFilter(user))
+  const serviceUsers = sortEvent.data.filter((user: EnrichedUserModel) => user.active && serviceFilter(user))
+  const otherUsers = sortEvent.data.filter((user: EnrichedUserModel) => user.active && othersFilter(user))
+
+  const inactiveAdminUsers = sortEvent.data.filter((user: EnrichedUserModel) => !user.active && adminFilter(user))
+  const inactiveManagerUsers = sortEvent.data.filter((user: EnrichedUserModel) => !user.active && managerFilter(user))
+  const inactiveServiceUsers = sortEvent.data.filter((user: EnrichedUserModel) => !user.active && serviceFilter(user))
+  const inactiveOtherUsers = sortEvent.data.filter((user: EnrichedUserModel) => !user.active && othersFilter(user))
+
+  const sortOthersFunction = (a: EnrichedUserModel, b: EnrichedUserModel) => {
+    const hasNoGroup = (user: EnrichedUserModel) =>
+      user.accessGroupList.length == 1 && user.accessGroupList[0] == 'none'
+
+    const aScore = hasNoGroup(a) ? 10 : 1
+    const bScore = hasNoGroup(b) ? 10 : 1
+
+    return aScore - bScore
+  }
+
+  otherUsers.sort(sortOthersFunction)
+  inactiveOtherUsers.sort(sortOthersFunction)
+
+  const sortedUsers = [...adminUsers, ...managerUsers, ...otherUsers, ...serviceUsers]
+
+  const inactiveSortedUsers = [
+    ...inactiveAdminUsers,
+    ...inactiveManagerUsers,
+    ...inactiveOtherUsers,
+    ...inactiveServiceUsers,
+  ]
+
+  return [
+    ...(sortEvent.order == 1 ? sortedUsers : sortedUsers.reverse()),
+    ...(sortEvent.order == 1 ? inactiveSortedUsers : inactiveSortedUsers.reverse()),
+  ]
+}
+
+export { accessGroupsSortFunction }

--- a/src/pages/SettingsPage/UsersSettings/UserList.jsx
+++ b/src/pages/SettingsPage/UsersSettings/UserList.jsx
@@ -106,6 +106,20 @@ const UserList = ({
 
   const tableData = userTableLoadingData(tableList, isLoading, 40, 'name')
 
+  const accessGroupsSortFunction = (sortEvent) => {
+    // Early return while data is still loading
+    if (sortEvent.data[0].isLoading) {
+      return sortEvent.data;
+    }
+    const validUsers = sortEvent.data.filter(e => e.accessGroupList.length != 1 || e.accessGroupList[0] != 'none')
+    const invalidUsers = sortEvent.data.filter(e => e.accessGroupList.length == 1 && e.accessGroupList[0] == 'none')
+    validUsers.sort((a, b) => {
+      return a.accessGroupList.join('').localeCompare(b.accessGroupList.join('')) * sortEvent.order
+    })
+
+    return [...validUsers, ...invalidUsers]
+  }
+
   // Render
   return (
     <Section wrap>
@@ -152,6 +166,7 @@ const UserList = ({
                   </span>
                 ))
             }
+            sortFunction={accessGroupsSortFunction}
             sortable
             resizeable
           />

--- a/src/pages/SettingsPage/UsersSettings/UserList.jsx
+++ b/src/pages/SettingsPage/UsersSettings/UserList.jsx
@@ -10,6 +10,7 @@ import styled from 'styled-components'
 import useCreateContext from '@hooks/useCreateContext'
 import clsx from 'clsx'
 import userTableLoadingData from '@hooks/userTableLoadingData'
+import { accessGroupsSortFunction } from '@helpers/user'
 
 const StyledProfileRow = styled.div`
   display: flex;
@@ -106,57 +107,6 @@ const UserList = ({
 
   const tableData = userTableLoadingData(tableList, isLoading, 40, 'name')
 
-  const accessGroupsSortFunction = (sortEvent) => {
-    // Early return while data is still loading
-    if (sortEvent.data[0].isLoading) {
-      return sortEvent.data
-    }
-    const adminFilter = (user) => user.isAdmin && !user.isService
-    const managerFilter = (user) => user.isManager && !user.isAdmin && !user.isService
-    const serviceFilter = (user) => user.isService
-    const othersFilter = (user) => !user.isAdmin && !user.isManager && !user.isService
-
-    const adminUsers = sortEvent.data.filter((user) => user.active && adminFilter(user))
-    const managerUsers = sortEvent.data.filter((user) => user.active && managerFilter(user))
-    const serviceUsers = sortEvent.data.filter((user) => user.active && serviceFilter(user))
-    const otherUsers = sortEvent.data.filter((user) => user.active && othersFilter(user))
-
-    const inactiveAdminUsers = sortEvent.data.filter((user) => !user.active && adminFilter(user))
-    const inactiveManagerUsers = sortEvent.data.filter(
-      (user) => !user.active && managerFilter(user),
-    )
-    const inactiveServiceUsers = sortEvent.data.filter(
-      (user) => !user.active && serviceFilter(user),
-    )
-    const inactiveOtherUsers = sortEvent.data.filter((user) => !user.active && othersFilter(user))
-
-    const sortOthersFunction = (a, b) => {
-      const hasNoGroup = (user) =>
-        user.accessGroupList.length == 1 && user.accessGroupList[0] == 'none'
-
-      const aScore = hasNoGroup(a) ? 10 : 1
-      const bScore = hasNoGroup(b) ? 10 : 1
-
-      return aScore - bScore
-    }
-
-    otherUsers.sort(sortOthersFunction)
-    inactiveOtherUsers.sort(sortOthersFunction)
-
-    const sortedUsers = [...adminUsers, ...managerUsers, ...otherUsers, ...serviceUsers]
-
-    const inactiveSortedUsers = [
-      ...inactiveAdminUsers,
-      ...inactiveManagerUsers,
-      ...inactiveOtherUsers,
-      ...inactiveServiceUsers,
-    ]
-
-    return [
-      ...(sortEvent.order == 1 ? sortedUsers : sortedUsers.reverse()),
-      ...(sortEvent.order == 1 ? inactiveSortedUsers : inactiveSortedUsers.reverse()),
-    ]
-  }
 
   // Render
   return (


### PR DESCRIPTION
Users with no Project access are filtered out and appended to the sorted list when sorting by Project access, no matter the order.


https://github.com/user-attachments/assets/a236ce7a-05f2-4deb-90b0-6ebb5cf22e52

Closes #718 