### PR TITLE
fix(tasks) Changing status of unselected tasks in list view dashboard…

### DIFF
--- a/src/components/ListItem/ListItem.jsx
+++ b/src/components/ListItem/ListItem.jsx
@@ -110,6 +110,7 @@ const ListItem = forwardRef(
           value={task.assignees}
           align="right"
           size={18}
+          onOpen={!selected && onClick}
           onChange={(v) => onUpdate('assignees', v)}
           disabledValues={disabledProjectUsers}
         />

--- a/src/pages/UserDashboardPage/UserDashboardTasks/ListGroup/ListGroup.jsx
+++ b/src/pages/UserDashboardPage/UserDashboardTasks/ListGroup/ListGroup.jsx
@@ -76,7 +76,7 @@ const ListGroup = ({
                   selected={selectedTasks.includes(task.id)}
                   selectedLength={selectedTasks.length}
                   onClick={(e) => {
-                    if (e.detail == 2) {
+                    if (e && e.detail == 2) {
                       navigate(getTaskRoute(task))
                       return
                     }


### PR DESCRIPTION
Bug was caused by accessing click property on undefined event (ItemStatus onOpen doesn't propagate click event). Adding guard to avoid error.

https://github.com/user-attachments/assets/8ee229a7-1de2-4be8-b432-dc6402c2ee9c

Closes #729 