### PR TITLE
fix(bundles): Selecting production bundle in bundles settings if none…

### DIFF
--- a/src/pages/SettingsPage/Bundles/Bundles.jsx
+++ b/src/pages/SettingsPage/Bundles/Bundles.jsx
@@ -95,6 +95,11 @@ const Bundles = () => {
 
     if (foundBundle) {
       setSelectedBundles([foundBundle.name])
+    } else {
+      const productionBundle = bundleList.filter((e) => e.isProduction)
+      setSelectedBundles([
+        productionBundle.length > 0 ? productionBundle[0].name : bundleList[0].name,
+      ])
     }
 
     const duplicateParam = searchParams.get('duplicate')


### PR DESCRIPTION
Production bundle is selected by default when accessing Bundle Settings page and no previous selection/query param identifier exists.

https://github.com/user-attachments/assets/f29c219e-38a7-4af5-a6af-44bd56e2feee


Closes #738 