### PR TITLE
Bundles: Fixing error on navigating to bundles page when no bundles exist

### DIFF
--- a/src/pages/SettingsPage/Bundles/Bundles.jsx
+++ b/src/pages/SettingsPage/Bundles/Bundles.jsx
@@ -97,9 +97,11 @@ const Bundles = () => {
       setSelectedBundles([foundBundle.name])
     } else {
       const productionBundle = bundleList.filter((e) => e.isProduction)
-      setSelectedBundles([
-        productionBundle.length > 0 ? productionBundle[0].name : bundleList[0].name,
-      ])
+      if (productionBundle.length > 0) {
+        setSelectedBundles([productionBundle[0].name])
+      } else if (bundleList.length > 0) {
+        setSelectedBundles([bundleList[0].name])
+      }
     }
 
     const duplicateParam = searchParams.get('duplicate')


### PR DESCRIPTION
Checking that bundle list is not empty before pushing to selected bundles list it's first item name.

Closes #748 