### PR TITLE
Editor: Use 'key' to filter columns instead of props.field.

### DIFF
--- a/src/pages/EditorPage/EditorPage.jsx
+++ b/src/pages/EditorPage/EditorPage.jsx
@@ -1632,7 +1632,8 @@ const EditorPage = () => {
             changes={changes}
             styled
             tasks={tasks}
-            folders={foldersObject} />
+            folders={foldersObject}
+          />
         )}
         style={{ width: columnsWidths['name'] || 230, height: 33 }}
         sortable
@@ -1686,7 +1687,7 @@ const EditorPage = () => {
 
   // only filter columns if required
   if (shownColumns.length < allColumns.length) {
-    allColumns = allColumns.filter(({ props }) => shownColumns.includes(props.field))
+    allColumns = allColumns.filter(({ key }) => shownColumns.includes(key))
   }
 
   // filter nodes that are undefined for editor


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
The name field had changed to `field="labelThenName"` and so it didn't match `name` in all columns. Now the columns filter uses the key value of the column instead of the field.
