### PR TITLE
Settings: Color Picker dialog size broken in settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@rtk-query/codegen-openapi": "^1.2.0",
     "@rtk-query/graphql-request-base-query": "^2.3.1",
     "@uiw/react-textarea-code-editor": "^2.1.9",
-    "@ynput/ayon-react-components": "^1.7.3",
+    "@ynput/ayon-react-components": "^1.7.5",
     "axios": "^1.6.3",
     "chart.js": "^4.2.0",
     "clsx": "^2.1.1",


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
- Fixes an issue where the ColorPicker dialog was too small. Now it sizes correctly.
- Root fix in ARC -> https://github.com/ynput/ayon-react-components/commit/2d097cbbf02116f9a00c047dcfba2d8c4b644b8d

![image](https://github.com/user-attachments/assets/edea2d17-ce1d-4306-bf69-82cb8a955f7a)


