### PR TITLE
Entity Path: Populating correct version id in breadcrumb segments data

### DIFF
--- a/src/containers/DetailsPanel/helpers/getEntityPathData.ts
+++ b/src/containers/DetailsPanel/helpers/getEntityPathData.ts
@@ -39,7 +39,7 @@ const getEntityPathData = (entity: $Any, folders: FoldersMap) => {
   if (entity.entityType === 'version') {
     const productVersion = `${entity.product?.name} - ${entity.name}`
     // add product - version
-    segments.push({ type: 'version', label: productVersion, id: entity.product?.id })
+    segments.push({ type: 'version', label: productVersion, id: entity.id })
   }
   if (entity.entityType === 'task') {
     // add task


### PR DESCRIPTION
Breadcrumbs segment data was using the product id instead of the version id for its last segment.

https://github.com/user-attachments/assets/dba556af-ffa4-4632-b9aa-e45e98bb4c05

Closes #782 