### PR TITLE
Update product type `vdb` to `vdbcache` name for icon

### DIFF
--- a/src/features/project.js
+++ b/src/features/project.js
@@ -15,7 +15,7 @@ export const productTypes = {
   setdress: { name: 'setdress', icon: 'forest' },
   groom: { name: 'groom', icon: 'content_cut' },
   matchmove: { name: 'matchmove', icon: 'switch_video' },
-  vdb: { name: 'vdb', icon: 'local_fire_department' },
+  vdbcache: { name: 'vdbcache', icon: 'local_fire_department' },
   lightrig: { name: 'lightrig', icon: 'wb_incandescent' },
   lut: { name: 'lut', icon: 'opacity' },
   workfile: { name: 'workfile', icon: 'home_repair_service' },


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

I'm pretty sure that VDBs published from Houdini and Maya do not show the relevant `vdb` icon because the product type is `vdbcache` and not `vdb`. So this refactors the hardcoded icon to match `vdbcache` name.

I did not test this. :)

## Technical details
<!-- Please state any technical details such as limitations -->

Also see: https://github.com/ynput/ayon-traypublisher/pull/13

## Additional context
<!-- Add any other context or screenshots here. -->

No idea whether changing this may affect anything else.
