### PR TITLE
Bundles: Avoiding form reset on bundle addon version changes

### DIFF
--- a/src/pages/SettingsPage/Bundles/NewBundle.jsx
+++ b/src/pages/SettingsPage/Bundles/NewBundle.jsx
@@ -63,8 +63,6 @@ const NewBundle = ({ initBundle, onSave, addons, installers, isDev, developerMod
 
   const bundleCheckError = bundleCheckData.issues?.some((issue) => issue.severity === 'error')
 
-  const addonsString = JSON.stringify(formData?.addons)
-  const installersString = JSON.stringify(formData?.installers)
 
   //   build initial form data
   useEffect(() => {
@@ -100,7 +98,7 @@ const NewBundle = ({ initBundle, onSave, addons, installers, isDev, developerMod
 
       setFormData(initForm)
     }
-  }, [initBundle, addonsString, installersString])
+  }, [initBundle])
 
   // Select addon if query search has addon=addonName
   const addonListRef = useRef()


### PR DESCRIPTION
When adding a new bundle, the effect listening to addon version changes was triggering another form update which resulted in overwriting the the form name/installer version to its defaults. Addon changes are not really needed, we're removing them.

https://github.com/user-attachments/assets/35287f59-8416-48f4-b7c8-a178200f2c19

Closes #785 