### PR TITLE
Bundles: Cancelling file upload on window close

### DIFF
--- a/src/components/AddonDialog/AddonDialog.jsx
+++ b/src/components/AddonDialog/AddonDialog.jsx
@@ -5,8 +5,10 @@ import AddonUpload from '@pages/SettingsPage/AddonInstall/AddonUpload'
 const AddonDialog = ({ uploadOpen, setUploadOpen, uploadHeader }) => {
   // keep track is an addon was installed
   const [restartRequired, setRestartRequired] = useState(false)
+  const abortController = new AbortController()
 
   const handleAddonInstallFinish = () => {
+    abortController.abort();
     if (restartRequired) setRestartRequired(false)
     setUploadOpen(false)
   }
@@ -20,6 +22,7 @@ const AddonDialog = ({ uploadOpen, setUploadOpen, uploadHeader }) => {
     >
       {uploadOpen && (
         <AddonUpload
+          abortController={abortController}
           onClose={handleAddonInstallFinish}
           type={uploadOpen}
           onInstall={(uploadOpen) => uploadOpen === 'addon' && setRestartRequired(true)}

--- a/src/components/AddonDialog/AddonDialog.jsx
+++ b/src/components/AddonDialog/AddonDialog.jsx
@@ -1,17 +1,44 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { Dialog } from '@ynput/ayon-react-components'
 import AddonUpload from '@pages/SettingsPage/AddonInstall/AddonUpload'
+import { confirmDialog } from 'primereact/confirmdialog'
+import { toast } from 'react-toastify'
 
 const AddonDialog = ({ uploadOpen, setUploadOpen, uploadHeader }) => {
   // keep track is an addon was installed
+  const [isUploading, setIsUploading] = useState(false)
   const [restartRequired, setRestartRequired] = useState(false)
-  const abortController = new AbortController()
+  const abortController = useRef(new AbortController())
 
   const handleAddonInstallFinish = () => {
-    abortController.abort();
-    if (restartRequired) setRestartRequired(false)
-    setUploadOpen(false)
+    if (!isUploading) {
+      setUploadOpen(false)
+      setIsUploading(false)
+      return
+    }
+
+    confirmDialog({
+      header: 'Cancel upload operation',
+      message: (
+        <>
+          <p>This action will stop the files upload from completing.</p>
+          <p>Are you sure you want to cancel?</p>
+        </>
+      ),
+      accept: () => {
+        toast.error('Upload was cancelled')
+        abortController.current.abort()
+        abortController.current = new AbortController()
+        setUploadOpen(false)
+        setIsUploading(false)
+
+        if (restartRequired) {
+          setRestartRequired(false)
+        }
+      },
+    })
   }
+
   return (
     <Dialog
       isOpen={!!uploadOpen}
@@ -22,9 +49,10 @@ const AddonDialog = ({ uploadOpen, setUploadOpen, uploadHeader }) => {
     >
       {uploadOpen && (
         <AddonUpload
-          abortController={abortController}
+          abortController={abortController.current}
           onClose={handleAddonInstallFinish}
           type={uploadOpen}
+          onUploadStateChange={setIsUploading}
           onInstall={(uploadOpen) => uploadOpen === 'addon' && setRestartRequired(true)}
         />
       )}

--- a/src/pages/SettingsPage/AddonInstall/AddonInstall.jsx
+++ b/src/pages/SettingsPage/AddonInstall/AddonInstall.jsx
@@ -8,6 +8,9 @@ import AddonUpload from './AddonUpload'
 const AddonInstall = () => {
   const user = useSelector((state) => state.user)
 
+  const abortController = new AbortController()
+  const handleClose = () => abortController.abort()
+
   if (!user?.data?.isAdmin) {
     return (
       <Section style={{ alignItems: 'center', justifyContent: 'center' }}>
@@ -18,7 +21,7 @@ const AddonInstall = () => {
 
   return (
     <Section style={{ alignItems: 'center', justifyContent: 'center' }}>
-      <AddonUpload />
+      <AddonUpload abortController={abortController} onClose={handleClose} />
     </Section>
   )
 }

--- a/src/pages/SettingsPage/AddonInstall/AddonUpload.jsx
+++ b/src/pages/SettingsPage/AddonInstall/AddonUpload.jsx
@@ -44,7 +44,14 @@ const StyledProgressBar = styled.hr`
   transition: width 0.3s;
 `
 
-const AddonUpload = ({ onClose, type = 'addon', onInstall, dropOnly, ...props }) => {
+const AddonUpload = ({
+  onClose,
+  type = 'addon',
+  onInstall,
+  dropOnly,
+  abortController,
+  ...props
+}) => {
   const dispatch = useDispatch()
   const [files, setFiles] = useState([])
   const [isUploading, setIsUploading] = useState(false)
@@ -104,7 +111,11 @@ const AddonUpload = ({ onClose, type = 'addon', onInstall, dropOnly, ...props })
     try {
       let success, res
       if (type === 'installer') {
-        res = await uploadInstallers({ files: filesToUpload, isNameEndpoint: true }).unwrap()
+        res = await uploadInstallers({
+          files: filesToUpload,
+          isNameEndpoint: true,
+          abortController,
+        }).unwrap()
         success = true
       } else if (type === 'package') {
         res = await uploadPackages({ files: filesToUpload, isNameEndpoint: true }).unwrap()
@@ -184,7 +195,6 @@ const AddonUpload = ({ onClose, type = 'addon', onInstall, dropOnly, ...props })
     onInstall(type)
   }
 
-  const abortController = new AbortController()
   const cancelToken = axios.CancelToken
   const cancelTokenSource = cancelToken.source()
 

--- a/src/services/queryUpload.js
+++ b/src/services/queryUpload.js
@@ -3,10 +3,9 @@ import { onUploadFinished, onUploadProgress } from '@state/context'
 
 const queryUpload = async (arg, api, { endpoint, method = 'put', overwrite = false }) => {
   // isNameEndpoint is used to determine if the endpoint has the name of the file in the url
-  const { files, isNameEndpoint } = arg
+  const { files, isNameEndpoint, abortController } = arg
   const { dispatch } = api
 
-  const abortController = new AbortController()
   const cancelToken = axios.CancelToken
   const cancelTokenSource = cancelToken.source()
 
@@ -16,7 +15,7 @@ const queryUpload = async (arg, api, { endpoint, method = 'put', overwrite = fal
   for (const file of files) {
     try {
       const opts = {
-        signal: abortController.signal,
+        signal: abortController?.signal,
         cancelToken: cancelTokenSource.token,
         onUploadProgress: (e) =>
           dispatch(


### PR DESCRIPTION
When uploading installers/addons, whenever the upload dialog is closed, an abort signal is sent to axios, stopping the upload.

https://github.com/user-attachments/assets/5a5a7996-8b18-47d0-949a-234753d0a9d6


closes #733