### PR TITLE
Viewer: Slide out not showing

### DIFF
--- a/src/containers/DetailsPanel/DetailsPanelSlideOut/DetailsPanelSlideOut.jsx
+++ b/src/containers/DetailsPanel/DetailsPanelSlideOut/DetailsPanelSlideOut.jsx
@@ -8,7 +8,7 @@ const DetailsPanelSlideOut = ({ projectsInfo, scope }) => {
   const dispatch = useDispatch()
   const slideOut = useSelector((state) => state.details.slideOut[scope])
   const { entityType, entityId, projectName } = slideOut || {}
-  const isSlideOutOpen = entityType && entityId && projectName
+  const isSlideOutOpen = !!entityType && !!entityId && !!projectName
 
   const { data: users } = useGetUsersAssigneeQuery({ projectName }, { skip: !projectName })
 

--- a/src/containers/Viewer/Viewer.styled.ts
+++ b/src/containers/Viewer/Viewer.styled.ts
@@ -63,5 +63,4 @@ export const ViewerDetailsPanelWrapper = styled.div`
   min-width: clamp(460px, 25vw, 600px);
   position: relative;
   z-index: 1000;
-  overflow: hidden;
 `

--- a/src/containers/Viewer/ViewerDialog.tsx
+++ b/src/containers/Viewer/ViewerDialog.tsx
@@ -7,6 +7,7 @@ import styled from 'styled-components'
 import { useLocation } from 'react-router'
 import { $Any } from '@/types'
 import isHTMLElement from '@helpers/isHTMLElement'
+import { closeSlideOut } from '@state/details'
 
 const StyledDialog = styled(Dialog)`
   /* dnd overlay must offset this 64px by 32px */
@@ -38,6 +39,7 @@ const ViewerDialog = () => {
   const folderId = useSelector((state: $Any) => state.viewer.folderId)
   const projectName = useSelector((state: $Any) => state.viewer.projectName)
   const fullscreen = useSelector((state: $Any) => state.viewer.fullscreen)
+  const slideOut = useSelector((state: $Any) => state.details.slideOut['review'])
 
   const handleClose = () => {
     // close the dialog
@@ -54,13 +56,20 @@ const ViewerDialog = () => {
       }
 
       if (e.key === 'Escape' && !fullscreen) {
-        handleClose()
+        // first check if slideOut is open
+        if (slideOut.entityId) {
+          // close the slideOut
+          dispatch(closeSlideOut())
+        } else {
+          // close the dialog
+          handleClose()
+        }
       }
     }
 
     document.addEventListener('keydown', handleEscape)
     return () => document.removeEventListener('keydown', handleEscape)
-  }, [productId, fullscreen])
+  }, [productId, fullscreen, slideOut.entityId])
 
   if ((!productId && !taskId && !folderId) || !projectName) return null
 


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
Inside of the viewer (review)...

- Slide was hidden by an `overflow: hidden;`
- Pressing `Escape` now closes the slide out first instead of closing the whole dialog.




