### PR TITLE
Previewer: Closing preview modal when clicking outside content/nav arrows.

### DIFF
--- a/src/containers/FileUploadPreview/FileUploadPreview.jsx
+++ b/src/containers/FileUploadPreview/FileUploadPreview.jsx
@@ -126,7 +126,7 @@ const FileUploadPreview = () => {
       onClose={handleClose}
       hideCancelButton={isImage}
       ref={dialogRef}
-      className={clsx({ isImage })}
+      className={clsx({ isImage }, 'block-shortcuts')}
       header={isImage ? null : name}
     >
       <div style={{ position: 'absolute', inset: 0, zIndex: zIndex }} onClick={handleClose}></div>

--- a/src/containers/FileUploadPreview/FileUploadPreview.jsx
+++ b/src/containers/FileUploadPreview/FileUploadPreview.jsx
@@ -93,28 +93,34 @@ const FileUploadPreview = () => {
   const handleNavigateToNext = () => canNavigateRight() && navigateRight()
 
   const isImage = typeId === 'image'
+  const zIndex = 50
 
-  if (!MimeComponent) return null
+  const handleKeyDown = (e) => {
+    if (e.code == 'ArrowUp') {
+      handleNavigateToPrevActivity()
+    }
+    if (e.code == 'ArrowDown') {
+      handleNavigateToNextActivity()
+    }
+    if (e.code == 'ArrowRight') {
+      handleNavigateToNext()
+    }
+    if (e.code == 'ArrowLeft') {
+      handleNavigateToPrevious()
+    }
+    if (e.key === 'Escape') {
+      e.preventDefault()
+      handleClose()
+    }
+  }
+
+  if (!MimeComponent) {
+    return null
+  }
 
   return (
     <Styled.DialogWrapper
-      onKeyDown={(e) => {
-        if (e.code == 'ArrowUp') {
-          handleNavigateToPrevActivity()
-        }
-        if (e.code == 'ArrowDown') {
-          handleNavigateToNextActivity()
-        }
-        if (e.code == 'ArrowRight') {
-          handleNavigateToNext()
-        }
-        if (e.code == 'ArrowLeft') {
-          handleNavigateToPrevious()
-        }
-        if (e.key === 'Escape') {
-          handleClose()
-        }
-      }}
+      onKeyDown={handleKeyDown}
       size="full"
       isOpen={id && projectName}
       onClose={handleClose}
@@ -123,13 +129,21 @@ const FileUploadPreview = () => {
       className={clsx({ isImage })}
       header={isImage ? null : name}
     >
+      <div style={{ position: 'absolute', inset: 0, zIndex: zIndex }} onClick={handleClose}></div>
+
       <Icon
+        style={{ zIndex: zIndex + 1 }}
         icon="chevron_left"
         className={clsx('navIcon', 'left', { disabled: !canNavigateLeft() })}
         onClick={handleNavigateToPrevious}
       />
-      <MimeComponent file={file} />
+
+      <div style={{ zIndex: zIndex + 1 }}>
+        <MimeComponent file={file} />
+      </div>
+
       <Icon
+        style={{ zIndex: zIndex + 1 }}
         icon="chevron_right"
         className={clsx('navIcon', 'right', { disabled: !canNavigateRight() })}
         onClick={handleNavigateToNext}

--- a/src/containers/Viewer/ViewerDialog.tsx
+++ b/src/containers/Viewer/ViewerDialog.tsx
@@ -51,6 +51,7 @@ const ViewerDialog = () => {
       if (isHTMLElement(e.target)) {
         if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return
         if (e.target.isContentEditable) return
+        if (e.target.closest('.block-shortcuts')) return
       }
 
       if (e.key === 'Escape' && !fullscreen) {
@@ -75,12 +76,7 @@ const ViewerDialog = () => {
 
   return (
     <>
-      <StyledDialog
-        isOpen
-        hideCancelButton
-        size="full"
-        onClose={() => {}}
-      >
+      <StyledDialog isOpen hideCancelButton size="full" onClose={() => {}}>
         <Viewer onClose={handleClose} />
       </StyledDialog>
     </>

--- a/src/features/context.js
+++ b/src/features/context.js
@@ -469,17 +469,12 @@ const contextSlice = createSlice({
     },
     onCommentImageOpen: (state, action) => {
       // set the preview file
-      console.log('inside action:')
-      console.log(action.payload.files)
-      console.log(action.payload.activityId)
-      console.log(action.payload.index)
       state.previewFiles = action.payload.files
       state.previewFilesProjectName = action.payload.projectName
       state.previewFilesActivityId = action.payload.activityId
       state.previewFilesIndex = action.payload.index
     },
     onCommentImageActivityAndIndexChange: (state, action) => {
-      console.log(state, action)
       state.previewFilesActivityId = action.payload.activityId
       state.previewFilesIndex = action.payload.index
     },


### PR DESCRIPTION
Added extra overlay to capture clicks outside content / arrow components, closing previewer when clicked.
Pressing escape while in preview mode no longer propagates event.

https://github.com/user-attachments/assets/a8f74938-51d6-426a-bd31-797b6ffbd5a0

Closes #835 
