### PR TITLE
Addons: Fixed missing context issues, style improvements

### DIFF
--- a/src/hooks/useAddonContextResend.ts
+++ b/src/hooks/useAddonContextResend.ts
@@ -1,0 +1,19 @@
+import { useEffect } from 'react'
+
+const useAddonContextResend = (onMessageReceivedHandler: Function) => {
+
+  const handlePostMessage = (event: MessageEvent) => {
+    if (event.data?.action === 'request_context') {
+      onMessageReceivedHandler()
+    }
+  }
+
+  useEffect(() => {
+    window.addEventListener('message', handlePostMessage, false)
+    return () => {
+      window.removeEventListener('message', handlePostMessage, false)
+    }
+  }, [])
+}
+
+export default useAddonContextResend

--- a/src/pages/ProjectAddon.jsx
+++ b/src/pages/ProjectAddon.jsx
@@ -5,6 +5,7 @@ import styled from 'styled-components'
 
 import Hierarchy from '@containers/hierarchy'
 import TaskList from '@containers/taskList'
+import useAddonContextResend from '@hooks/useAddonContextResend'
 
 const AddonWrapper = styled.iframe`
   flex-grow: 1;
@@ -160,11 +161,13 @@ const ProjectAddon = ({ addonName, addonVersion, sidebar, ...props }) => {
   }
 
   // Push context on addon load and on every context change
-
   useEffect(() => {
     if (loading) return
     pushContext()
   }, [focusedFolders])
+
+  // Push context to addon whenever explicitly requested
+  useAddonContextResend(pushContext)
 
   // Render sidebar
   // Each addon may have a sidebar component that is rendered on the left side of the screen

--- a/src/pages/ProjectAddon.jsx
+++ b/src/pages/ProjectAddon.jsx
@@ -6,6 +6,7 @@ import styled from 'styled-components'
 import Hierarchy from '@containers/hierarchy'
 import TaskList from '@containers/taskList'
 import useAddonContextResend from '@hooks/useAddonContextResend'
+import LoadingPage from './LoadingPage'
 
 const AddonWrapper = styled.iframe`
   flex-grow: 1;
@@ -135,6 +136,11 @@ const ProjectAddon = ({ addonName, addonVersion, sidebar, ...props }) => {
     setRequestModal({ callback, requestType })
   }
 
+  //Switching between addons didn't update the loading state which affects the rest of the logic
+  useEffect(() => {
+    setLoading(true)
+  }, [addonUrl])
+
   useEffect(() => {
     window.modalRequest = modalRequest
     return () => (window.modalRequest = undefined)
@@ -162,7 +168,9 @@ const ProjectAddon = ({ addonName, addonVersion, sidebar, ...props }) => {
 
   // Push context on addon load and on every context change
   useEffect(() => {
-    if (loading) return
+    if (loading) {
+      return
+    }
     pushContext()
   }, [focusedFolders])
 
@@ -191,7 +199,11 @@ const ProjectAddon = ({ addonName, addonVersion, sidebar, ...props }) => {
       {sidebarComponent}
       <Section>
         <RequestModal {...requestModal} onClose={() => setRequestModal(null)} />
+        <div style={{ position: 'absolute', inset: 0 }}>
+          {loading && <LoadingPage style={{ position: 'absolute' }} />}
+        </div>
         <AddonWrapper
+          style={{ opacity: loading ? 0 : 1 }}
           src={`${addonUrl}/?id=${window.senderId}`}
           ref={addonRef}
           onLoad={onAddonLoad}

--- a/src/pages/SettingsPage/SettingsAddon.jsx
+++ b/src/pages/SettingsPage/SettingsAddon.jsx
@@ -2,6 +2,7 @@ import { useRef, useMemo, useState, useEffect } from 'react'
 import { useSelector } from 'react-redux'
 import { Section } from '@ynput/ayon-react-components'
 import styled from 'styled-components'
+import useAddonContextResend from '@hooks/useAddonContextResend'
 
 const AddonWrapper = styled.iframe`
   flex-grow: 1;
@@ -30,6 +31,9 @@ const SettingsAddon = ({ addonName, addonVersion, sidebar }) => {
       addonVersion,
     })
   }
+
+  // Push context to addon whenever explicitly requested
+  useAddonContextResend(pushContext)
 
   const sidebarComponent = useMemo(() => {
     if (sidebar === 'addonList') {

--- a/src/pages/SettingsPage/SettingsAddon.jsx
+++ b/src/pages/SettingsPage/SettingsAddon.jsx
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux'
 import { Section } from '@ynput/ayon-react-components'
 import styled from 'styled-components'
 import useAddonContextResend from '@hooks/useAddonContextResend'
+import LoadingPage from '@pages/LoadingPage'
 
 const AddonWrapper = styled.iframe`
   flex-grow: 1;
@@ -17,6 +18,11 @@ const SettingsAddon = ({ addonName, addonVersion, sidebar }) => {
 
   const context = useSelector((state) => state.context)
   const addonUrl = `${window.location.origin}/addons/${addonName}/${addonVersion}/frontend`
+
+  //Switching between addons didn't update the loading state which affects the rest of the logic
+  useEffect(() => {
+    setLoading(true)
+  }, [addonUrl])
 
   const pushContext = () => {
     if (!addonRef.current) {
@@ -56,7 +62,9 @@ const SettingsAddon = ({ addonName, addonVersion, sidebar }) => {
     <main>
       {sidebarComponent}
       <Section>
-        {loading && <div style={{ display: 'none' }}>Loading...</div>}
+        <div style={{ position: 'absolute', inset: 0 }}>
+          {loading && <LoadingPage style={{ position: 'absolute' }} />}
+        </div>
         <AddonWrapper src={`${addonUrl}/?id=${window.senderId}`} ref={addonRef} onLoad={onAddonLoad} />
       </Section>
     </main>


### PR DESCRIPTION
Project/Settings addon pages now listen to 'request_context' messages and push context accordingly.
The avoids addon errors due to missing context information.