### PR TITLE
Navigation: Avoiding redirect to Browser page on refresh

### DIFF
--- a/src/containers/Breadcrumbs/Breadcrumbs.jsx
+++ b/src/containers/Breadcrumbs/Breadcrumbs.jsx
@@ -126,6 +126,7 @@ const Breadcrumbs = () => {
       goThere(e)
     }
   }
+
   useEffect(() => {
     if (ctxUri !== localUri) {
       setLocalUri(ctxUri)
@@ -135,7 +136,7 @@ const Breadcrumbs = () => {
     const encodedAyonEntity = urlParams.get(ayonUrlParam)
     if (encodedAyonEntity !== null) {
       const ayonEntity = decodeURIComponent(encodedAyonEntity)
-      if (ayonEntity != ctxUri) {
+      if (ayonEntity != ctxUri && ctxUri !== '') {
         navigate(ayonEntity)
       }
     }

--- a/src/pages/UserDashboardPage/util/getSortedTasks.js
+++ b/src/pages/UserDashboardPage/util/getSortedTasks.js
@@ -16,8 +16,6 @@ export const getSortedTasks = (tasks = [], sortBy = [], anatomy = {}) => {
         bVal = anatomy[id].findIndex((option) => option.value === bVal)
       }
 
-      console.log(id, a)
-
       const dateA = new Date(aVal)
       const dateB = new Date(bVal)
       const decreaseIfSort = sortOrder ? -1 : 1


### PR DESCRIPTION
Skipping navigation after page refresh, which redirected users to browser page if hitting refresh in Dashboard page while having tasks selected. 

https://github.com/user-attachments/assets/76861fd9-1824-411f-ab07-b77a20205b4a

