### PR TITLE
PiP: users query all users can access

### DIFF
--- a/src/containers/DetailsPanel/DetailsPanelFloating/DetailsPanelFloating.tsx
+++ b/src/containers/DetailsPanel/DetailsPanelFloating/DetailsPanelFloating.tsx
@@ -8,8 +8,10 @@ import Feed from '@containers/Feed/Feed'
 import PiPWrapper from '@context/pip/PiPWrapper'
 import { useGetEntitiesDetailsPanelQuery } from '@queries/entity/getEntityPanel'
 import { useAppSelector } from '@state/store'
-import { useGetProjectsInfoQuery } from '@queries/userDashboard/getUserDashboard'
-import { useGetAllAssigneesQuery } from '@queries/user/getUsers'
+import {
+  useGetKanbanProjectUsersQuery,
+  useGetProjectsInfoQuery,
+} from '@queries/userDashboard/getUserDashboard'
 import getAllProjectStatuses from '../helpers/getAllProjectsStatuses'
 
 type Entity = {
@@ -31,14 +33,18 @@ export interface DetailsPanelFloatingProps {}
 
 const DetailsPanelFloating: FC<DetailsPanelFloatingProps> = () => {
   const { entities, entityType, scope, statePath } = useAppSelector((state) => state.details.pip)
+  const isOpen = entities.length > 0 && !!entityType
 
   const projects: string[] = entities.map((e: any) => e.projectName)
 
-  const { data: allUsers = [] } = useGetAllAssigneesQuery({})
+  const { data: allUsers = [] } = useGetKanbanProjectUsersQuery({ projects }, { skip: !isOpen })
 
-  const { data: projectsInfo = {}, isFetching: isFetchingInfo } = useGetProjectsInfoQuery({
-    projects: projects,
-  })
+  const { data: projectsInfo = {}, isFetching: isFetchingInfo } = useGetProjectsInfoQuery(
+    {
+      projects: projects,
+    },
+    { skip: !isOpen },
+  )
 
   // get all statuses from projects info, removing duplicate names
   const statuses = useMemo(
@@ -49,7 +55,7 @@ const DetailsPanelFloating: FC<DetailsPanelFloatingProps> = () => {
   const { data = [], isFetching: isFetchingEntitiesDetails } = useGetEntitiesDetailsPanelQuery(
     { entityType, entities: entities, projectsInfo },
     {
-      skip: !entities.length || isFetchingInfo,
+      skip: !isOpen || isFetchingInfo,
     },
   )
   const entitiesData: Entity[] = data.filter((e: Entity | null) => !!e)


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes
- Fix the users query so that every user (not just admins) can see the users.
- Skip queries if the PiP is not open.



## Technical details
<!-- Please state any technical details such as limitations -->
- The graphql query `users` is not accessible by regular users so the rest endpoint for project users is required.

## Testing
<!-- Add any other context or screenshots here. -->
1. Log in as a regular user
2. Open a pip with assignees
3. Check assignees still show in pip
4. Check logs for any queries that fail related to the pip

![image](https://github.com/user-attachments/assets/b1000230-3e44-4d73-96d9-261565620cba)

