### PR TITLE
Watchers: Invalidate versions watchers when changing tasks watchers

### DIFF
--- a/src/containers/Watchers/Watchers.tsx
+++ b/src/containers/Watchers/Watchers.tsx
@@ -8,7 +8,7 @@ import { toast } from 'react-toastify'
 interface WatchersProps extends Omit<WatcherSelectProps, 'currentUser'> {
   entities: { id: string; projectName: string }[]
   entityType: string
-  onWatchersUpdate?: (added: any[], removed: any[]) => void,
+  onWatchersUpdate?: (added: any[], removed: any[]) => void
 }
 
 export const Watchers = forwardRef<DropdownRef, WatchersProps>(

--- a/src/pages/TasksProgressPage/TasksProgressPage.tsx
+++ b/src/pages/TasksProgressPage/TasksProgressPage.tsx
@@ -54,7 +54,7 @@ const TasksProgressPage: FC = () => {
                 style={{
                   minWidth: 300,
                   maxWidth: 800,
-                  zIndex: 200,
+                  zIndex: 500,
                 }}
               >
                 <TaskProgressDetailsPanel projectInfo={projectInfo} projectName={projectName} />

--- a/src/services/watchers.ts
+++ b/src/services/watchers.ts
@@ -49,7 +49,10 @@ const injectedApi = enhancedApi.injectEndpoints({
         }
       },
       providesTags: (_result, _error, { entities }) =>
-        entities.map((entity) => ({ type: 'watchers', id: entity.entityId })),
+        entities.flatMap((entity) => [
+          { type: 'watchers', id: entity.entityId },
+          { type: 'watchers', id: `${entity.entityType.toUpperCase()}-LIST` },
+        ]),
     }),
   }),
 })
@@ -119,6 +122,11 @@ const injectedApi2 = injectedApi.injectEndpoints({
           patches.forEach((patch) => patch?.undo())
         }
       },
+      // invalidates all versions if any of the entities are tasks
+      invalidatesTags: (_result, _error, { entities }) =>
+        entities.some((entity) => entity.entityType === 'task')
+          ? [{ type: 'watchers', id: 'VERSION-LIST' }]
+          : [],
     }),
   }),
 })


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes
Whenever the watchers for a task updates it should invalidate the caches for any versions watchers.
Based on this BE logic: https://github.com/ynput/ayon-backend/pull/398/files

https://github.com/user-attachments/assets/1444b40f-4ff1-4bfd-9b82-a7ebddc6ceb7



## Technical details
<!-- Please state any technical details such as limitations -->
It's a bit annoying that every versions watchers cache is invalidated and not just the versions for the task, but I think this is a worthwhile tradeoff to keep things simple. There are usually no more than 3 version caches around at anyone time anyway.


## Testing
<!-- Add any other context or screenshots here. -->
1. Open a task to see the watchers and then open a version on the task to see those watchers.
2. If the watchers on the task changes then the watchers on the versions should also update.
3. Watcher changes on the version does NOT affect the task watchers, only task -> versions link.
4. If watching a task, new versions created should have watchers from the task added automatically.

