### PR TITLE
Onboarding: Setup pipeline prompt

### DIFF
--- a/src/components/InstallerDownload/InstallerDownloadPrompt.jsx
+++ b/src/components/InstallerDownload/InstallerDownloadPrompt.jsx
@@ -33,12 +33,11 @@ const InstallerDownloadPrompt = () => {
     <Styled.Container>
       {directDownload && (
         <Styled.DownloadButton icon={'install_desktop'} onClick={handleDirectDownload}>
-          Download Launcher
+          Download launcher
         </Styled.DownloadButton>
       )}
 
       <Styled.CloseButton
-        $isSpecial={true}
         icon="close"
         onClick={() => setInstallersDownloaded([...installersDownloaded, directDownload.filename])}
       />

--- a/src/containers/ReleaseInstallerDialog/ReleaseInstallerPrompt/ReleaseInstallerPrompt.styled.ts
+++ b/src/containers/ReleaseInstallerDialog/ReleaseInstallerPrompt/ReleaseInstallerPrompt.styled.ts
@@ -1,0 +1,37 @@
+import { Button } from '@ynput/ayon-react-components'
+import styled, { css } from 'styled-components'
+
+export const Container = styled.div`
+  position: relative;
+  display: flex;
+  align-items: center;
+  z-index: 50;
+`
+
+export const ButtonColors = css`
+  background-color: var(--md-sys-color-primary);
+
+  &:hover {
+    background-color: var(--md-sys-color-primary-hover, var(--md-sys-color-primary));
+  }
+  &,
+  .icon {
+    color: var(--md-sys-color-on-primary);
+  }
+`
+
+export const DownloadButton = styled(Button)`
+  border-radius: 4px 0 0 4px;
+  flex: 1;
+  max-height: unset;
+
+  ${ButtonColors}
+`
+
+export const CloseButton = styled(Button)`
+  border-radius: 0 4px 4px 0;
+  left: -4px;
+  position: relative;
+
+  ${ButtonColors}
+`

--- a/src/containers/ReleaseInstallerDialog/ReleaseInstallerPrompt/ReleaseInstallerPrompt.tsx
+++ b/src/containers/ReleaseInstallerDialog/ReleaseInstallerPrompt/ReleaseInstallerPrompt.tsx
@@ -1,0 +1,62 @@
+import useLocalStorage from '@hooks/useLocalStorage'
+import * as Styled from './ReleaseInstallerPrompt.styled'
+import { useNavigate } from 'react-router'
+import { useAppDispatch } from '@state/store'
+import { toggleReleaseInstaller } from '@state/releaseInstaller'
+import { useListInstallersQuery } from '@queries/installers/getInstallers'
+import { useListDependencyPackagesQuery } from '@queries/dependencyPackages/getDependencyPackages'
+
+type Props = {
+  isAdmin: boolean
+}
+
+const ReleaseInstallerPrompt = ({ isAdmin }: Props) => {
+  const navigate = useNavigate()
+  const dispatch = useAppDispatch()
+
+  const [showPrompt, setShowPrompt] = useLocalStorage<boolean>('releaseInstallPrompt', true)
+  const notAdminOrDismissed = !showPrompt || !isAdmin
+
+  // get installers and dep packages and show if there are no installers or no dep packages
+  const { data: { installers } = {}, isSuccess: isInstallersSuccess } = useListInstallersQuery(
+    {},
+    { skip: notAdminOrDismissed },
+  )
+  const { data: { packages } = {}, isSuccess: isPackagesSuccess } = useListDependencyPackagesQuery(
+    undefined,
+    {
+      skip: notAdminOrDismissed,
+    },
+  )
+
+  const hasInstallersAndPackages =
+    installers && !!installers?.length && packages && !!packages?.length
+
+  if (
+    !showPrompt ||
+    !isAdmin ||
+    hasInstallersAndPackages ||
+    !isInstallersSuccess ||
+    !isPackagesSuccess
+  )
+    return null
+
+  const handleOpen = () => {
+    // go to bundles page
+    navigate('/settings/bundles')
+    // open menu
+    dispatch(toggleReleaseInstaller(true))
+  }
+
+  return (
+    <Styled.Container>
+      <Styled.DownloadButton icon={'valve'} onClick={handleOpen}>
+        Setup pipeline
+      </Styled.DownloadButton>
+
+      <Styled.CloseButton icon="close" onClick={() => setShowPrompt(false)} />
+    </Styled.Container>
+  )
+}
+
+export default ReleaseInstallerPrompt

--- a/src/containers/ReleaseInstallerDialog/components/Card.tsx
+++ b/src/containers/ReleaseInstallerDialog/components/Card.tsx
@@ -28,7 +28,7 @@ export const Card = forwardRef<HTMLDivElement, CardProps>(
         </div>
         {onChange && (
           <Button onClick={onChange} variant={required ? 'filled' : 'surface'}>
-            Change
+            {required ? `Pick ${title}` : 'Change'}
           </Button>
         )}
       </Styled.Card>

--- a/src/containers/ReleaseInstallerDialog/forms/ReleaseInstallerOverview.tsx
+++ b/src/containers/ReleaseInstallerDialog/forms/ReleaseInstallerOverview.tsx
@@ -1,6 +1,11 @@
 import { FC } from 'react'
 import { Card, Footer } from '../components'
-import { createAddonsSubtitle, createInstallersSubtitle, createReleaseSubtitle } from '../helpers'
+import {
+  areAddonsOnlyMandatory,
+  createAddonsSubtitle,
+  createInstallersSubtitle,
+  createReleaseSubtitle,
+} from '../helpers'
 import { ReleaseFormType } from '@state/releaseInstaller'
 import { ReleaseListItemModel } from '@api/rest/releases'
 import { ReleaseForm } from '../hooks/useReleaseForm'
@@ -52,7 +57,10 @@ export const ReleaseInstallerOverview: FC<ReleaseInstallerOverviewProps> = ({
         icon="extension"
         isLoading={isLoading}
         onChange={() => onSwitchDialog('addons')}
-        required={releaseForm.addons.length === 0}
+        required={
+          releaseForm.addons.length === 0 ||
+          areAddonsOnlyMandatory(releaseForm.addons, release?.mandatoryAddons, release?.addons)
+        }
       />
       <Card
         title="AYON launchers"

--- a/src/containers/ReleaseInstallerDialog/helpers.ts
+++ b/src/containers/ReleaseInstallerDialog/helpers.ts
@@ -164,3 +164,12 @@ export const createBundleFromRelease = (
     isProduction: !hasProduction,
   }
 }
+
+export const areAddonsOnlyMandatory = (
+  addons: string[],
+  mandatoryAddons: string[] = [],
+  releaseAddons: string[] = [],
+) => {
+  const filteredAddons = addons.filter((addon) => releaseAddons.includes(addon))
+  return filteredAddons.every((addon) => mandatoryAddons.includes(addon))
+}

--- a/src/containers/header/AppHeader.jsx
+++ b/src/containers/header/AppHeader.jsx
@@ -7,7 +7,7 @@ import Breadcrumbs from '../Breadcrumbs/Breadcrumbs'
 import HeaderButton from './HeaderButton'
 import AppMenu from '@components/Menu/Menus/AppMenu'
 import ProjectMenu from '../ProjectMenu/projectMenu'
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from '@state/store'
 import InstallerDownloadPrompt from '@components/InstallerDownload/InstallerDownloadPrompt'
 import { toggleMenuOpen, setMenuOpen } from '@state/context'
 import { HelpMenu, UserMenu } from '@components/Menu'
@@ -19,6 +19,7 @@ import styled from 'styled-components'
 import { useRestart } from '@context/restartContext'
 import clsx from 'clsx'
 import InboxNotificationIcon from './InboxNotification'
+import ReleaseInstallerPrompt from '@containers/ReleaseInstallerDialog/ReleaseInstallerPrompt/ReleaseInstallerPrompt'
 
 const FlexWrapper = styled.div`
   display: flex;
@@ -71,14 +72,14 @@ const StyledSwitch = styled(InputSwitch)`
 `
 
 const Header = () => {
-  const dispatch = useDispatch()
-  const menuOpen = useSelector((state) => state.context.menuOpen)
+  const dispatch = useAppDispatch()
+  const menuOpen = useAppSelector((state) => state.context.menuOpen)
   const handleToggleMenu = (menu) => dispatch(toggleMenuOpen(menu))
   const handleSetMenu = (menu) => dispatch(setMenuOpen(menu))
   const location = useLocation()
   const navigate = useNavigate()
   // get user from redux store
-  const user = useSelector((state) => state.user)
+  const user = useAppSelector((state) => state.user)
 
   // restart server notification
   const { isSnoozing } = useRestart()
@@ -176,6 +177,7 @@ const Header = () => {
       <Breadcrumbs />
       <FlexWrapper style={{ justifyContent: 'end' }} id="header-menu-right">
         <InstallerDownloadPrompt />
+        <ReleaseInstallerPrompt isAdmin={user.data.isAdmin} />
         {isDeveloper && (
           <DeveloperSwitch $isChecked={developerMode} onClick={handleDeveloperMode}>
             <span>Developer Mode</span>


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes
When no installers or dependency packages are installed then this prompt will show.

Clicking on the prompt will open the **Install pipeline release** dialog.

The aim is to help direct new admins to set up the pipeline for the first time.

This new prompt will be reference by a new tutorial called **Pipeline setup**.


![image](https://github.com/user-attachments/assets/48cba007-f7e8-40e0-982b-e47ca7c98f8f)


## Other changes
<!-- Please state any technical details such as limitations -->
- Improved the mandatory buttons inside **Install pipeline release** dialog to say "Pick {items}" rather than just "Change".
- "Pick Addons" button shows when only mandatory addons have been selected.


## Testing
<!-- Add any other context or screenshots here. -->
1. Ensure the server has no installers or packages.
![image](https://github.com/user-attachments/assets/cdbd5d27-62aa-4300-92c6-7fca62c9409c)
2. Ensure user logged in is an admin.
3. Click on setup pipeline prompt and install release modal should open.
![image](https://github.com/user-attachments/assets/402bdb61-d15b-4c8d-be36-400269e34c40)
4. After install release is finished and the server has restarted the prompt should not show.
5. Dismissing the prompt will set a local storage flag to hide it.

## Further notes
This could be extended in the future to show whenever there is a new release that needs to be downloaded. Acting a bit like a notification for new released.
