### PR TITLE
Dashboard: Show addons that are scoped to dashboard

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -200,6 +200,11 @@ const App = () => {
                                 exact
                                 element={<UserDashboardPage />}
                               />
+                              <Route
+                                path="/dashboard/addon/:addonName"
+                                exact
+                                element={<UserDashboardPage />}
+                              />
 
                               <Route
                                 path="/manageProjects/:module"

--- a/src/pages/ProjectDashboard/DashboardAddon.jsx
+++ b/src/pages/ProjectDashboard/DashboardAddon.jsx
@@ -53,20 +53,18 @@ const DashboardAddon = ({ addonName, addonVersion }) => {
   }, [context])
 
   return (
-    <main>
-      <Section>
-        {loading && (
-          <div style={{ position: 'absolute', inset: 0 }}>
-            <LoadingPage style={{ position: 'absolute' }} />
-          </div>
-        )}
-        <AddonWrapper
-          src={`${addonUrl}/?id=${window.senderId}`}
-          ref={addonRef}
-          onLoad={onAddonLoad}
-        />
-      </Section>
-    </main>
+    <Section style={{ height: '100%' }}>
+      {loading && (
+        <div style={{ position: 'absolute', inset: 0 }}>
+          <LoadingPage style={{ position: 'absolute' }} />
+        </div>
+      )}
+      <AddonWrapper
+        src={`${addonUrl}/?id=${window.senderId}`}
+        ref={addonRef}
+        onLoad={onAddonLoad}
+      />
+    </Section>
   )
 }
 

--- a/src/pages/ProjectDashboard/DashboardAddon.jsx
+++ b/src/pages/ProjectDashboard/DashboardAddon.jsx
@@ -1,0 +1,73 @@
+import { useRef, useState, useEffect } from 'react'
+import { useSelector } from 'react-redux'
+import { Section } from '@ynput/ayon-react-components'
+import styled from 'styled-components'
+import useAddonContextResend from '@hooks/useAddonContextResend'
+import LoadingPage from '@pages/LoadingPage'
+
+const AddonWrapper = styled.iframe`
+  flex-grow: 1;
+  background: 'transparent';
+  border: 0;
+  overflow: auto;
+`
+
+const DashboardAddon = ({ addonName, addonVersion }) => {
+  const addonRef = useRef(null)
+  const [loading, setLoading] = useState(true)
+
+  const context = useSelector((state) => state.context)
+  const addonUrl = `${window.location.origin}/addons/${addonName}/${addonVersion}/frontend`
+
+  //Switching between addons didn't update the loading state which affects the rest of the logic
+  useEffect(() => {
+    setLoading(true)
+  }, [addonUrl])
+
+  const pushContext = () => {
+    if (!addonRef.current) {
+      return
+    }
+    const addonWnd = addonRef.current.contentWindow
+    addonWnd.postMessage({
+      scope: 'dashboard',
+      accessToken: localStorage.getItem('accessToken'),
+      context,
+      addonName,
+      addonVersion,
+    })
+  }
+
+  // Push context to addon whenever explicitly requested
+  useAddonContextResend(pushContext)
+
+  const onAddonLoad = () => {
+    setLoading(false)
+    pushContext()
+  }
+
+  useEffect(() => {
+    if (addonRef.current) {
+      pushContext()
+    }
+  }, [context])
+
+  return (
+    <main>
+      <Section>
+        {loading && (
+          <div style={{ position: 'absolute', inset: 0 }}>
+            <LoadingPage style={{ position: 'absolute' }} />
+          </div>
+        )}
+        <AddonWrapper
+          src={`${addonUrl}/?id=${window.senderId}`}
+          ref={addonRef}
+          onLoad={onAddonLoad}
+        />
+      </Section>
+    </main>
+  )
+}
+
+export default DashboardAddon

--- a/src/pages/UserDashboardPage/UserDashboardPage.jsx
+++ b/src/pages/UserDashboardPage/UserDashboardPage.jsx
@@ -13,9 +13,18 @@ import ProjectDashboard from '../ProjectDashboard'
 import NewProjectDialog from '../ProjectManagerPage/NewProjectDialog'
 import { useDeleteProjectMutation, useUpdateProjectMutation } from '@queries/project/updateProject'
 import confirmDelete from '@helpers/confirmDelete'
+import { useGetDashboardAddonsQuery } from '@queries/addons/getAddons'
+import DashboardAddon from '@pages/ProjectDashboard/DashboardAddon'
 
 const UserDashboardPage = () => {
-  let { module } = useParams()
+  let { module, addonName } = useParams()
+
+  const {
+    data: addonsData = [],
+    //isLoading: addonsLoading,
+    //isError: addonsIsError,
+  } = useGetDashboardAddonsQuery({})
+
   const links = [
     {
       name: 'Tasks',
@@ -31,6 +40,19 @@ const UserDashboardPage = () => {
       accessLevels: [],
     },
   ]
+
+  for (const addon of addonsData) {
+    links.push({
+      name: addon.title,
+      path: `/dashboard/addon/${addon.name}`,
+      module: addon.name,
+    })
+  }
+
+  const addData = addonsData.find((addon) => addon.name === addonName)
+  const addonModule = addData ? (
+    <DashboardAddon addonName={addData.name} addonVersion={addData.version} />
+  ) : null
 
   const navigate = useNavigate()
   const [showNewProject, setShowNewProject] = useState(false)
@@ -115,6 +137,7 @@ const UserDashboardPage = () => {
             />
           )}
           {module === 'overview' && <ProjectDashboard projectName={selectedProjects[0]} />}
+          {!!addonName && addonModule}
         </Section>
       </main>
       {showNewProject && (

--- a/src/pages/UserDashboardPage/UserDashboardPage.jsx
+++ b/src/pages/UserDashboardPage/UserDashboardPage.jsx
@@ -49,9 +49,10 @@ const UserDashboardPage = () => {
     })
   }
 
-  const addData = addonsData.find((addon) => addon.name === addonName)
-  const addonModule = addData ? (
-    <DashboardAddon addonName={addData.name} addonVersion={addData.version} />
+  const addonData = addonsData.find((addon) => addon.name === addonName)
+
+  const addonModule = addonData ? (
+    <DashboardAddon addonName={addonData.name} addonVersion={addonData.version} />
   ) : null
 
   const navigate = useNavigate()
@@ -110,26 +111,28 @@ const UserDashboardPage = () => {
       <AppNavLinks links={links} />
       <main style={{ overflow: 'hidden' }}>
         <Section direction="row" wrap style={{ position: 'relative', overflow: 'hidden' }}>
-          <ProjectList
-            wrap
-            isCollapsible
-            collapsedId="dashboard"
-            styleSection={{ position: 'relative', height: '100%', minWidth: 200, maxWidth: 200 }}
-            hideCode
-            multiselect={isProjectsMultiSelect}
-            selection={isProjectsMultiSelect ? selectedProjects : selectedProjects[0]}
-            onSelect={(p) => setSelectedProjects(isProjectsMultiSelect ? p : [p])}
-            onNoProject={(p) => p && setSelectedProjects([p])}
-            autoSelect
-            onSelectAll={
-              module !== 'overview' ? (projects) => setSelectedProjects(projects) : undefined
-            }
-            onSelectAllDisabled={!isProjectsMultiSelect}
-            isProjectManager={module === 'overview'}
-            onNewProject={() => setShowNewProject(true)}
-            onDeleteProject={handleDeleteProject}
-            onActivateProject={handleActivateProject}
-          />
+          {!addonName && (
+            <ProjectList
+              wrap
+              isCollapsible
+              collapsedId="dashboard"
+              styleSection={{ position: 'relative', height: '100%', minWidth: 200, maxWidth: 200 }}
+              hideCode
+              multiselect={isProjectsMultiSelect}
+              selection={isProjectsMultiSelect ? selectedProjects : selectedProjects[0]}
+              onSelect={(p) => setSelectedProjects(isProjectsMultiSelect ? p : [p])}
+              onNoProject={(p) => p && setSelectedProjects([p])}
+              autoSelect
+              onSelectAll={
+                module !== 'overview' ? (projects) => setSelectedProjects(projects) : undefined
+              }
+              onSelectAllDisabled={!isProjectsMultiSelect}
+              isProjectManager={module === 'overview'}
+              onNewProject={() => setShowNewProject(true)}
+              onDeleteProject={handleDeleteProject}
+              onActivateProject={handleActivateProject}
+            />
+          )}
           {module === 'tasks' && (
             <UserTasksContainer
               projectsInfo={projectsInfoWithProjects}

--- a/src/services/addons/getAddons.ts
+++ b/src/services/addons/getAddons.ts
@@ -64,10 +64,37 @@ const addonsApiInjected = addonsApi.injectEndpoints({
         return result
       },
     }),
+    // Return a list of addons with dashboard-scoped frontend
+    getDashboardAddons: build.query({
+      query: () => ({
+        url: `/api/addons`,
+        method: 'GET',
+      }),
+      providesTags: ['dashboardAddons'],
+      transformErrorResponse: (error: any) => error.data.detail || `Error ${error.status}`,
+      transformResponse: (response: any) => {
+        let result = []
+        for (const definition of response.addons) {
+          const versDef = definition.versions[definition.productionVersion]
+          if (!versDef) continue
+          const settingsScope = versDef.frontendScopes['dashboard']
+          if (!settingsScope) continue
+
+          result.push({
+            name: definition.name,
+            title: definition.title,
+            version: definition.productionVersion,
+            settings: settingsScope,
+          })
+        }
+        return result
+      },
+    }),
   }),
   overrideExisting: true,
 })
 
-export const { useGetProjectAddonsQuery, useGetSettingsAddonsQuery } = addonsApiInjected
+export const { useGetProjectAddonsQuery, useGetSettingsAddonsQuery, useGetDashboardAddonsQuery } =
+  addonsApiInjected
 
 export default addonsApiInjected


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
Addons can now show in the dashboard if they have the "dashboard" scope. This is useful for addons that do not always have a specific project, for example studio planning #819 .


## Technical details
<!-- Please state any technical details such as limitations -->
Something on the BE might need to be implemented @martastain?



