### PR TITLE
Task progress: spacebar to open selected folder

### DIFF
--- a/src/containers/TasksProgress/TasksProgress.tsx
+++ b/src/containers/TasksProgress/TasksProgress.tsx
@@ -376,9 +376,17 @@ const TasksProgress: FC<TasksProgressProps> = ({
   }
 
   const viewerIsOpen = useSelector((state: $Any) => state.viewer.isOpen)
-  const openInViewer = (id: string, quickView: boolean) => {
-    if (id && !viewerIsOpen) {
-      dispatch(openViewer({ taskId: id, projectName: projectName, quickView }))
+  const openInViewer = ({
+    taskId,
+    folderId,
+    quickView,
+  }: {
+    taskId?: string
+    folderId?: string
+    quickView?: boolean
+  }) => {
+    if ((taskId || folderId) && !viewerIsOpen) {
+      dispatch(openViewer({ taskId, folderId, projectName: projectName, quickView }))
     }
   }
 
@@ -444,7 +452,6 @@ const TasksProgress: FC<TasksProgressProps> = ({
               tableData={tableData}
               projectName={projectName}
               isLoading={isFetchingTasks}
-              selectedFolders={folderIdsToFetch}
               activeTask={activeTask}
               selectedAssignees={selectedAssignees}
               statuses={statuses} // status icons etc.

--- a/src/containers/TasksProgress/components/FolderBody/FolderBody.tsx
+++ b/src/containers/TasksProgress/components/FolderBody/FolderBody.tsx
@@ -18,6 +18,7 @@ interface FolderBodyProps {
   projectName: string
   onExpandToggle: () => void
   onFolderOpen?: (id: string) => void
+  onSpaceKey?: () => void
 }
 
 export const FolderBody: FC<FolderBodyProps> = ({
@@ -27,11 +28,20 @@ export const FolderBody: FC<FolderBodyProps> = ({
   projectName,
   onExpandToggle,
   onFolderOpen,
+  onSpaceKey,
 }) => {
   const thumbnailUrl = `/api/projects/${projectName}/folders/${folder.id}/thumbnail?updatedAt=${folder.updatedAt}`
 
+  // handle hitting enter or space on the cell
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === ' ') {
+      e.preventDefault()
+      onSpaceKey?.()
+    }
+  }
+
   return (
-    <Styled.Body className={clsx({ expanded: isExpanded })}>
+    <Styled.Body className={clsx({ expanded: isExpanded })} onKeyDown={handleKeyDown}>
       <Styled.ExpandButton
         icon={isExpanded ? 'collapse_all' : 'expand_all'}
         variant="text"

--- a/src/containers/TasksProgress/components/TasksProgressTable/TasksProgressTable.tsx
+++ b/src/containers/TasksProgress/components/TasksProgressTable/TasksProgressTable.tsx
@@ -60,7 +60,6 @@ interface TasksProgressTableProps
   tableData: FolderRow[]
   projectName: string
   isLoading: boolean
-  selectedFolders: string[]
   activeTask: string | null
   selectedAssignees: string[]
   statuses: Status[]
@@ -75,7 +74,15 @@ interface TasksProgressTableProps
   onCollapseRow: (folderId: string) => void
   onChange: TaskFieldChange
   onSelection: (taskId: string, meta: boolean, shift: boolean) => void
-  onOpenViewer: (taskId: string, quickView: boolean) => void
+  onOpenViewer: ({
+    taskId,
+    folderId,
+    quickView,
+  }: {
+    taskId?: string
+    folderId?: string
+    quickView?: boolean
+  }) => void
 }
 
 export const TasksProgressTable = ({
@@ -83,7 +90,6 @@ export const TasksProgressTable = ({
   tableData = [],
   projectName,
   isLoading,
-  selectedFolders = [],
   activeTask,
   selectedAssignees = [],
   statuses = [], // project statuses schema
@@ -201,7 +207,7 @@ export const TasksProgressTable = ({
         label: 'Open in viewer',
         icon: 'play_circle',
         shortcut: 'Spacebar',
-        command: () => onOpenViewer(taskId, false),
+        command: () => onOpenViewer({ taskId, quickView: true }),
       },
     ]
   }
@@ -366,6 +372,7 @@ export const TasksProgressTable = ({
               isExpanded={getIsExpanded(row.__folderId)}
               onExpandToggle={() => onExpandRow(row.__folderId)}
               onFolderOpen={handleFolderOpen}
+              onSpaceKey={() => onOpenViewer({ folderId: row.__folderId, quickView: true })}
             />
           )
         }
@@ -431,14 +438,14 @@ export const TasksProgressTable = ({
                     onSelection(task.id, e.metaKey || e.ctrlKey, e.shiftKey)
                   }
 
-                  // handle hitting enter on the cell
+                  // handle hitting enter or space on the cell
                   const handleCellKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
                     if (e.key === 'Enter') {
                       onSelection(task.id, e.metaKey || e.ctrlKey, e.shiftKey)
                     }
                     if (e.key === ' ') {
                       e.preventDefault()
-                      onOpenViewer(task.id, true)
+                      onOpenViewer({ taskId: task.id, quickView: true })
                     }
                   }
 

--- a/src/containers/Viewer/Viewer.tsx
+++ b/src/containers/Viewer/Viewer.tsx
@@ -173,9 +173,10 @@ const Viewer = ({ onClose }: ViewerProps) => {
       !isFetchingReviewables &&
       selectedVersion
     ) {
-      const firstReviewableId = selectedVersion.reviewables?.find(
-        (r) => r.availability === 'ready',
+      const firstReviewableId = selectedVersion.reviewables?.find((r) =>
+        ['ready', 'conversionRecommended'].includes(r.availability || ''),
       )?.fileId
+
       if (firstReviewableId) {
         dispatch(updateSelection({ reviewableIds: [firstReviewableId] }))
       }


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
- Selecting a folder on the progress page and hitting the spacebar should open the folder in the viewer.

https://github.com/user-attachments/assets/1874a420-acd7-46aa-af14-fad4976f96d7

- Fixed a bug where opening the viewer with no specific reviewableId (folder/product) would not auto-select the first reviewable if it was "conversion recommended". This would result with no reviewable selected and an empty video player.
<img width="470" alt="image" src="https://github.com/user-attachments/assets/4df4e380-5bdb-43d9-bc44-2bc1614a7777" />






