### PR TITLE
critical: Shortcuts were not being unmounted when moving pages

### DIFF
--- a/src/context/shortcutsContext.jsx
+++ b/src/context/shortcutsContext.jsx
@@ -1,4 +1,12 @@
-import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react'
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  useRef,
+} from 'react'
 import { useNavigate } from 'react-router'
 import { useAppDispatch, useAppSelector } from '@state/store'
 import { toggleMenuOpen } from '@state/context'
@@ -74,20 +82,31 @@ function ShortcutsProvider(props) {
     ],
     [navigate],
   )
-  // when these variables change, update shortcutshh
-  const deps = [searchParams]
 
   const defaultShortcuts = [...navigation, ...navBar]
+
+  // Separate global shortcuts from component shortcuts
+  const [globalShortcuts] = useState(defaultShortcuts)
+  const [componentShortcuts, setComponentShortcuts] = useState(new Map())
+
+  // Compute active shortcuts by combining global and component shortcuts
+  const activeShortcuts = useMemo(() => {
+    const allShortcuts = [...globalShortcuts]
+    componentShortcuts.forEach((shortcuts) => {
+      allShortcuts.push(...shortcuts)
+    })
+    return allShortcuts
+  }, [globalShortcuts, componentShortcuts])
 
   // keep track of what's being hovered
   const [hovered, setHovered] = useState(null)
   // start off with global shortcuts but others can be set per page
-  const [shortcuts, setShortcuts] = useState(defaultShortcuts)
+  const shortcutsRef = useRef(activeShortcuts)
 
-  // update shortcuts when these variables change
+  // Update ref whenever shortcuts change
   useEffect(() => {
-    setShortcuts(defaultShortcuts)
-  }, deps)
+    shortcutsRef.current = activeShortcuts
+  }, [activeShortcuts])
 
   const handleKeyPress = useCallback(
     (e) => {
@@ -117,10 +136,10 @@ function ShortcutsProvider(props) {
 
       // first check if the key pressed is a shortcut
       // const shortcut = shortcuts[e.key] || shortcuts[combo]
-      const shortcut = shortcuts.find((s) => s.key === combo || s.key === singleKey)
+      const shortcut = activeShortcuts.find((s) => s.key === combo || s.key === singleKey)
 
       // check if the key is part of a complex shortcut
-      const keyPartOfCombo = shortcuts.some((s) => s.key.includes(singleKey))
+      const keyPartOfCombo = activeShortcuts.some((s) => s.key.includes(singleKey))
 
       if (!keyPartOfCombo) return
 
@@ -143,8 +162,10 @@ function ShortcutsProvider(props) {
       // and run the action
       shortcut.action(hovered, isMeta, e)
     },
-    [lastPressed, shortcuts, hovered, disabled, allowed, reviewOpen],
+    [lastPressed, activeShortcuts, hovered, disabled, allowed, reviewOpen],
   )
+
+  console.log(activeShortcuts.map((s) => s.key))
 
   // Add event listeners
   useEffect(() => {
@@ -157,19 +178,21 @@ function ShortcutsProvider(props) {
 
   // create function that can be used in components to add shortcuts, when the component mounts
   // and removes them when it unmounts
-  const addShortcuts = (newShortcuts) => {
-    setShortcuts((oldShortcuts) => {
-      const oldShortcutsFiltered = oldShortcuts.filter(
-        (s) => !newShortcuts.some((n) => n.key === s.key),
-      )
-      return [...oldShortcutsFiltered, ...newShortcuts]
+  const addShortcuts = useCallback((id, newShortcuts) => {
+    setComponentShortcuts((current) => {
+      const updated = new Map(current)
+      updated.set(id, newShortcuts)
+      return updated
     })
-  }
+  }, [])
 
-  const removeShortcuts = (shortcutsToRemove) => {
-    // console.log('removing shortcuts', shortcutsToRemove)
-    setShortcuts((oldShortcuts) => oldShortcuts.filter((s) => !shortcutsToRemove.includes(s.key)))
-  }
+  const removeShortcuts = useCallback((id) => {
+    setComponentShortcuts((current) => {
+      const updated = new Map(current)
+      updated.delete(id)
+      return updated
+    })
+  }, [])
 
   const removeEventListener = () =>
     document.removeEventListener('mouseover', (e) => {
@@ -177,7 +200,7 @@ function ShortcutsProvider(props) {
     })
 
   useEffect(() => {
-    if (shortcuts.some((s) => s.closest)) {
+    if (activeShortcuts.some((s) => s.closest)) {
       document.addEventListener('mouseover', (e) => {
         setHovered(e)
       })
@@ -186,7 +209,7 @@ function ShortcutsProvider(props) {
     }
 
     return () => removeEventListener()
-  }, [shortcuts])
+  }, [activeShortcuts])
 
   return (
     <ShortcutsContext.Provider

--- a/src/hooks/useShortcuts.js
+++ b/src/hooks/useShortcuts.js
@@ -1,15 +1,16 @@
-import { useEffect } from 'react'
+import { useEffect, useId } from 'react'
 import { useShortcutsContext } from '@context/shortcutsContext'
 
 const useShortcuts = (shortcuts, deps = []) => {
   const { addShortcuts, removeShortcuts } = useShortcutsContext()
+  const id = useId()
 
   useEffect(() => {
-    addShortcuts(shortcuts)
+    addShortcuts(id, shortcuts)
     return () => {
-      removeShortcuts(shortcuts)
+      removeShortcuts(id)
     }
-  }, deps)
+  }, [id, shortcuts, ...deps])
 }
 
 export default useShortcuts


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
The shortcuts were not being properly removed when switching pages causing odd behaviours. It was possible to trigger a shortcut action of a completely different page.


## Technical details
<!-- Please state any technical details such as limitations -->
This was due to a stale setState method.


## Additional context
<!-- Add any other context or screenshots here. -->
https://community.ynput.io/t/site-settings-shortcut-issues

