### PR TITLE
Bundles: Remove bundle status shortcuts

### DIFF
--- a/src/pages/SettingsPage/Bundles/BundleDetail.jsx
+++ b/src/pages/SettingsPage/Bundles/BundleDetail.jsx
@@ -71,7 +71,6 @@ const BundleDetail = ({ bundles = [], onDuplicate, installers, toggleBundleStatu
               onClick={() => toggleBundleStatus(name, bundle.name)}
               disabled={bundles.length > 1}
               data-tooltip={`${!active ? 'Set' : 'Unset'} bundle to ${name}`}
-              data-shortcut={`shift+${name.charAt(0).toUpperCase()}`}
             >
               {!active ? 'Set' : ''} {upperFirst(name)}
             </Styled.BadgeButton>

--- a/src/pages/SettingsPage/Bundles/BundleList.jsx
+++ b/src/pages/SettingsPage/Bundles/BundleList.jsx
@@ -79,11 +79,9 @@ const BundleList = ({
     const isStatus = bundle[key]
     const label = isStatus ? unsetLabel : setLabel
     const icon = isStatus ? 'remove' : 'add'
-    let shortcut = `Shift+${status.charAt(0).toUpperCase()}`
-    if (status === 'dev') shortcut = null
     const command = () => toggleBundleStatus(status, bundle.name)
     const disabled = selectedBundles.length > 1 || disabledExtra
-    return { label, icon, shortcut, command, disabled }
+    return { label, icon, command, disabled }
   }
 
   const [ctxMenuShow] = useCreateContext([])

--- a/src/pages/SettingsPage/Bundles/Bundles.jsx
+++ b/src/pages/SettingsPage/Bundles/Bundles.jsx
@@ -368,16 +368,6 @@ const Bundles = () => {
       action: () => setUploadOpen('package'),
     },
     {
-      key: 'S',
-      action: () => toggleBundleStatus('staging', selectedBundles[0]),
-      disabled: selectedBundles.length !== 1,
-    },
-    {
-      key: 'P',
-      action: () => toggleBundleStatus('production', selectedBundles[0]),
-      disabled: selectedBundles.length !== 1,
-    },
-    {
       key: 'D',
       action: () => handleDuplicateBundle(selectedBundles[0]),
       disabled: selectedBundles.length !== 1 && !newBundleOpen,


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
Remove set production and set staging shortcuts on bundles as it could be dangerous.

https://community.ynput.io/t/site-settings-shortcut-issues

