### PR TITLE
Removed version column from anatomy presets list

### DIFF
--- a/src/pages/SettingsPage/AnatomyPresets/PresetList.jsx
+++ b/src/pages/SettingsPage/AnatomyPresets/PresetList.jsx
@@ -97,7 +97,6 @@ const PresetList = ({
           rowClassName={(data) => clsx({ default: data.primary, loading: isLoading })}
         >
           <Column field="label" header="Name" />
-          <Column field="version" header="Version" style={{ maxWidth: 80 }} />
           <Column
             field="primary"
             header="Primary"


### PR DESCRIPTION
This PR removes the "Version" column from the Anatomy Presets table. The column was originally intended to track the version of the anatomy model associated with presets, but it has caused confusion because it is not relevant for direct preset versioning.