### PR TITLE
Users: updating multiple users respects mixed fields

### DIFF
--- a/src/pages/SettingsPage/UsersSettings/UserLicenseForm.tsx
+++ b/src/pages/SettingsPage/UsersSettings/UserLicenseForm.tsx
@@ -32,7 +32,7 @@ const UserLicenseForm: FC<UserLicenseFormProps> = ({
   const isUsingPools = !!userPools.length
 
   const licenseActiveTooltip = `Inactive users cannot log in and will lose their assigned license.`
-  const poolSelectTooltip = `Login requires an assigned license. If none is assigned, the system will automatically assign one from an available pool.  You cannot log in if no licenses are available. [Read more](https://docs.ayon.io/docs/)`
+  const poolSelectTooltip = `Login requires an assigned license. If none is assigned, the system will automatically assign one from an available fixed pool.  You cannot log in if no licenses are available. [License documentation](https://ayon.ynput.io/docs/admin_server_licenses)`
 
   return (
     <>

--- a/src/pages/SettingsPage/UsersSettings/UserLicenseForm.tsx
+++ b/src/pages/SettingsPage/UsersSettings/UserLicenseForm.tsx
@@ -31,12 +31,18 @@ const UserLicenseForm: FC<UserLicenseFormProps> = ({
   const { data: userPools = [], isLoading: isLoadingPools } = useGetUserPoolsQuery()
   const isUsingPools = !!userPools.length
 
+  const licenseActiveTooltip = `Inactive users cannot log in and will lose their assigned license.`
+  const poolSelectTooltip = `Login requires an assigned license. If none is assigned, the system will automatically assign one from an available pool.  You cannot log in if no licenses are available. [Read more](https://docs.ayon.io/docs/)`
+
   return (
     <>
       <b>{isUsingPools ? 'License control' : 'Login control'}</b>
       <FormLayout>
         <FormRowStyled label="User active">
-          <div style={{ width: 'fit-content' }}>
+          <div
+            style={{ width: 'fit-content' }}
+            data-tooltip={isUsingPools ? licenseActiveTooltip : ''}
+          >
             <InputSwitch
               checked={active}
               // @ts-ignore
@@ -53,7 +59,8 @@ const UserLicenseForm: FC<UserLicenseFormProps> = ({
               disabledValues={disabledPools(userPools)}
               disabled={!active || isLoadingPools || isDisabled}
               isMultiple={isPoolMixed}
-              data-tooltip="User requires an assigned license pool to log in"
+              data-tooltip={poolSelectTooltip}
+              data-tooltip-as="markdown"
               onChange={(value) => onPoolChange(value[0])}
             />
           </FormRowStyled>
@@ -68,7 +75,7 @@ export default UserLicenseForm
 const buildPoolsOptions = (pools: UserPoolModel[]): { value: string; label: string }[] => {
   return pools.map((pool) => ({
     value: pool.id,
-    label: `${pool.label} (${pool.used}/${pool.max})`,
+    label: `${pool.label} (${pool.used}/${pool.max}) ${!pool.valid ? '(invalid)' : ''}`,
   }))
 }
 

--- a/src/pages/SettingsPage/UsersSettings/userDetail.jsx
+++ b/src/pages/SettingsPage/UsersSettings/userDetail.jsx
@@ -199,7 +199,7 @@ const UserDetail = ({
 }) => {
   const [formData, setFormData] = useState(null)
   const [initData, setInitData] = useState({})
-  const [changesMade, setChangesMade] = useState(false)
+  const [changesMade, setChangesMade] = useState([])
   const [formUsers, setFormUsers] = useState([])
   const toastId = useRef(null)
 
@@ -234,20 +234,32 @@ const UserDetail = ({
       ...initDataWithoutAccessGroups
     } = initData || {}
 
-    const isDiffForm = !isEqual(formDataWithoutAccessGroups, initDataWithoutAccessGroups)
-    const isDiffAccessGroups = !isEqual(formDataAccessGroups, initDataAccessGroups)
-    const isDiffDefaultAccessGroups = !isEqual(
-      formDataDefaultAccessGroups,
-      initDataDefaultAccessGroups,
-    )
+    // Check which fields have changed
+    const changedFields = []
 
-    const isDiff =
-      isDiffForm || isDiffAccessGroups || isDiffDefaultAccessGroups || selectedUsers.length > 1
+    // Check regular fields
+    Object.keys(formDataWithoutAccessGroups).forEach((key) => {
+      if (!isEqual(formDataWithoutAccessGroups[key], initDataWithoutAccessGroups[key])) {
+        changedFields.push(key)
+      }
+    })
+
+    // Check access groups
+    if (!isEqual(formDataAccessGroups, initDataAccessGroups)) {
+      changedFields.push('accessGroups')
+    }
+
+    // Check default access groups
+    if (!isEqual(formDataDefaultAccessGroups, initDataDefaultAccessGroups)) {
+      changedFields.push('defaultAccessGroups')
+    }
+
+    const isDiff = changedFields.length > 0 || selectedUsers.length > 1
 
     if (isDiff && (!isSelfSelected || selectedUsers.length === 1)) {
-      if (!changesMade) setChangesMade(true)
+      setChangesMade(changedFields)
     } else {
-      setChangesMade(false)
+      setChangesMade([])
     }
   }, [formData, initData, selectedUsers])
 
@@ -267,46 +279,53 @@ const UserDetail = ({
     toastId.current = toast.info(`Updating ${usersString}...`)
     const updates = []
     for (const user of formUsers) {
-      const data = {
-        accessGroups: formData.accessGroups[user.name],
-        defaultAccessGroups: formData.defaultAccessGroups,
-      }
+      const data = {}
       const attrib = {}
+      const patch = {}
 
-      if (singleUserEdit) {
-        attributes.forEach(({ name }) => (attrib[name] = formData[name]))
+      // Only update changed fields
+      for (const field of changesMade) {
+        if (field === 'accessGroups') {
+          data.accessGroups = formData.accessGroups[user.name]
+        } else if (field === 'defaultAccessGroups') {
+          data.defaultAccessGroups = formData.defaultAccessGroups
+        } else if (field === 'userLevel') {
+          data.isAdmin = formData.userLevel === 'admin'
+          data.isManager = formData.userLevel === 'manager'
+          data.isService = formData.userLevel === 'service'
+        } else if (field === 'userPool') {
+          data.userPool = formData.userPool
+        } else if (field === 'userActive') {
+          patch.active = formData.userActive
+        } else if (field === 'isGuest') {
+          data.isGuest = formData.isGuest
+        } else if (field === 'isDeveloper') {
+          data.isDeveloper = formData.isDeveloper && formData.userLevel === 'admin'
+        } else if (singleUserEdit && attributes.find((a) => a.name === field)) {
+          attrib[field] = formData[field]
+        }
       }
 
-      // update user level && do access group clean-up
-      data.isAdmin = formData.userLevel === 'admin'
-      data.isManager = formData.userLevel === 'manager'
-      data.isService = formData.userLevel === 'service'
-      data.isGuest = formData.isGuest
-      data.isDeveloper = formData.isDeveloper && data.isAdmin
-      data.userPool = formData.userPool
+      // Only include non-empty objects in the patch
+      if (Object.keys(data).length > 0) patch.data = data
+      if (Object.keys(attrib).length > 0) patch.attrib = attrib
 
-      const patch = {
-        active: formData.userActive,
-        attrib,
-        data,
+      // Only push update if there are changes
+      if (Object.keys(patch).length > 0) {
+        updates.push({ name: user.name, patch })
       }
 
-      const update = {
-        name: user.name,
-        patch,
-      }
-
-      updates.push(update)
-
+      // Update Redux state if it's the current user
       if (user.self) {
-        dispatch(updateUserData(data))
-        dispatch(updateUserAttribs(attrib))
+        if (Object.keys(data).length > 0) dispatch(updateUserData(data))
+        if (Object.keys(attrib).length > 0) dispatch(updateUserAttribs(attrib))
       }
-    } // for user
+    }
 
     try {
       await updateUsers(updates).unwrap()
 
+      setChangesMade([])
       toast.update(toastId.current, {
         render: `Updated ${usersString} successfully`,
         type: toast.TYPE.SUCCESS,
@@ -327,7 +346,7 @@ const UserDetail = ({
 
   // onclose, no users selected but check if changes made
   const onClose = () => {
-    if (changesMade && selectedUsers.length === 1) {
+    if (changesMade.length && selectedUsers.length === 1) {
       return toast.error('Changes not saved')
     }
     setSelectedUsers([])
@@ -430,14 +449,14 @@ const UserDetail = ({
           onClick={onCancel}
           label="Cancel"
           icon="clear"
-          disabled={!changesMade || selectedUsers.length > 1}
+          disabled={!changesMade.length || selectedUsers.length > 1}
         />
         <SaveButton
           onClick={onSave}
           label="Save selected users"
-          active={changesMade}
+          active
           saving={isUpdating || isFetchingUsers}
-          disabled={isUpdating || isFetchingUsers}
+          disabled={isUpdating || isFetchingUsers || !changesMade.length}
         />
       </PanelButtonsStyled>
     </Section>


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
Selecting multiple users and changing one value would affect all values even if they were mixed. You could change one field and then an untouched field would be overwritten to one value for the selection. This could be dangerous as use permissions were part of this.

Now only fields that have been "touched" are updated, leaving alone fields with mixed state.


https://github.com/user-attachments/assets/2acda30b-d8cc-41f1-9447-e16273a7bc2a



## Testing

Select many users with different levels. Now change the guest switch and save. All selected users should have the same guest value but all other value, included level, should remain the same for each user.

