### PR TITLE
Overview: Attribute details form not showing null values

### DIFF
--- a/src/components/AttribForm/AttribForm.jsx
+++ b/src/components/AttribForm/AttribForm.jsx
@@ -2,6 +2,22 @@ import React, { useEffect } from 'react'
 import * as Styled from './AttribForm.styled'
 import AttribFormType from './AttribFormType'
 
+export const getDefaultFromType = (type) => {
+  switch (type) {
+    case 'string':
+      return ''
+    case 'number':
+      return 0
+    case 'boolean':
+      return false
+    case 'array':
+      return []
+
+    default:
+      return undefined
+  }
+}
+
 const AttribForm = ({ form = {}, onChange, fields, isLoading }) => {
   //   we build the attrib form data based on the schema, trying to match the data types
   // we do this in case form.attrib is missing any fields

--- a/src/pages/ProjectDashboard/panels/ProjectDetails/ProjectDetails.jsx
+++ b/src/pages/ProjectDashboard/panels/ProjectDetails/ProjectDetails.jsx
@@ -5,7 +5,7 @@ import AttributeTable from '@containers/attributeTable'
 import { format } from 'date-fns'
 import { Button, SaveButton, Toolbar } from '@ynput/ayon-react-components'
 import * as Styled from './ProjectDetails.styled'
-import AttribForm from '@components/AttribForm/AttribForm'
+import AttribForm, { getDefaultFromType } from '@components/AttribForm/AttribForm'
 import { useGetAnatomySchemaQuery } from '@queries/anatomy/getAnatomy'
 import { isEmpty, isEqual } from 'lodash'
 import { useSelector } from 'react-redux'
@@ -42,8 +42,22 @@ const ProjectDetails = ({ projectName }) => {
   const setInitFormState = (projectData) => {
     const updatedProjectForm = { ...projectFormInit }
     for (const key in projectFormInit) {
-      updatedProjectForm[key] = projectData[key]
+      if (key === 'attrib') {
+        updatedProjectForm[key] = { ...projectData[key] }
+      } else {
+        updatedProjectForm[key] = projectData[key]
+      }
     }
+
+    // add any fields that have not been added to the form
+    for (const key in fields) {
+      if (updatedProjectForm.attrib[key] === undefined) {
+        const field = fields[key]
+        // add missing field
+        updatedProjectForm.attrib[key] = getDefaultFromType(field.type)
+      }
+    }
+
     setProjectForm(updatedProjectForm)
     // update init data to compare changes
     setInitData(updatedProjectForm)
@@ -57,7 +71,7 @@ const ProjectDetails = ({ projectName }) => {
       // update project form with only the fields we need from the projectForm init state
       setInitFormState(data)
     }
-  }, [data, isFetching])
+  }, [data, isFetching, fields])
 
   const { attrib = {}, active, code, library } = data
 
@@ -192,7 +206,7 @@ const ProjectDetails = ({ projectName }) => {
           </Styled.Header>
         )
       }
-      stylePanel={{ height: 'calc(100% - 8px)', flex: 1, overflow: 'hidden' }}
+      stylePanel={{ height: 'calc(100% - 8px)', flex: 1, overflow: 'hidden', minHeight: 'unset' }}
       style={{ height: '100%', overflow: 'hidden' }}
     >
       {editing ? (


### PR DESCRIPTION
Fixes #1005

<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
There was an issue where fields that had a null value would not show when editing the values. They now show and are editable.

![image](https://github.com/user-attachments/assets/f35e5046-441c-4ed2-b59a-8a304e8af2c8)


