### PR TITLE
Inbox: Clear all, clears all messages (not just ones on screen)

### DIFF
--- a/src/api/rest/inbox.ts
+++ b/src/api/rest/inbox.ts
@@ -28,6 +28,8 @@ export type ManageInboxItemRequest = {
   projectName: string
   /** List of reference_ids of items to be managed */
   ids?: string[]
+  /** If true, all items will be managed */
+  all?: boolean
   /** Status to set for the items */
   status: 'unread' | 'read' | 'inactive'
 }

--- a/src/pages/InboxPage/Inbox/Inbox.jsx
+++ b/src/pages/InboxPage/Inbox/Inbox.jsx
@@ -176,7 +176,7 @@ const Inbox = ({ filter }) => {
     listRef,
   })
 
-  const clearMessages = async (id, messagesToClear = [], projectName) => {
+  const clearMessages = async (id, messagesToClear = [], projectName, allMessages) => {
     if (selected.length) {
       // select next message in the list
       const selectedMessageIndex = groupedMessages.findIndex((m) => m.activityId === id)
@@ -189,7 +189,7 @@ const Inbox = ({ filter }) => {
     const isRead = messagesToClear.every((m) => m.read)
     const status = isActive ? 'inactive' : 'unread'
 
-    handleUpdateMessages(idsToClear, status, projectName, true, isRead)
+    handleUpdateMessages(idsToClear, status, projectName, true, isRead, allMessages)
   }
 
   const handleClearMessage = (id) => {
@@ -212,7 +212,7 @@ const Inbox = ({ filter }) => {
     let promises = []
     // for each project, clear all messages
     for (const [projectName, messages] of Object.entries(groupedByProject)) {
-      const promise = clearMessages(null, messages, projectName)
+      const promise = clearMessages(null, messages, projectName, true)
       promises.push(promise)
     }
 

--- a/src/pages/InboxPage/Inbox/Inbox.jsx
+++ b/src/pages/InboxPage/Inbox/Inbox.jsx
@@ -22,6 +22,7 @@ import useGroupMessages from '../hooks/useGroupMessages'
 import useKeydown from '../hooks/useKeydown'
 import useUpdateInboxMessage from '../hooks/useUpdateInboxMessage'
 import useInboxRefresh from '../hooks/useInboxRefresh'
+import { useListProjectsQuery } from '@queries/project/getProject'
 
 const placeholderMessages = Array.from({ length: 100 }, (_, i) => ({
   activityId: `placeholder-${i}`,
@@ -39,6 +40,9 @@ const filters = {
 
 const Inbox = ({ filter }) => {
   const dispatch = useDispatch()
+
+  // get all project names
+  const { data: projects = [] } = useListProjectsQuery({})
 
   const user = useSelector((state) => state.user.name)
 
@@ -64,7 +68,9 @@ const Inbox = ({ filter }) => {
   const [getInboxMessages] = useLazyGetInboxMessagesQuery()
   // load more messages
   const handleLoadMore = () => {
-    if (!hasPreviousPage || isFetchingInbox) return
+    if (!hasPreviousPage || isFetchingInbox || !messages.length) return
+
+    console.log('loading more messages...')
 
     getInboxMessages({ last, active: isActive, important: isImportant, cursor: lastCursor })
   }
@@ -185,7 +191,7 @@ const Inbox = ({ filter }) => {
       else setSelected([])
     } else setSelected([])
 
-    const idsToClear = messagesToClear.map((m) => m.referenceId)
+    const idsToClear = allMessages ? undefined : messagesToClear.map((m) => m.referenceId)
     const isRead = messagesToClear.every((m) => m.read)
     const status = isActive ? 'inactive' : 'unread'
 
@@ -202,26 +208,16 @@ const Inbox = ({ filter }) => {
   }
 
   const handleClearAll = async () => {
-    // first group messages by projectName
-    const groupedByProject = messages.reduce((acc, message) => {
-      if (!acc[message.projectName]) acc[message.projectName] = []
-      acc[message.projectName].push(message)
-      return acc
-    }, {})
-
     let promises = []
-    // for each project, clear all messages
-    for (const [projectName, messages] of Object.entries(groupedByProject)) {
-      const promise = clearMessages(null, messages, projectName, true)
+    // for all projects, clear all messages
+    for (const project of projects) {
+      const promise = clearMessages(null, [], project.name, true)
       promises.push(promise)
     }
 
     try {
       await Promise.all(promises)
       toast.success('All messages cleared')
-
-      // refresh the inbox to get any new messages
-      if (hasPreviousPage) handleLoadMore()
     } catch (error) {
       console.error(error)
     }
@@ -398,7 +394,7 @@ const Inbox = ({ filter }) => {
               onContextMenu={handleContextMenu}
             />
           ))}
-          {hasPreviousPage && !isLoadingInbox && (
+          {hasPreviousPage && !isLoadingInbox && !!messages.length && (
             <InView
               onChange={(inView) => inView && handleLoadMore()}
               rootMargin={'0px 0px 500px 0px'}

--- a/src/pages/InboxPage/hooks/useUpdateInboxMessage.ts
+++ b/src/pages/InboxPage/hooks/useUpdateInboxMessage.ts
@@ -17,6 +17,7 @@ const useUpdateInboxMessage = ({ last, isActive, isImportant }: Config) => {
     projectName: ManageInboxItemRequest['projectName'],
     isActiveChange = false,
     isRead = false,
+    isAll = false,
   ) => {
     if (ids.length > 0) {
       // cacheKeyArgs are not used in the patch but are used to match the cache key to a query (for optimistic updates)
@@ -31,7 +32,12 @@ const useUpdateInboxMessage = ({ last, isActive, isImportant }: Config) => {
       // we use optimistic updates inside updateMessages query
       try {
         await updateMessages({
-          manageInboxItemRequest: { status: status, projectName: projectName, ids: ids },
+          manageInboxItemRequest: {
+            status: status,
+            projectName: projectName,
+            ids: ids,
+            all: isAll,
+          },
           ...cacheKeyArgs,
         }).unwrap()
       } catch (error) {

--- a/src/pages/InboxPage/hooks/useUpdateInboxMessage.ts
+++ b/src/pages/InboxPage/hooks/useUpdateInboxMessage.ts
@@ -19,7 +19,7 @@ const useUpdateInboxMessage = ({ last, isActive, isImportant }: Config) => {
     isRead = false,
     isAll = false,
   ) => {
-    if (ids.length > 0) {
+    if (ids?.length > 0 || isAll) {
       // cacheKeyArgs are not used in the patch but are used to match the cache key to a query (for optimistic updates)
       const cacheKeyArgs = {
         last,

--- a/src/services/project/ProjectTypes.ts
+++ b/src/services/project/ProjectTypes.ts
@@ -1,0 +1,11 @@
+import { DefinitionsFromApi, OverrideResultType, TagTypesFromApi } from '@reduxjs/toolkit/query'
+import { api, ListProjectsApiResponse } from '@api/rest/project'
+
+type listProjectsResult = NonNullable<ListProjectsApiResponse['projects']>
+
+type Definitions = DefinitionsFromApi<typeof api>
+export type TagTypes = TagTypesFromApi<typeof api>
+// update the definitions to include the new types
+export type UpdatedDefinitions = Omit<Definitions, 'listProjects'> & {
+  listProjects: OverrideResultType<Definitions['listProjects'], listProjectsResult>
+}

--- a/src/services/project/getProject.ts
+++ b/src/services/project/getProject.ts
@@ -1,6 +1,7 @@
-import { api } from '@api/rest/project'
+import { api, ListProjectsApiResponse } from '@api/rest/project'
 // @ts-ignore
 import { selectProject, setProjectData } from '@state/project'
+import { TagTypes, UpdatedDefinitions } from './ProjectTypes'
 
 // TODO: use graphql api and write custom types
 // We will need to inject the endpoint as it cannot be generated
@@ -55,7 +56,7 @@ const getProjectInjected = api.injectEndpoints({
 import { $Any } from '@/types'
 
 // TODO: sort out the types
-const getProjectApi = getProjectInjected.enhanceEndpoints({
+const getProjectApi = getProjectInjected.enhanceEndpoints<TagTypes, UpdatedDefinitions>({
   endpoints: {
     getProject: {
       transformErrorResponse: (error: $Any) => error.data.detail || `Error ${error.status}`,
@@ -110,7 +111,7 @@ const getProjectApi = getProjectInjected.enhanceEndpoints({
       },
     },
     listProjects: {
-      transformResponse: (res: $Any) => res?.projects || [],
+      transformResponse: (res: ListProjectsApiResponse) => res?.projects || [],
       transformErrorResponse: (error: $Any) => error.data.detail || `Error ${error.status}`,
       // @ts-ignore
       providesTags: (_res, _error, { active }) => [


### PR DESCRIPTION
Clear all button on the inbox page will clear all messages even if they have not been loaded yet.

![image](https://github.com/user-attachments/assets/ce17b1bb-deac-4fb0-8826-68df3dd7fd26)

### Testing

[REQUIRES ynput/ayon-backend/pull/498 on the server]

1. Create over 100 inbox items for multiple projects.
   - This is to ensure we have messages from other projects that are never loaded onto the page.
2. Clicking "Clear All" should remove all messages.
3. Refresh to ensure all messages have actually been cleared.

### Technical
Uses the new endpoint argument `all` on updateInbox query to apply those changes to all inbox items. This is still on a per-project level so we must do run this query for every project to ensure all messages from all projects are updated.
