### PR TITLE
Feed: Editing 1 comment and adding drawings to comments

### DIFF
--- a/src/components/CommentInput/CommentInput.jsx
+++ b/src/components/CommentInput/CommentInput.jsx
@@ -75,7 +75,6 @@ const CommentInput = ({
   const [isDropping, setIsDropping] = useState(false)
 
   const { annotations, removeAnnotation, goToAnnotation } = useAnnotationsSync({
-    openCommentInput: onOpen,
     entityId: entities[0]?.id,
     filesUploading,
   })

--- a/src/components/CommentInput/hooks/useAnnotationsSync.ts
+++ b/src/components/CommentInput/hooks/useAnnotationsSync.ts
@@ -1,9 +1,9 @@
+import { FEED_NEW_COMMENT, useFeed } from '@context/FeedContext'
 import { useAppDispatch, useAppSelector } from '@state/store'
 import { Annotation, goToFrame, removeAnnotation } from '@state/viewer'
 import { useEffect } from 'react'
 
 type Props = {
-  openCommentInput: () => void
   entityId: string
   filesUploading: File[]
 }
@@ -13,25 +13,34 @@ type AnnotationPreview = Annotation & {
 }
 
 // annotations are temporary store
-const useAnnotationsSync = ({ openCommentInput, entityId, filesUploading }: Props) => {
-  const dispatch = useAppDispatch()
-  // listen to the viewer for annotations
-  const allAnnotations = useAppSelector((state) => state.viewer.annotations)
-  // filter out annotations that are for this entity and are NOT uploading
-  const annotations = Object.values(allAnnotations)
+export const filterEntityAnnotations = (
+  annotations: Record<string, Annotation>,
+  entityId: string,
+  filesUploading: File[],
+): AnnotationPreview[] => {
+  return Object.values(annotations)
     .filter(
       (annotation) =>
         annotation.versionId === entityId &&
         !filesUploading.some((file) => file.name === annotation.name),
     )
     .map((annotation) => ({ ...annotation, isAnnotation: true })) as AnnotationPreview[]
+}
+
+const useAnnotationsSync = ({ entityId, filesUploading }: Props) => {
+  const dispatch = useAppDispatch()
+  const { editingId, setEditingId } = useFeed()
+  // listen to the viewer for annotations
+  const allAnnotations = useAppSelector((state) => state.viewer.annotations)
+  // filter out annotations that are for this entity and are NOT uploading
+  const annotations = filterEntityAnnotations(allAnnotations, entityId, filesUploading)
 
   // when annotations change, update the state
   // convert the base64 image to a file
   useEffect(() => {
-    // open the comment input if there are annotations
-    if (annotations.length > 0) {
-      openCommentInput()
+    // open the comment input if there are annotations and something is not being edited already
+    if (annotations.length > 0 && !editingId) {
+      setEditingId(FEED_NEW_COMMENT)
     }
   }, [annotations])
 

--- a/src/components/Feed/ActivityComment/ActivityComment.tsx
+++ b/src/components/Feed/ActivityComment/ActivityComment.tsx
@@ -1,13 +1,12 @@
 import clsx from 'clsx'
-import { useMemo, useRef, useState } from 'react'
+import { useMemo, useRef } from 'react'
 import ReactMarkdown from 'react-markdown'
-import { useSelector } from 'react-redux'
+import { useAppSelector } from '@state/store'
 import emoji from 'remark-emoji'
 import remarkGfm from 'remark-gfm'
 import remarkDirective from 'remark-directive'
 import remarkDirectiveRehype from 'remark-directive-rehype'
 
-import { UserModel } from '@api/rest/users'
 import CommentInput from '@components/CommentInput/CommentInput'
 import MenuContainer from '@/components/Menu/MenuComponents/MenuContainer'
 import Reactions from '@components/ReactionContainer/Reactions'
@@ -31,6 +30,9 @@ import { mapGraphQLReactions } from './mappers'
 import { Icon } from '@ynput/ayon-react-components'
 import ActivityStatus from '../ActivityStatus/ActivityStatus'
 import { Status } from '@api/rest/project'
+import { useFeed } from '@context/FeedContext'
+import { filterEntityAnnotations } from '@components/CommentInput/hooks/useAnnotationsSync'
+import { removeAnnotation } from '@state/viewer'
 
 type Props = {
   activity: $Any
@@ -88,28 +90,34 @@ const ActivityComment = ({
   if (!authorFullName) authorFullName = author?.fullName || authorName
   let menuId = `comment-${scope}-${activity.activityId}`
   if (statePath) menuId += '-' + statePath
-  const isMenuOpen = useSelector((state: $Any) => state.context.menuOpen) === menuId
-  const user = useSelector((state: $Any) => state.user) as UserModel
+  const isMenuOpen = useAppSelector((state) => state.context.menuOpen) === !!menuId
+  const user = useAppSelector((state) => state.user)
+  const allAnnotations = useAppSelector((state) => state.viewer.annotations)
+  // filter out annotations that are for this entity and are NOT uploading
+  const annotations = filterEntityAnnotations(allAnnotations, entityId, [])
 
   const [deleteReactionToActivity] = useDeleteReactionToActivityMutation()
   const [createReactionToActivity] = useCreateReactionToActivityMutation()
 
-  // EDITING
-  const [isEditing, setIsEditing] = useState(false)
+  const { editingId, setEditingId } = useFeed()
 
   const handleEditComment = () => {
-    setIsEditing(true)
+    setEditingId(activityId)
   }
 
   const handleEditCancel = () => {
-    setIsEditing(false)
+    // close the edit comment
+    setEditingId(null)
+    // remove any annotations
+    annotations.forEach((annotation) => dispatch(removeAnnotation(annotation.id)))
   }
 
   const handleSave = async (value: $Any, files: $Any) => {
     await onUpdate(value, files)
-    // this won't run if the update fails
-    setIsEditing(false)
+    setEditingId(null)
   }
+
+  const isEditing = editingId === activityId
 
   const isRef = referenceType !== 'origin' || showOrigin
 
@@ -253,6 +261,7 @@ const ActivityComment = ({
                 </ReactMarkdown>
               </CommentWrapper>
               {/* file uploads */}
+              {/* @ts-ignore */}
               <FilesGrid
                 files={files}
                 isCompact={files.length > 6}

--- a/src/containers/DetailsPanel/DetailsPanel.jsx
+++ b/src/containers/DetailsPanel/DetailsPanel.jsx
@@ -17,6 +17,7 @@ import { isEmpty } from 'lodash'
 import useGetEntityPath from './hooks/useGetEntityPath'
 import { usePiPWindow } from '@context/pip/PiPProvider'
 import getAllProjectStatuses from './helpers/getAllProjectsStatuses'
+import { FeedProvider } from '@context/FeedContext'
 
 export const entitiesWithoutFeed = ['product', 'representation']
 
@@ -206,18 +207,20 @@ const DetailsPanel = ({
           statePath={statePath}
         />
         {selectedTab === 'feed' && !isError && (
-          <Feed
-            entityType={entityType}
-            entities={isFetchingEntitiesDetails ? entitiesToQuery : entityDetailsData}
-            activeUsers={activeProjectUsers}
-            selectedTasksProjects={selectedTasksProjects}
-            projectInfo={firstProjectInfo}
-            projectName={firstProject}
-            isMultiProjects={projectNames.length > 1}
-            scope={scope}
-            statePath={statePath}
-            statuses={allStatuses}
-          />
+          <FeedProvider>
+            <Feed
+              entityType={entityType}
+              entities={isFetchingEntitiesDetails ? entitiesToQuery : entityDetailsData}
+              activeUsers={activeProjectUsers}
+              selectedTasksProjects={selectedTasksProjects}
+              projectInfo={firstProjectInfo}
+              projectName={firstProject}
+              isMultiProjects={projectNames.length > 1}
+              scope={scope}
+              statePath={statePath}
+              statuses={allStatuses}
+            />
+          </FeedProvider>
         )}
         {selectedTab === 'files' && (
           <DetailsPanelFiles

--- a/src/containers/DetailsPanel/DetailsPanelFloating/DetailsPanelFloating.tsx
+++ b/src/containers/DetailsPanel/DetailsPanelFloating/DetailsPanelFloating.tsx
@@ -13,6 +13,7 @@ import {
   useGetProjectsInfoQuery,
 } from '@queries/userDashboard/getUserDashboard'
 import getAllProjectStatuses from '../helpers/getAllProjectsStatuses'
+import { FeedProvider } from '@context/FeedContext'
 
 type Entity = {
   id: string
@@ -121,21 +122,23 @@ const DetailsPanelFloating: FC<DetailsPanelFloatingProps> = () => {
           <AssigneeField users={users} style={{ pointerEvents: 'none' }} />
         </Styled.Row>
         <Styled.FeedContainer>
-          <Feed
-            entityType={entityType}
-            // @ts-ignore
-            entities={entitiesData}
-            activeUsers={[]}
-            // selectedTasksProjects={{}}
-            // projectInfo={firstProjectInfo}
-            projectName={projectName}
-            isMultiProjects={false}
-            scope={scope || undefined}
-            statePath={statePath || undefined}
-            readOnly
-            // @ts-ignore
-            statuses={statuses}
-          />
+          <FeedProvider>
+            <Feed
+              entityType={entityType}
+              // @ts-ignore
+              entities={entitiesData}
+              activeUsers={[]}
+              // selectedTasksProjects={{}}
+              // projectInfo={firstProjectInfo}
+              projectName={projectName}
+              isMultiProjects={false}
+              scope={scope || undefined}
+              statePath={statePath || undefined}
+              readOnly
+              // @ts-ignore
+              statuses={statuses}
+            />
+          </FeedProvider>
         </Styled.FeedContainer>
       </Styled.Container>
     </PiPWrapper>

--- a/src/containers/Feed/Feed.jsx
+++ b/src/containers/Feed/Feed.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef, useState } from 'react'
+import React, { useMemo, useRef } from 'react'
 import ActivityItem from '@components/Feed/ActivityItem'
 import CommentInput from '@components/CommentInput/CommentInput'
 import * as Styled from './Feed.styled'
@@ -21,6 +21,7 @@ import ActivityReferenceTooltip from '@components/Feed/ActivityReferenceTooltip/
 import { isFilePreviewable } from '@containers/FileUploadPreview/FileUploadPreview'
 import { useGetKanbanProjectUsersQuery } from '@queries/userDashboard/getUserDashboard'
 import EmptyPlaceholder from '@components/EmptyPlaceholder/EmptyPlaceholder'
+import { useFeed, FEED_NEW_COMMENT } from '@context/FeedContext'
 
 // number of activities to get
 export const activitiesLast = 30
@@ -38,6 +39,7 @@ const Feed = ({
   statuses = [],
 }) => {
   const dispatch = useDispatch()
+  const { editingId, setEditingId } = useFeed()
   const userName = useSelector((state) => state.user.name)
   const activityTypes = useSelector((state) => state.details[statePath][scope].activityTypes)
   const filter = useSelector((state) => state.details[statePath][scope].filter)
@@ -47,7 +49,6 @@ const Feed = ({
   const hideCommentInput = ['publishes'].includes(filter)
 
   // STATES
-  const [isCommentInputOpen, setIsCommentInputOpen] = useState(false)
 
   const entitiesToQuery = useMemo(
     () =>
@@ -141,7 +142,7 @@ const Feed = ({
   // const commentInputRef = useRef(null)
 
   // scroll by height of comment input when it opens or closes
-  useScrollOnInputOpen({ feedRef, isCommentInputOpen, height: 93 })
+  useScrollOnInputOpen({ feedRef, isCommentInputOpen: editingId === FEED_NEW_COMMENT, height: 93 })
 
   // save scroll position of a feed
   useSaveScrollPos({
@@ -310,9 +311,9 @@ const Feed = ({
           <CommentInput
             initValue={null}
             onSubmit={submitComment}
-            isOpen={isCommentInputOpen}
-            onClose={() => setIsCommentInputOpen(false)}
-            onOpen={() => setIsCommentInputOpen(true)}
+            isOpen={editingId === FEED_NEW_COMMENT}
+            onClose={() => setEditingId(null)}
+            onOpen={() => setEditingId(FEED_NEW_COMMENT)}
             projectName={projectName}
             entities={entities}
             entityType={entityType}

--- a/src/context/FeedContext.tsx
+++ b/src/context/FeedContext.tsx
@@ -1,0 +1,23 @@
+import React, { createContext, useContext, useState } from 'react'
+
+export const FEED_NEW_COMMENT = '__new__' as const
+
+type EditingState = null | typeof FEED_NEW_COMMENT | string
+
+interface FeedContextType {
+  editingId: EditingState
+  setEditingId: (id: EditingState) => void
+}
+
+const FeedContext = createContext<FeedContextType>({
+  editingId: null,
+  setEditingId: () => {},
+})
+
+export const FeedProvider = ({ children }: { children: React.ReactNode }) => {
+  const [editingId, setEditingId] = useState<EditingState>(null)
+
+  return <FeedContext.Provider value={{ editingId, setEditingId }}>{children}</FeedContext.Provider>
+}
+
+export const useFeed = () => useContext(FeedContext)

--- a/src/features/viewer.ts
+++ b/src/features/viewer.ts
@@ -138,8 +138,6 @@ const viewerSlice = createSlice({
       delete state.annotations[payload]
       // set clearAnnotation to true to trigger a reset of that frame
 
-      console.log(page)
-
       state.clearAnnotation = page
     },
     clearAnnotation: (state: ViewerState, { payload }: PayloadAction<number | null>) => {


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
- Fixes a bug that would crash the window when editing a comment and then drawing an annotation.
- Only one comment is editable at once now.
- You can now add annotation attachments to previous comments by going into editing mode and drawing on the canvas.

https://github.com/user-attachments/assets/c94569a7-ad0a-4d69-ba02-cb9c28408cb7


