### PR TITLE
Market: Use V2

### DIFF
--- a/gen/openapi-config.ts
+++ b/gen/openapi-config.ts
@@ -53,7 +53,7 @@ const buildOutputFiles = (files: { [name: string]: string[] }) =>
   }, {})
 
 const config: ConfigFile = {
-  schemaFile: `https://test.ayon.dev/openapi.json`,
+  schemaFile: `http://localhost:5000/openapi.json`,
   apiFile: '../src/services/ayon.ts',
   exportName: 'api',
   apiImport: 'RestAPI',

--- a/src/api/rest/market.ts
+++ b/src/api/rest/market.ts
@@ -34,7 +34,7 @@ export type MarketAddonVersionDetailApiArg = {
   addonName: string
   addonVersion: string
 }
-export type GetLicensesApiResponse = /** status 200 Successful Response */ object[]
+export type GetLicensesApiResponse = /** status 200 Successful Response */ LicenseListModel
 export type GetLicensesApiArg = {
   refresh?: boolean
 }
@@ -48,15 +48,17 @@ export type AddonListItem = {
   title: string
   /** Addon description */
   description?: string
-  /** Organization name */
   orgName?: string
-  /** Organization title */
   orgTitle?: string
   icon?: string
+  category?: string
+  tags?: string[]
   /** Latest version of the addon */
   latestVersion?: string
   /** Links to the addon's homepage and GitHub repository */
   links?: LinkModel[]
+  /** Addon is avaliable for download */
+  available?: boolean
   currentProductionVersion?: string
   currentLatestVersion?: string
   isOutdated?: boolean
@@ -74,6 +76,7 @@ export type HttpValidationError = {
 }
 export type AddonVersionListItem = {
   version: string
+  /** Required Ayon server version to run the addon */
   ayonVersion?: string
   createdAt?: string
   updatedAt?: string
@@ -89,15 +92,17 @@ export type AddonDetail = {
   title: string
   /** Addon description */
   description?: string
-  /** Organization name */
   orgName?: string
-  /** Organization title */
   orgTitle?: string
   icon?: string
+  category?: string
+  tags?: string[]
   /** Latest version of the addon */
   latestVersion?: string
   /** Links to the addon's homepage and GitHub repository */
   links?: LinkModel[]
+  /** Addon is avaliable for download */
+  available?: boolean
   currentProductionVersion?: string
   currentLatestVersion?: string
   isOutdated?: boolean
@@ -111,15 +116,17 @@ export type AddonVersionDetail = {
   title: string
   /** Addon description */
   description?: string
-  /** Organization name */
   orgName?: string
-  /** Organization title */
   orgTitle?: string
   icon?: string
+  category?: string
+  tags?: string[]
   /** Latest version of the addon */
   latestVersion?: string
   /** Links to the addon's homepage and GitHub repository */
   links?: LinkModel[]
+  /** Addon is avaliable for download */
+  available?: boolean
   currentProductionVersion?: string
   currentLatestVersion?: string
   isOutdated?: boolean
@@ -139,4 +146,8 @@ export type AddonVersionDetail = {
   isProduction?: boolean
   /** Is this version compatible? */
   isCompatible?: boolean
+}
+export type LicenseListModel = {
+  licenses?: object[]
+  syncedAt?: number
 }

--- a/src/api/rest/releases.ts
+++ b/src/api/rest/releases.ts
@@ -21,17 +21,18 @@ export type GetReleaseInfoApiArg = {
 }
 export type ReleaseListItemModel = {
   name: string
-  release: string
   label: string
-  bio?: string
+  release: string
+  description?: string
   icon?: string
   createdAt: string
+  mandatoryAddons?: string[]
   isLatest: boolean
   addons: string[]
-  mandatoryAddons?: string[]
 }
 export type ReleaseListModel = {
   releases: ReleaseListItemModel[]
+  detail?: string
 }
 export type ValidationError = {
   loc: (string | number)[]
@@ -41,26 +42,46 @@ export type ValidationError = {
 export type HttpValidationError = {
   detail?: ValidationError[]
 }
-export type ReleaseAddon = {
+export type LinkModel = {
+  type?: 'homepage' | 'github' | 'documentation' | 'license'
+  label?: string
+  url: string
+}
+export type AddonVersionDetail = {
   name: string
-  title?: string
+  title: string
+  /** Addon description */
   description?: string
+  orgName?: string
+  orgTitle?: string
   icon?: string
-  preview?: string
-  features?: string[]
-  families?: string[]
   tags?: string[]
-  docs?: {
-    [key: string]: string
-  }
-  github?: string
-  discussion?: string
-  isFree?: boolean
-  version?: string
+  flags?: string[]
+  /** Latest version of the addon */
+  latestVersion?: string
+  /** Links to the addon's homepage and GitHub repository */
+  links?: LinkModel[]
+  /** Addon is avaliable for download */
+  available?: boolean
+  currentProductionVersion?: string
+  currentLatestVersion?: string
+  isOutdated?: boolean
+  version: string
   url?: string
-  /** Checksum of the zip file */
+  altUrl?: string
   checksum?: string
-  mandatory?: boolean
+  /** The version of Ayon this version is compatible with */
+  ayonVersion?: string
+  /** When this version was created */
+  createdAt?: string
+  /** When this version was last updated */
+  updatedAt?: string
+  /** Is this version installed? */
+  isInstalled?: boolean
+  /** Is this version in production? */
+  isProduction?: boolean
+  /** Is this version compatible? */
+  isCompatible?: boolean
 }
 export type SourceModel = {
   /** If set to server, the file is stored on the server. If set to http, the file is downloaded from the specified URL. */
@@ -119,8 +140,12 @@ export type DependencyPackageManifest = {
 export type ReleaseInfoModel = {
   name: string
   label: string
-  createdAt?: string
-  addons?: ReleaseAddon[]
+  release: string
+  description?: string
+  icon?: string
+  createdAt: string
+  mandatoryAddons?: string[]
+  addons?: AddonVersionDetail[]
   installers?: InstallerManifest[]
   dependencyPackages?: DependencyPackageManifest[]
 }

--- a/src/components/AddonsSelectGrid/AddonsSelectGrid.tsx
+++ b/src/components/AddonsSelectGrid/AddonsSelectGrid.tsx
@@ -1,4 +1,4 @@
-import { ReleaseAddon } from '@api/rest/releases'
+import { AddonVersionDetail } from '@api/rest/releases'
 import AddonCard, { AddonCardProps } from '@components/AddonCard/AddonCard'
 import clsx from 'clsx'
 import { FC, HTMLAttributes } from 'react'
@@ -16,13 +16,13 @@ const Grid = styled.div`
   overflow: auto;
 `
 
-type Addon = Pick<ReleaseAddon, 'name' | 'title' | 'version'>
+type Addon = Pick<AddonVersionDetail, 'name' | 'title' | 'version'>
 
 interface AddonsSelectGridProps extends Omit<HTMLAttributes<HTMLDivElement>, 'onSelect'> {
   isLoading: boolean
   placeholderCount: number
   addons: Addon[]
-  disabledAddons: string[]
+  disabledAddons?: string[]
   selected: string[]
   onSelect: (name: string) => void
   pt?: {

--- a/src/components/MarketAddonCard/MarketAddonCard.tsx
+++ b/src/components/MarketAddonCard/MarketAddonCard.tsx
@@ -2,10 +2,11 @@ import clsx from 'clsx'
 import * as Styled from './MarketAddonCard.styled'
 import Type from '@/theme/typography.module.css'
 import AddonIcon from '../AddonIcon/AddonIcon'
-import { ButtonProps, Icon } from '@ynput/ayon-react-components'
+import { Button, ButtonProps, Icon } from '@ynput/ayon-react-components'
 import { upperFirst } from 'lodash'
 import { HTMLAttributes } from 'react'
 import PowerpackButton from '@components/Powerpack/PowerpackButton'
+import { PricingLink } from '@components/PricingLink'
 
 export type ListItemType = 'addon' | 'release' | 'placeholder'
 
@@ -27,7 +28,9 @@ interface MarketAddonCardProps extends HTMLAttributes<HTMLDivElement> {
   isFailed?: boolean
   isFinished?: boolean
   isActive?: boolean
-  onDownload: (name: string, version?: string) => void
+  available?: boolean
+  flags?: string[]
+  onDownload?: (name: string, version?: string) => void
 }
 
 export const MarketAddonCard = ({
@@ -48,6 +51,8 @@ export const MarketAddonCard = ({
   isFailed,
   isFinished,
   isActive,
+  available,
+  flags,
   onDownload,
   ...props
 }: MarketAddonCardProps) => {
@@ -71,7 +76,7 @@ export const MarketAddonCard = ({
 
   const handleActionClick = () => {
     if (['install', 'update'].includes(state)) {
-      onDownload(name, latestVersion)
+      onDownload?.(name, latestVersion)
     }
   }
 
@@ -103,7 +108,7 @@ export const MarketAddonCard = ({
           <Styled.Author className={Type.labelMedium}>{author}</Styled.Author>
         </Styled.AuthorWrapper>
       </Styled.Content>
-      {!isPlaceholder && (
+      {!isPlaceholder && available && (
         <Styled.Buttons>
           {isActive ? (
             <Styled.Tag
@@ -116,9 +121,14 @@ export const MarketAddonCard = ({
               {upperFirst(state)}
             </Styled.Tag>
           ) : (
-            <PowerpackButton feature="releases" />
+            <PowerpackButton feature="annotations" />
           )}
         </Styled.Buttons>
+      )}
+      {flags?.includes('licensed') && !available && !isPlaceholder && (
+        <PricingLink>
+          <Button variant="tertiary">Subscribe</Button>
+        </PricingLink>
       )}
     </Styled.Container>
   )

--- a/src/components/Powerpack/PowerpackButton.tsx
+++ b/src/components/Powerpack/PowerpackButton.tsx
@@ -1,4 +1,4 @@
-import { PowerpackFeature, powerpackFeatures, usePowerpack } from '@context/powerpackContext'
+import { PowerpackFeature, usePowerpack } from '@context/powerpackContext'
 import { Button, ButtonProps } from '@ynput/ayon-react-components'
 import clsx from 'clsx'
 import { forwardRef, MouseEvent } from 'react'
@@ -48,7 +48,7 @@ const PowerpackButton = forwardRef<HTMLButtonElement, CloudButtonProps>(
         ref={ref}
         onClick={handleOnClick}
         className={clsx('cloud-button', props.className || '', { border: !!props.children })}
-        data-tooltip={`Powerpack feature: ${powerpackFeatures[feature].label}`}
+        data-tooltip={`Power feature`}
         data-tooltip-delay={0}
       >
         {props.children}

--- a/src/components/Powerpack/PowerpackDialog.tsx
+++ b/src/components/Powerpack/PowerpackDialog.tsx
@@ -2,6 +2,7 @@ import { powerpackFeatures, usePowerpack } from '@context/powerpackContext'
 import * as Styled from './PowerpackDialog.styled'
 import { FC } from 'react'
 import { Icon } from '@ynput/ayon-react-components'
+import { PricingLink } from '@components/PricingLink'
 
 interface PowerpackDialogProps {}
 
@@ -37,13 +38,9 @@ const PowerpackDialog: FC<PowerpackDialogProps> = ({}) => {
           <li className="more">More coming soon!</li>
         </ul>
       </Styled.FeaturesList>
-      <a
-        href="https://ynput.cloud/subscribe/ayon?utm_source=powerpack"
-        target="_blank"
-        rel="noreferrer"
-      >
+      <PricingLink>
         <Styled.MoreButton>Find out more</Styled.MoreButton>
-      </a>
+      </PricingLink>
     </Styled.PowerpackDialog>
   )
 }

--- a/src/components/PricingLink.tsx
+++ b/src/components/PricingLink.tsx
@@ -1,0 +1,14 @@
+import { pricingUrl } from '@/constants'
+import { forwardRef } from 'react'
+
+interface PricingLinkProps extends React.HTMLAttributes<HTMLAnchorElement> {}
+
+export const PricingLink = forwardRef<HTMLAnchorElement, PricingLinkProps>(
+  ({ children, ...props }, ref) => {
+    return (
+      <a href={pricingUrl} target="_blank" rel="noopener noreferrer" {...props} ref={ref}>
+        {children}
+      </a>
+    )
+  },
+)

--- a/src/components/Release/ReleasePreset.jsx
+++ b/src/components/Release/ReleasePreset.jsx
@@ -7,7 +7,7 @@ import clsx from 'clsx'
 
 const ReleasePreset = ({
   label,
-  bio,
+  description,
   icon,
   name,
   createdAt,
@@ -55,7 +55,7 @@ const ReleasePreset = ({
         <Icon icon={icon} />
         <div>
           <h3 className={Type.titleLarge}>{label || name}</h3>
-          <span className="bio">{bio}</span>
+          <span className="description">{description}</span>
         </div>
       </Styled.Header>
       {isSelected && (

--- a/src/components/Release/ReleasePreset.styled.js
+++ b/src/components/Release/ReleasePreset.styled.js
@@ -21,7 +21,7 @@ export const Preset = styled.li`
     background-color: var(--md-sys-color-surface-container-highest-hover);
   }
 
-  .bio {
+  .description {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -34,7 +34,7 @@ export const Preset = styled.li`
       background-color: var(--md-sys-color-primary-container);
     }
 
-    .bio {
+    .description {
       white-space: normal;
     }
   }

--- a/src/components/SubChip/SubChip.tsx
+++ b/src/components/SubChip/SubChip.tsx
@@ -1,0 +1,94 @@
+import { PricingLink } from '@components/PricingLink'
+import { theme } from '@ynput/ayon-react-components'
+import clsx from 'clsx'
+import { FC } from 'react'
+import styled from 'styled-components'
+
+const Chip = styled(PricingLink)`
+  display: flex;
+  user-select: none;
+
+  span {
+    ${theme.labelLarge}
+  }
+`
+
+const Pro = styled.span`
+  padding: 2px 6px;
+  color: var(--color-sub-pro);
+  border: solid 1px var(--color-sub-pro);
+  /* border radius left */
+  border-radius: 4px 0 0 4px;
+
+  &.included {
+    background-color: var(--color-sub-pro);
+    color: var(--color-on-sub-pro);
+
+    &:hover {
+      background-color: var(--color-sub-pro-hover);
+      border-color: var(--color-sub-pro-hover);
+    }
+  }
+`
+
+const Studio = styled.span`
+  padding: 2px 6px;
+  color: var(--color-sub-studio);
+  border: solid 1px var(--color-sub-studio);
+  /* border radius right */
+  border-radius: 0 4px 4px 0;
+
+  &.included {
+    background-color: var(--color-sub-studio);
+    color: var(--color-on-sub-studio);
+
+    &:hover {
+      background-color: var(--color-sub-studio-hover);
+      border-color: var(--color-sub-studio-hover);
+    }
+  }
+`
+
+interface SubChipProps {
+  includedWithPro?: boolean // is it included with Pro sub?
+  includedWithStudio?: boolean // is it included with Studio sub? (default true)
+  size?: 'sm' | 'md'
+}
+
+const SubChip: FC<SubChipProps> = ({
+  size = 'md',
+  includedWithPro = false,
+  includedWithStudio = true,
+}) => {
+  const proLabel = size === 'md' ? 'Pro' : 'P'
+  const studioLabel = size === 'md' ? 'Studio' : 'S'
+
+  return (
+    <Chip>
+      <Pro
+        className={clsx({ included: includedWithPro })}
+        data-tooltip={
+          includedWithPro
+            ? 'Included with AYON Pro subscription'
+            : 'Available as a paid addon with AYON Pro subscription'
+        }
+        data-tooltip-delay={0}
+      >
+        {proLabel}
+      </Pro>
+      <Studio
+        data-tooltip={
+          includedWithStudio
+            ? 'Included with AYON Studio subscription'
+            : 'Available as a paid addon with AYON Studio subscription'
+        }
+        data-tooltip-delay={0}
+        className={clsx({ included: includedWithStudio })}
+      >
+        {studioLabel}
+      </Studio>
+    </Chip>
+  )
+}
+
+export default SubChip

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,3 +1,4 @@
 const ayonUrlParam = 'uri'
+const pricingUrl = 'https://ynput.io/ayon/pricing?utm_source=ayon'
 
-export { ayonUrlParam }
+export { ayonUrlParam, pricingUrl }

--- a/src/containers/ReleaseInstallerDialog/forms/ReleaseInstallerAddons.tsx
+++ b/src/containers/ReleaseInstallerDialog/forms/ReleaseInstallerAddons.tsx
@@ -1,12 +1,12 @@
 import { FC, useEffect, useState } from 'react'
 import { ReleaseForm } from '../hooks/useReleaseForm'
-import { ReleaseAddon } from '@api/rest/releases'
+import { AddonVersionDetail } from '@api/rest/releases'
 import AddonsSelectGrid from '@components/AddonsSelectGrid/AddonsSelectGrid'
 import { Footer } from '../components'
 
 interface ReleaseInstallerAddonsProps {
   releaseForm: ReleaseForm
-  releaseAddons: ReleaseAddon[]
+  releaseAddons: AddonVersionDetail[]
   mandatoryAddons: string[]
   isLoading: boolean
   onCancel: () => void

--- a/src/containers/ReleaseInstallerDialog/forms/ReleaseInstallerOverview.tsx
+++ b/src/containers/ReleaseInstallerDialog/forms/ReleaseInstallerOverview.tsx
@@ -39,11 +39,13 @@ export const ReleaseInstallerOverview: FC<ReleaseInstallerOverviewProps> = ({
 }) => {
   return (
     <>
-      <p className="bio">
+      <p className="description">
         Releases are official bundles with the latest tested and stable addons, launchers and their
         dependencies for your pipeline.
       </p>
-      <p className="bio">Your install is pre-configured here, but you can adjust it if needed.</p>
+      <p className="description">
+        Your install is pre-configured here, but you can adjust it if needed.
+      </p>
 
       <Card
         title="Release"

--- a/src/containers/ReleaseInstallerDialog/hooks/useReleaseInfo.ts
+++ b/src/containers/ReleaseInstallerDialog/hooks/useReleaseInfo.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useGetReleaseInfoQuery } from '@queries/releases/getReleases'
-import { ReleaseAddon, ReleaseInfoModel, ReleaseListItemModel } from '@api/rest/releases'
+import { AddonVersionDetail, ReleaseInfoModel, ReleaseListItemModel } from '@api/rest/releases'
 import { ReleaseForm } from './useReleaseForm'
 
 type Props = {
@@ -15,7 +15,7 @@ export const useReleaseInfo = ({
   release,
 }: Props): [
   ReleaseInfoModel | undefined,
-  ReleaseAddon[],
+  AddonVersionDetail[],
   {
     isError: boolean
     isLoading: boolean
@@ -29,7 +29,7 @@ export const useReleaseInfo = ({
   } = useGetReleaseInfoQuery({ releaseName: selectedRelease as string }, { skip: !selectedRelease })
   const releaseInfoError = !releaseInfo && !isLoadingReleaseInfo && !isUninitialized
 
-  const [releaseAddons, setReleaseAddons] = useState<ReleaseAddon[]>([])
+  const [releaseAddons, setReleaseAddons] = useState<AddonVersionDetail[]>([])
 
   useEffect(() => {
     if (!releaseInfo || isLoadingReleaseInfo) return

--- a/src/containers/Slicer/SlicerDropdown.tsx
+++ b/src/containers/Slicer/SlicerDropdown.tsx
@@ -58,7 +58,7 @@ const SlicerDropdown = forwardRef<DropdownRef, SlicerDropdownProps>(
     return (
       <StyledDropdown
         {...props}
-        data-tooltip="Powerpack feature - Slicer"
+        data-tooltip="Power feature - Slicer"
         data-tooltip-delay={0}
         onChange={handleOnChange}
         options={options}

--- a/src/pages/MarketPage/MarketAddonsList.tsx
+++ b/src/pages/MarketPage/MarketAddonsList.tsx
@@ -68,6 +68,7 @@ interface ExtendedMarketAddonItem extends MarketAddonItem {
   isFailed?: boolean
   isFinished?: boolean
   isActive?: boolean
+  flags?: string[]
 }
 
 export type MarketListItem = {
@@ -218,6 +219,8 @@ const MarketAddonsList = ({
                 name,
                 latestVersion,
                 icon,
+                available,
+                flags,
                 isOfficial,
                 isVerified,
                 isDownloaded,
@@ -241,6 +244,7 @@ const MarketAddonsList = ({
                     onDownload={(n, v) => onDownload(type, n, v)}
                     style={{ paddingLeft: group ? 40 : 4 }}
                     isActive={isActive || type === 'addon'}
+                    flags={flags}
                     {...{
                       title,
                       name,
@@ -255,6 +259,7 @@ const MarketAddonsList = ({
                       isDownloading,
                       isFailed,
                       isFinished,
+                      available,
                     }}
                   />,
                 )

--- a/src/pages/MarketPage/MarketDetails/AddonDetails.tsx
+++ b/src/pages/MarketPage/MarketDetails/AddonDetails.tsx
@@ -14,6 +14,8 @@ import { AddonDetail, LinkModel } from '@api/rest/market'
 import MetaPanelRow from './MetaPanelRow'
 import remarkGfm from 'remark-gfm'
 import emoji from 'remark-emoji'
+import SubChip from '@components/SubChip/SubChip'
+import { PricingLink } from '@components/PricingLink'
 
 type ExtendedAddonDetail = AddonDetail & {
   downloadedVersions: Record<string, string>
@@ -28,6 +30,7 @@ type ExtendedAddonDetail = AddonDetail & {
   isFinished: boolean
   isFailed: boolean
   error: string
+  flags: string[]
 }
 
 type AddonDetailsProps = {
@@ -62,6 +65,8 @@ const AddonDetails = ({ addon, isLoading, onDownload, isUpdatingAll }: AddonDeta
     isVerified,
     isOfficial,
     warning,
+    flags,
+    available,
   } = addon || {}
 
   const versionKeys = isEmpty(downloadedVersions) ? [] : Object.keys(downloadedVersions)
@@ -124,6 +129,7 @@ const AddonDetails = ({ addon, isLoading, onDownload, isUpdatingAll }: AddonDeta
   }
 
   let actionButton = null
+  const subRequired = flags?.includes('licensed') && !available
 
   // Download button (top right)
   if (isDownloading) {
@@ -156,6 +162,14 @@ const AddonDetails = ({ addon, isLoading, onDownload, isUpdatingAll }: AddonDeta
         {`Download v${latestVersion}`}
       </Button>
     )
+  } else if (subRequired) {
+    actionButton = (
+      <PricingLink style={{ width: '100%' }}>
+        <Button variant="tertiary" style={{ width: '100%' }}>
+          Subscribe
+        </Button>
+      </PricingLink>
+    )
   }
 
   const versionsOptions = useMemo(
@@ -180,13 +194,16 @@ const AddonDetails = ({ addon, isLoading, onDownload, isUpdatingAll }: AddonDeta
             <Styled.Header className={clsx({ loading: isLoading })}>
               <AddonIcon size={64} src={icon} alt={name + ' icon'} isPlaceholder={isLoading} />
               <div className="titles">
-                <h2 className={Type.headlineSmall}>{title}</h2>
+                <h2 className={Type.headlineSmall}>{title} </h2>
                 <span className={clsx(verifiedString.toLowerCase(), 'verification')}>
                   {verifiedIcon}
                   {verifiedString}
                 </span>
               </div>
             </Styled.Header>
+            {flags?.includes('licensed') && !isLoading && (
+              <SubChip includedWithPro={flags.includes('power-feature')} />
+            )}
             {isFailed && (
               <Styled.ErrorCard direction="row">
                 <Icon icon="error_outline" />
@@ -214,23 +231,25 @@ const AddonDetails = ({ addon, isLoading, onDownload, isUpdatingAll }: AddonDeta
             <Styled.Download className={clsx({ loading: isLoading })}>
               {actionButton}
 
-              <Styled.VersionDropdown
-                options={versionsOptions}
-                align="right"
-                value={[]}
-                widthExpand
-                onChange={(v) => handleDownload(v[0])}
-                itemStyle={{ justifyContent: 'space-between' }}
-                // @ts-expect-error
-                buttonProps={{ 'data-tooltip': 'Download a specific version' }}
-                search={versions.length > 10}
-                itemTemplate={(option) => (
-                  <Styled.VersionDropdownItem>
-                    <Icon icon={option.isDownloaded ? 'check' : 'download'} />
-                    {option.label}
-                  </Styled.VersionDropdownItem>
-                )}
-              />
+              {!!versionsOptions.length && (
+                <Styled.VersionDropdown
+                  options={versionsOptions}
+                  align="right"
+                  value={[]}
+                  widthExpand
+                  onChange={(v) => handleDownload(v[0])}
+                  itemStyle={{ justifyContent: 'space-between' }}
+                  // @ts-expect-error
+                  buttonProps={{ 'data-tooltip': 'Download a specific version' }}
+                  search={versions.length > 10}
+                  itemTemplate={(option) => (
+                    <Styled.VersionDropdownItem>
+                      <Icon icon={option.isDownloaded ? 'check' : 'download'} />
+                      {option.label}
+                    </Styled.VersionDropdownItem>
+                  )}
+                />
+              )}
             </Styled.Download>
             <Styled.MetaPanel className={clsx({ loading: isLoading })}>
               <MetaPanelRow label="Downloaded Versions">

--- a/src/pages/MarketPage/MarketDetails/ReleaseDetails.tsx
+++ b/src/pages/MarketPage/MarketDetails/ReleaseDetails.tsx
@@ -22,7 +22,7 @@ type ReleaseDetailsProps = {
 const ReleaseDetails = ({ release, isLoading, onDownload }: ReleaseDetailsProps) => {
   // latestVersion: is the latest version of the addon
   // versions: is an array of all versions DOWNLOADED of the addon
-  const { name, label, createdAt, icon, bio, isActive, addons } = release || {}
+  const { name, label, createdAt, icon, description, isActive, addons } = release || {}
 
   const verifiedString = 'Official'
   const verifiedIcon = <img src="/favicon-32x32.png" width={15} height={15} />
@@ -58,7 +58,7 @@ const ReleaseDetails = ({ release, isLoading, onDownload }: ReleaseDetailsProps)
                 </a>
               </Styled.ErrorCard>
             )}
-            <ReactMarkdown className={clsx({ loading: isLoading })}>{bio}</ReactMarkdown>
+            <ReactMarkdown className={clsx({ loading: isLoading })}>{description}</ReactMarkdown>
             <Styled.ReleaseAddons>
               {addons?.map((addon) => (
                 <Styled.ReleaseAddonLink

--- a/src/pages/MarketPage/MarketFilters.tsx
+++ b/src/pages/MarketPage/MarketFilters.tsx
@@ -56,6 +56,17 @@ export const addonFilters: MarketFilter[] = [
     tooltip: 'All addons, downloaded or not',
   },
   {
+    id: 'free',
+    type: 'addons',
+    name: 'Free',
+    filter: [
+      {
+        flags: (v?: string[]) => !v?.includes('licensed'),
+      },
+    ],
+    tooltip: 'Addons free to download.',
+  },
+  {
     id: 'updates',
     type: 'addons',
     name: 'Updates Available',

--- a/src/pages/MarketPage/MarketPage.jsx
+++ b/src/pages/MarketPage/MarketPage.jsx
@@ -24,6 +24,7 @@ import { filterItems, transformReleasesToTable } from './helpers'
 import ReleaseDetails from './MarketDetails/ReleaseDetails'
 import { useAppDispatch } from '@state/store'
 import { toggleReleaseInstaller } from '@state/releaseInstaller'
+import { useGetYnputConnectionsQuery } from '@queries/ynputConnect'
 
 const placeholders = [...Array(20)].map((_, i) => ({
   type: 'placeholder',
@@ -48,6 +49,8 @@ const MarketPage = () => {
   // GET ALL INSTALLED ADDONS for addon details
   const { data: { addons: downloadedAddons = [] } = {}, isLoading: isLoadingDownloaded } =
     useListAddonsQuery({})
+
+  const { data: connectData } = useGetYnputConnectionsQuery({})
 
   // keep track of which addons are being downloaded
   const [downloadingAddons, setDownloadingAddons] = useState([])
@@ -146,17 +149,18 @@ const MarketPage = () => {
   const { data: selectedAddonData = {}, isFetching: isFetchingAddon } = useMarketAddonDetailQuery(
     { addonName: selectedItemId },
     {
-      skip: !selectedItemId || filterType !== 'addons',
+      skip: !selectedItemId || filterType !== 'addons' || !connectData,
     },
   )
 
-  // // merge downloaded with market addons
-  // let marketAddons = useMemo(() => {
-  //   return mergeAddonsData(marketAddonsData, downloadedAddons)
-  // }, [marketAddonsData, downloadedAddons])
-
   let marketAddons = useMemo(() => {
     let addons = [...marketAddonsData]
+
+    // filter out addons that are for cloud only (when not on the cloud)
+    addons = addons?.filter(
+      (addon) => !!connectData?.managed || !addon?.flags?.includes('cloud-only'),
+    )
+
     // sort by isDownloaded, isOutdated, isOfficial, name
     addons?.sort(
       (a, b) =>
@@ -172,7 +176,7 @@ const MarketPage = () => {
     }
 
     return addons
-  }, [marketAddonsData, filter])
+  }, [marketAddonsData, filter, connectData])
 
   // update addon if downloadingAddons or finishedDownloading changes
   marketAddons = useMemo(() => {

--- a/src/pages/OnBoarding/Step/AddonSelectStep.tsx
+++ b/src/pages/OnBoarding/Step/AddonSelectStep.tsx
@@ -26,9 +26,9 @@ export const AddonSelectStep = ({
   isLoadingRelease,
   isLoadingAddons,
 }: AddonSelectStepProps) => {
-  const { addons = [] } = release || {}
+  const { addons = [], mandatoryAddons } = release || {}
   // filter out mandatory addons
-  const notMandatoryAddons = addons.filter((addon) => !addon.mandatory)
+  const notMandatoryAddons = addons.filter((addon) => !mandatoryAddons?.includes(addon.name))
 
   // get placeholders for loading
   const placeholders = useMemo(() => {

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -60,6 +60,14 @@ strong {
 
   // table colors
   --color-table-border: hsl(210 8% 18%);
+
+  // sub colors
+  --color-sub-pro: var(--md-sys-color-tertiary);
+  --color-sub-pro-hover: var(--md-sys-color-tertiary-hover);
+  --color-on-sub-pro: var(--md-sys-color-on-tertiary);
+  --color-sub-studio: hsl(42, 100%, 50%);
+  --color-on-sub-studio: hsl(53, 100%, 11%);
+  --color-sub-studio-hover: hsl(42, 100%, 45%);
 }
 
 #root {


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
- Uses market v2 model https://github.com/ynput/ayon-backend/pull/509
- New "free" filter
- Subscribe button for addons not avaliable
- Pro/Studio chip to show if the addon requires a subscription.

## Additional context
<!-- Add any other context or screenshots here. -->
![image](https://github.com/user-attachments/assets/e05ed1e6-06c4-4891-9dea-c7ba58dd4690)


