### PR TITLE
Disable `1px solid yellow` outline for text widgets

### DIFF
--- a/src/containers/SettingsEditor/Widgets/TextWidget.tsx
+++ b/src/containers/SettingsEditor/Widgets/TextWidget.tsx
@@ -197,9 +197,14 @@ export const TextWidget = (props: $Any) => {
 
   const hlstyle: $Any = {}
   if (valueInitialized && value !== props.value) {
+    /* Fix #539: Disable yellow outline
+       Yellow outline is confusing most users, so we're disabling it for now.
+       However we may want to still highlight the value differences in another
+       way.
     if (!['color'].includes(props.schema.widget)) {
       hlstyle.outline = '1px solid yellow'
     }
+     */
   } else if (originalValue !== undefined && props.value !== originalValue)
     hlstyle.outline = '1px solid var(--color-changed)'
 


### PR DESCRIPTION
## Description of changes 

Disables yellow outline around text fields if the value is 'initialized' yet does not match the current text fields value.
This seems to be confusing the users often, without actually representing an issue.

## Technical details

Fix #593

## Additional context

This may actually be hiding another issue because we may just be invalidly doing the comparison on whether something matches the value or not (e.g. `null` versus empty strings or alike?)

Do we just want to avoid setting the border for now? Or actually figure out why we're flagging some text widgets?
