### PR TITLE
Fix typo: `AllProjectsPremissions` -> `AllProjectsPermissions`

### DIFF
--- a/src/hooks/useUserProjectPermissions.ts
+++ b/src/hooks/useUserProjectPermissions.ts
@@ -2,7 +2,7 @@ import { StudioManagementPermissions, ProjectManagementPermissions } from '@api/
 import { Module } from '@pages/ProjectManagerPage/mappers'
 import { useGetCurrentUserPermissionsQuery } from '@queries/permissions/getPermissions'
 
-type AllProjectsPremissions = {
+type AllProjectsPermissions = {
   projects: {
     [projectName: string]: {
       project: ProjectManagementPermissions
@@ -26,10 +26,10 @@ export enum UserPermissionsEntity {
 }
 
 class UserPermissions {
-  permissions: AllProjectsPremissions
+  permissions: AllProjectsPermissions
   hasElevatedPrivileges: boolean
 
-  constructor(permissions: AllProjectsPremissions, hasLimitedPermissions: boolean = false) {
+  constructor(permissions: AllProjectsPermissions, hasLimitedPermissions: boolean = false) {
     this.permissions = permissions
     this.hasElevatedPrivileges = !hasLimitedPermissions
   }


### PR DESCRIPTION
## Description of changes 

Fix typo: `AllProjectsPremissions` -> `AllProjectsPermissions`

## Technical details

Code cosmetics

## Additional context

For those who can't unsee it.

