### PR TITLE
Dashboard: Force assignees filter to "me" when user has no permissions to list users

### DIFF
--- a/src/pages/UserDashboardPage/UserDashboardTasks/DashboardTasksToolbar/DashboardTasksToolbar.jsx
+++ b/src/pages/UserDashboardPage/UserDashboardTasks/DashboardTasksToolbar/DashboardTasksToolbar.jsx
@@ -57,6 +57,16 @@ const DashboardTasksToolbar = ({ isLoading, view, setView }) => {
     setAssignees(payload)
   }
 
+  // When user does not have permission to list other users, force the
+  // assignees filter to "me" to avoid being unable to list tasks.
+  if (!isManager && assigneesFilter !== "me") {
+    console.log("Force assignees filter to 'me'")
+    setAssignees({
+      assignees: [],
+      filter: "me"
+    })
+  }
+
   return (
     <Styled.TasksToolbar>
       <SortingDropdown

--- a/src/services/auth/getAuth.js
+++ b/src/services/auth/getAuth.js
@@ -36,6 +36,7 @@ const authApiInjected = authApi.injectEndpoints({
         localStorage.removeItem('dashboard-selectedProjects')
         localStorage.removeItem('dashboard-tasks-collapsedColumns')
         localStorage.removeItem('dashboard-tasks-assignees')
+        localStorage.removeItem('dashboard-tasks-assigneesFilter')
         localStorage.removeItem('dashboard-tasks-selected')
         // clear dashboard state
         dispatch(onClearDashboard())


### PR DESCRIPTION
## Description of changes 

Force assignees filter to "me" when user has no permissions to list other users (and hence the `MeOrUserSwitch` component is hidden to switch it manually)

## Technical details

This seems to work, but this might need a `useEffect`?

```jsx
  useEffect(() => {
    if (!isManager && assigneesFilter !== "me") {
      console.log("Force assignees filter to me")
      setAssignees({
        assignees: [],
        filter: "me"
      })
    }
  }, [assigneesFilter, isManager])
```

Fix https://github.com/ynput/ayon-frontend/issues/1030

- [x] Note that the assignees and filter come from the `localStorage` and maybe (if they aren't yet) should be cleared on log out and log in to avoid the issue to begin with. Should be implemented with https://github.com/ynput/ayon-frontend/pull/1031/commits/1ab1c60a6e0ac5cdc73d1c13252c1872b21d7825

## Additional context
<!-- Add any other context or screenshots here. -->

