### PR TITLE
Annotations: pass dimensions correctly for the upcoming new Power Pack version

### DIFF
--- a/src/containers/VideoPlayer/VideoPlayer.jsx
+++ b/src/containers/VideoPlayer/VideoPlayer.jsx
@@ -94,6 +94,8 @@ const VideoPlayer = ({ src, frameRate, aspectRatio, autoplay, onPlay, reviewable
     width: null,
     height: null,
   })
+  // used to set intrinsic size for the Annotations canvas
+  const [actualVideoDimensions, setActualVideoDimensions] = useState(null)
 
   useGoToFrame({ setCurrentTime, frameRate, duration, videoElement: videoRef.current })
 
@@ -105,13 +107,8 @@ const VideoPlayer = ({ src, frameRate, aspectRatio, autoplay, onPlay, reviewable
     if (!videoRowRef.current || showStill) return
 
     const updateVideoDimensions = () => {
-      // DO NOT TOUCH THAT *0.95 ! IT'S AN IMPORTANT MAGIC!
-      // Screw you, magic numbers! I'm changing it to 0.999
-      //
-      // For some reason, this seems to be the sweetspot
-      // Going under 2 px behaves weird
-      const clientWidth = videoRowRef.current?.clientWidth - 2
-      const clientHeight = videoRowRef.current?.clientHeight - 2
+      const clientWidth = videoRowRef.current?.clientWidth
+      const clientHeight = videoRowRef.current?.clientHeight
 
       if (clientWidth / clientHeight > aspectRatio) {
         const width = Math.round(clientHeight * aspectRatio)
@@ -148,6 +145,10 @@ const VideoPlayer = ({ src, frameRate, aspectRatio, autoplay, onPlay, reviewable
       const width = videoRef.current?.clientWidth
       const height = videoRef.current?.clientHeight
       setVideoDimensions({ width, height })
+      setActualVideoDimensions({
+        width: videoRef.current?.videoWidth,
+        height: videoRef.current?.videoHeight,
+      })
       setIsPlaying(!videoRef.current?.paused)
       setBufferedRanges([])
     }
@@ -346,7 +347,7 @@ const VideoPlayer = ({ src, frameRate, aspectRatio, autoplay, onPlay, reviewable
     <VideoPlayerContainer>
       <AnnotationsProvider
         backgroundRef={videoRef}
-        containerRef={videoRowRef}
+        containerDimensions={actualVideoDimensions}
         pageNumber={currentFrame}
         onAnnotationsChange={addAnnotation}
         annotations={annotations}
@@ -387,7 +388,7 @@ const VideoPlayer = ({ src, frameRate, aspectRatio, autoplay, onPlay, reviewable
             />
             {AnnotationsCanvas && isLoadedAnnotations && (
               <AnnotationsContainer style={{ visibility: isPlaying ? 'hidden' : 'visible' }}>
-                <AnnotationsCanvas width={videoDimensions.width} height={videoDimensions.height} />
+                {actualVideoDimensions && <AnnotationsCanvas width={actualVideoDimensions.width} height={actualVideoDimensions.height} />}
               </AnnotationsContainer>
             )}
           </div>

--- a/src/containers/VideoPlayer/VideoPlayer.jsx
+++ b/src/containers/VideoPlayer/VideoPlayer.jsx
@@ -352,6 +352,7 @@ const VideoPlayer = ({ src, frameRate, aspectRatio, autoplay, onPlay, reviewable
         onAnnotationsChange={addAnnotation}
         annotations={annotations}
         id={reviewableId}
+        src={src}
       >
         <div
           className={clsx('video-row video-container', { 'no-content': loadError })}

--- a/src/containers/Viewer/Viewer.styled.ts
+++ b/src/containers/Viewer/Viewer.styled.ts
@@ -54,6 +54,7 @@ export const Image = styled.img`
   width: auto;
   height: auto;
   object-fit: contain;
+  display: block;
 `
 
 export const ViewerDetailsPanelWrapper = styled.div`

--- a/src/containers/Viewer/ViewerImage.tsx
+++ b/src/containers/Viewer/ViewerImage.tsx
@@ -34,6 +34,7 @@ const ViewerImage: FC<ViewerImageProps> = ({ reviewableId, src, alt, ...props })
       onAnnotationsChange={addAnnotation}
       annotations={annotations}
       id={reviewableId}
+      src={src}
     >
       <div style={{ position: 'relative' }}>
         <Image

--- a/src/containers/Viewer/ViewerImage.tsx
+++ b/src/containers/Viewer/ViewerImage.tsx
@@ -1,7 +1,8 @@
-import { FC, useRef } from 'react'
+import { FC, useRef, useState } from 'react'
 import { Image } from './Viewer.styled'
 import { useViewer } from '@context/viewerContext'
 import styled from 'styled-components'
+import { AnnotationsContainerDimensions } from './hooks/useViewerAnnotations'
 
 const AnnotationsContainer = styled.div`
   position: absolute;
@@ -14,8 +15,8 @@ interface ViewerImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {
 }
 
 const ViewerImage: FC<ViewerImageProps> = ({ reviewableId, src, alt, ...props }) => {
-  const containerRef = useRef<HTMLDivElement>(null)
   const imageRef = useRef<HTMLImageElement>(null)
+  const [containerDimensions, setContainerDimensions] = useState<AnnotationsContainerDimensions | null>(null)
 
   const {
     createToolbar,
@@ -28,18 +29,27 @@ const ViewerImage: FC<ViewerImageProps> = ({ reviewableId, src, alt, ...props })
   return (
     <AnnotationsProvider
       backgroundRef={imageRef}
-      containerRef={containerRef}
+      containerDimensions={containerDimensions}
       pageNumber={1}
       onAnnotationsChange={addAnnotation}
       annotations={annotations}
       id={reviewableId}
     >
-      <div ref={containerRef} style={{ position: 'relative' }}>
-        <Image src={src} alt={alt} {...props} ref={imageRef} />
+      <div style={{ position: 'relative' }}>
+        <Image
+          ref={imageRef}
+          src={src}
+          alt={alt}
+          {...props}
+          onLoad={({ target }) => {
+            const image = target as HTMLImageElement
+            setContainerDimensions({ width: image.naturalWidth, height: image.naturalHeight });
+          }}
+        />
       </div>
-      {AnnotationsCanvas && isLoadedAnnotations && (
+      {AnnotationsCanvas && isLoadedAnnotations && containerDimensions && (
         <AnnotationsContainer>
-          <AnnotationsCanvas width={imageRef.current?.width} height={imageRef.current?.height} />
+          <AnnotationsCanvas {...containerDimensions} />
         </AnnotationsContainer>
       )}
       {createToolbar()}

--- a/src/containers/Viewer/hooks/useViewerAnnotations.ts
+++ b/src/containers/Viewer/hooks/useViewerAnnotations.ts
@@ -21,6 +21,7 @@ export type AnnotationsContainerDimensions = {
 export type AnnotationsProviderProps = {
   children: React.ReactNode
   id?: string
+  src: string
   backgroundRef?: React.MutableRefObject<
     HTMLCanvasElement | HTMLImageElement | HTMLVideoElement | null
   >

--- a/src/containers/Viewer/hooks/useViewerAnnotations.ts
+++ b/src/containers/Viewer/hooks/useViewerAnnotations.ts
@@ -13,13 +13,18 @@ export type AnnotationMetadata = {
   compositeData?: string // base64 image
 }
 
+export type AnnotationsContainerDimensions = {
+  width?: number;
+  height?: number;
+}
+
 export type AnnotationsProviderProps = {
   children: React.ReactNode
   id?: string
   backgroundRef?: React.MutableRefObject<
     HTMLCanvasElement | HTMLImageElement | HTMLVideoElement | null
   >
-  containerRef?: React.MutableRefObject<HTMLDivElement | null>
+  containerDimensions: AnnotationsContainerDimensions | null
   pageNumber: number
   annotations?: Map<string, string | null> | undefined
   onAnnotationsChange?:


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

- pass container dimensions (width/height) to `AnnotationsCanvas` instead of passing the `containerRef`, as per the new Power Pack version requirements
- use the actual media dimensions (i.e. video frame size and original image size) for the `AnnotationsCanvas`
- set the `ViewerImage`'s `<img>` to `display: block` - gets rid of extra space at the bottom
- remove 2px offset for the video viewer - we believe this is no longer needed and makes the canvas fit perfectly on top of the video

## Technical details

- we are not 100% sure why the 2px offset was needed previously. We haven't been able to reproduce any issues once the offset was removed.
- canvas compositing can now take a while for larger images. This causes noticeable lag while the annotated thumbnail is being generated. To be addressed separately.

## Additional context

Should fix #1021 

The new Power Pack version should be configured so it will alert the user if they're using a version of AYON server that doesn't have these changes yet.

