### PR TITLE
Global Customizations: Allow to remove an uploaded image

### DIFF
--- a/src/pages/SettingsPage/ServerConfig/ServerConfig.tsx
+++ b/src/pages/SettingsPage/ServerConfig/ServerConfig.tsx
@@ -93,6 +93,24 @@ const ServerConfig = () => {
     }
   }
 
+  const handleClearUpload = async (field: 'login_background' | 'studio_logo') => {
+    try {
+      // clear the filename in the formData and update the server config
+      // local fileName state will be updated by the useEffect above
+      await setServerConfig({
+        serverConfigModel: {
+          ...formData,
+          customization: {
+            ...formData.customization,
+            [field]: '',
+          },
+        },
+      }).unwrap()
+    } catch (error) {
+      toast.error('Failed to clear upload')
+    }
+  }
+
   return (
     <>
       <StyledSection direction="column" style={{ overflow: 'hidden', paddingBottom: 0 }}>
@@ -125,6 +143,7 @@ const ServerConfig = () => {
             fileType="login_background"
             fileName={backgroundFileName}
             setFileName={setBackgroundFileName}
+            onClear={() => handleClearUpload('login_background')}
           />,
           bgElement,
         )}
@@ -134,6 +153,7 @@ const ServerConfig = () => {
             fileType="studio_logo"
             fileName={logoFileName}
             setFileName={setLogoFileName}
+            onClear={() => handleClearUpload('studio_logo')}
           />,
           logoElement,
         )}

--- a/src/pages/SettingsPage/ServerConfig/ServerConfigUpload.tsx
+++ b/src/pages/SettingsPage/ServerConfig/ServerConfigUpload.tsx
@@ -92,7 +92,7 @@ const ServerConfigUpload: FC<ServerConfigUploadProps> = ({ fileType, fileName, s
           <Button icon='cancel' onClick={onClear}>
             Remove
           </Button>
-          ): (
+          ) : (
           <Button icon={loading ? 'sync' : 'upload'} onClick={handleButtonClick}>
               Upload
           </Button>

--- a/src/pages/SettingsPage/ServerConfig/ServerConfigUpload.tsx
+++ b/src/pages/SettingsPage/ServerConfig/ServerConfigUpload.tsx
@@ -50,6 +50,10 @@ const Filename = styled.div`
   text-overflow: ellipsis;
 `
 
+const UploadButton = styled(Button)`
+  width: 100px;
+`
+
 const HiddenInput = styled.input`
   display: none;
 `
@@ -89,13 +93,13 @@ const ServerConfigUpload: FC<ServerConfigUploadProps> = ({ fileType, fileName, s
     <UploadContainer>
       <Filename>{fileName}</Filename>
       {fileName ? (
-          <Button icon='cancel' onClick={onClear}>
+          <UploadButton icon='cancel' onClick={onClear}>
             Remove
-          </Button>
+          </UploadButton>
         ) : (
-          <Button icon={loading ? 'sync' : 'upload'} onClick={handleButtonClick}>
+          <UploadButton icon={loading ? 'sync' : 'upload'} onClick={handleButtonClick}>
               Upload
-          </Button>
+          </UploadButton>
         )}
       <HiddenInput ref={inputRef} type="file" onChange={handleFileChange} />
     </UploadContainer>

--- a/src/pages/SettingsPage/ServerConfig/ServerConfigUpload.tsx
+++ b/src/pages/SettingsPage/ServerConfig/ServerConfigUpload.tsx
@@ -92,11 +92,11 @@ const ServerConfigUpload: FC<ServerConfigUploadProps> = ({ fileType, fileName, s
           <Button icon='cancel' onClick={onClear}>
             Remove
           </Button>
-          ) : (
+        ) : (
           <Button icon={loading ? 'sync' : 'upload'} onClick={handleButtonClick}>
               Upload
           </Button>
-          )}
+        )}
       <HiddenInput ref={inputRef} type="file" onChange={handleFileChange} />
     </UploadContainer>
   )

--- a/src/pages/SettingsPage/ServerConfig/ServerConfigUpload.tsx
+++ b/src/pages/SettingsPage/ServerConfig/ServerConfigUpload.tsx
@@ -84,13 +84,22 @@ const ServerConfigUpload: FC<ServerConfigUploadProps> = ({ fileType, fileName, s
     inputRef.current?.click()
   }
 
+  const handleClear = () => {
+    setFileName("")
+  }
+
   return (
     <UploadContainer>
       <Filename>{fileName}</Filename>
-
-      <Button icon={loading ? 'sync' : 'upload'} onClick={handleButtonClick}>
-        Upload
-      </Button>
+      {fileName ? (
+          <Button icon='cancel' onClick={handleClear}>
+            Remove
+          </Button>
+          ): (
+          <Button icon={loading ? 'sync' : 'upload'} onClick={handleButtonClick}>
+              Upload
+          </Button>
+          )}
       <HiddenInput ref={inputRef} type="file" onChange={handleFileChange} />
     </UploadContainer>
   )

--- a/src/pages/SettingsPage/ServerConfig/ServerConfigUpload.tsx
+++ b/src/pages/SettingsPage/ServerConfig/ServerConfigUpload.tsx
@@ -9,6 +9,7 @@ interface ServerConfigUploadProps {
   fileType: UploadServerConfigFileApiArg['fileType']
   fileName: string
   setFileName: (value: string) => void
+  onClear: () => Promise<void>
 }
 
 const spinCCW = keyframes`
@@ -53,7 +54,7 @@ const HiddenInput = styled.input`
   display: none;
 `
 
-const ServerConfigUpload: FC<ServerConfigUploadProps> = ({ fileType, fileName, setFileName }) => {
+const ServerConfigUpload: FC<ServerConfigUploadProps> = ({ fileType, fileName, setFileName, onClear }) => {
   const [loading, setLoading] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
 
@@ -84,15 +85,11 @@ const ServerConfigUpload: FC<ServerConfigUploadProps> = ({ fileType, fileName, s
     inputRef.current?.click()
   }
 
-  const handleClear = () => {
-    setFileName("")
-  }
-
   return (
     <UploadContainer>
       <Filename>{fileName}</Filename>
       {fileName ? (
-          <Button icon='cancel' onClick={handleClear}>
+          <Button icon='cancel' onClick={onClear}>
             Remove
           </Button>
           ): (


### PR DESCRIPTION
## Description of changes 

Toggle the upload component to "Remove" button if it currently contains an uploaded file so that you can remove things.

## Technical details

@Innders visually it looks good - but I can't get the _clear_ to actually influence the stored result. So when refreshing you can see it never actually 'cleared' anything.

- [x] Fix persisting removal.

Fix #1036

## Additional context

![image](https://github.com/user-attachments/assets/18867f40-4dbd-49ae-8993-751da9b1d145)
![image](https://github.com/user-attachments/assets/7edb7926-f673-474b-85b1-5ca8e19071d0)


