### PR TITLE
Users: Show total license used

### DIFF
--- a/src/components/LicensesDialog/LicensesDialog.tsx
+++ b/src/components/LicensesDialog/LicensesDialog.tsx
@@ -191,7 +191,7 @@ const LicensesDialog: FC<LicensesDialogProps> = ({ onClose }) => {
         onClose={onClose}
         size="lg"
         header="Instance and licenses"
-        style={{ maxHeight: '90vh' }}
+        style={{ maxHeight: '90vh', minHeight: '50vh' }}
       >
         <Container>
           <EmptyPlaceholder message="Connect this instance to Ynput Cloud to get license information." />

--- a/src/pages/SettingsPage/UsersSettings/UsersOverview.tsx
+++ b/src/pages/SettingsPage/UsersSettings/UsersOverview.tsx
@@ -1,3 +1,6 @@
+import { UserPoolModel } from '@api/rest/auth'
+import { useGetUserPoolsQuery } from '@queries/auth/getAuth'
+import { useMemo } from 'react'
 import styled from 'styled-components'
 
 const Totals = styled.div`
@@ -32,12 +35,16 @@ type UsersOverviewProps = {
 
 const UsersOverview = ({ users = [] }: UsersOverviewProps) => {
   const usersWithoutService = users.filter((user) => !user.isService)
+  const { data: userPools = [] } = useGetUserPoolsQuery()
+  const isUsingPools = !!userPools.length
+
+  const totalLicenses = useMemo(() => getLicensesTotal(userPools), [userPools])
 
   const totals: {
     [key: string]: {
       label: string
       tooltip?: string
-      value: number
+      value: number | string
     }
   } = {
     total: {
@@ -63,6 +70,15 @@ const UsersOverview = ({ users = [] }: UsersOverviewProps) => {
     },
   }
 
+  // add licenses to the totals if there are pools
+  if (isUsingPools) {
+    totals.licenses = {
+      label: 'Licenses',
+      tooltip: getLicensesTooltip(totalLicenses),
+      value: getLicensesString(totalLicenses),
+    }
+  }
+
   return (
     <Totals>
       {Object.entries(totals).map(([key, { label, tooltip, value }]) => (
@@ -75,3 +91,49 @@ const UsersOverview = ({ users = [] }: UsersOverviewProps) => {
 }
 
 export default UsersOverview
+
+type LicsCount = {
+  fixed: {
+    used: number
+    max: number
+  }
+  metered: {
+    used: number
+    max: number
+  }
+  total: {
+    used: number
+    max: number
+  }
+}
+const getLicensesTotal = (userPools: UserPoolModel[]): LicsCount => {
+  const total: LicsCount = {
+    fixed: { used: 0, max: 0 },
+    metered: { used: 0, max: 0 },
+    total: { used: 0, max: 0 },
+  }
+  for (const pool of userPools) {
+    if (pool.type === 'fixed') {
+      total.fixed.max += pool.max
+      total.fixed.used += pool.used
+    }
+    if (pool.type === 'metered') {
+      total.metered.max += pool.max
+      total.metered.used += pool.used
+    }
+    // update total
+    total.total.max += pool.max
+    total.total.used += pool.used
+  }
+
+  return total
+}
+
+const getLicensesString = (counts: LicsCount): string => {
+  return `${counts.total.used}/${counts.total.max}`
+}
+
+// full details on the licenses
+const getLicensesTooltip = (counts: LicsCount): string => {
+  return `Base: ${counts.fixed.used}/${counts.fixed.max}\nMetered: ${counts.metered.used}/${counts.metered.max}`
+}


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
If your instance is using license pools, show a useful total of licenses consumed and available.

![image](https://github.com/user-attachments/assets/8d858bd8-94ff-4e78-9402-63140684d356)






