### PR TITLE
Viewer: display images with portrait aspect ratios correctly

### DIFF
--- a/src/containers/Viewer/Viewer.styled.ts
+++ b/src/containers/Viewer/Viewer.styled.ts
@@ -44,16 +44,12 @@ export const FullScreenWrapper = styled(FullScreen)`
   align-items: center;
   background-color: var(--md-sys-color-surface-container);
   z-index: 1000;
+  overflow: hidden;
 `
 
 export const Image = styled.img`
-  min-width: 300px;
-  min-height: 300px;
-  max-width: 100%;
-  max-height: 100%;
-  width: auto;
-  height: auto;
-  object-fit: contain;
+  width: 100%;
+  height: 100%;
   display: block;
 `
 

--- a/src/containers/Viewer/ViewerImage.tsx
+++ b/src/containers/Viewer/ViewerImage.tsx
@@ -1,11 +1,13 @@
 import { FC, useRef, useState } from 'react'
 import { Image } from './Viewer.styled'
 import { useViewer } from '@context/viewerContext'
-import styled from 'styled-components'
-import { AnnotationsContainerDimensions } from './'
+import styled, { CSSProperties } from 'styled-components'
+import { AnnotationsContainerDimensions, ViewerOrientation } from './'
 
 const AnnotationsContainer = styled.div`
   position: absolute;
+  top: 0;
+  left: 0;
 `
 
 interface ViewerImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {
@@ -16,7 +18,7 @@ interface ViewerImageProps extends React.ImgHTMLAttributes<HTMLImageElement> {
 
 const ViewerImage: FC<ViewerImageProps> = ({ reviewableId, src, alt, ...props }) => {
   const imageRef = useRef<HTMLImageElement>(null)
-  const [containerDimensions, setContainerDimensions] = useState<AnnotationsContainerDimensions | null>(null)
+  const [containerDims, setContainerDims] = useState<AnnotationsContainerDimensions | null>(null)
 
   const {
     createToolbar,
@@ -25,16 +27,28 @@ const ViewerImage: FC<ViewerImageProps> = ({ reviewableId, src, alt, ...props })
     isLoaded: isLoadedAnnotations,
   } = useViewer()
 
+  const orientation: ViewerOrientation = (containerDims?.width as number) > (containerDims?.height as number)
+    ? "landscape"
+    : "portrait";
+  const aspectRatio = `${containerDims?.width} / ${containerDims?.height}`;
+
+  const containerStyle: CSSProperties = {
+    position: 'relative',
+    aspectRatio,
+    width: orientation === "landscape" ? "100%" : "auto",
+    height: orientation === "landscape" ? "auto" : "100%",
+  };
+
   return (
     <AnnotationsEditorProvider
       backgroundRef={imageRef}
-      containerDimensions={containerDimensions}
+      containerDimensions={containerDims}
       pageNumber={1}
       id={reviewableId}
       src={src}
       mediaType="image"
     >
-      <div style={{ position: 'relative' }}>
+      <div style={containerStyle}>
         <Image
           ref={imageRef}
           src={src}
@@ -42,15 +56,15 @@ const ViewerImage: FC<ViewerImageProps> = ({ reviewableId, src, alt, ...props })
           {...props}
           onLoad={({ target }) => {
             const image = target as HTMLImageElement
-            setContainerDimensions({ width: image.naturalWidth, height: image.naturalHeight });
+            setContainerDims({ width: image.naturalWidth, height: image.naturalHeight });
           }}
         />
+        {AnnotationsCanvas && isLoadedAnnotations && containerDims && (
+          <AnnotationsContainer>
+            <AnnotationsCanvas {...containerDims} />
+          </AnnotationsContainer>
+        )}
       </div>
-      {AnnotationsCanvas && isLoadedAnnotations && containerDimensions && (
-        <AnnotationsContainer>
-          <AnnotationsCanvas {...containerDimensions} />
-        </AnnotationsContainer>
-      )}
       {createToolbar()}
     </AnnotationsEditorProvider>
   )

--- a/src/containers/Viewer/index.ts
+++ b/src/containers/Viewer/index.ts
@@ -53,3 +53,5 @@ export type AnnotationsProviderProps = {
   versionId: string,
   children: React.ReactNode;
 }
+
+export type ViewerOrientation = "landscape" | "portrait";


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

- adds some extra styling to the `ViewerImage` component so portrait images are viewed correctly

## Technical details
<!-- Please state any technical details such as limitations -->

- also added overflow: hidden to the container, so that the surrounding UI isn't overlapped.

## Additional context
<!-- Add any other context or screenshots here. -->

before:

![image](https://github.com/user-attachments/assets/1393d6c4-2161-4487-94ad-8e0cd71a3552)

after:

![image](https://github.com/user-attachments/assets/1a3ef7a0-fa23-4be1-872c-63c9e9d0250b)

