### PR TITLE
Modules: Set min required version for remote load

### DIFF
--- a/src/remote/useLoadModule.ts
+++ b/src/remote/useLoadModule.ts
@@ -1,6 +1,7 @@
 import { useRemoteModules } from '@/remote/remoteModulesContext'
 import { loadRemote } from '@module-federation/enhanced/runtime'
 import { useEffect, useRef, useState } from 'react'
+import semver from 'semver'
 
 interface Props<T> {
   addon: string
@@ -8,6 +9,7 @@ interface Props<T> {
   module: string
   fallback: T
   debug?: boolean
+  minVersion?: string // minimum version required for this module
 }
 
 const useLoadModule = <T>({
@@ -15,9 +17,11 @@ const useLoadModule = <T>({
   remote,
   module,
   fallback,
-}: Props<T>): [T, { isLoaded: boolean }] => {
+  minVersion,
+}: Props<T>): [T, { isLoaded: boolean; outdated?: { current: string; required: string } }] => {
   const { remotesInitialized, modules } = useRemoteModules()
   const [isLoaded, setIsLoaded] = useState(false)
+  const [isOutdated, setIsOutdated] = useState(false)
   const loadedRemote = useRef<T>(fallback)
 
   useEffect(() => {
@@ -25,7 +29,29 @@ const useLoadModule = <T>({
     if (!remotesInitialized || !addon || !remote || !module) return
 
     // check if remote and module exist
-    const initializedModule = modules.find((m) => m.addonName === addon)?.modules[remote]
+    const initializedRemote = modules.find((m) => m.addonName === addon)
+
+    if (!initializedRemote) return console.log('remote not found', { addon, remote, module })
+
+    // check remote meets minimum version requirement
+    if (minVersion && !semver.gte(initializedRemote.addonVersion, minVersion)) {
+      console.log('remote version does not meet minimum requirement', {
+        addon,
+        remote,
+        module,
+        current: initializedRemote.addonVersion,
+        required: minVersion,
+      })
+
+      setIsOutdated(true)
+
+      // use fallback if version requirement not met
+      return
+    }
+
+    setIsOutdated(false)
+
+    const initializedModule = initializedRemote.modules[remote]
 
     if (!initializedModule) return console.log('module not found', { addon, remote, module })
 
@@ -42,9 +68,20 @@ const useLoadModule = <T>({
       .catch((e) => {
         console.error('error loading remote', remote, module, e)
       })
-  }, [isLoaded, remotesInitialized, modules, addon, remote, module])
+  }, [isLoaded, remotesInitialized, modules, addon, remote, module, minVersion])
 
-  return [loadedRemote.current, { isLoaded }]
+  return [
+    loadedRemote.current,
+    {
+      isLoaded,
+      outdated: isOutdated
+        ? {
+            current: modules.find((m) => m.addonName === addon)?.addonVersion || 'unknown',
+            required: minVersion || 'unknown',
+          }
+        : undefined,
+    },
+  ]
 }
 
 export default useLoadModule


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
When an addon version remote module is not compatible with the server, prevent it from from loading and show warning. 


## Technical details
<!-- Please state any technical details such as limitations -->
The remote modules will not load and use the fallback code (default behaviour).


## Testing
<!-- Add any other context or screenshots here. -->
1. Test with FE `1.7.3`.
2. Have powerpack `0.0.1` installed.
3. Open a reviewable in the viewer.
4. A warning toast should appear.

![image](https://github.com/user-attachments/assets/dec15674-9862-4839-8187-eccfe9e12c1c)

