### PR TITLE
Settings: fix array copy in settings

### DIFF
--- a/src/containers/AddonList.jsx
+++ b/src/containers/AddonList.jsx
@@ -43,7 +43,7 @@ const AddonList = ({
         if (projectName && !addon.hasProjectSiteSettings)
           // project site overrides
           continue
-      } else if (projectName && !addon.hasProjectSettings) continue
+      } else if (projectName && !addon.hasProjectSettings && !addon.isBroken) continue
       else if (!addon.hasSettings && !addon.isBroken) continue
 
       const addonKey = `${addon.name}|${addon.version}|${variant}|${siteId || '_'}|${

--- a/src/containers/SettingsEditor/FormTemplates/FieldTemplate.tsx
+++ b/src/containers/SettingsEditor/FormTemplates/FieldTemplate.tsx
@@ -104,7 +104,6 @@ function FieldTemplate(props: FieldTemplateProps) {
     model.push({
       label: 'Copy',
       command: () => {
-        console.log('Copy Field', props.formData)
         if (!props.formData || (Array.isArray(props.formData) && props.formData.length === 0)) {
           toast.warn('No data to copy')
           return
@@ -120,7 +119,7 @@ function FieldTemplate(props: FieldTemplateProps) {
     })
 
     return model
-  }, [override, path])
+  }, [override, props.formData, path])
 
   const onContextMenu = (e: $Any) => {
     e.preventDefault()

--- a/src/containers/SettingsEditor/FormTemplates/FieldTemplate.tsx
+++ b/src/containers/SettingsEditor/FormTemplates/FieldTemplate.tsx
@@ -9,6 +9,7 @@ import { $Any } from '@types'
 import { FieldTemplateProps } from '@rjsf/utils'
 import { CSS } from 'styled-components/dist/types'
 import { matchesFilterKeys } from './searchMatcher'
+import { toast } from 'react-toastify'
 
 const arrayStartsWith = (arr1: $Any, arr2: $Any) => {
   // return true, if first array starts with second array
@@ -39,7 +40,12 @@ function FieldTemplate(props: FieldTemplateProps) {
   const section = props.schema.section
 
   const divider = useMemo(() => {
-    const matches = matchesFilterKeys(props.formContext.searchText, props.formContext.filterKeys, props.formContext.addonName, props.id)
+    const matches = matchesFilterKeys(
+      props.formContext.searchText,
+      props.formContext.filterKeys,
+      props.formContext.addonName,
+      props.id,
+    )
     if (props.schema.section && matches) {
       return <Divider> {props.schema.section !== '---' && props.schema.section} </Divider>
     }
@@ -97,7 +103,14 @@ function FieldTemplate(props: FieldTemplateProps) {
 
     model.push({
       label: 'Copy',
-      command: () => copyToClipboard(JSON.stringify(props.formData, null, 2)),
+      command: () => {
+        console.log('Copy Field', props.formData)
+        if (!props.formData || (Array.isArray(props.formData) && props.formData.length === 0)) {
+          toast.warn('No data to copy')
+          return
+        }
+        copyToClipboard(JSON.stringify(props.formData, null, 2))
+      },
     })
 
     model.push({
@@ -135,7 +148,12 @@ function FieldTemplate(props: FieldTemplateProps) {
 
     if (!classes.includes('obj-override-edit')) classes.push(`obj-override-${overrideLevel}`)
 
-    const matches = matchesFilterKeys(props.formContext.searchText, props.formContext.filterKeys, props.formContext.addonName, props.id)
+    const matches = matchesFilterKeys(
+      props.formContext.searchText,
+      props.formContext.filterKeys,
+      props.formContext.addonName,
+      props.id,
+    )
 
     return (
       <div
@@ -181,7 +199,12 @@ function FieldTemplate(props: FieldTemplateProps) {
   // let className = `form-inline-field ${
   //   props.errors.props.errors && props.schema.widget !== 'color' ? 'error' : ''
   // }`
-  const matches = matchesFilterKeys(props.formContext.searchText, props.formContext.filterKeys, props.formContext.addonName, props.id)
+  const matches = matchesFilterKeys(
+    props.formContext.searchText,
+    props.formContext.filterKeys,
+    props.formContext.addonName,
+    props.id,
+  )
 
   return (
     <div

--- a/src/containers/SettingsEditor/FormTemplates/ObjectFieldTemplate.tsx
+++ b/src/containers/SettingsEditor/FormTemplates/ObjectFieldTemplate.tsx
@@ -1,4 +1,5 @@
 import clsx from 'clsx'
+import { toast } from 'react-toastify'
 import { useMemo } from 'react'
 import ReactMarkdown from 'react-markdown'
 import SettingsPanel from '../SettingsPanel'
@@ -104,7 +105,7 @@ function ObjectFieldTemplate(props: { id: string } & ObjectFieldTemplateProps) {
         else otherFields.push(element.content)
       }
       return (
-        <div style={{width: '100%'}}>
+        <div style={{ width: '100%' }}>
           {longDescription}
           <div className={className}>
             <div className="name-field">{nameField}</div>
@@ -118,7 +119,12 @@ function ObjectFieldTemplate(props: { id: string } & ObjectFieldTemplateProps) {
       )
     } // ugly layout
 
-    const matches = matchesFilterKeys(props.formContext.searchText, props.formContext.filterKeys, props.formContext.addonName, props.idSchema.$id)
+    const matches = matchesFilterKeys(
+      props.formContext.searchText,
+      props.formContext.filterKeys,
+      props.formContext.addonName,
+      props.idSchema.$id,
+    )
 
     return (
       <div
@@ -190,7 +196,14 @@ function ObjectFieldTemplate(props: { id: string } & ObjectFieldTemplateProps) {
     model.push(
       {
         label: 'Copy',
-        command: () => copyToClipboard(JSON.stringify(props.formData, null, 2)),
+        command: () => {
+          if (!props.formData || (Array.isArray(props.formData) && props.formData.length === 0)) {
+            console.log('No data to copy', props)
+            toast.warn('No data to copy')
+            return
+          }
+          copyToClipboard(JSON.stringify(props.formData, null, 2))
+        },
       },
       {
         label: 'Paste',
@@ -273,7 +286,12 @@ function ObjectFieldTemplate(props: { id: string } & ObjectFieldTemplateProps) {
     contextMenu(e, contextMenuModel)
   }
 
-  const matches = matchesFilterKeys(props.formContext.searchText, props.formContext.filterKeys, props.formContext.addonName, props.idSchema.$id)
+  const matches = matchesFilterKeys(
+    props.formContext.searchText,
+    props.formContext.filterKeys,
+    props.formContext.addonName,
+    props.idSchema.$id,
+  )
 
   return (
     <div

--- a/src/helpers/copyToClipboard.js
+++ b/src/helpers/copyToClipboard.js
@@ -1,7 +1,10 @@
 import { toast } from 'react-toastify'
 
 const copyToClipboard = (message, toastMessage = false) => {
-  if (!message) return
+  if (!message) {
+    toast.warn('Nothing to copy')
+    return
+  }
 
   try {
     if (navigator.clipboard) {


### PR DESCRIPTION
Due to missing "props.formData" dependency in useMemo for context menu items, copy function didn't work properly on arrays.
This is now fixed. Additionally a warning is now displayed if there's nothing to copy.

### Testing notes

- Right after page loads, find a setting of type `list[SomeSubModel]` in normal (collapsible) layout
- Copy the entire array by right-clicking the panel header
- paste the data somewhere

Note: This worked before when you switched to another addon and back, but not after page load.