### PR TITLE
Show version comment on the version activity in the activity feed

### DIFF
--- a/src/components/Feed/ActivityVersions/ActivityVersions.jsx
+++ b/src/components/Feed/ActivityVersions/ActivityVersions.jsx
@@ -45,12 +45,10 @@ const ActivityVersions = ({
             <Styled.Card onClick={() => handleClick(id, productId)} key={id}>
               <Styled.Content>
                 <div>
-                <Styled.Title>
-                  <div style={{ lineHeight: '' }}>
-                    <span>{productName}</span><br/>
-                  </div>
-                  <ActivityDate date={createdAt} isExact />
-                </Styled.Title>
+                  <Styled.Title>
+                    <span>{productName}</span>
+                    <ActivityDate date={createdAt} isExact />
+                  </Styled.Title>
                   <span className="version">{name}</span>
                 </div>
                 <Styled.Thumbnail

--- a/src/components/Feed/ActivityVersions/ActivityVersions.jsx
+++ b/src/components/Feed/ActivityVersions/ActivityVersions.jsx
@@ -50,7 +50,6 @@ const ActivityVersions = ({
                   </div>
                   <ActivityDate date={createdAt} isExact />
                 </Styled.Title>
-
                 <Styled.Thumbnail
                   {...{ projectName }}
                   entityId={id}

--- a/src/components/Feed/ActivityVersions/ActivityVersions.jsx
+++ b/src/components/Feed/ActivityVersions/ActivityVersions.jsx
@@ -43,13 +43,15 @@ const ActivityVersions = ({
           (index < limit || showAll) && (
             <Styled.Card onClick={() => handleClick(id, productId)} key={id}>
               <Styled.Content>
+                <div>
                 <Styled.Title>
-                  <div>
+                  <div style={{ lineHeight: '' }}>
                     <span>{productName}</span><br/>
-                    <span className="version">{name}</span>
                   </div>
                   <ActivityDate date={createdAt} isExact />
                 </Styled.Title>
+                  <span className="version">{name}</span>
+                </div>
                 <Styled.Thumbnail
                   {...{ projectName }}
                   entityId={id}

--- a/src/components/Feed/ActivityVersions/ActivityVersions.jsx
+++ b/src/components/Feed/ActivityVersions/ActivityVersions.jsx
@@ -16,6 +16,7 @@ const ActivityVersions = ({
   filter,
 }) => {
   let { authorName, authorFullName, createdAt, versions = [] } = activity
+
   const [showAll, setShowAll] = useState(filter === 'publishes')
   const limit = 2
 

--- a/src/components/Feed/ActivityVersions/ActivityVersions.jsx
+++ b/src/components/Feed/ActivityVersions/ActivityVersions.jsx
@@ -3,7 +3,6 @@ import ActivityHeader from '../ActivityHeader/ActivityHeader'
 import * as Styled from './ActivityVersions.styled'
 import { useState } from 'react'
 import { More } from '../ActivityGroup/ActivityGroup.styled'
-import ActivityDate from '../ActivityDate'
 import { useDispatch } from 'react-redux'
 import { openViewer } from '@state/viewer'
 
@@ -16,7 +15,6 @@ const ActivityVersions = ({
   filter,
 }) => {
   let { authorName, authorFullName, createdAt, versions = [] } = activity
-
   const [showAll, setShowAll] = useState(filter === 'publishes')
   const limit = 2
 
@@ -38,16 +36,16 @@ const ActivityVersions = ({
         entityType={entityType}
         onReferenceClick={onReferenceClick}
       />
-      {versions.flatMap(
-        ({ name, id, productId, productName, updatedAt, createdAt }, index) =>
+      {versions.flatMap((version, index) => {
+        const { name, id, productId, productName, updatedAt, comment } = version
+        return (
           (index < limit || showAll) && (
             <Styled.Card onClick={() => handleClick(id, productId)} key={id}>
               <Styled.Content>
                 <Styled.Title>
-                  <span>{productName}</span>
-                  <ActivityDate date={createdAt} isExact />
+                  <span>{productName} - {name}</span>
                 </Styled.Title>
-                <span className="version">{name}</span>
+                <Styled.Comment>{comment}</Styled.Comment>
               </Styled.Content>
               <Styled.Thumbnail
                 {...{ projectName }}
@@ -59,8 +57,9 @@ const ActivityVersions = ({
                 icon={'play_circle'}
               />
             </Styled.Card>
-          ),
-      )}
+          )
+        )
+      })}
       {filter !== 'publishes' && versions.length > limit && (
         <More onClick={() => setShowAll(!showAll)}>
           <Icon name="more" />

--- a/src/components/Feed/ActivityVersions/ActivityVersions.jsx
+++ b/src/components/Feed/ActivityVersions/ActivityVersions.jsx
@@ -44,20 +44,24 @@ const ActivityVersions = ({
             <Styled.Card onClick={() => handleClick(id, productId)} key={id}>
               <Styled.Content>
                 <Styled.Title>
-                  <span>{productName} - {name}</span>
+                  <div>
+                    <span>{productName}</span><br/>
+                    <span className="version">{name}</span>
+                  </div>
                   <ActivityDate date={createdAt} isExact />
                 </Styled.Title>
-                {comment && <Styled.Comment>{comment}</Styled.Comment>}
+
+                <Styled.Thumbnail
+                  {...{ projectName }}
+                  entityId={id}
+                  entityType="version"
+                  onError={() => setThumbnailError(true)}
+                  iconOnly={thumbnailError}
+                  entityUpdatedAt={updatedAt}
+                  icon={'play_circle'}
+                />
               </Styled.Content>
-              <Styled.Thumbnail
-                {...{ projectName }}
-                entityId={id}
-                entityType="version"
-                onError={() => setThumbnailError(true)}
-                iconOnly={thumbnailError}
-                entityUpdatedAt={updatedAt}
-                icon={'play_circle'}
-              />
+              {comment && <Styled.Comment>{comment}</Styled.Comment>}
             </Styled.Card>
           )
         )

--- a/src/components/Feed/ActivityVersions/ActivityVersions.jsx
+++ b/src/components/Feed/ActivityVersions/ActivityVersions.jsx
@@ -3,6 +3,7 @@ import ActivityHeader from '../ActivityHeader/ActivityHeader'
 import * as Styled from './ActivityVersions.styled'
 import { useState } from 'react'
 import { More } from '../ActivityGroup/ActivityGroup.styled'
+import ActivityDate from '../ActivityDate'
 import { useDispatch } from 'react-redux'
 import { openViewer } from '@state/viewer'
 
@@ -44,6 +45,7 @@ const ActivityVersions = ({
               <Styled.Content>
                 <Styled.Title>
                   <span>{productName} - {name}</span>
+                  <ActivityDate date={createdAt} isExact />
                 </Styled.Title>
                 <Styled.Comment>{comment}</Styled.Comment>
               </Styled.Content>

--- a/src/components/Feed/ActivityVersions/ActivityVersions.jsx
+++ b/src/components/Feed/ActivityVersions/ActivityVersions.jsx
@@ -47,7 +47,7 @@ const ActivityVersions = ({
                   <span>{productName} - {name}</span>
                   <ActivityDate date={createdAt} isExact />
                 </Styled.Title>
-                <Styled.Comment>{comment}</Styled.Comment>
+                {comment && <Styled.Comment>{comment}</Styled.Comment>}
               </Styled.Content>
               <Styled.Thumbnail
                 {...{ projectName }}

--- a/src/components/Feed/ActivityVersions/ActivityVersions.styled.js
+++ b/src/components/Feed/ActivityVersions/ActivityVersions.styled.js
@@ -17,9 +17,6 @@ export const Container = styled.li`
 
 export const Card = styled.div`
 
-  gap: var(--base-gap-large);
-  align-items: center;
-  justify-content: space-between;
   border-radius: var(--border-radius-m);
   padding: var(--padding-m);
 
@@ -32,7 +29,6 @@ export const Card = styled.div`
 
     /* show date */
     .date {
-      float: right;
       display: inline;
     }
   }
@@ -42,7 +38,6 @@ export const Content = styled.div`
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-  width: 100%;
 
   gap: var(--base-gap-small);
 `

--- a/src/components/Feed/ActivityVersions/ActivityVersions.styled.js
+++ b/src/components/Feed/ActivityVersions/ActivityVersions.styled.js
@@ -58,7 +58,8 @@ export const Title = styled.div`
 
 export const Thumbnail = styled(ThumbnailSimple)`
   width: 74px;
-  height: 100%;
+  min-width: 74px;
+  height: unset;
   aspect-ratio: 1.7778;
   margin: unset;
 

--- a/src/components/Feed/ActivityVersions/ActivityVersions.styled.js
+++ b/src/components/Feed/ActivityVersions/ActivityVersions.styled.js
@@ -73,7 +73,6 @@ export const Thumbnail = styled(ThumbnailSimple)`
 
 export const Comment = styled.div`
   margin-top: var(--base-gap-small);
-  color: var(--md-sys-color-on-surface-variant);
-  line-height: 1.25rem;
+  color: var(--md-sys-color-outline);
   word-break: break-word;
 `

--- a/src/components/Feed/ActivityVersions/ActivityVersions.styled.js
+++ b/src/components/Feed/ActivityVersions/ActivityVersions.styled.js
@@ -16,7 +16,7 @@ export const Container = styled.li`
 `
 
 export const Card = styled.div`
-  display: flex;
+
   gap: var(--base-gap-large);
   align-items: center;
   justify-content: space-between;
@@ -32,6 +32,7 @@ export const Card = styled.div`
 
     /* show date */
     .date {
+      float: right;
       display: inline;
     }
   }
@@ -39,8 +40,9 @@ export const Card = styled.div`
 
 export const Content = styled.div`
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   justify-content: space-between;
+  width: 100%;
 
   gap: var(--base-gap-small);
 `

--- a/src/components/Feed/ActivityVersions/ActivityVersions.styled.js
+++ b/src/components/Feed/ActivityVersions/ActivityVersions.styled.js
@@ -70,3 +70,10 @@ export const Thumbnail = styled(ThumbnailSimple)`
     object-fit: cover;
   }
 `
+
+export const Comment = styled.div`
+  margin-top: var(--base-gap-small);
+  color: var(--md-sys-color-on-surface-variant);
+  line-height: 1.25rem;
+  word-break: break-word;
+`

--- a/src/containers/Feed/helpers/groupActivityVersions.js
+++ b/src/containers/Feed/helpers/groupActivityVersions.js
@@ -9,6 +9,7 @@ const activityToVersionItem = (activity = {}) => {
     createdAt,
     origin: { name, id } = {},
     activityData: { context: { productName, productType, productId } = {} } = {},
+    version
   } = activity
 
   return {
@@ -19,6 +20,7 @@ const activityToVersionItem = (activity = {}) => {
     productType,
     updatedAt,
     createdAt,
+    comment: version?.attrib?.comment || null
   }
 }
 

--- a/src/services/activities/activityQueries.js
+++ b/src/services/activities/activityQueries.js
@@ -122,7 +122,6 @@ export const getTypeFields = (type) => {
             path
           }
         }
-        comment
       `
     default:
       return ''

--- a/src/services/activities/activityQueries.js
+++ b/src/services/activities/activityQueries.js
@@ -35,6 +35,11 @@ fragment ActivityFragment on ActivityNode {
       reaction
       timestamp
     }
+    version {
+      attrib {
+        comment
+      }
+    }
   }
 `
 
@@ -117,6 +122,7 @@ export const getTypeFields = (type) => {
             path
           }
         }
+        comment
       `
     default:
       return ''


### PR DESCRIPTION
## Description of changes 

Show version comment on the version activity in the activity feed

## Technical details

Show `version.attrib.commen` on the version activity in the activity feed

I moved the version number to after the product name, because otherwise the layout looked very odd.
Plus it matches visually with how we're display product+version on the breadcrumbs in the entity sidecard, like here:

![image](https://github.com/user-attachments/assets/21ce2f0d-75f2-4d1f-bce4-dab4d3547313)

Fix https://github.com/ynput/ayon-frontend/issues/778

## Additional context

Before:
![image](https://github.com/user-attachments/assets/89fd85e0-d87a-4054-8b60-c8c4052c4310)

After:
![image](https://github.com/user-attachments/assets/20b223d3-8372-465f-90bb-9d24dfa55c30)

---
Without comment:

Before:
![image](https://github.com/user-attachments/assets/aed47549-84a7-4df2-914b-fb3c93652735)

After:
![image](https://github.com/user-attachments/assets/bfbe9b88-984f-4c19-a65f-64748d3d6e9c)

