### PR TITLE
Login: Logo shows without text and full width and height

### DIFF
--- a/src/pages/LoginPage/LoginPage.jsx
+++ b/src/pages/LoginPage/LoginPage.jsx
@@ -170,7 +170,7 @@ const LoginPage = ({ isFirstTime = false }) => {
     <main className="center">
       {loginPageBackground && <Styled.BG src={loginPageBackground} />}
       <Styled.LoginForm>
-        {motd && (
+        {(motd || loginPageBrand) && (
           <Panel>
             {loginPageBrand && <Styled.Logo src={loginPageBrand} />}
             <Styled.MessageMarkdown remarkPlugins={remarkGfm}>{motd}</Styled.MessageMarkdown>

--- a/src/pages/LoginPage/LoginPage.styled.jsx
+++ b/src/pages/LoginPage/LoginPage.styled.jsx
@@ -94,9 +94,10 @@ export const Ayon = styled.img`
   height: 60px;
 `
 export const Logo = styled.img`
-  max-height: 60px;
+  max-height: 100%;
   width: 100%;
   object-fit: contain;
+  overflow: hidden;
 `
 
 export const BG = styled.img`


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
- Ability to show the logo even if there is no MOTD
- Always shows the logo full width and max 100% height.

We made this change so that by default the logo could in theory fill the entire space giving the uploader more control over the size of the logo.

**Before**: The logo was capped at max 60px height making it very small. It would only work well be very wide logos.
![image](https://github.com/user-attachments/assets/3d421b85-42dc-4256-8740-a8d70d5435ad)

**After**: The logo fills all the space, im this case the logo becomes too big but we have a solution for that.
![image](https://github.com/user-attachments/assets/d95b7863-dcc3-4dbd-9e97-0f2927aa6334)

**Size control**: Now we can control the size of the logo by adding horizontal margin. The more margin added, the smaller the logo.
![image](https://github.com/user-attachments/assets/cb544e6d-70da-4c6a-81a1-4ffbd059c306)

![image](https://github.com/user-attachments/assets/6f69293b-271e-43c9-b79c-61906f4c8e3c)
