### PR TITLE
Auth: Better handle WS disconnect

### DIFF
--- a/src/context/websocketContext.jsx
+++ b/src/context/websocketContext.jsx
@@ -7,6 +7,7 @@ import useWebSocket, { ReadyState } from 'react-use-websocket'
 import { debounce } from 'lodash'
 import api from '@api'
 import RefreshToast from '@components/RefreshToast'
+import { useLogOutMutation } from '@queries/auth/getAuth'
 
 export const SocketContext = createContext()
 
@@ -19,10 +20,20 @@ export const SocketProvider = (props) => {
   // get user logged in
   const [serverRestartingVisible, setServerRestartingVisible] = useState(false)
   const [topics, setTopics] = useState([])
+  const [logout] = useLogOutMutation()
 
   const wsOpts = {
     shouldReconnect: () => {
-      if (user?.name) setServerRestartingVisible(true)
+      // check if there is a token
+      const accessToken = localStorage.getItem('accessToken')
+      // if not, log out user
+      if (!accessToken) {
+        try {
+          logout().unwrap()
+        } catch (error) {
+          console.error('Logout error', error)
+        }
+      }
       return true
     },
   }

--- a/src/context/websocketContext.jsx
+++ b/src/context/websocketContext.jsx
@@ -7,7 +7,7 @@ import useWebSocket, { ReadyState } from 'react-use-websocket'
 import { debounce } from 'lodash'
 import api from '@api'
 import RefreshToast from '@components/RefreshToast'
-import { useLogOutMutation } from '@queries/auth/getAuth'
+import { useLazyGetInfoQuery, useLogOutMutation } from '@queries/auth/getAuth'
 
 export const SocketContext = createContext()
 
@@ -21,6 +21,7 @@ export const SocketProvider = (props) => {
   const [serverRestartingVisible, setServerRestartingVisible] = useState(false)
   const [topics, setTopics] = useState([])
   const [logout] = useLogOutMutation()
+  const [getInfo] = useLazyGetInfoQuery()
 
   const wsOpts = {
     shouldReconnect: () => {
@@ -33,6 +34,10 @@ export const SocketProvider = (props) => {
         } catch (error) {
           console.error('Logout error', error)
         }
+      } else {
+        // test if the token is valid
+        // if it's not then this will automatically log out the user
+        getInfo()
       }
       return true
     },


### PR DESCRIPTION
Sometimes the access token can get cleared. This won't log the user out as they still have the cookie but the websocket will fail to connect and continue to keep trying to connect. This will cause a restart screen every 5 seconds (everytime ws tries to connect).

Now when the WS can not connect we check for an accessToken in localstorage and if there isn't one then we log the user out.