### PR TITLE
fix(kanban): Due date sorting not working

### DIFF
--- a/src/pages/UserDashboardPage/UserDashboardTasks/DashboardTasksToolbar/KanBanSortByOptions.ts
+++ b/src/pages/UserDashboardPage/UserDashboardTasks/DashboardTasksToolbar/KanBanSortByOptions.ts
@@ -11,7 +11,7 @@ const sortByOptions: SortByOption[] = [
   { id: 'folderName', label: 'Folder', sortOrder: true },
   { id: 'status', label: 'Status', sortOrder: true },
   { id: 'priority', label: 'Priority', sortOrder: true, sortByEnumOrder: true },
-  { id: 'endDate', label: 'Due Date', sortOrder: true },
+  { id: 'dueDate', label: 'Due Date', sortOrder: true },
 ]
 
 export default sortByOptions


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes
Fixes due date sorting on the artist dashboard page.
