### PR TITLE
Include `build` in semver version comparison

### DIFF
--- a/src/components/InstallerDownload/useGetInstallerDownload.js
+++ b/src/components/InstallerDownload/useGetInstallerDownload.js
@@ -1,6 +1,6 @@
 import { useMemo } from 'react'
 import { useListBundlesQuery } from '@queries/bundles/getBundles'
-import { coerce, rcompare } from 'semver'
+import { coerce, compareBuild } from 'semver'
 import useLocalStorage from '@hooks/useLocalStorage'
 import { toast } from 'react-toastify'
 import { useListInstallersQuery } from '@queries/installers/getInstallers'
@@ -29,7 +29,7 @@ const useGetInstallerDownload = () => {
           return -1
         }
         // If both have valid versions, compare them
-        return rcompare(a.semver?.version, b.semver?.version) || b.version.localeCompare(a.version)
+        return (-1 * compareBuild(a.semver?.version, b.semver?.version)) || b.version.localeCompare(a.version)
       })
   }, [installers])
 

--- a/src/pages/MarketPage/MarketDetails/AddonDetails.tsx
+++ b/src/pages/MarketPage/MarketDetails/AddonDetails.tsx
@@ -5,7 +5,7 @@ import Type from '@/theme/typography.module.css'
 import clsx from 'clsx'
 import { capitalize, isEmpty } from 'lodash'
 import AddonIcon from '@components/AddonIcon/AddonIcon'
-import { rcompare } from 'semver'
+import { compareBuild } from 'semver'
 import useUninstall from './useUninstall'
 import { Link } from 'react-router-dom'
 import { getSimplifiedUrl } from '@helpers/url'
@@ -83,7 +83,7 @@ const AddonDetails = ({ addon, isLoading, onDownload, isUpdatingAll }: AddonDeta
 
   const [showAllVersions, setShowAllVersions] = useState(false)
 
-  const versionKeysSorted = downloaded.sort((a, b) => rcompare(a, b))
+  const versionKeysSorted = downloaded.sort((a, b) => -1 * compareBuild(a, b))
   const versionsToShow = versionKeysSorted.length
     ? showAllVersions
       ? versionKeysSorted

--- a/src/pages/ServicesPage/NewServiceDialog.jsx
+++ b/src/pages/ServicesPage/NewServiceDialog.jsx
@@ -1,6 +1,6 @@
 import { useState, useMemo } from 'react'
 import { toast } from 'react-toastify'
-import { rcompare } from 'semver'
+import { compareBuild } from 'semver'
 import { Dialog, Dropdown } from '@ynput/ayon-react-components'
 import {
   FormLayout,
@@ -45,7 +45,7 @@ const NewServiceDialog = ({ onHide }) => {
     if (!selectedAddon) return []
     return Object.keys(selectedAddon.versions)
       .filter((v) => Object.keys(selectedAddon.versions[v].services || []).length)
-      .sort((a, b) => rcompare(a, b))
+      .sort((a, b) => -1 * compareBuild(a, b))
       .map((v) => {
         return { value: v, label: `${selectedAddon.title} ${v}` }
       })

--- a/src/pages/SettingsPage/Bundles/BundlesAddonList.jsx
+++ b/src/pages/SettingsPage/Bundles/BundlesAddonList.jsx
@@ -3,7 +3,7 @@ import { useListAddonsQuery } from '@queries/addons/getAddons'
 import { DataTable } from 'primereact/datatable'
 import { Column } from 'primereact/column'
 import { SocketContext } from '@context/websocketContext'
-import { rcompare, coerce } from 'semver'
+import { compareBuild, coerce } from 'semver'
 import { InputSwitch, InputText, VersionSelect } from '@ynput/ayon-react-components'
 import { FilePath, LatestIcon } from './Bundles.styled'
 import useCreateContext from '@hooks/useCreateContext'
@@ -46,10 +46,10 @@ const AddonListItem = ({ version, setVersion, selection, addons = [], versions }
             const foundAddon = addons.find((a) => a.name === s.name)
             if (!foundAddon) return ['NONE']
             const versionList = Object.keys(foundAddon.versions || {})
-            versionList.sort((a, b) => rcompare(a, b))
+            versionList.sort((a, b) => -1 * compareBuild(a, b))
             return [...versionList, 'NONE']
           })
-        : [[...versions.sort((a, b) => rcompare(a, b)), 'NONE']],
+        : [[...versions.sort((a, b) => -1 * compareBuild(a, b)), 'NONE']],
 
     [selection, addons],
   )
@@ -208,7 +208,7 @@ const BundlesAddonList = React.forwardRef(
             const currentVersion = addon.version
             const allVersions = addon.versions
             const sortedVersions = Object.keys(allVersions).sort((a, b) => {
-              const comparison = rcompare(coerce(a), coerce(b))
+              const comparison = -1 * compareBuild(coerce(a), coerce(b))
               if (comparison === 0) {
                 return b.localeCompare(a)
               }

--- a/src/pages/SettingsPage/Bundles/getLatestSemver.js
+++ b/src/pages/SettingsPage/Bundles/getLatestSemver.js
@@ -1,9 +1,9 @@
-import { rcompare } from 'semver'
+import { compareBuild } from 'semver'
 
 const getLatestSemver = (versionList = []) => {
   if (!versionList.length) return
   // sort the version list by semver, with the latest version first
-  const sortedVersions = versionList.sort((a, b) => rcompare(a, b))
+  const sortedVersions = versionList.sort((a, b) => -1 * compareBuild(a, b))
   // return the latest version
   return sortedVersions[0]
 }

--- a/src/services/installers/getInstallers.ts
+++ b/src/services/installers/getInstallers.ts
@@ -1,5 +1,5 @@
 import { api, ListInstallersApiResponse } from '@api/rest/installers'
-import { coerce, rcompare } from 'semver'
+import { coerce, compareBuild } from 'semver'
 
 const installersApi = api.enhanceEndpoints({
   endpoints: {
@@ -16,7 +16,7 @@ const installersApi = api.enhanceEndpoints({
         const sortedInstallers = installers
           .sort((a, b) => {
             if (a.semver && b.semver) {
-              const semverComparison = rcompare(a.semver, b.semver)
+              const semverComparison = -1 * compareBuild(a.semver, b.semver)
               if (semverComparison === 0) {
                 return b.version.localeCompare(a.version)
               } else {


### PR DESCRIPTION
## Description of changes 

Include `build` in semver version comparison

## Technical details

Switched from `semver.rcompare` to reversed `semver.compareBuild`.

The reversing is done by multiplying with -1. Another approach could be to remove the multiplication and instead swap a and b in the comparison. Thoughts?


## Additional context

As came up on community forum [here](https://community.ynput.io/t/how-does-ayon-handles-bundle-version-sorting-order/2443/2?u=bigroy).
