### PR TITLE
Pipeline Updater: Bundle name uses studio name or "Bundle"

### DIFF
--- a/src/containers/ReleaseInstallerDialog/ReleaseInstaller.tsx
+++ b/src/containers/ReleaseInstallerDialog/ReleaseInstaller.tsx
@@ -28,6 +28,7 @@ import { ReleaseFormType, switchDialog } from '@state/releaseInstaller'
 import { useRestart } from '@context/restartContext'
 import { useCreateBundleMutation } from '@queries/bundles/updateBundles'
 import { useNavigate } from 'react-router'
+import { useGetConfigValueQuery } from '@queries/config/getConfig'
 
 interface ReleaseInstallerProps {
   onFinish: () => void
@@ -53,6 +54,8 @@ const ReleaseInstaller: FC<ReleaseInstallerProps> = ({ onFinish }) => {
   const { data: { bundles = [] } = {}, isLoading: isLoadingBundles } = useListBundlesQuery({
     archived: false,
   })
+
+  const { data: studioName } = useGetConfigValueQuery({ key: 'studio_name' })
 
   // QUERIES
 
@@ -120,6 +123,7 @@ const ReleaseInstaller: FC<ReleaseInstallerProps> = ({ onFinish }) => {
       releaseForm.addons,
       releaseForm.platforms,
       bundles,
+      studioName,
     )
 
     // then create the bundle

--- a/src/containers/ReleaseInstallerDialog/ReleaseInstaller.tsx
+++ b/src/containers/ReleaseInstallerDialog/ReleaseInstaller.tsx
@@ -28,7 +28,6 @@ import { ReleaseFormType, switchDialog } from '@state/releaseInstaller'
 import { useRestart } from '@context/restartContext'
 import { useCreateBundleMutation } from '@queries/bundles/updateBundles'
 import { useNavigate } from 'react-router'
-import { useGetConfigValueQuery } from '@queries/config/getConfig'
 
 interface ReleaseInstallerProps {
   onFinish: () => void
@@ -54,8 +53,6 @@ const ReleaseInstaller: FC<ReleaseInstallerProps> = ({ onFinish }) => {
   const { data: { bundles = [] } = {}, isLoading: isLoadingBundles } = useListBundlesQuery({
     archived: false,
   })
-
-  const { data: studioName } = useGetConfigValueQuery({ key: 'studio_name' })
 
   // QUERIES
 
@@ -123,7 +120,6 @@ const ReleaseInstaller: FC<ReleaseInstallerProps> = ({ onFinish }) => {
       releaseForm.addons,
       releaseForm.platforms,
       bundles,
-      studioName,
     )
 
     // then create the bundle

--- a/src/containers/ReleaseInstallerDialog/helpers.ts
+++ b/src/containers/ReleaseInstallerDialog/helpers.ts
@@ -130,7 +130,6 @@ export const createBundleFromRelease = (
   selectedAddons: string[],
   selectedPlatforms: string[],
   bundleList: BundleModel[],
-  studioName?: string,
 ) => {
   const { installers = [], dependencyPackages = [] } = release
 
@@ -153,7 +152,7 @@ export const createBundleFromRelease = (
     bundleDepPackages[depPackage.platform] = depPackage.filename
   }
 
-  const name = getNewBundleName(studioName, bundleList)
+  const name = getNewBundleName(release.release, bundleList)
 
   // check if there is already a production bundles
   const hasProduction = bundleList.some((bundle) => bundle?.isProduction)

--- a/src/containers/ReleaseInstallerDialog/helpers.ts
+++ b/src/containers/ReleaseInstallerDialog/helpers.ts
@@ -130,6 +130,7 @@ export const createBundleFromRelease = (
   selectedAddons: string[],
   selectedPlatforms: string[],
   bundleList: BundleModel[],
+  studioName?: string,
 ) => {
   const { installers = [], dependencyPackages = [] } = release
 
@@ -152,7 +153,7 @@ export const createBundleFromRelease = (
     bundleDepPackages[depPackage.platform] = depPackage.filename
   }
 
-  const name = getNewBundleName(release.name, bundleList)
+  const name = getNewBundleName(studioName, bundleList)
 
   // check if there is already a production bundles
   const hasProduction = bundleList.some((bundle) => bundle?.isProduction)

--- a/src/pages/SettingsPage/Bundles/getNewBundleName.js
+++ b/src/pages/SettingsPage/Bundles/getNewBundleName.js
@@ -2,7 +2,7 @@
 // xx is a number that increments for each bundle created on the same day
 
 const getNewBundleName = (studioName, bundleList = []) => {
-  const defaultStudio = 'Studio-Name'
+  const defaultStudio = 'Bundle'
   const now = new Date()
   const year = now.getFullYear()
   const month = (now.getMonth() + 1).toString().padStart(2, '0')


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
The new bundle created by the pipeline updater should be named with the release version not release name or "Bundle" if there is no name for any reason.

This ensures that the release suffix "kitsu", "ftrack", "shotgrid" is not included in the bundle name.

