### PR TITLE
Settings: Select all option for dropdowns with more than 10 options

### DIFF
--- a/src/containers/SettingsEditor/Widgets/SelectWidget.tsx
+++ b/src/containers/SettingsEditor/Widgets/SelectWidget.tsx
@@ -92,6 +92,11 @@ const SelectWidget = (props: $Any) => {
       multiSelect={props.multiple}
       style={hlstyle}
       disabled={props.schema?.disabled}
+      onSelectAll={
+        props.multiple && props.options.enumOptions.length > 10
+          ? () => setValue(props.options.enumOptions.map((opt: $Any) => opt.value))
+          : undefined
+      }
     />
   )
 }


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
Sometimes you just want to select all of the options for enum field in the settings. This is super annoying if there are lots of items to select.

This PR adds the "Select all" button if there are more than 10 options and the dropdown is multi-select.

![image](https://github.com/user-attachments/assets/451032a8-7111-4c7c-bb7c-8b7625183c8e)

