### PR TITLE
Actions: Client side triggers

### DIFF
--- a/src/components/ActionsDropdown/ActionsDropdown.jsx
+++ b/src/components/ActionsDropdown/ActionsDropdown.jsx
@@ -21,6 +21,7 @@ const ActionsDropdown = ({ options, isLoading, onAction }) => {
       disabled={isLoading}
       className={clsx('more', { loading: isLoading })}
       options={options}
+      maxOptionsShown={100}
       value={[]}
       placeholder=""
       itemTemplate={(option) => <ActionsDropdownItem {...option} />}

--- a/src/containers/Actions/Actions.jsx
+++ b/src/containers/Actions/Actions.jsx
@@ -163,7 +163,6 @@ const Actions = ({ entities, entityType, entitySubTypes, isLoadingEntity }) => {
 
       if (!response.success) throw new Error('Error executing action')
 
-      toast.success(response?.message || 'Action executed successfully')
       if (response?.uri) {
         customProtocolCheck(
           response.uri,
@@ -172,6 +171,7 @@ const Actions = ({ entities, entityType, entitySubTypes, isLoadingEntity }) => {
           2000,
         )
       }
+      toast.success(response?.message || 'Action executed successfully', { autoClose: 2000 })
 
       // Use the new hook to handle payload
       if (response?.payload) {

--- a/src/containers/Actions/Actions.jsx
+++ b/src/containers/Actions/Actions.jsx
@@ -7,6 +7,8 @@ import { useExecuteActionMutation, useGetActionsFromContextQuery } from '@/servi
 import ActionsDropdown from '@/components/ActionsDropdown/ActionsDropdown'
 import ActionIcon from './ActionIcon'
 import customProtocolCheck from 'custom-protocol-check'
+import { useLocation, useNavigate } from 'react-router'
+import useActionTriggers from '@/hooks/useActionTriggers'
 
 const placeholder = {
   identifier: 'placeholder',
@@ -15,6 +17,9 @@ const placeholder = {
 }
 
 const Actions = ({ entities, entityType, entitySubTypes, isLoadingEntity }) => {
+  // special triggers the actions can make to perform stuff on the client
+  const { handleActionPayload } = useActionTriggers()
+
   const context = useMemo(() => {
     if (!entities.length) return null
     if (!entities[0].projectName) return null
@@ -166,6 +171,11 @@ const Actions = ({ entities, entityType, entitySubTypes, isLoadingEntity }) => {
           () => {},
           2000,
         )
+      }
+
+      // Use the new hook to handle payload
+      if (response?.payload) {
+        handleActionPayload(response.payload)
       }
     } catch (error) {
       console.warn('Error executing action', error)

--- a/src/containers/Actions/Actions.styled.js
+++ b/src/containers/Actions/Actions.styled.js
@@ -11,6 +11,7 @@ export const FeaturedAction = styled(Button)`
   padding: 6px;
   user-select: none;
   position: relative;
+  max-width: 32px;
   img {
     width: 20px;
     height: 20px;

--- a/src/containers/DetailsPanel/FeedFilters/FeedFilters.styled.js
+++ b/src/containers/DetailsPanel/FeedFilters/FeedFilters.styled.js
@@ -3,7 +3,7 @@ import { Toolbar, Button } from '@ynput/ayon-react-components'
 
 export const FiltersToolbar = styled(Toolbar)`
   border-radius: 0 0 8px 8px;
-  gap: var(--base-gap-small);
+  gap: var(--base-gap-small) !important;
   position: relative;
 
   z-index: 100;

--- a/src/hooks/useActionTriggers.ts
+++ b/src/hooks/useActionTriggers.ts
@@ -1,0 +1,89 @@
+import { useNavigate, useSearchParams } from 'react-router-dom'
+
+interface QueryParams {
+  [key: string]: string
+}
+
+interface ActionPayload {
+  __queryParams?: QueryParams // adds query params to the URL
+  __navigate?: string // navigates to a different page
+  __download?: string // triggers a file download from a URL
+  __copy?: string // copies string content to clipboard
+  [key: string]: any
+}
+
+const useActionTriggers = () => {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const navigate = useNavigate()
+
+  const handleActionPayload = (payload: ActionPayload | null): void => {
+    if (!payload) return
+
+    // Handle query parameters
+    if ('__queryParams' in payload) {
+      // Validate it is an object of key:value pairs with value being string
+      const isValid = Object.values(payload.__queryParams as QueryParams).every((value) => {
+        return typeof value === 'string'
+      })
+
+      if (!isValid) {
+        throw new Error('Invalid payload: __queryParams')
+      } else {
+        // Add query params to URL
+        for (const [key, value] of Object.entries(payload.__queryParams as QueryParams)) {
+          searchParams.set(key, value)
+        }
+        setSearchParams(searchParams)
+      }
+    }
+
+    if ('__navigate' in payload) {
+      // Validate it is a string
+      if (typeof payload.__navigate !== 'string') {
+        throw new Error('Invalid payload: __navigate')
+      } else {
+        // Navigate to the specified page
+        navigate(payload.__navigate)
+      }
+    }
+
+    if ('__download' in payload) {
+      // Validate it is a string
+      if (typeof payload.__download !== 'string') {
+        throw new Error('Invalid payload: __download')
+      } else {
+        // Trigger file download from the URL
+        const downloadUrl = new URL(payload.__download, window.location.origin).href
+        console.log(downloadUrl)
+        // Create a hidden anchor element
+        const link = document.createElement('a')
+        link.href = downloadUrl
+        link.target = '_blank'
+        link.rel = 'noopener noreferrer'
+        // Set download attribute if it's a direct file download
+        // If it's an API endpoint that handles the download, this is still good
+        link.download = ''
+        // Append to document, click and then remove
+        document.body.appendChild(link)
+        link.click()
+        document.body.removeChild(link)
+      }
+    }
+
+    if ('__copy' in payload) {
+      // Validate it is a string
+      if (typeof payload.__copy !== 'string') {
+        throw new Error('Invalid payload: __copy')
+      } else {
+        // Copy content to clipboard
+        navigator.clipboard.writeText(payload.__copy).catch((err) => {
+          console.error('Failed to copy text to clipboard:', err)
+        })
+      }
+    }
+  }
+
+  return { handleActionPayload }
+}
+
+export default useActionTriggers


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
The client can now handle web actions to perform different tasks.

When these key value pairs are present in the payload of an action response they will trigger different actions on the client.

```ts
interface QueryParams {
  [key: string]: string
}

interface ActionPayload {
  __queryParams?: QueryParams // adds query params to the URL
  __navigate?: string // navigates to a different page
  __download?: string // triggers a file download from a relative URL
  __copy?: string // copies string content to clipboard
}
```




## Technical details
<!-- Please state any technical details such as limitations -->
Example of an action definition in an addon.

```python
            navigate_url = "/dashboard/tasks"
            
            return await executor.get_server_action_response(
                message=f"Navigating to: {navigate_url}",
                __navigate=navigate_url
            )
 ```

## Additional context
<!-- Add any other context or screenshots here. -->
Here is an example of a web action being used to set some query parameters and in turn open an addons modal.

https://github.com/user-attachments/assets/0cb7906b-2a75-4e20-8ff8-7d1ee6c8845a



