### PR TITLE
Overview: New entities respect slicer selection

### DIFF
--- a/src/components/NewEntity/NewEntity.tsx
+++ b/src/components/NewEntity/NewEntity.tsx
@@ -22,6 +22,7 @@ import FolderSequence from '@components/FolderSequence/FolderSequence'
 import { EntityForm, NewEntityType, useNewEntityContext } from '@context/NewEntityContext'
 import { ProjectModel } from '@api/rest/project'
 import useCreateEntityShortcuts from '@hooks/useCreateEntityShortcuts'
+import { useSlicerContext } from '@context/slicerContext'
 
 const ContentStyled = styled.div`
   display: flex;
@@ -88,9 +89,10 @@ const NewEntity: React.FC<NewEntityProps> = ({ disabled }) => {
 
   const [createMore, setCreateMore] = useState(false)
   const { selectedCells } = useSelectionContext()
+  const { rowSelection: slicerSelection, sliceType } = useSlicerContext()
   const { getEntityById, projectInfo } = useProjectTableContext()
 
-  const { selectedFolderIds, selectedFolders } = React.useMemo(() => {
+  const selectedFolderIds = React.useMemo(() => {
     const selectedRowIds = Array.from(
       new Set(
         Array.from(selectedCells)
@@ -103,28 +105,30 @@ const NewEntity: React.FC<NewEntityProps> = ({ disabled }) => {
     const selectedEntities = selectedRowIds.map((id) => getEntityById(id))
 
     const selectedFolders = selectedEntities
-      .filter(
-        // @ts-ignore
-        (entity) => !entity?.folderId,
-      )
+      .filter((entity) => entity?.entityType === 'folder')
       .filter(Boolean) as MatchingFolder[]
     const selectedTasks = selectedEntities
-      .filter(
-        // @ts-ignore
-        (entity) => entity?.folderId,
-      )
+      .filter((entity) => entity?.entityType === 'task')
       .filter(Boolean) as EditorTaskNode[]
 
     // Extract folder IDs from selected folders and tasks
     const folderIdsFromFolders = selectedFolders.map((folder) => folder.id)
+    // get parent folder ids from tasks
     const folderIdsFromTasks = selectedTasks.map((task) => task.folderId)
 
     // Combine and remove duplicate folder IDs
     // These are the folders to create the new entity in
     const selectedFolderIds = Array.from(new Set([...folderIdsFromFolders, ...folderIdsFromTasks]))
 
-    return { selectedFolderIds, selectedFolders }
-  }, [selectedCells, getEntityById])
+    // if no folders or tasks are selected, try to get the selected folder from the slicer
+    if (!selectedFolderIds.length && sliceType === 'hierarchy') {
+      // add the selected folder ids from the slicer
+      const selectedFolderIdsFromSlicer = Object.keys(slicerSelection)
+      selectedFolderIds.push(...selectedFolderIdsFromSlicer)
+    }
+
+    return selectedFolderIds
+  }, [selectedCells, slicerSelection, sliceType, getEntityById])
 
   const isRoot = isEmpty(selectedFolderIds)
 
@@ -366,7 +370,6 @@ const NewEntity: React.FC<NewEntityProps> = ({ disabled }) => {
               increment={sequenceForm.increment}
               length={sequenceForm.length}
               prefix={sequenceForm.prefix}
-              parentLabel={selectedFolders[0]?.label}
               prefixDepth={sequenceForm.prefixDepth}
               entityType="folder"
               nesting={false}

--- a/src/components/NewEntity/NewEntity.tsx
+++ b/src/components/NewEntity/NewEntity.tsx
@@ -70,9 +70,11 @@ const StyledCreateItem = styled.span`
   }
 `
 
-interface NewEntityProps {}
+interface NewEntityProps {
+  disabled?: boolean
+}
 
-const NewEntity: React.FC<NewEntityProps> = () => {
+const NewEntity: React.FC<NewEntityProps> = ({ disabled }) => {
   const {
     entityType,
     setEntityType,
@@ -307,6 +309,8 @@ const NewEntity: React.FC<NewEntityProps> = () => {
         itemStyle={{
           paddingRight: 16,
         }}
+        disabled={disabled}
+        data-tooltip={disabled ? 'Enable hierarchy to create new entity' : 'Create new entity'}
       />
       {entityType && (
         <Dialog

--- a/src/components/NewEntity/NewEntity.tsx
+++ b/src/components/NewEntity/NewEntity.tsx
@@ -124,10 +124,10 @@ const NewEntity: React.FC<NewEntityProps> = ({ disabled }) => {
     if (!selectedFolderIds.length && sliceType === 'hierarchy') {
       // add the selected folder ids from the slicer
       const selectedFolderIdsFromSlicer = Object.keys(slicerSelection)
-      selectedFolderIds.push(...selectedFolderIdsFromSlicer)
+      return selectedFolderIdsFromSlicer
+    } else {
+      return selectedFolderIds
     }
-
-    return selectedFolderIds
   }, [selectedCells, slicerSelection, sliceType, getEntityById])
 
   const isRoot = isEmpty(selectedFolderIds)

--- a/src/context/NewEntityContext.tsx
+++ b/src/context/NewEntityContext.tsx
@@ -81,12 +81,15 @@ export const NewEntityProvider: React.FC<NewEntityProviderProps> = ({ children }
     // add extra data from slicer
     const slicerData: Record<string, any> = {}
     if (sliceType !== 'hierarchy' && !isEmpty(rowSelection) && entityType === 'task') {
+      const selection = Object.keys(rowSelection).filter(
+        (key) => !['hasValue', 'noValue'].includes(key),
+      )
       switch (sliceType) {
         case 'assignees':
-          slicerData.assignees = Object.keys(rowSelection)
+          slicerData.assignees = selection
           break
         case 'status':
-          slicerData.status = Object.keys(rowSelection)[0]
+          slicerData.status = selection[0]
           break
         default:
           break

--- a/src/context/NewEntityContext.tsx
+++ b/src/context/NewEntityContext.tsx
@@ -233,6 +233,9 @@ export const NewEntityProvider: React.FC<NewEntityProviderProps> = ({ children }
 
         // Create entity-specific patch operation with the correct type casting
         if (entityType === 'folder') {
+          let path = operation.data.parentId && paths[operation.data.parentId]
+          path = path ? path + '/' + operation.data.name : ''
+
           const folderPatch: PatchNewFolderOperation = {
             type: 'create',
             entityType: 'folder',
@@ -246,9 +249,7 @@ export const NewEntityProvider: React.FC<NewEntityProviderProps> = ({ children }
               updatedAt: new Date().toISOString(),
               status: firstStatusForFolder,
               ownAttrib: [],
-              path: operation.data.parentId
-                ? paths[operation.data.parentId] + '/' + operation.data.name
-                : '',
+              path: path,
               tags: [],
               attrib: filteredAttribs,
             } as MatchingFolder,

--- a/src/pages/ProjectOverviewPage/ProjectOverviewPage.tsx
+++ b/src/pages/ProjectOverviewPage/ProjectOverviewPage.tsx
@@ -92,7 +92,7 @@ const ProjectOverviewPage: FC = () => {
         <SplitterPanel size={88}>
           <Section wrap direction="column" style={{ height: '100%' }}>
             <Toolbar style={{ gap: 8 }}>
-              <NewEntity />
+              <NewEntity disabled={!showHierarchy} />
               <SearchFilterWrapper
                 filters={filtersWithHierarchy}
                 onChange={handleFiltersChange}


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
- Fix: When creating new entities the slicer folder selection is now taken into account. Use the slicer to select a folder you want to create an entity in.
- Fix: Attach path to new entity patches so that they work with slicer filtering (otherwise they won't show).
- Fix: Disable create entity when not in show hierarchy mode.
- Improvement: Slicer attributes will now be added to new tasks. For example if you are filtering by assignees, those assignees will be automatically added to the new task.


https://github.com/user-attachments/assets/6346f355-e8a0-4354-8665-137c31b5cae9


_Creating a new task with an assignee_


