### PR TITLE
Overview: Updating details panel folders will invalidate queries

### DIFF
--- a/src/services/entity/updateEntity.js
+++ b/src/services/entity/updateEntity.js
@@ -387,6 +387,15 @@ const updateEntity = api.injectEndpoints({
             if (entityType === 'folder') {
               // patch the overview page
               patchOverviewFolders(operationsWithEntityId, { state, dispatch }, overviewPatches)
+              console.log('invalidate overview folders')
+              // invalidate overview folders query
+              dispatch(api.util.invalidateTags([{ type: 'folder', id: 'LIST' }]))
+              // invalidate overview tasks with folder as a parent
+              dispatch(
+                api.util.invalidateTags(
+                  operationsWithEntityId.map((o) => ({ type: 'overviewTask', id: o.entityId })),
+                ),
+              )
             }
           }
 

--- a/src/services/overview/getOverview.ts
+++ b/src/services/overview/getOverview.ts
@@ -50,7 +50,12 @@ const getOverviewTaskTags = (
     id,
   }))
 
-  return [...taskTags, ...parentTags, { type: 'overviewTask', id: projectName }]
+  return [
+    ...taskTags,
+    ...parentTags,
+    { type: 'overviewTask', id: projectName },
+    { type: 'overviewTask', id: 'LIST' },
+  ]
 }
 
 type GetTasksListResult = {
@@ -164,7 +169,8 @@ const injectedApi = enhancedApi.injectEndpoints({
       forceRefetch({ currentArg, previousArg }) {
         return !isEqual(currentArg, previousArg)
       },
-      providesTags: [{ type: 'overviewTask', id: 'LIST' }],
+      providesTags: (result, _e, { parentIds, projectName }) =>
+        getOverviewTaskTags(result, projectName, parentIds),
     }),
     // queryTasksFolders is a post so it's a bit annoying to consume
     // we wrap it in a queryFn to make it easier to consume as a query hook


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
When updating a folder in the details panel the optimistic updates wouldn't take inheritance into consideration.

Because the details panel updating logic is completely detached from the overview it was very hard to calculate the changes on the client.

The solution for now is to invalidate the overview queries so that the fresh inheritance data if fetched.

