### PR TITLE
useLocalStorage key updates

### DIFF
--- a/shared/src/ProjectTreeTable/context/ProjectTableContext.tsx
+++ b/shared/src/ProjectTreeTable/context/ProjectTableContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, ReactNode, useCallback, useContext, useMemo } from 'react'
+import { createContext, ReactNode, useCallback, useContext } from 'react'
 import { ExpandedState, OnChangeFn, SortingState } from '@tanstack/react-table'
 import useOverviewTable from '../hooks/useOverviewTable'
 import { Filter } from '@ynput/ayon-react-components'
@@ -20,7 +20,6 @@ import { RowId } from '../utils/cellUtils'
 import { ProjectModel } from '../types/project'
 import { AttributeWithPermissions, LoadingTasks } from '../types'
 import { QueryFilter } from '../types/folders'
-import { OperationModel, OperationsRequestModel } from '../types/operations'
 
 type User = {
   name: string

--- a/shared/src/hooks/useLocalStorage.ts
+++ b/shared/src/hooks/useLocalStorage.ts
@@ -31,9 +31,6 @@ export function useLocalStorage<T>(key: string, defaultValue: T): [T, (value: T)
     const currentItem = localStorage.getItem(key)
     setValue(parseJSONString(currentItem, defaultValueRef.current))
 
-    if (key.startsWith('overview-')) {
-      console.log('key', { key })
-    }
     if (!currentItem) {
       localStorage.setItem(key, JSON.stringify(defaultValueRef.current))
     }

--- a/src/containers/TasksProgress/helpers/formatSearchQueryFilters.ts
+++ b/src/containers/TasksProgress/helpers/formatSearchQueryFilters.ts
@@ -2,7 +2,7 @@
 
 import { AttributeFilterInput, ProjectNodeTasksArgs } from '@api/graphql'
 import getFilterFromId from '@components/SearchFilter/getFilterFromId'
-import { Filter } from '@components/SearchFilter/types'
+import { Filter } from '@ynput/ayon-react-components'
 import { TaskFilterValue } from '../hooks/useFilterBySlice'
 import { TaskProgressSliceType } from '@pages/TasksProgressPage/TasksProgressPage'
 

--- a/src/pages/ProjectOverviewPage/containers/SearchFilterWrapper.tsx
+++ b/src/pages/ProjectOverviewPage/containers/SearchFilterWrapper.tsx
@@ -69,7 +69,7 @@ const SearchFilterWrapper: FC<SearchFilterWrapperProps> = ({
     setFilters(
       _filters.filter((filter, index, self) => self.findIndex((f) => f.id === filter.id) === index),
     )
-  }, [_filters, setFilters, projectNames])
+  }, [_filters, setFilters])
 
   return (
     <SearchFilter

--- a/src/pages/ProjectOverviewPage/containers/SearchFilterWrapper.tsx
+++ b/src/pages/ProjectOverviewPage/containers/SearchFilterWrapper.tsx
@@ -69,7 +69,7 @@ const SearchFilterWrapper: FC<SearchFilterWrapperProps> = ({
     setFilters(
       _filters.filter((filter, index, self) => self.findIndex((f) => f.id === filter.id) === index),
     )
-  }, [_filters, setFilters])
+  }, [_filters, setFilters, projectNames])
 
   return (
     <SearchFilter

--- a/src/pages/ProjectOverviewPage/context/ProjectOverviewContext.tsx
+++ b/src/pages/ProjectOverviewPage/context/ProjectOverviewContext.tsx
@@ -81,9 +81,11 @@ export const ProjectOverviewProvider = ({ children }: ProjectOverviewProviderPro
     setColumnSorting,
   } = useProjectDataContext()
 
-  const scope = `overview-${projectName}`
+  const getLocalKey = (page: string, key: string) => `${page}-${key}-${projectName}`
 
-  const [expanded, setExpanded] = useLocalStorage<ExpandedState>(`expanded-${scope}`, {})
+  const page = 'overview'
+
+  const [expanded, setExpanded] = useLocalStorage<ExpandedState>(getLocalKey(page, 'expanded'), {})
   const updateExpanded: OnChangeFn<ExpandedState> = (expandedUpdater) => {
     setExpanded(functionalUpdate(expandedUpdater, expanded))
   }
@@ -96,9 +98,9 @@ export const ProjectOverviewProvider = ({ children }: ProjectOverviewProviderPro
     })
   }
 
-  const [filters, setFilters] = useLocalStorage<Filter[]>(`overview-filters-${projectName}`, [])
+  const [filters, setFilters] = useLocalStorage<Filter[]>(getLocalKey(page, 'filters'), [])
   const [showHierarchy, updateShowHierarchy] = useLocalStorage<boolean>(
-    `overview-show-hierarchy-${projectName}`,
+    getLocalKey(page, 'showHierarchy'),
     true,
   )
 


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
Fixes an issue where the local storage state would not update it's stored value when changing it's key. This resulted in seeing the same filters for all projects, even when they had different filters set.

