### PR TITLE
Fix: Copy settings from dev bundle

### DIFF
--- a/src/pages/SettingsPage/Bundles/CopyBundleSettingsDialog/CopyBundleSettingsDialog.tsx
+++ b/src/pages/SettingsPage/Bundles/CopyBundleSettingsDialog/CopyBundleSettingsDialog.tsx
@@ -142,8 +142,8 @@ const CopyBundleSettingsDialog = ({
         migrateBundleSettingsRequest: {
           sourceBundle: sourceBundle,
           targetBundle: bundle.name,
-          sourceVariant: sourceVariant,
-          targetVariant: envTarget,
+          sourceVariant: ['production', 'staging'].includes(sourceVariant) ? sourceVariant : sourceBundle,
+          targetVariant: ['production', 'staging'].includes(envTarget) ? envTarget : bundle.name,
         },
       }).unwrap()
       toast.success(`Settings copied from ${sourceBundle} successfully`)


### PR DESCRIPTION
This pull request modifies the `CopyBundleSettingsDialog` component to improve the handling of `sourceVariant` and `targetVariant` values in the `migrateBundleSettingsRequest` object.

When specifying dev bundle, variant must equal to the bundle name.
There's an additional (optional) backend PR that performs a sanity check and returns an error when there's a mismatch.

https://github.com/ynput/ayon-backend/pull/588