### PR TITLE
Allow null status scope

### DIFF
--- a/shared/src/hooks/useScopedStatuses.ts
+++ b/shared/src/hooks/useScopedStatuses.ts
@@ -16,7 +16,7 @@ export const useScopedStatuses = (projects: string[], entityTypes: string[]) => 
   let currentStatuses: EntityStatus[] | undefined
   for (const item of Object.values(response.data) as ProjectModel[]) {
     const filteredStatuses = item.statuses!.filter((status: EntityStatus) =>
-      entityTypes.every((type) => status.scope!.includes(type)),
+      entityTypes.every((type) => (!status.scope || status.scope!.includes(type))),
     )
     if (currentStatuses === undefined) {
       currentStatuses = filteredStatuses

--- a/shared/src/hooks/useScopedStatuses.ts
+++ b/shared/src/hooks/useScopedStatuses.ts
@@ -16,7 +16,7 @@ export const useScopedStatuses = (projects: string[], entityTypes: string[]) => 
   let currentStatuses: EntityStatus[] | undefined
   for (const item of Object.values(response.data) as ProjectModel[]) {
     const filteredStatuses = item.statuses!.filter((status: EntityStatus) =>
-      entityTypes.every((type) => (!status.scope || status.scope!.includes(type))),
+      entityTypes.every((type) => (!status.scope || status.scope?.includes(type))),
     )
     if (currentStatuses === undefined) {
       currentStatuses = filteredStatuses


### PR DESCRIPTION
If status scope is null (which may happen when importing an old project, it should be considered as "all entity types" instead of crashing the page. Empty list should be considered as a status that is not shown at all.