### PR TITLE
Rename anatomy presets

### DIFF
--- a/shared/src/api/generated/anatomy.ts
+++ b/shared/src/api/generated/anatomy.ts
@@ -29,6 +29,19 @@ const injectedRtkApi = api.injectEndpoints({
         method: 'POST',
       }),
     }),
+    unsetPrimaryPreset: build.mutation<UnsetPrimaryPresetApiResponse, UnsetPrimaryPresetApiArg>({
+      query: (queryArg) => ({
+        url: `/api/anatomy/presets/${queryArg.presetName}/primary`,
+        method: 'DELETE',
+      }),
+    }),
+    renameAnatomyPreset: build.mutation<RenameAnatomyPresetApiResponse, RenameAnatomyPresetApiArg>({
+      query: (queryArg) => ({
+        url: `/api/anatomy/presets/${queryArg.presetName}/rename`,
+        method: 'POST',
+        body: queryArg.renamePresetModel,
+      }),
+    }),
   }),
   overrideExisting: false,
 })
@@ -54,6 +67,15 @@ export type DeleteAnatomyPresetApiArg = {
 export type SetPrimaryPresetApiResponse = unknown
 export type SetPrimaryPresetApiArg = {
   presetName: string
+}
+export type UnsetPrimaryPresetApiResponse = unknown
+export type UnsetPrimaryPresetApiArg = {
+  presetName: string
+}
+export type RenameAnatomyPresetApiResponse = unknown
+export type RenameAnatomyPresetApiArg = {
+  presetName: string
+  renamePresetModel: RenamePresetModel
 }
 export type AnatomyPresetListItem = {
   name: string
@@ -132,6 +154,21 @@ export type ProjectAttribModel = {
   endDate?: string
   /** Textual description of the entity */
   description?: string
+  ftrackId?: string
+  ftrackPath?: string
+  /** The Shotgrid ID of this entity. */
+  shotgridId?: string
+  /** The Shotgrid Type of this entity. */
+  shotgridType?: string
+  inheritableString?: string
+  /** Push changes done to this project to Shotgrid. Requires the transmitter service. */
+  shotgridPush?: boolean
+  tools?: string[]
+  applications?: string[]
+  sokoId?: string
+  booo?: boolean
+  sokoPath?: string
+  myAdvancedEnum?: 'first' | 'second'
 }
 export type FolderType = {
   name: string
@@ -193,4 +230,8 @@ export type ValidationError = {
 }
 export type HttpValidationError = {
   detail?: ValidationError[]
+}
+export type RenamePresetModel = {
+  /** The new name of the anatomy preset. */
+  name: string
 }

--- a/src/pages/SettingsPage/AnatomyPresets/AnatomyPresets.jsx
+++ b/src/pages/SettingsPage/AnatomyPresets/AnatomyPresets.jsx
@@ -109,6 +109,13 @@ const AnatomyPresets = () => {
     })
   }
 
+  // RENAME PRESET
+  
+  const handleRenamePreset = (name) => {
+    // open dialog to rename preset
+  }
+
+
   // SET PRIMARY PRESET
   const setPrimaryPreset = (name = '_') => {
     // if name is not provided, set primary preset to "_"
@@ -188,6 +195,7 @@ const AnatomyPresets = () => {
           setSelectedPreset={setSelectedPreset}
           onSetPrimary={setPrimaryPreset}
           onDelete={handleDeletePreset}
+          onRename={handleRenamePreset}
           isLoading={isLoading}
           presetList={presetList}
         />

--- a/src/pages/SettingsPage/AnatomyPresets/PresetList.jsx
+++ b/src/pages/SettingsPage/AnatomyPresets/PresetList.jsx
@@ -28,6 +28,7 @@ const PresetList = ({
   setSelectedPreset,
   onSetPrimary,
   onDelete,
+  onRename,
   presetList,
   isLoading,
 }) => {
@@ -35,20 +36,26 @@ const PresetList = ({
     (data = {}) => {
       // empty string is default preset
       const isDefault = !('primary' in data)
-      const primarySelected = data.primary === 'PRIMARY'
+      console.log(data)
 
       const items = [
         {
           label: 'Set as primary',
           icon: 'flag',
           command: () => onSetPrimary(isDefault ? '_' : data.name),
-          disabled: primarySelected || isDefault,
+          disabled: data.primary || isDefault,
+        },
+        {
+          label: 'Rename',
+          icon: 'edit',
+          disabled: isDefault,
+          command: () => onRename(data.name),
         },
         {
           label: 'Delete',
           icon: 'delete',
           disabled: isDefault,
-          command: () => onDelete(data.name, primarySelected),
+          command: () => onDelete(data.name, data.primary),
           danger: true,
         },
       ]

--- a/src/pages/SettingsPage/AnatomyPresets/PresetList.jsx
+++ b/src/pages/SettingsPage/AnatomyPresets/PresetList.jsx
@@ -36,6 +36,7 @@ const PresetList = ({
     (data = {}) => {
       // empty string is default preset
       const isDefault = !('primary' in data)
+      const isBuiltIn = data.name === '_'
       console.log(data)
 
       const items = [
@@ -43,18 +44,18 @@ const PresetList = ({
           label: 'Set as primary',
           icon: 'flag',
           command: () => onSetPrimary(isDefault ? '_' : data.name),
-          disabled: data.primary || isDefault,
+          disabled: data.primary || isDefault || isBuiltIn,
         },
         {
           label: 'Rename',
           icon: 'edit',
-          disabled: isDefault,
+          disabled: isDefault || isBuiltIn,
           command: () => onRename(data.name),
         },
         {
           label: 'Delete',
           icon: 'delete',
-          disabled: isDefault,
+          disabled: isDefault || isBuiltIn,
           command: () => onDelete(data.name, data.primary),
           danger: true,
         },

--- a/src/pages/SettingsPage/AnatomyPresets/PresetNameDialog.jsx
+++ b/src/pages/SettingsPage/AnatomyPresets/PresetNameDialog.jsx
@@ -1,0 +1,54 @@
+import React, { useRef, useEffect } from 'react'
+import { Dialog, SaveButton, InputText } from '@ynput/ayon-react-components'
+
+const PresetNameDialog = ({
+  isOpen,
+  onClose,
+  onSubmit,
+  title,
+  placeholder,
+  initialValue = '',
+  submitLabel = 'Save',
+}) => {
+  const [value, setValue] = React.useState(initialValue)
+  const inputRef = useRef(null)
+
+  useEffect(() => {
+    if (isOpen && inputRef.current) {
+      setTimeout(() => inputRef.current.focus(), 100)
+    }
+  }, [isOpen])
+
+  const handleSave = () => {
+    if (value.trim()) {
+      onSubmit(value.trim())
+    }
+  }
+
+  return (
+    <Dialog
+      header={title}
+      isOpen={isOpen}
+      onClose={onClose}
+      size="sm"
+      footer={
+        <SaveButton
+          label={submitLabel}
+          onClick={handleSave}
+          active={!!value.trim()}
+          style={{ marginLeft: 'auto' }}
+        />
+      }
+    >
+      <InputText
+        value={value}
+        ref={inputRef}
+        onChange={(e) => setValue(e.target.value)}
+        placeholder={placeholder}
+        style={{ width: '100%' }}
+      />
+    </Dialog>
+  )
+}
+
+export default PresetNameDialog

--- a/src/services/anatomy/updateAnatomy.js
+++ b/src/services/anatomy/updateAnatomy.js
@@ -23,6 +23,17 @@ const getAnatomy = api.injectEndpoints({
         { type: 'anatomyPresets', id: 'LIST' },
       ],
     }),
+    renamePreset: build.mutation({
+      query: ({ name, newName }) => ({
+        url: `/api/anatomy/presets/${name}/rename`,
+        method: 'POST',
+        body: { name: newName },
+      }),
+      invalidatesTags: (result, error, { name }) => [
+        { type: 'anatomyPresets', id: name },
+        { type: 'anatomyPresets', id: 'LIST' },
+      ],
+    }),
     updatePrimaryPreset: build.mutation({
       query: ({ name }) => ({
         url: `/api/anatomy/presets/${name}/primary`,
@@ -50,6 +61,7 @@ const getAnatomy = api.injectEndpoints({
 export const {
   useUpdatePresetMutation,
   useDeletePresetMutation,
+  useRenamePresetMutation,
   useUpdatePrimaryPresetMutation,
   useUnsetPrimaryPresetMutation,
 } = getAnatomy


### PR DESCRIPTION
This pull request introduces a new feature to rename anatomy presets and refactors the preset creation dialog to improve usability and maintainability. The changes include the addition of a reusable `PresetNameDialog` component, new API support for renaming presets, and updates to the UI to integrate these enhancements.