### PR TITLE
Truncate last path segment in DetailsPanel to avoid panel width being affected

### DIFF
--- a/shared/src/components/EntityPath/EntityPath.styled.ts
+++ b/shared/src/components/EntityPath/EntityPath.styled.ts
@@ -43,6 +43,18 @@ export const Segment = styled.span`
   }
 `
 
+export const FinalSegmentLabel = styled.span`
+  /*
+    ensures the segment doesn't grow too long,
+    which could affect the panel's width
+  */
+  max-width: 10ch;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  display: inline-block;
+  white-space: nowrap;
+`
+
 const NotClickableHover = css`
   background-color: var(--md-sys-color-surface-container);
   &,

--- a/shared/src/components/EntityPath/EntityPath.styled.ts
+++ b/shared/src/components/EntityPath/EntityPath.styled.ts
@@ -25,7 +25,9 @@ export const Segment = styled.span`
   position: relative;
   padding: 0px 2px;
   border-radius: var(--border-radius-m);
-  transition: color 0.2s, background-color 0.2s;
+  transition:
+    color 0.2s,
+    background-color 0.2s;
   min-width: max-content;
 
   display: flex;
@@ -44,11 +46,6 @@ export const Segment = styled.span`
 `
 
 export const FinalSegmentLabel = styled.span`
-  /*
-    ensures the segment doesn't grow too long,
-    which could affect the panel's width
-  */
-  max-width: 10ch;
   text-overflow: ellipsis;
   overflow: hidden;
   display: inline-block;

--- a/shared/src/components/EntityPath/EntityPath.tsx
+++ b/shared/src/components/EntityPath/EntityPath.tsx
@@ -191,7 +191,9 @@ export const EntityPath: FC<EntityPathProps> = ({
               isOpen={dropdownOpen === 'versions'}
             >
               <Styled.Segment>
-                <span className="label">{versionSegment.label}</span>
+                <Styled.FinalSegmentLabel className="label">
+                  {versionSegment.label}
+                </Styled.FinalSegmentLabel>
                 <Icon icon="expand_more" />
               </Styled.Segment>
             </SegmentProvider>


### PR DESCRIPTION
## Description of changes 

Sometimes even after some of the path segments are collapsed, the resulting path is still too wide to fit inside the panel width. This PR adds an extra layout effect which truncates the last segment's text to compensate for this.

## Technical details

It's possible sometimes the reduction will over-correct, because I wanted to avoid calculating the exact remaining path width again - I'm just using the current width at the time when the layout effect runs.

## Additional context

![image](https://github.com/user-attachments/assets/42974a3c-141d-4542-99d7-1a74cced2df5)
