### PR TITLE
Webactions: Use groupLabel if available

### DIFF
--- a/shared/src/containers/Actions/Actions.tsx
+++ b/shared/src/containers/Actions/Actions.tsx
@@ -118,7 +118,7 @@ export const Actions = ({
 
       const groupOptions = groupedActions[category].map((action) => ({
         value: action.identifier,
-        label: action.label,
+        label: action.groupLabel ? action.groupLabel + ' ' + action.label : action.label,
         icon: action.icon,
         hasConfig: !!action.configFields,
       }))
@@ -282,7 +282,7 @@ export const Actions = ({
             // @ts-expect-error
             isPlaceholder: action.isPlaceholder,
           })}
-          data-tooltip={action.label}
+          data-tooltip={action.groupLabel ? action.groupLabel + ' ' + action.label: action.label}
           // @ts-expect-error
           disabled={action.isPlaceholder}
           onClick={(e) => handleExecuteAction(action.identifier, e)}


### PR DESCRIPTION
## Description of changes 
Use group label of webactions in actions combobox and tooltip.

## Technical details
Group label was added to action manifest but UI did not respect which makes the attribute unusable.

## Screenshot before
![image](https://github.com/user-attachments/assets/831315cf-a1e9-4d09-b2c3-5b8465385e61)

## Screenshot now
![image](https://github.com/user-attachments/assets/d16c9d9a-83a2-4307-9b9c-699de48fd249)


Resolves https://github.com/ynput/ayon-frontend/issues/1152