### PR TITLE
Fix: overview cannot copy empty array and clear field option

### DIFF
--- a/shared/src/containers/ProjectTreeTable/context/ClipboardContext.tsx
+++ b/shared/src/containers/ProjectTreeTable/context/ClipboardContext.tsx
@@ -252,12 +252,13 @@ export const ClipboardProvider: React.FC<ClipboardProviderProps> = ({ children, 
         clipboardError(`Failed to read from clipboard: ${error.message}`)
         return
       }
+
+      // we can have empty text in the clipboard
       //if (!clipboardText.trim()) return
 
       // Parse the clipboard text
       const parsedData = parseClipboardText(clipboardText)
       if (!parsedData.length) return
-      console.log('Parsed clipboard data:', parsedData)
 
       // Determine if we have a single value in the clipboard (one row, one column)
       const isSingleCellValue = parsedData.length === 1 && parsedData[0].values.length === 1

--- a/shared/src/containers/ProjectTreeTable/context/ClipboardContext.tsx
+++ b/shared/src/containers/ProjectTreeTable/context/ClipboardContext.tsx
@@ -252,11 +252,12 @@ export const ClipboardProvider: React.FC<ClipboardProviderProps> = ({ children, 
         clipboardError(`Failed to read from clipboard: ${error.message}`)
         return
       }
-      if (!clipboardText.trim()) return
+      //if (!clipboardText.trim()) return
 
       // Parse the clipboard text
       const parsedData = parseClipboardText(clipboardText)
       if (!parsedData.length) return
+      console.log('Parsed clipboard data:', parsedData)
 
       // Determine if we have a single value in the clipboard (one row, one column)
       const isSingleCellValue = parsedData.length === 1 && parsedData[0].values.length === 1

--- a/shared/src/containers/ProjectTreeTable/context/clipboard/clipboardUtils.ts
+++ b/shared/src/containers/ProjectTreeTable/context/clipboard/clipboardUtils.ts
@@ -52,6 +52,9 @@ export const processFieldValue = (
 ): any => {
   if (fieldValueType === 'array') {
     try {
+      if (value === '') {
+        return []
+      }
       // Try to parse as JSON first (for copied arrays)
       try {
         const parsed = JSON.parse(value)

--- a/shared/src/containers/ProjectTreeTable/widgets/CellWidget.tsx
+++ b/shared/src/containers/ProjectTreeTable/widgets/CellWidget.tsx
@@ -179,8 +179,16 @@ const EditorCellComponent: FC<EditorCellProps> = ({
         return null
 
       default:
+        console.warn(`Unrecognized type "${type}" for cell ${cellId}.`)
+        // TODO: We should not allow editing unrecognized types
+        // At this point, only list_of_strings without proper options is unrecognized
+        // (tags if not tags are specified in anatomy) and in that case, validation
+        // on the server fails with a string value. Unless we have a widget that 
+        // accepts a string value AND options at the same time we shouldn't show
+        // any edit widget
+        return null
         // if the type is not recognized, fall back to the TextWidget
-        return <TextWidget value={value as string} {...sharedProps} />
+        //return <TextWidget value={value as string} {...sharedProps} />
     }
   }, [cellId, value, type, isCurrentCellEditing, options, isCollapsed])
 

--- a/shared/src/containers/ProjectTreeTable/widgets/CellWidget.tsx
+++ b/shared/src/containers/ProjectTreeTable/widgets/CellWidget.tsx
@@ -169,8 +169,9 @@ const EditorCellComponent: FC<EditorCellProps> = ({
       case textTypes.includes(type as TextWidgetType):
         return <TextWidget value={value as string} isInherited={isInherited} {...sharedProps} />
 
-      case type === 'datetime' && value !== null && value !== undefined:
-        return <DateWidget value={value as string} isInherited={isInherited} {...sharedProps} />
+      //case type === 'datetime' && value !== null && value !== undefined:
+      case type === 'datetime':
+        return <DateWidget value={value ? value as string : undefined} isInherited={isInherited} {...sharedProps} />
 
       case type === 'boolean':
         return <BooleanWidget value={value as boolean} {...sharedProps} />
@@ -179,13 +180,14 @@ const EditorCellComponent: FC<EditorCellProps> = ({
         return null
 
       default:
-        console.warn(`Unrecognized type "${type}" for cell ${cellId}.`)
         // TODO: We should not allow editing unrecognized types
         // At this point, only list_of_strings without proper options is unrecognized
         // (tags if not tags are specified in anatomy) and in that case, validation
         // on the server fails with a string value. Unless we have a widget that 
         // accepts a string value AND options at the same time we shouldn't show
         // any edit widget
+
+        //console.log(`Unrecognized type "${type}" for cell ${cellId}.`)
         return null
         // if the type is not recognized, fall back to the TextWidget
         //return <TextWidget value={value as string} {...sharedProps} />

--- a/shared/src/containers/ProjectTreeTable/widgets/DateWidget.tsx
+++ b/shared/src/containers/ProjectTreeTable/widgets/DateWidget.tsx
@@ -6,7 +6,7 @@ import { WidgetBaseProps } from './CellWidget'
 interface DateWidgetProps
   extends Omit<React.HTMLAttributes<HTMLSpanElement>, 'onChange'>,
     WidgetBaseProps {
-  value: string
+  value?: string
   isReadOnly?: boolean
   isInherited?: boolean
 }
@@ -14,11 +14,13 @@ interface DateWidgetProps
 export const DateWidget = forwardRef<HTMLSpanElement, DateWidgetProps>(
   ({ value, isEditing, isReadOnly, isInherited, onChange, onCancelEdit, ...props }, ref) => {
     let dateString = ''
-    try {
-      dateString = format(new Date(value), 'dd-MM-yyyy')
-    } catch (error) {
-      console.error('Invalid date value:', value)
-      dateString = 'Invalid Date'
+    if (value) {
+      try {
+          dateString = format(new Date(value), 'dd-MM-yyyy')
+      } catch (error) {
+        console.error('Invalid date value:', value)
+        dateString = 'Invalid Date'
+      }
     }
 
     if (isEditing) {


### PR DESCRIPTION
This pull request introduces several changes to improve the handling of clipboard data, date values, and unrecognized types in the `ProjectTreeTable` component. The key updates include allowing empty clipboard text, refining how empty or invalid values are processed, and adding safeguards for unrecognized data types.