### PR TITLE
Fix CommentInput autofocus side effect

### DIFF
--- a/shared/src/containers/Feed/components/CommentInput/CommentInput.tsx
+++ b/shared/src/containers/Feed/components/CommentInput/CommentInput.tsx
@@ -122,10 +122,15 @@ const CommentInput: FC<CommentInputProps> = ({
     if (isOpen) {
       editorRef.current?.getEditor()?.enable()
       // block autofocus if opened from an annotation
-      const blockAutoFocus = !!annotations.length && files.length === 0
-      !blockAutoFocus && editorRef.current?.focus()
+      if (annotations.length > 0 && files.length === 0) {
+        return
+      }
+
+      editorRef.current?.focus()
     }
-  }, [isOpen, editorRef, annotations, files])
+    // We don't set annotations or files as useEffect dependencies, because we don't want to focus
+    // the input if it's already open but annotations change (e.g. are removed).
+  }, [isOpen, editorRef])
 
   mentionTypes.sort((a, b) => b.length - a.length)
 


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

The side effect that autofocuses the CommentInput has a bug where if the annotations array changes (even if it goes from one empty array to another empty array), the side effect runs and the input gets focused.

This means it can happen that the input keeps getting focused because technically, `annotations` are empty and they keep changing.

In reality, annotations changing should not trigger the side effect at all, it should only be triggered when `isOpen` changes.

## Technical details
<!-- Please state any technical details such as limitations -->

I removed the 2 dependencies which were causing the side effect to run again and again when it shouldn't.

## Additional context
<!-- Add any other context or screenshots here. -->

