### PR TITLE
Fix fetching tooltip data for mentions

### DIFF
--- a/shared/src/containers/Feed/context/FeedContext.tsx
+++ b/shared/src/containers/Feed/context/FeedContext.tsx
@@ -120,9 +120,9 @@ export const FeedProvider = ({ children, ...props }: FeedContextProps) => {
   })
 
   const [refTooltip, setRefTooltip] = useState<RefTooltip | null>(null)
-  const skip = !props.projectName || !refTooltip?.id
+  const skip = !props.projectName || !refTooltip?.id || refTooltip.type === 'user'
   const { data: entityTooltipData, isFetching: isFetchingTooltip } = useGetEntityTooltipQuery(
-    { entityType: props.entityType, entityId: refTooltip?.id, projectName: props.projectName },
+    { entityType: refTooltip?.type, entityId: refTooltip?.id, projectName: props.projectName },
     { skip: skip },
   )
 


### PR DESCRIPTION
This PR fixes a bug in the mention tooltip data fetching, that used the feed context entity type instead of the type of the hovered mentioned entity. That caused malformed requests and log flooding in the case when for example mentioned user tooltip was displayed in the version entity feed and data for `version id=username` was requested.