### PR TITLE
Details Panel: Details panel thumbnail uses contain

### DIFF
--- a/shared/src/components/Thumbnail/StackedThumbnails.tsx
+++ b/shared/src/components/Thumbnail/StackedThumbnails.tsx
@@ -43,6 +43,10 @@ const StackedStyled = styled.div<StackedStyledProps>`
     & > * + * {
       margin-left: ${({ $length }) => `${Math.max(-20, -$length * 1.5 - 8)}px`};
     }
+
+    .thumbnail img {
+      object-fit: cover;
+    }
   }
 `
 

--- a/shared/src/components/Thumbnail/Thumbnail.styled.ts
+++ b/shared/src/components/Thumbnail/Thumbnail.styled.ts
@@ -4,7 +4,7 @@ export const Card = styled.div`
   position: relative;
   width: 100%;
   height: 52px;
-  aspect-ratio: 1.77;
+  aspect-ratio: 1.7;
   overflow: hidden;
   border-radius: var(--border-radius-l);
   margin: auto;
@@ -71,12 +71,7 @@ export const Card = styled.div`
     cursor: pointer;
 
     &:hover {
-      &.loaded:not(.error) {
-        background-color: var(--md-sys-color-on-surface);
-      }
-
       img {
-        opacity: 0.9;
         scale: 1.1;
       }
 
@@ -101,7 +96,7 @@ export const Card = styled.div`
 export const Image = styled.img`
   width: 100%;
   height: 100%;
-  object-fit: cover;
+  object-fit: contain;
   border-radius: var(--border-radius-m);
   overflow: hidden;
 


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
The details panel thumbnail now uses the contain object fitting so that the full image is always visible.

16/9 images will always fit perfectly while other ratios will have black bars.

![image](https://github.com/user-attachments/assets/d62cb9d7-2e67-4fff-8a44-d4371405b752)

https://feedback.ayon.app/p/11square-thumbnail-size-support
