### PR TITLE
Hide admin addon frontends to non admins (configurable)

### DIFF
--- a/src/pages/ProjectPage/ProjectPage.tsx
+++ b/src/pages/ProjectPage/ProjectPage.tsx
@@ -149,9 +149,6 @@ const ProjectPage = () => {
       })),
       ...addonsData
         .filter((addon) => {
-          console.log('addon', addon)
-          console.log('isAdmin', isAdmin)
-          console.log('isManager', isManager)
           if (addon.settings.admin && !isAdmin) return false
           if (addon.settings.manager && !isManager) return false
           return true

--- a/src/pages/ProjectPage/ProjectPage.tsx
+++ b/src/pages/ProjectPage/ProjectPage.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect, useMemo } from 'react'
 import { useParams, useNavigate, useLocation, useSearchParams } from 'react-router-dom'
-import { useSelector } from 'react-redux'
 import { useAppDispatch, useAppSelector } from '@state/store'
 import { Button, Dialog } from '@ynput/ayon-react-components'
 
@@ -52,8 +51,8 @@ const ProjectPage = () => {
    * project data to the store, and renders the requested page.
    */
 
-  const isManager = useSelector((state) => state.user.data.isManager)
-  const isAdmin = useSelector((state) => state.user.data.isAdmin)
+  const isManager = useAppSelector((state) => state.user.data.isManager)
+  const isAdmin = useAppSelector((state) => state.user.data.isAdmin)
   const navigate = useNavigate()
   const { projectName, module = '', addonName } = useParams()
   const dispatch = useAppDispatch()

--- a/src/pages/ProjectPage/ProjectPage.tsx
+++ b/src/pages/ProjectPage/ProjectPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useMemo } from 'react'
 import { useParams, useNavigate, useLocation, useSearchParams } from 'react-router-dom'
+import { useSelector } from 'react-redux'
 import { useAppDispatch, useAppSelector } from '@state/store'
 import { Button, Dialog } from '@ynput/ayon-react-components'
 
@@ -51,6 +52,8 @@ const ProjectPage = () => {
    * project data to the store, and renders the requested page.
    */
 
+  const isManager = useSelector((state) => state.user.data.isManager)
+  const isAdmin = useSelector((state) => state.user.data.isAdmin)
   const navigate = useNavigate()
   const { projectName, module = '', addonName } = useParams()
   const dispatch = useAppDispatch()
@@ -144,11 +147,20 @@ const ProjectPage = () => {
         module: remote.module,
         path: `/projects/${projectName}/${remote.module}`,
       })),
-      ...addonsData.map((addon) => ({
-        name: addon.title,
-        path: `/projects/${projectName}/addon/${addon.name}`,
-        module: addon.name,
-      })),
+      ...addonsData
+        .filter((addon) => {
+          console.log('addon', addon)
+          console.log('isAdmin', isAdmin)
+          console.log('isManager', isManager)
+          if (addon.settings.admin && !isAdmin) return false
+          if (addon.settings.manager && !isManager) return false
+          return true
+        })
+        .map((addon) => ({
+          name: addon.title,
+          path: `/projects/${projectName}/addon/${addon.name}`,
+          module: addon.name,
+        })),
       { node: 'spacer' },
       {
         node: (

--- a/src/pages/UserDashboardPage/UserDashboardPage.jsx
+++ b/src/pages/UserDashboardPage/UserDashboardPage.jsx
@@ -18,6 +18,9 @@ import DashboardAddon from '@pages/ProjectDashboard/DashboardAddon'
 
 const UserDashboardPage = () => {
   let { module, addonName } = useParams()
+  const user = useSelector((state) => state.user)
+  const isAdmin = user?.data?.isAdmin
+  const isManager = user?.data?.isManager
 
   const {
     data: addonsData = [],
@@ -42,6 +45,8 @@ const UserDashboardPage = () => {
   ]
 
   for (const addon of addonsData) {
+    if (addon?.settings?.admin && !isAdmin) continue
+    if (addon?.settings?.manager && !isManager) continue
     links.push({
       name: addon.title,
       path: `/dashboard/addon/${addon.name}`,
@@ -61,9 +66,9 @@ const UserDashboardPage = () => {
   //   redux states
   const dispatch = useDispatch()
   //   selected projects
-  const user = useSelector((state) => state.user)
   const selectedProjects = useSelector((state) => state.dashboard.selectedProjects)
   const setSelectedProjects = (projects) => dispatch(onProjectSelected(projects))
+
 
   // get all the info required for the projects selected, like status icons and colours
   const { data: projectsInfo = {}, isFetching: isLoadingInfo } = useGetProjectsInfoQuery(


### PR DESCRIPTION
This pull request introduces role-based access control for add-ons in both the `ProjectPage` and `UserDashboardPage` components. It ensures that only users with the appropriate roles (`isAdmin` or `isManager`) can access certain add-ons. The changes also include some minor code refactoring to support this functionality.

`admin` and `manager` flags are supported since forever, but added to FrontendScopeSettings typeddict on the server in https://github.com/ynput/ayon-backend/pull/606