### PR TITLE
Annotations storage improvements

### DIFF
--- a/shared/src/containers/Feed/components/ActivityComment/ActivityComment.tsx
+++ b/shared/src/containers/Feed/components/ActivityComment/ActivityComment.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx'
-import { useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 import ReactMarkdown from 'react-markdown'
 import emoji from 'remark-emoji'
 import remarkGfm from 'remark-gfm'
@@ -23,6 +23,8 @@ import { useFeedContext } from '../../context/FeedContext'
 import { confirmDelete } from '../../../../util'
 import ActivityHeader, { ActivityHeaderProps } from '../ActivityHeader/ActivityHeader'
 import type { Status } from '../../../ProjectTreeTable/types/project'
+import { SavedAnnotationMetadata } from '../CommentInput/hooks/useAnnotationsUpload'
+import { useDetailsPanelContext } from '@shared/context'
 
 type Props = {
   activity: any
@@ -79,6 +81,7 @@ const ActivityComment = ({
   if (!authorFullName) authorFullName = author?.fullName || authorName
 
   const { editingId, setEditingId } = useFeedContext()
+  const { onGoToFrame } = useDetailsPanelContext()
 
   const handleEditComment = () => {
     setEditingId(activityId)
@@ -150,6 +153,15 @@ const ActivityComment = ({
       })
     }
   }
+
+  const onAnnotationClick = useCallback(
+    (file: any) => {
+      if (!file.annotation) return
+      // annotation frame numbers are 1-based
+      onGoToFrame?.((file.annotation as SavedAnnotationMetadata).range[0] - 1)
+    },
+    [onGoToFrame],
+  )
 
   return (
     <>
@@ -252,6 +264,7 @@ const ActivityComment = ({
                 projectName={projectName}
                 isDownloadable
                 onExpand={onFileExpand}
+                onAnnotationClick={onAnnotationClick}
                 onRemove={undefined}
               />
             </>

--- a/shared/src/containers/Feed/components/ActivityComment/ActivityComment.tsx
+++ b/shared/src/containers/Feed/components/ActivityComment/ActivityComment.tsx
@@ -23,7 +23,7 @@ import { useFeedContext } from '../../context/FeedContext'
 import { confirmDelete } from '../../../../util'
 import ActivityHeader, { ActivityHeaderProps } from '../ActivityHeader/ActivityHeader'
 import type { Status } from '../../../ProjectTreeTable/types/project'
-import { SavedAnnotationMetadata } from '../CommentInput/hooks/useAnnotationsUpload'
+import { SavedAnnotationMetadata } from '../../index'
 import { useDetailsPanelContext } from '@shared/context'
 
 type Props = {

--- a/shared/src/containers/Feed/components/CommentInput/CommentInput.tsx
+++ b/shared/src/containers/Feed/components/CommentInput/CommentInput.tsx
@@ -31,8 +31,9 @@ import useMentionLink from './hooks/useMentionLink'
 import useAnnotationsSync from './hooks/useAnnotationsSync'
 
 // State management
-import useAnnotationsUpload, { SavedAnnotationMetadata } from './hooks/useAnnotationsUpload'
+import useAnnotationsUpload from './hooks/useAnnotationsUpload'
 import { useFeedContext } from '../../context/FeedContext'
+import { SavedAnnotationMetadata } from '../../index'
 
 var Delta = Quill.import('delta')
 

--- a/shared/src/containers/Feed/components/CommentInput/helpers.tsx
+++ b/shared/src/containers/Feed/components/CommentInput/helpers.tsx
@@ -33,8 +33,13 @@ const cancelToken = axios.CancelToken
 const cancelTokenSource = cancelToken.source()
 import { toast } from 'react-toastify'
 
+type UploadedFile = {
+  file: any
+  data: any
+}
+
 // used to upload files (quill ImageUploader module)
-export const uploadFile = (file, projectName, onUploadProgress) => {
+export const uploadFile = (file, projectName, onUploadProgress): Promise<UploadedFile> => {
   return new Promise((resolve, reject) => {
     const formData = new FormData()
     formData.append('image', file)

--- a/shared/src/containers/Feed/components/CommentInput/hooks/useAnnotationsSync.ts
+++ b/shared/src/containers/Feed/components/CommentInput/hooks/useAnnotationsSync.ts
@@ -8,7 +8,7 @@ type Props = {
 }
 
 export type AnnotationPreview = any & {
-  isAnnotation: true
+  isUnsavedAnnotation: true
 }
 
 // annotations are temporary store

--- a/shared/src/containers/Feed/components/CommentInput/hooks/useAnnotationsSync.ts
+++ b/shared/src/containers/Feed/components/CommentInput/hooks/useAnnotationsSync.ts
@@ -23,7 +23,7 @@ export const filterEntityAnnotations = (
         annotation.versionId === entityId &&
         !filesUploading.some((file) => file.name === annotation.name),
     )
-    .map((annotation) => ({ ...annotation, isAnnotation: true })) as AnnotationPreview[]
+    .map((annotation) => ({ ...annotation, isUnsavedAnnotation: true })) as AnnotationPreview[]
 }
 
 const useAnnotationsSync = ({ entityId, filesUploading }: Props) => {

--- a/shared/src/containers/Feed/components/CommentInput/hooks/useAnnotationsUpload.ts
+++ b/shared/src/containers/Feed/components/CommentInput/hooks/useAnnotationsUpload.ts
@@ -1,17 +1,11 @@
 import { uploadFile } from '../helpers'
 import { toast } from 'react-toastify'
 import { useFeedContext } from '../../../context/FeedContext'
+import { SavedAnnotationMetadata } from '../../../index'
 
 type Props = {
   projectName: string
   onSuccess: (data: any) => void
-}
-
-export type SavedAnnotationMetadata = {
-  id: string
-  composite: string
-  transparent: string
-  range: number[]
 }
 
 const useAnnotationsUpload = ({ projectName, onSuccess }: Props) => {

--- a/shared/src/containers/Feed/components/CommentInput/hooks/useAnnotationsUpload.ts
+++ b/shared/src/containers/Feed/components/CommentInput/hooks/useAnnotationsUpload.ts
@@ -7,49 +7,71 @@ type Props = {
   onSuccess: (data: any) => void
 }
 
+export type SavedAnnotationMetadata = {
+  id: string
+  composite: string
+  transparent: string
+  range: number[]
+}
+
 const useAnnotationsUpload = ({ projectName, onSuccess }: Props) => {
   const { removeAnnotation, exportAnnotationComposite } = useFeedContext()
 
   const uploadAnnotations = async (annotations: any[]) => {
     try {
       const uploadPromises = annotations.map(async (annotation) => {
-        const blob = await exportAnnotationComposite?.(annotation.id)
-        if (!blob) {
+        const composite = await exportAnnotationComposite?.(annotation.id)
+        if (!composite) {
           throw new Error(`Exporting composite image for annotation ${annotation.id} failed`)
         }
 
-        const file = new File([blob], annotation.name, {
+        const compositeFile = new File([composite], annotation.name, {
           type: 'image/png',
         })
 
-        return uploadFile(file, projectName, () => {})
+        const transparent = await fetch(annotation.annotationData).then(r => r.blob())
+        const transparentFile = new File([transparent], `annotation-${annotation.name}`, {
+          type: 'image/png',
+        })
+
+        const uploads = await Promise.all([
+          uploadFile(compositeFile, projectName, () => {}),
+          uploadFile(transparentFile, projectName, () => {}),
+        ])
+
+        return { annotation, uploads }
       })
 
       const res = await Promise.allSettled(uploadPromises)
 
       const successfulFiles: any[] = []
-      //   for each result, if successful use callback
-      res.forEach((result: any) => {
+      const metadata: SavedAnnotationMetadata[] = []
+
+      res.forEach((result) => {
         if (result.status === 'fulfilled') {
-          const newFile = onSuccess(result.value)
+          const { uploads, annotation } = result.value
 
-          successfulFiles.push(newFile)
+          uploads.forEach((upload: any) => {
+            successfulFiles.push(onSuccess(upload))
+          })
 
-          const annotationId = annotations.find(
-            (annotation) => annotation.name === result.value.file.name,
-          )?.id
-          if (annotationId) {
-            removeAnnotation?.(annotationId)
-          }
+          metadata.push({
+            range: annotation.range,
+            id: annotation.id,
+            composite: uploads[0].data.id,
+            transparent: uploads[1].data.id,
+          })
+
+          removeAnnotation?.(annotation.id)
         } else {
           toast.error('Upload failed: ' + result.reason.message)
         }
       })
 
-      return successfulFiles
+      return { files: successfulFiles, metadata }
     } catch (error: any) {
       toast.error('Upload failed: ' + error.message)
-      return []
+      return { files: [], metadata: [] }
     }
   }
 

--- a/shared/src/containers/Feed/components/FileUploadCard/FileUploadCard.styled.ts
+++ b/shared/src/containers/Feed/components/FileUploadCard/FileUploadCard.styled.ts
@@ -46,17 +46,6 @@ export const File = styled.div`
   .download-icon {
     color: var(--md-sys-color-outline);
   }
-
-  .expand-icon {
-    pointer-events: none;
-    position: absolute;
-    /* center */
-    left: 50%;
-    bottom: calc(50% - 20px);
-    transform: translate(-50%, -50%);
-
-    display: none;
-  }
 `
 
 export const Footer = styled.footer`
@@ -172,14 +161,14 @@ export const ContentWrapper = styled.div`
   }
 
   /* previewable styles (it can be expanded) */
-  /* on hover it shows the expand icon */
+  /* on hover it shows the expand buttons */
   &.isPreviewable,
-  &.isAnnotation {
+  &.isUnsavedAnnotation {
     cursor: pointer;
 
     &:hover {
-      .expand-icon {
-        display: block;
+      .expand-buttons {
+        display: flex;
       }
       .type-icon {
         display: none;
@@ -225,4 +214,13 @@ export const ImageWrapper = styled.div`
       }
     }
   }
+`
+
+export const Buttons = styled.div`
+  display: none;
+  gap: var(--padding-s);
+  position: absolute;
+  left: 50%;
+  top: calc(50% - 10px);
+  transform: translate(-50%, -50%);
 `

--- a/shared/src/containers/Feed/components/FileUploadCard/FileUploadCard.styled.ts
+++ b/shared/src/containers/Feed/components/FileUploadCard/FileUploadCard.styled.ts
@@ -1,3 +1,4 @@
+import { Button } from '@ynput/ayon-react-components'
 import styled from 'styled-components'
 
 export const File = styled.div`
@@ -175,6 +176,10 @@ export const ContentWrapper = styled.div`
       }
     }
   }
+
+  &:hover .image-wrapper::after {
+    opacity: 0.8;
+  }
 `
 
 export const ImageWrapper = styled.div`
@@ -204,10 +209,6 @@ export const ImageWrapper = styled.div`
 
   &.isDownloadable {
     &:hover {
-      &::after {
-        opacity: 0.8;
-      }
-
       .icon {
         display: block;
         z-index: 10;
@@ -218,9 +219,24 @@ export const ImageWrapper = styled.div`
 
 export const Buttons = styled.div`
   display: none;
-  gap: var(--padding-s);
   position: absolute;
-  left: 50%;
-  top: calc(50% - 10px);
-  transform: translate(-50%, -50%);
+  left: 0;
+  top: 0;
+  transform: none;
+  height: calc(100% - 20px);
+  width: 100%;
+  gap: 0;
+`
+
+export const ExpandButton = styled(Button)`
+  height: 100%;
+  width: 100%;
+  border: none;
+  opacity: 0.5;
+  transition: opacity 250ms;
+
+  &:hover {
+    background: none;
+    opacity: 1;
+  }
 `

--- a/shared/src/containers/Feed/components/FileUploadCard/FileUploadCard.tsx
+++ b/shared/src/containers/Feed/components/FileUploadCard/FileUploadCard.tsx
@@ -4,6 +4,7 @@ import clsx from 'clsx'
 import { useState } from 'react'
 import { isFilePreviewable } from '../FileUploadPreview'
 import { SavedAnnotationMetadata } from '@shared/containers'
+import { useDetailsPanelContext } from '@shared/context'
 
 export interface FileUploadCardProps extends React.HTMLAttributes<HTMLDivElement> {
   name: string
@@ -92,6 +93,7 @@ const FileUploadCard = ({
   const inProgress = progress && progress < 100
 
   const [imageError, setImageError] = useState(false)
+  const { feedAnnotationsEnabled } = useDetailsPanelContext()
 
   // split name and file extension
   const nameParts = name.split('.')
@@ -125,6 +127,7 @@ const FileUploadCard = ({
         {isImage && src && (
           <Styled.ImageWrapper
             className={clsx({
+              'image-wrapper': true,
               isDownloadable: isDownloadable || isPreviewable || isUnsavedAnnotation,
             })}
           >
@@ -139,15 +142,15 @@ const FileUploadCard = ({
         )}
         <Styled.Buttons className="expand-buttons">
           {isPreviewable && (
-            <Button
+            <Styled.ExpandButton
               data-tooltip="Open preview"
               icon="open_in_full"
               variant="nav"
               onClick={onExpand}
             />
           )}
-          {(isUnsavedAnnotation || savedAnnotation) && (
-            <Button
+          {(isUnsavedAnnotation || (feedAnnotationsEnabled && savedAnnotation)) && (
+            <Styled.ExpandButton
               data-tooltip="Jump to annotation"
               icon="play_circle"
               variant="nav"

--- a/shared/src/containers/Feed/components/FileUploadCard/FileUploadCard.tsx
+++ b/shared/src/containers/Feed/components/FileUploadCard/FileUploadCard.tsx
@@ -3,7 +3,7 @@ import * as Styled from './FileUploadCard.styled'
 import clsx from 'clsx'
 import { useState } from 'react'
 import { isFilePreviewable } from '../FileUploadPreview'
-import { SavedAnnotationMetadata } from '../CommentInput/hooks/useAnnotationsUpload'
+import { SavedAnnotationMetadata } from '@shared/containers'
 
 export interface FileUploadCardProps extends React.HTMLAttributes<HTMLDivElement> {
   name: string
@@ -138,9 +138,21 @@ const FileUploadCard = ({
           </Styled.ImageWrapper>
         )}
         <Styled.Buttons className="expand-buttons">
-          {isPreviewable && <Button icon="open_in_full" variant="nav" onClick={onExpand} />}
+          {isPreviewable && (
+            <Button
+              data-tooltip="Open preview"
+              icon="open_in_full"
+              variant="nav"
+              onClick={onExpand}
+            />
+          )}
           {(isUnsavedAnnotation || savedAnnotation) && (
-            <Button icon="play_circle" variant="nav" onClick={onJumpTo} />
+            <Button
+              data-tooltip="Jump to annotation"
+              icon="play_circle"
+              variant="nav"
+              onClick={onJumpTo}
+            />
           )}
         </Styled.Buttons>
       </Styled.ContentWrapper>

--- a/shared/src/containers/Feed/components/FileUploadCard/FileUploadCard.tsx
+++ b/shared/src/containers/Feed/components/FileUploadCard/FileUploadCard.tsx
@@ -3,18 +3,21 @@ import * as Styled from './FileUploadCard.styled'
 import clsx from 'clsx'
 import { useState } from 'react'
 import { isFilePreviewable } from '../FileUploadPreview'
+import { SavedAnnotationMetadata } from '../CommentInput/hooks/useAnnotationsUpload'
 
 export interface FileUploadCardProps extends React.HTMLAttributes<HTMLDivElement> {
   name: string
   mime?: string
   src?: string
-  isAnnotation?: boolean
+  isUnsavedAnnotation?: boolean
+  savedAnnotation: SavedAnnotationMetadata
   size: number
   progress: number
   onRemove?: () => void
   isCompact?: boolean
   isDownloadable?: boolean
   onExpand?: () => void
+  onJumpTo?: () => void
 }
 
 const fileIcons: { [key: string]: string[] } = {
@@ -74,13 +77,15 @@ const FileUploadCard = ({
   name,
   mime,
   src,
-  isAnnotation,
+  isUnsavedAnnotation,
+  savedAnnotation,
   size,
   progress,
   onRemove,
   isCompact,
   isDownloadable = false,
   onExpand,
+  onJumpTo,
   className,
   ...props
 }: FileUploadCardProps) => {
@@ -94,7 +99,7 @@ const FileUploadCard = ({
   const fileName = nameParts.join('.')
 
   const isPreviewable = isFilePreviewable(mime || '.' + extension)
-  const isImage = mime?.includes('image/') || isAnnotation
+  const isImage = mime?.includes('image/') || isUnsavedAnnotation
 
   const downloadComponent = (
     <>
@@ -103,29 +108,25 @@ const FileUploadCard = ({
     </>
   )
 
-  const handleImageClick = () => {
-    if ((!isPreviewable && !isAnnotation) || !onExpand || imageError) return
-    onExpand()
-  }
-
   return (
     <Styled.File
       className={clsx(className, {
         compact: isCompact,
         isDownloadable,
         isPreviewable,
-        isAnnotation,
+        isUnsavedAnnotation,
       })}
       {...props}
     >
       <Styled.ContentWrapper
-        className={clsx('content-wrapper', { isPreviewable, isAnnotation })}
-        onClick={handleImageClick}
+        className={clsx('content-wrapper', { isPreviewable, isUnsavedAnnotation })}
       >
         <Icon icon={getIconForType(mime || '.' + extension)} className="type-icon" />
         {isImage && src && (
           <Styled.ImageWrapper
-            className={clsx({ isDownloadable: isDownloadable || isPreviewable || isAnnotation })}
+            className={clsx({
+              isDownloadable: isDownloadable || isPreviewable || isUnsavedAnnotation,
+            })}
           >
             <img
               src={src}
@@ -136,8 +137,12 @@ const FileUploadCard = ({
             />
           </Styled.ImageWrapper>
         )}
-        {isPreviewable && <Icon icon="open_in_full" className="expand-icon" />}
-        {isAnnotation && <Icon icon="play_circle" className="expand-icon" />}
+        <Styled.Buttons className="expand-buttons">
+          {isPreviewable && <Button icon="open_in_full" variant="nav" onClick={onExpand} />}
+          {(isUnsavedAnnotation || savedAnnotation) && (
+            <Button icon="play_circle" variant="nav" onClick={onJumpTo} />
+          )}
+        </Styled.Buttons>
       </Styled.ContentWrapper>
       <Styled.Footer className={clsx({ inProgress, isPreviewable, isDownloadable })}>
         <span className="progress" style={{ right: `${100 - progress}%` }} />

--- a/shared/src/containers/Feed/components/FilesGrid/FilesGrid.tsx
+++ b/shared/src/containers/Feed/components/FilesGrid/FilesGrid.tsx
@@ -55,7 +55,9 @@ const FilesGrid: React.FC<FilesGridProps> = ({
           isUnsavedAnnotation={file.isUnsavedAnnotation}
           savedAnnotation={file.annotation}
           progress={file.progress}
-          onRemove={onRemove ? () => onRemove(file.id, file.name, file.isAnnotation) : undefined}
+          onRemove={
+            onRemove ? () => onRemove(file.id, file.name, file.isUnsavedAnnotation) : undefined
+          }
           isCompact={isCompact}
           isDownloadable={isDownloadable}
           onExpand={() => handleExpand(index)}

--- a/shared/src/containers/Feed/components/FilesGrid/FilesGrid.tsx
+++ b/shared/src/containers/Feed/components/FilesGrid/FilesGrid.tsx
@@ -2,12 +2,13 @@ import * as Styled from './FilesGrid.styled'
 import clsx from 'clsx'
 import FileUploadCard from '../FileUploadCard'
 import { isFilePreviewable } from '../FileUploadPreview'
+import { useCallback } from 'react'
 
 export interface FilesGridProps {
   files?: any[]
   activityId?: string
   isCompact?: boolean
-  onRemove?: (id: string, name: string, isAnnotation: boolean) => void
+  onRemove?: (id: string, name: string, isUnsavedAnnotation: boolean) => void
   projectName: string
   isDownloadable?: boolean
   onExpand?: (data: { files: any[]; index: number; activityId: string }) => void
@@ -28,15 +29,14 @@ const FilesGrid: React.FC<FilesGridProps> = ({
 }) => {
   if (!files.length) return null
 
-  const handleExpand = (file: any, index: number) => {
-    if (file.isAnnotation) {
-      onAnnotationClick?.(file)
-    } else {
+  const handleExpand = useCallback(
+    (index: number) => {
       const filteredFiles = files.filter((file) => isFilePreviewable(file.mime, file.ext))
       const updatedIndex = filteredFiles.findIndex((file) => file.id === files[index].id)
       onExpand?.({ files: filteredFiles, index: updatedIndex, activityId: activityId || '' })
-    }
-  }
+    },
+    [onExpand],
+  )
 
   return (
     <Styled.Grid className={clsx({ compact: isCompact })} {...props}>
@@ -47,13 +47,19 @@ const FilesGrid: React.FC<FilesGridProps> = ({
           name={file.name}
           mime={file.mime || file.type}
           size={file.size}
-          src={file.isAnnotation ? file.thumbnail : `/api/projects/${projectName}/files/${file.id}`}
-          isAnnotation={file.isAnnotation}
+          src={
+            file.isUnsavedAnnotation
+              ? file.thumbnail
+              : `/api/projects/${projectName}/files/${file.id}`
+          }
+          isUnsavedAnnotation={file.isUnsavedAnnotation}
+          savedAnnotation={file.annotation}
           progress={file.progress}
           onRemove={onRemove ? () => onRemove(file.id, file.name, file.isAnnotation) : undefined}
           isCompact={isCompact}
           isDownloadable={isDownloadable}
-          onExpand={() => handleExpand(file, index)}
+          onExpand={() => handleExpand(index)}
+          onJumpTo={() => onAnnotationClick?.(file)}
         />
       ))}
     </Styled.Grid>

--- a/shared/src/containers/Feed/helpers/mergeAnnotationAttachments.ts
+++ b/shared/src/containers/Feed/helpers/mergeAnnotationAttachments.ts
@@ -1,0 +1,25 @@
+import { SavedAnnotationMetadata } from '../../index'
+
+export default (activities: any[]) => {
+  return activities.map((activity) => {
+    if (activity.activityType !== 'comment' || !activity.activityData?.annotations) return activity
+
+    const files = activity.files
+      .map((file: any) => {
+        // look for an annotation that is using this file
+        const annotation = activity.activityData.annotations.find(
+          (annotation: SavedAnnotationMetadata) =>
+            annotation.composite === file.id || annotation.transparent === file.id,
+        )
+
+        // if the file is the transparent version of the annotation, ignore it
+        if (annotation.transparent === file.id) return null
+
+        return { ...file, annotation }
+      })
+      .filter(Boolean)
+
+    const newActivity = { ...activity, files }
+    return newActivity
+  })
+}

--- a/shared/src/containers/Feed/hooks/useCommentMutations.ts
+++ b/shared/src/containers/Feed/hooks/useCommentMutations.ts
@@ -116,7 +116,7 @@ const useCommentMutations = ({
 
   const getActivityId = (): string => uuid1().replace(/-/g, '')
 
-  const submitComment = async (value: string, files: File[] = []): Promise<void> => {
+  const submitComment = async (value: string, files: File[] = [], data: any = {}): Promise<void> => {
     // map over all the entities and create a new comment for each
     let patchId: string | null = null
     const promises = entities.map(({ id: entityId, subTitle }) => {
@@ -129,6 +129,7 @@ const useCommentMutations = ({
         activityType: 'comment',
         id: newId,
         files: fileIds,
+        data,
       }
 
       // create a new patch for optimistic update

--- a/shared/src/containers/Feed/hooks/useTransformActivities.ts
+++ b/shared/src/containers/Feed/hooks/useTransformActivities.ts
@@ -49,41 +49,13 @@ const useTransformActivities = (
     [activities],
   )
 
-  // 1,33. Annotations are stored as 2 separate uploaded files - composite with the video frame as background,
-  // and transparent, which can be drawn on top of any video. They can be merged by checking the `annotations`
-  // array in the activity data object.
-  const activitiesWithAnnotationsResolved = useMemo(() => {
-    return activitiesWithIcons
-      .map((activity) => {
-        if (activity.activityType !== 'comment' || !activity.activityData?.annotations) return activity
-
-        const files = activity.files
-          .map((file: any) => {
-            // look for an annotation that is using this file
-            const annotation = activity.activityData.annotations.find(
-              (annotation: SavedAnnotationMetadata) =>
-                annotation.composite === file.id || annotation.transparent === file.id,
-            )
-
-            // if the file is the transparent version of the annotation, ignore it
-            if (annotation.transparent === file.id) return null
-
-            return { ...file, annotation }
-          })
-          .filter(Boolean)
-
-        const newActivity = { ...activity, files }
-        return newActivity
-      })
-  }, [activitiesWithIcons, userName])
-
-  // 1,66. add any extra meta data to the activities
+  // 1,5. add any extra meta data to the activities
   const activitiesWithMeta = useMemo(() => {
-    return activitiesWithAnnotationsResolved.map((activity) => {
+    return activitiesWithIcons.map((activity) => {
       const newActivity = { ...activity, isOwner: userName === activity.authorName }
       return newActivity
     })
-  }, [activitiesWithAnnotationsResolved, userName])
+  }, [activitiesWithIcons, userName])
 
   // 2. versions should not have relations shown (comments posted on parent task)
   const activitiesWithoutRelations = useMemo(

--- a/shared/src/containers/Feed/hooks/useTransformActivities.ts
+++ b/shared/src/containers/Feed/hooks/useTransformActivities.ts
@@ -49,13 +49,41 @@ const useTransformActivities = (
     [activities],
   )
 
-  // add any extra meta data to the activities
+  // 1,33. Annotations are stored as 2 separate uploaded files - composite with the video frame as background,
+  // and transparent, which can be drawn on top of any video. They can be merged by checking the `annotations`
+  // array in the activity data object.
+  const activitiesWithAnnotationsResolved = useMemo(() => {
+    return activitiesWithIcons
+      .map((activity) => {
+        if (activity.activityType !== 'comment' || !activity.activityData?.annotations) return activity
+
+        const files = activity.files
+          .map((file: any) => {
+            // look for an annotation that is using this file
+            const annotation = activity.activityData.annotations.find(
+              (annotation: SavedAnnotationMetadata) =>
+                annotation.composite === file.id || annotation.transparent === file.id,
+            )
+
+            // if the file is the transparent version of the annotation, ignore it
+            if (annotation.transparent === file.id) return null
+
+            return { ...file, annotation }
+          })
+          .filter(Boolean)
+
+        const newActivity = { ...activity, files }
+        return newActivity
+      })
+  }, [activitiesWithIcons, userName])
+
+  // 1,66. add any extra meta data to the activities
   const activitiesWithMeta = useMemo(() => {
-    return activitiesWithIcons.map((activity) => {
+    return activitiesWithAnnotationsResolved.map((activity) => {
       const newActivity = { ...activity, isOwner: userName === activity.authorName }
       return newActivity
     })
-  }, [activitiesWithIcons, userName])
+  }, [activitiesWithAnnotationsResolved, userName])
 
   // 2. versions should not have relations shown (comments posted on parent task)
   const activitiesWithoutRelations = useMemo(

--- a/shared/src/containers/Feed/index.ts
+++ b/shared/src/containers/Feed/index.ts
@@ -8,3 +8,10 @@ export * from './context/FeedContext'
 export { ActivityReferenceTooltip, FileUploadPreview }
 
 export * from './hooks/useTableKeyboardNavigation'
+
+export type SavedAnnotationMetadata = {
+  id: string
+  composite: string
+  transparent: string
+  range: number[]
+}

--- a/shared/src/context/DetailsPanelContext.tsx
+++ b/shared/src/context/DetailsPanelContext.tsx
@@ -4,7 +4,7 @@ import { DetailsPanelEntityType } from '@shared/api'
 import type { UserModel } from '@shared/api'
 import { useLocation, useNavigate, useParams } from 'react-router-dom'
 import { useSearchParams } from 'react-router-dom'
-import { SavedAnnotationMetadata } from '@shared/containers/Feed/components/CommentInput/hooks/useAnnotationsUpload'
+import { SavedAnnotationMetadata } from '@shared/containers'
 
 export type FeedFilters = 'activity' | 'comments' | 'versions' | 'checklists'
 
@@ -51,6 +51,7 @@ export interface DetailsPanelContextProps {
   useNavigate: typeof useNavigate
   useLocation: typeof useLocation
   useSearchParams: typeof useSearchParams
+  feedAnnotationsEnabled?: boolean
 }
 
 // Interface for our simplified context

--- a/shared/src/context/DetailsPanelContext.tsx
+++ b/shared/src/context/DetailsPanelContext.tsx
@@ -4,6 +4,7 @@ import { DetailsPanelEntityType } from '@shared/api'
 import type { UserModel } from '@shared/api'
 import { useLocation, useNavigate, useParams } from 'react-router-dom'
 import { useSearchParams } from 'react-router-dom'
+import { SavedAnnotationMetadata } from '@shared/containers/Feed/components/CommentInput/hooks/useAnnotationsUpload'
 
 export type FeedFilters = 'activity' | 'comments' | 'versions' | 'checklists'
 
@@ -78,6 +79,10 @@ export interface DetailsPanelContextType extends DetailsPanelContextProps {
   pip: DetailsPanelPip | null
   openPip: (pip: DetailsPanelPip) => void
   closePip: () => void
+
+  // Annotations
+  feedAnnotations: SavedAnnotationMetadata[]
+  setFeedAnnotations: (annotations: SavedAnnotationMetadata[]) => void
 }
 
 // Create the context
@@ -96,6 +101,7 @@ export const DetailsPanelProvider: React.FC<DetailsPanelProviderProps> = ({
 }) => {
   // keep track of the currently open panel by scope
   const [panelOpenByScope, setPanelOpenByScope] = useState<OpenStateByScope>({})
+  const [feedAnnotations, setFeedAnnotations] = useState<SavedAnnotationMetadata[]>([])
 
   //  get the current open state for a specific scope
   const getOpenForScope = useCallback(
@@ -202,6 +208,8 @@ export const DetailsPanelProvider: React.FC<DetailsPanelProviderProps> = ({
     pip,
     openPip,
     closePip,
+    feedAnnotations,
+    setFeedAnnotations,
     ...forwardedProps,
   }
 

--- a/src/pages/ProjectListsPage/context/ListsModulesContext.tsx
+++ b/src/pages/ProjectListsPage/context/ListsModulesContext.tsx
@@ -19,7 +19,7 @@ export const ListsModuleProvider: React.FC<ListsModuleProviderProps> = ({ childr
     remote: 'slicer',
     module: 'ListsAttributesSettings',
     fallback: ListsAttributeSettingsFallback,
-    minVersion: '1.0.5-dev',
+    minVersion: '1.0.5',
   })
 
   const value = {


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

The DetailsPanel component now handles annotations in a smarter way. Annotations are saved as 2 separate files - composite and transparent, alongside a bit of metadata that lets us reconstruct the annotation as necessary.

When Activities are loaded, the files which belong to the same annotation are "merged" and presented as a single attachment. This attachment then has the ability to jump to the video frame where the annotation range starts. Also, the DetailsPanelContext now exposes a `feedAnnotations` array which lets the consumer app display all the annotations currently in the feed.

## Technical details
<!-- Please state any technical details such as limitations -->


## Additional context
<!-- Add any other context or screenshots here. -->

