### PR TITLE
Feed: clear feed annotations array if no activities found in feed

### DIFF
--- a/shared/src/containers/Feed/Feed.tsx
+++ b/shared/src/containers/Feed/Feed.tsx
@@ -63,7 +63,10 @@ export const Feed = ({ isMultiProjects, readOnly, statuses = [] }: FeedProps) =>
   )
 
   useEffect(() => {
-    if (!activitiesWithMergedAnnotations.length) return
+    if (!activitiesWithMergedAnnotations.length) {
+      setFeedAnnotations([])
+    }
+
     const annotations = activitiesWithMergedAnnotations
       .map((activity) => activity.activityData?.annotations)
       .filter(Boolean)


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

With the Feed component now exposing a list of all annotations shown in the comments, there's an edge case where if the feed is actually empty, the annotations list stays set from the previous state of the feed.

This PR makes it so the annotations list is cleared if no activities are found in the feed.

## Technical details
<!-- Please state any technical details such as limitations -->


## Additional context
<!-- Add any other context or screenshots here. -->

