### PR TITLE
Add activity IDs to feed annotations and highlight activities on annotation click

### DIFF
--- a/shared/src/containers/Feed/Feed.tsx
+++ b/shared/src/containers/Feed/Feed.tsx
@@ -18,6 +18,7 @@ import { Status } from '../ProjectTreeTable/types/project'
 import { useDetailsPanelContext } from '@shared/context'
 import { DetailsPanelEntityType } from '@shared/api'
 import mergeAnnotationAttachments from './helpers/mergeAnnotationAttachments'
+import { SavedAnnotationMetadata } from '.'
 
 // number of activities to get
 export const activitiesLast = 30
@@ -68,7 +69,12 @@ export const Feed = ({ isMultiProjects, readOnly, statuses = [] }: FeedProps) =>
     }
 
     const annotations = activitiesWithMergedAnnotations
-      .map((activity) => activity.activityData?.annotations)
+      .map((activity) =>
+        activity.activityData?.annotations?.map((a: SavedAnnotationMetadata) => ({
+          ...a,
+          activityId: activity.activityId,
+        })),
+      )
       .filter(Boolean)
       .flat()
 

--- a/shared/src/containers/Feed/components/ActivityComment/ActivityComment.tsx
+++ b/shared/src/containers/Feed/components/ActivityComment/ActivityComment.tsx
@@ -81,7 +81,7 @@ const ActivityComment = ({
   if (!authorFullName) authorFullName = author?.fullName || authorName
 
   const { editingId, setEditingId } = useFeedContext()
-  const { onGoToFrame } = useDetailsPanelContext()
+  const { onGoToFrame, setHighlightedActivities } = useDetailsPanelContext()
 
   const handleEditComment = () => {
     setEditingId(activityId)
@@ -159,6 +159,7 @@ const ActivityComment = ({
       if (!file.annotation) return
       // annotation frame numbers are 1-based
       onGoToFrame?.((file.annotation as SavedAnnotationMetadata).range[0] - 1)
+      setHighlightedActivities([activityId])
     },
     [onGoToFrame],
   )

--- a/shared/src/containers/Feed/index.ts
+++ b/shared/src/containers/Feed/index.ts
@@ -14,4 +14,5 @@ export type SavedAnnotationMetadata = {
   composite: string
   transparent: string
   range: number[]
+  activityId?: string
 }


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

In order for UIs using the DetailsPanel to see which annotations are associated with which activities (e.g. to highlight them from the outside), we need to add the `activityId` to each annotation.

We also highlight the activity if an annotation is jumped to from the FileUploadCard.

## Technical details
<!-- Please state any technical details such as limitations -->

I added the `activityId` as an optional field so it shouldn't clash with anything.

## Additional context
<!-- Add any other context or screenshots here. -->

