### PR TITLE
HOTFIX: handle the case where annotations metadata is mysteriously there but undefined

### DIFF
--- a/shared/src/containers/Feed/components/CommentInput/hooks/useAnnotationsUpload.ts
+++ b/shared/src/containers/Feed/components/CommentInput/hooks/useAnnotationsUpload.ts
@@ -5,7 +5,7 @@ import { SavedAnnotationMetadata } from '../../../index'
 
 type Props = {
   projectName: string
-  onSuccess: (data: any) => void
+  onSuccess: (data: any) => any
 }
 
 const useAnnotationsUpload = ({ projectName, onSuccess }: Props) => {
@@ -23,7 +23,7 @@ const useAnnotationsUpload = ({ projectName, onSuccess }: Props) => {
           type: 'image/png',
         })
 
-        const transparent = await fetch(annotation.annotationData).then(r => r.blob())
+        const transparent = await fetch(annotation.annotationData).then((r) => r.blob())
         const transparentFile = new File([transparent], `annotation-${annotation.name}`, {
           type: 'image/png',
         })

--- a/shared/src/containers/Feed/helpers/mergeAnnotationAttachments.ts
+++ b/shared/src/containers/Feed/helpers/mergeAnnotationAttachments.ts
@@ -9,8 +9,10 @@ export default (activities: any[]) => {
         // look for an annotation that is using this file
         const annotation = activity.activityData.annotations.find(
           (annotation: SavedAnnotationMetadata) =>
-            annotation.composite === file.id || annotation.transparent === file.id,
+            annotation?.composite === file.id || annotation?.transparent === file.id,
         )
+
+        if (!annotation) return file
 
         // if the file is the transparent version of the annotation, ignore it
         if (annotation.transparent === file.id) return null


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Add some defensive checks for when annotation metadata array attached to an Activity is loaded, but an item in the array is undefined. This seems to happen for regular attachments.

## Technical details
<!-- Please state any technical details such as limitations -->


## Additional context
<!-- Add any other context or screenshots here. -->

I will try to find out why this is happening in the first place, but this should fix the error at least.

