### PR TITLE
Improve how annotations are displayed in the Feed

### DIFF
--- a/shared/src/containers/Feed/components/ActivityComment/ActivityComment.tsx
+++ b/shared/src/containers/Feed/components/ActivityComment/ActivityComment.tsx
@@ -158,7 +158,7 @@ const ActivityComment = ({
     (file: any) => {
       if (!file.annotation) return
       // annotation frame numbers are 1-based
-      onGoToFrame?.((file.annotation as SavedAnnotationMetadata).range[0] - 1)
+      onGoToFrame?.((file.annotation as SavedAnnotationMetadata).range[0])
       setHighlightedActivities([activityId])
     },
     [onGoToFrame],

--- a/shared/src/containers/Feed/components/CommentInput/hooks/useAnnotationsSync.ts
+++ b/shared/src/containers/Feed/components/CommentInput/hooks/useAnnotationsSync.ts
@@ -46,7 +46,6 @@ const useAnnotationsSync = ({ entityId, filesUploading }: Props) => {
 
   const handleGoToAnnotation = (annotation: AnnotationPreview) => {
     const firstFrame = annotation.range[0]
-    console.log(firstFrame)
     onGoToFrame?.(firstFrame)
   }
 

--- a/shared/src/containers/Feed/components/CommentInput/hooks/useAnnotationsSync.ts
+++ b/shared/src/containers/Feed/components/CommentInput/hooks/useAnnotationsSync.ts
@@ -8,7 +8,7 @@ type Props = {
 }
 
 export type AnnotationPreview = any & {
-  isUnsavedAnnotation: true
+  unsavedAnnotation: any
 }
 
 // annotations are temporary store
@@ -23,7 +23,10 @@ export const filterEntityAnnotations = (
         annotation.versionId === entityId &&
         !filesUploading.some((file) => file.name === annotation.name),
     )
-    .map((annotation) => ({ ...annotation, isUnsavedAnnotation: true })) as AnnotationPreview[]
+    .map((annotationFile) => ({
+      ...annotationFile,
+      unsavedAnnotation: annotationFile,
+    })) as AnnotationPreview[]
 }
 
 const useAnnotationsSync = ({ entityId, filesUploading }: Props) => {
@@ -43,6 +46,7 @@ const useAnnotationsSync = ({ entityId, filesUploading }: Props) => {
 
   const handleGoToAnnotation = (annotation: AnnotationPreview) => {
     const firstFrame = annotation.range[0]
+    console.log(firstFrame)
     onGoToFrame?.(firstFrame)
   }
 

--- a/shared/src/containers/Feed/components/FileUploadCard/FileUploadCard.styled.ts
+++ b/shared/src/containers/Feed/components/FileUploadCard/FileUploadCard.styled.ts
@@ -90,6 +90,12 @@ export const Footer = styled.footer`
     white-space: nowrap;
     z-index: 20;
     display: inherit;
+
+    .icon {
+      font-size: inherit;
+      margin-right: var(--padding-s);
+      vertical-align: text-top;
+    }
   }
 
   .extension {

--- a/shared/src/containers/Feed/components/FilesGrid/FilesGrid.tsx
+++ b/shared/src/containers/Feed/components/FilesGrid/FilesGrid.tsx
@@ -48,15 +48,15 @@ const FilesGrid: React.FC<FilesGridProps> = ({
           mime={file.mime || file.type}
           size={file.size}
           src={
-            file.isUnsavedAnnotation
+            file.unsavedAnnotation
               ? file.thumbnail
               : `/api/projects/${projectName}/files/${file.id}`
           }
-          isUnsavedAnnotation={file.isUnsavedAnnotation}
+          unsavedAnnotation={file.unsavedAnnotation}
           savedAnnotation={file.annotation}
           progress={file.progress}
           onRemove={
-            onRemove ? () => onRemove(file.id, file.name, file.isUnsavedAnnotation) : undefined
+            onRemove ? () => onRemove(file.id, file.name, !!file.unsavedAnnotation) : undefined
           }
           isCompact={isCompact}
           isDownloadable={isDownloadable}


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

- fixed a wrong offset when skipping to the annotation's frame
- if a comment attachment is an annotation, we now don't show the file name. Instead, we show a small annotation icon and the frame range

![image](https://github.com/user-attachments/assets/97e55400-1894-44df-9424-7992afebbd22)


## Technical details
<!-- Please state any technical details such as limitations -->

- for an unsaved annotation, instead of just passing a boolean `isUnsavedAnnotation` to `FileUploadCard`, we pass all the annotation data. This way, even unsaved annotations can show the range instead of file name.

## Additional context
<!-- Add any other context or screenshots here. -->

