### PR TITLE
URI: Navigation not correctly going to focused entity in browser page 

### DIFF
--- a/src/context/UriContext.jsx
+++ b/src/context/UriContext.jsx
@@ -40,21 +40,18 @@ function URIProvider({ children }) {
       }
     }
 
-    const focusedTypePriorityOrder = [
-      'folder',
-      'task',
-      'product',
-      'version',
-      'representation',
-      'workfile',
-    ]
-
-    const focusedType = focusedTypePriorityOrder.findLast((type) => {
-      return focused[type + 's'].length > 0
-    })
+    const focusedTypePriorityOrder = ['folder', 'task', 'product', 'version', 'workfile']
+    let focusedType = null
+    for (let i = focusedTypePriorityOrder.length - 1; i >= 0; i--) {
+      const type = focusedTypePriorityOrder[i]
+      const pluralType = type + 's'
+      if (focused[pluralType] && focused[pluralType].length > 0) {
+        focusedType = type
+        break
+      }
+    }
 
     focused.type = focusedType
-
     dispatch(onUriNavigate(focused))
 
     const path = window.location.pathname
@@ -77,7 +74,7 @@ function URIProvider({ children }) {
           }
           const entities = res.data[0].entities
           if (!entities.length) {
-            // toast.error('No entities found')
+            toast.error('No entities found')
             return
           }
           focusEntities(entities)


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
Fixes a type error where representations was removed in the focused array but it still accessed by a findLast function causing a silent error and the uri navigation to fail.

![image](https://github.com/user-attachments/assets/08a48d20-aa3b-4150-ae96-23ad4bde02ed)

Updates to remove faulty key and also use new logic that means it won't error if the key not longer exists.

