### PR TITLE
Added site settings link to the menu for normal users

### DIFF
--- a/src/components/Menu/Menus/AppMenu.jsx
+++ b/src/components/Menu/Menus/AppMenu.jsx
@@ -46,6 +46,16 @@ export const AppMenu = ({ user, ...props }) => {
     },
   ]
 
+  if (isUser)
+    items.push(
+      {
+        id: 'siteSettings',
+        link: '/settings/site',
+        label: 'Site Settings',
+        icon: 'computer',
+      },
+    )
+
   if (!isUser)
     items.unshift({
       id: 'settings',


### PR DESCRIPTION
Since normal users don't have access to the settings page, they cannot access site settings