### PR TITLE
overview: Fixed an issue where changes did not update on other pages

### DIFF
--- a/shared/src/api/queries/overview/updateOverview.ts
+++ b/shared/src/api/queries/overview/updateOverview.ts
@@ -569,6 +569,23 @@ const operationsApiEnhancedInjected = operationsEnhanced.injectEndpoints({
           }
         }
       },
+      invalidatesTags: (_r, _e, { operationsRequestModel, projectName }) => {
+        type Tags = { id: string; type: string }[]
+        const userDashboardTags: Tags = [{ type: 'kanban', id: 'project-' + projectName }],
+          taskProgressTags: Tags = []
+
+        operationsRequestModel.operations?.forEach((op) => {
+          const { entityId } = op
+          if (entityId) {
+            taskProgressTags.push({ type: 'progress', id: entityId })
+          } else {
+            // new entity created, so we should invalidate everything
+            taskProgressTags.push({ type: 'progress', id: 'LIST' })
+          }
+        })
+
+        return [...userDashboardTags, ...taskProgressTags]
+      },
     }),
   }),
 })

--- a/src/components/NewEntity/NewEntity.tsx
+++ b/src/components/NewEntity/NewEntity.tsx
@@ -106,7 +106,6 @@ const NewEntity: React.FC<NewEntityProps> = ({ disabled }) => {
     )
 
     const selectedEntities = selectedRowIds.map((id) => getEntityById(id))
-    console.log(selectedEntities)
 
     const selectedFolders = selectedEntities
       .filter((entity) => entity?.entityType === 'folder')

--- a/src/services/tasksProgress/getTasksProgress.ts
+++ b/src/services/tasksProgress/getTasksProgress.ts
@@ -49,7 +49,7 @@ const provideTagsTasksProgress = (result: GetTasksProgressResult | undefined) =>
   // progress tags
   const progressTags = [...folderTags, ...taskTags].map((tag) => ({ id: tag.id, type: 'progress' }))
 
-  return [...folderTags, ...taskTags, ...progressTags]
+  return [...folderTags, ...taskTags, ...progressTags, { type: 'progress', id: 'LIST' }]
 }
 
 import { DefinitionsFromApi, OverrideResultType, TagTypesFromApi } from '@reduxjs/toolkit/query'


### PR DESCRIPTION
We now properly invalidate the correct tags for task progress and user dashboard to ensure they are always up to date with the overview.