### PR TITLE
Preserve hidden visibility of download launcher button

### DIFF
--- a/src/services/auth/logout.ts
+++ b/src/services/auth/logout.ts
@@ -10,8 +10,14 @@ const authApiInjected = authenticationApi.enhanceEndpoints({
         dispatch(logout())
         // reset global state
         dispatch(authenticationApi.util.resetApiState())
-        // clear local storage
-        localStorage.clear()
+        // clear local storage except for specific keys
+        const keysToPreserve = ['installers-downloaded', 'releaseInstallPrompt'] // Add your specific keys here
+        const allKeys = Object.keys(localStorage)
+        allKeys.forEach((key) => {
+          if (!keysToPreserve.includes(key)) {
+            localStorage.removeItem(key)
+          }
+        })
         // clear dashboard state
         dispatch(onClearDashboard())
         // @ts-expect-error - no args are defined


### PR DESCRIPTION
You should be able to hide this versions launcher download button if you do not need it. Currently it will re-appear everytime you log out/log in. Now specific local storage keys are preserved when logging out, like this one.

<img width="275" alt="image" src="https://github.com/user-attachments/assets/0e5865a3-9b17-476a-a33c-c896b26803cb" />
