### PR TITLE
Overview: Inheritance with history fixes

### DIFF
--- a/shared/src/containers/ProjectTreeTable/hooks/useFolderRelationships.ts
+++ b/shared/src/containers/ProjectTreeTable/hooks/useFolderRelationships.ts
@@ -152,7 +152,6 @@ export default function useFolderRelationships({
       // Traverse up the folder hierarchy until we've found values for all attributes
       // or we've reached the root folder
       while (pendingAttribs.size > 0) {
-        if (!currentId) break
         const folder = getEntityById(currentId)
         if (!folder || !currentId) {
           // use the project attrib

--- a/shared/src/containers/ProjectTreeTable/hooks/useFolderRelationships.ts
+++ b/shared/src/containers/ProjectTreeTable/hooks/useFolderRelationships.ts
@@ -23,7 +23,7 @@ export type FindInheritedValueFromAncestors = (
   attribName: string,
 ) => any
 export type FindNonInheritedValues = (
-  folderId: string,
+  folderId: string | undefined,
   attribNames: string[],
 ) => Record<string, any>
 export type GetAncestorsOf = (id: string) => string[]
@@ -152,7 +152,7 @@ export default function useFolderRelationships({
       // Traverse up the folder hierarchy until we've found values for all attributes
       // or we've reached the root folder
       while (pendingAttribs.size > 0) {
-        const folder = getEntityById(currentId)
+        const folder = getEntityById(currentId || '')
         if (!folder || !currentId) {
           // use the project attrib
           for (const attribName of pendingAttribs) {

--- a/shared/src/containers/ProjectTreeTable/hooks/useHistory.ts
+++ b/shared/src/containers/ProjectTreeTable/hooks/useHistory.ts
@@ -56,7 +56,7 @@ const useHistory = (maxHistorySize = 50): UseHistoryReturn => {
       (acc, entity) => {
         if (typeof entity === 'function') {
           acc[2].push(entity)
-        } else if (entity.wasInherited && entity.folderId) {
+        } else if (entity.wasInherited) {
           acc[1].push({
             entityId: entity.id,
             entityType: entity.type,

--- a/shared/src/containers/ProjectTreeTable/hooks/useUpdateTableData.ts
+++ b/shared/src/containers/ProjectTreeTable/hooks/useUpdateTableData.ts
@@ -26,7 +26,7 @@ export type InheritFromParentEntity = {
   entityType: string
   attribs: string[]
   ownAttrib: string[]
-  folderId: string
+  folderId?: string // the parent folder ID
   meta?: Record<string, any>
 }
 export type InheritFromParent = (
@@ -89,7 +89,7 @@ const useUpdateTableData = (props?: UseUpdateTableDataProps) => {
               isAttrib,
               wasInherited, // Track inheritance status for undo
               ownAttrib: ownAttrib,
-              folderId: entityData?.folderId,
+              folderId: entityData?.folderId || entityData?.parentId,
               meta,
             }
           },


### PR DESCRIPTION
- Fixes an issue where if the top folder does not have a explicit value then the inherited value would be null. Now it uses the project attrib value as a fallback.
- Fixes an issue where setting an explicit value on a folder and then pressing undo would only reinstate the value and the inheritance state.  