### PR TITLE
Disable password login option for users

### DIFF
--- a/gen/graphql.schema.json
+++ b/gen/graphql.schema.json
@@ -11986,6 +11986,22 @@
             "deprecationReason": null
           },
           {
+            "name": "disablePasswordLogin",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "name",
             "description": null,
             "args": [],

--- a/shared/src/api/generated/graphql.ts
+++ b/shared/src/api/generated/graphql.ts
@@ -1211,6 +1211,7 @@ export type UserNode = {
   hasPassword: Scalars['Boolean']['output'];
   isAdmin: Scalars['Boolean']['output'];
   isDeveloper: Scalars['Boolean']['output'];
+  disablePasswordLogin: Scalars['Boolean']['output'];
   isGuest: Scalars['Boolean']['output'];
   isManager: Scalars['Boolean']['output'];
   isService: Scalars['Boolean']['output'];

--- a/shared/src/api/queries/users/getUsers.ts
+++ b/shared/src/api/queries/users/getUsers.ts
@@ -21,6 +21,7 @@ const USER_BY_NAME_QUERY = `
           accessGroups
           defaultAccessGroups
           hasPassword
+          disablePasswordLogin
           allAttrib
         }
       }
@@ -43,6 +44,7 @@ const USERS_QUERY = `
           accessGroups
           defaultAccessGroups
           hasPassword
+          disablePasswordLogin
           createdAt
           updatedAt
           apiKeyPreview

--- a/src/pages/SettingsPage/UsersSettings/UserAccessForm.jsx
+++ b/src/pages/SettingsPage/UsersSettings/UserAccessForm.jsx
@@ -68,7 +68,16 @@ const UserAccessForm = ({ accessGroupsData, formData, onChange, disabled }) => {
   return (
     <>
       <b>Access</b>
+
       <FormLayout>
+
+        <FormRowStyled label="Disable password">
+          <InputSwitch
+            checked={!!formData?.disablePasswordLogin}
+            onChange={(e) => updateFormData('disablePasswordLogin', !!e.target.checked)}
+          />
+        </FormRowStyled>
+
         <FormRowStyled label="Guest">
           <div
             data-tooltip={isAdmin ? 'Admins cannot be guests' : undefined}

--- a/src/pages/SettingsPage/UsersSettings/userDetail.jsx
+++ b/src/pages/SettingsPage/UsersSettings/userDetail.jsx
@@ -64,6 +64,13 @@ const fields = [
     },
   },
   {
+    name: 'disablePasswordLogin',
+    label: 'Disable Password Login',
+    data: {
+      type: 'boolean',
+    },
+  },
+  {
     name: 'userLevel',
     label: 'User Level',
     data: {
@@ -112,6 +119,11 @@ const mergeMultipleUsers = (users = [], defaultForm = {}, initForm = {}) => {
     if (index !== 0 && initForm.userActive !== user.active)
       initForm.userActive = defaultForm.userActive
     else initForm.userActive = user.active
+
+    // disablePasswordLogin
+    if (index !== 0 && initForm.disablePasswordLogin !== user.disablePasswordLogin)
+      initForm.disablePasswordLogin = defaultForm.disablePasswordLogin
+    else initForm.disablePasswordLogin = user.disablePasswordLogin
 
     // userPool
     if (index !== 0 && initForm.userPool !== user.userPool) {
@@ -303,6 +315,8 @@ const UserDetail = ({
           data.isDeveloper = formData.isDeveloper && formData.userLevel === 'admin'
         } else if (singleUserEdit && attributes.find((a) => a.name === field)) {
           attrib[field] = formData[field]
+        } else if (field === 'disablePasswordLogin') {
+          data.disablePasswordLogin = formData.disablePasswordLogin
         }
       }
 


### PR DESCRIPTION
This is a frontend counterpart to https://github.com/ynput/ayon-backend/pull/633

This pull request introduces a new `disablePasswordLogin` field to manage user authentication settings, updates the GraphQL schema, and integrates the field into the user management UI and API queries.