### PR TITLE
Show Actions button as purple when in developer mode

### DIFF
--- a/shared/src/containers/Actions/Actions.tsx
+++ b/shared/src/containers/Actions/Actions.tsx
@@ -25,6 +25,7 @@ interface ActionsProps extends ActionTriggersProps {
   isLoadingEntity: boolean
   projectActionsProjectName?: string
   featuredCount?: number
+  isDeveloperMode: boolean
 }
 
 export const Actions = ({
@@ -35,6 +36,7 @@ export const Actions = ({
   projectActionsProjectName,
   searchParams,
   featuredCount = 2,
+  isDeveloperMode,
   onNavigate,
   onSetSearchParams,
 }: ActionsProps) => {
@@ -44,7 +46,7 @@ export const Actions = ({
   const [interactiveForm, setInteractiveForm] = useState<any>(null)
 
   const context: ActionContext | null = useMemo(() => {
-    if (projectActionsProjectName){
+    if (projectActionsProjectName) {
       return {
         entityType: 'project',
         projectName: projectActionsProjectName,
@@ -318,6 +320,7 @@ export const Actions = ({
         isLoading={isLoading && featuredCount > 0}
         onAction={handleExecuteAction}
         onConfig={handleConfigureAction}
+        isDeveloperMode={isDeveloperMode}
       />
       <ActionConfigDialog
         action={actionBeingConfigured}

--- a/shared/src/containers/Actions/ActionsDropdown/ActionsDropdown.styled.ts
+++ b/shared/src/containers/Actions/ActionsDropdown/ActionsDropdown.styled.ts
@@ -25,6 +25,20 @@ export const StyledDropdown = styled(Dropdown)`
     }
   }
 
+  /* developer mode */
+  &.dev {
+    button {
+      background-color: var(--color-hl-developer-container);
+      .icon {
+        color: var(--color-hl-developer);
+      }
+
+      &:hover {
+        background-color: var(--color-hl-developer-container-hover);
+      }
+    }
+  }
+
   &.loading {
     border-radius: 4px;
   }

--- a/shared/src/containers/Actions/ActionsDropdown/ActionsDropdown.tsx
+++ b/shared/src/containers/Actions/ActionsDropdown/ActionsDropdown.tsx
@@ -74,6 +74,7 @@ export const ActionsDropdownItem = ({
 export type ActionsDropdownProps = {
   options: ActionsDropdownItemProps[]
   isLoading?: boolean
+  isDeveloperMode: boolean
   onAction: (value: string) => void
   onConfig: (e: any) => void
 }
@@ -81,6 +82,7 @@ export type ActionsDropdownProps = {
 export const ActionsDropdown = ({
   options,
   isLoading,
+  isDeveloperMode,
   onAction,
   onConfig,
 }: ActionsDropdownProps) => {
@@ -95,7 +97,7 @@ export const ActionsDropdown = ({
     <StyledDropdown
       ref={dropdownRef}
       disabled={isLoading}
-      className={clsx('more', { loading: isLoading })}
+      className={clsx('more', { loading: isLoading, dev: isDeveloperMode })}
       options={options}
       maxOptionsShown={100}
       value={[]}
@@ -103,8 +105,11 @@ export const ActionsDropdown = ({
       itemTemplate={(option) => <ActionsDropdownItem {...option} onConfig={handleConfigClick} />}
       valueTemplate={() => <DefaultValueTemplate placeholder="" value={[]} dropIcon={'category'} />}
       onChange={(v) => onAction(v[0])}
-      // @ts-expect-error
-      buttonProps={{ ['data-tooltip']: 'Actions', ['data-tooltip-delay']: 0 }}
+      buttonProps={{
+        // @ts-expect-error
+        ['data-tooltip']: isDeveloperMode ? 'Actions (dev bundle)' : 'Actions',
+        ['data-tooltip-delay']: 0,
+      }}
     />
   )
 }

--- a/shared/src/containers/DetailsPanel/DetailsPanelHeader/DetailsPanelHeader.tsx
+++ b/shared/src/containers/DetailsPanel/DetailsPanelHeader/DetailsPanelHeader.tsx
@@ -56,7 +56,7 @@ const DetailsPanelHeader = ({
   onOpenViewer,
   onEntityFocus,
 }: DetailsPanelHeaderProps) => {
-  const { useSearchParams, useNavigate } = useDetailsPanelContext()
+  const { useSearchParams, useNavigate, isDeveloperMode } = useDetailsPanelContext()
   const navigate = useNavigate()
   const [searchParams, setSearchParams] = useSearchParams()
 
@@ -278,6 +278,7 @@ const DetailsPanelHeader = ({
             entitySubTypes={entitySubTypes}
             isLoadingEntity={!!isFetching || !!isLoading}
             searchParams={searchParams}
+            isDeveloperMode={isDeveloperMode}
             onSetSearchParams={setSearchParams}
             onNavigate={navigate}
           />

--- a/shared/src/context/DetailsPanelContext.tsx
+++ b/shared/src/context/DetailsPanelContext.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useCallback, ReactNode, useState } from 'react'
 import { useLocalStorage } from '@shared/hooks'
-import { DetailsPanelEntityType } from '@shared/api'
+import { DetailsPanelEntityType, useGetCurrentUserQuery } from '@shared/api'
 import type { UserModel } from '@shared/api'
 import { useLocation, useNavigate, useParams } from 'react-router-dom'
 import { useSearchParams } from 'react-router-dom'
@@ -56,6 +56,8 @@ export interface DetailsPanelContextProps {
 
 // Interface for our simplified context
 export interface DetailsPanelContextType extends DetailsPanelContextProps {
+  // user
+  isDeveloperMode: boolean
   // Open state for the panel by scope
   panelOpenByScope: OpenStateByScope
   getOpenForScope: (scope: string) => boolean
@@ -100,6 +102,10 @@ export const DetailsPanelProvider: React.FC<DetailsPanelProviderProps> = ({
   defaultTab = 'activity',
   ...forwardedProps
 }) => {
+  // get current user
+  const { data: currentUser } = useGetCurrentUserQuery()
+  const isDeveloperMode = currentUser?.attrib?.developerMode ?? false
+
   // keep track of the currently open panel by scope
   const [panelOpenByScope, setPanelOpenByScope] = useState<OpenStateByScope>({})
   const [feedAnnotations, setFeedAnnotations] = useState<SavedAnnotationMetadata[]>([])
@@ -211,6 +217,7 @@ export const DetailsPanelProvider: React.FC<DetailsPanelProviderProps> = ({
     closePip,
     feedAnnotations,
     setFeedAnnotations,
+    isDeveloperMode,
     ...forwardedProps,
   }
 

--- a/src/pages/ProjectListsPage/ProjectListsPage.tsx
+++ b/src/pages/ProjectListsPage/ProjectListsPage.tsx
@@ -53,6 +53,7 @@ import {
   type Active,
   type Over,
 } from '@dnd-kit/core'
+import { useAppSelector } from '@state/store.ts'
 
 type ProjectListsPageProps = {
   projectName: string
@@ -218,6 +219,8 @@ const ProjectLists: FC<ProjectListsProps> = ({
   isReview,
   dndActiveId, // Destructure new prop
 }) => {
+  const user = useAppSelector((state) => state.user?.attrib)
+  const isDeveloperMode = user?.developerMode ?? false
   const navigate = useNavigate()
   const [searchParams, setSearchParams] = useSearchParams()
   const { projectName, projectInfo } = useProjectDataContext()
@@ -267,6 +270,7 @@ const ProjectLists: FC<ProjectListsProps> = ({
                   onSetSearchParams={setSearchParams}
                   searchParams={searchParams}
                   featuredCount={0}
+                  isDeveloperMode={isDeveloperMode}
                 />
                 <CustomizeButton />
               </Toolbar>

--- a/src/pages/ProjectOverviewPage/ProjectOverviewPage.tsx
+++ b/src/pages/ProjectOverviewPage/ProjectOverviewPage.tsx
@@ -30,6 +30,7 @@ import ReloadButton from './components/ReloadButton'
 import OverviewActions from './components/OverviewActions'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { useFiltersWithHierarchy } from '@shared/containers'
+import { useAppSelector } from '@state/store'
 
 const searchFilterTypes: FilterFieldType[] = [
   'attributes',
@@ -40,6 +41,8 @@ const searchFilterTypes: FilterFieldType[] = [
 ]
 
 const ProjectOverviewPage: FC = () => {
+  const user = useAppSelector((state) => state.user?.attrib)
+  const isDeveloperMode = user?.developerMode ?? false
   const { selectedRows } = useSelectedRowsContext()
   const [searchParams, setSearchParams] = useSearchParams()
   const navigate = useNavigate()
@@ -159,6 +162,7 @@ const ProjectOverviewPage: FC = () => {
                 onNavigate={navigate}
                 onSetSearchParams={setSearchParams}
                 searchParams={searchParams}
+                isDeveloperMode={isDeveloperMode}
               />
               <CustomizeButton />
             </Toolbar>


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
It's really not obvious that when in developer mode the actions are linked to the dev bundle and not the production one. This has caught us out many times before. Now we should the actions button as purple to indicate it is being affected by developer mode being turned on.

<img width="558" alt="image" src="https://github.com/user-attachments/assets/64a8bebb-774f-452e-9705-d24fcda2e873" />


