### PR TITLE
Overview: Improved folder and task creation workflow

### DIFF
--- a/shared/src/containers/ProjectTreeTable/context/ProjectTableContext.ts
+++ b/shared/src/containers/ProjectTreeTable/context/ProjectTableContext.ts
@@ -48,6 +48,7 @@ export interface ProjectTableContextType {
 
   // Expanded state
   expanded: ProjectTableProviderProps['expanded']
+  setExpanded: ProjectTableProviderProps['setExpanded']
   toggleExpanded: ProjectTableProviderProps['toggleExpanded']
   updateExpanded: ProjectTableProviderProps['updateExpanded']
   toggleExpandAll: ToggleExpandAll

--- a/shared/src/containers/ProjectTreeTable/context/ProjectTableProvider.tsx
+++ b/shared/src/containers/ProjectTreeTable/context/ProjectTableProvider.tsx
@@ -107,7 +107,7 @@ export interface ProjectTableProviderProps {
   expanded: ExpandedState
   toggleExpanded: (id: string) => void
   updateExpanded: OnChangeFn<ExpandedState>
-  setExpanded: (expanded: ExpandedState) => void
+  setExpanded: React.Dispatch<React.SetStateAction<ExpandedState>>
 
   // Sorting
   sorting: SortingState
@@ -316,6 +316,7 @@ export const ProjectTableProvider = ({
         updateShowHierarchy,
         // expanded state
         expanded,
+        setExpanded,
         toggleExpanded,
         updateExpanded,
         toggleExpandAll,

--- a/src/components/NewEntity/NewEntity.tsx
+++ b/src/components/NewEntity/NewEntity.tsx
@@ -21,7 +21,7 @@ import {
 } from '@shared/containers/ProjectTreeTable'
 import { parseCellId } from '@shared/containers/ProjectTreeTable/utils/cellUtils'
 import { EditorTaskNode, MatchingFolder } from '@shared/containers/ProjectTreeTable'
-import type { ProjectModel } from '@shared/api'
+import type { OperationResponseModel, ProjectModel } from '@shared/api'
 import FolderSequence from '@components/FolderSequence/FolderSequence'
 import { EntityForm, NewEntityType, useNewEntityContext } from '@context/NewEntityContext'
 import useCreateEntityShortcuts from '@hooks/useCreateEntityShortcuts'
@@ -74,11 +74,12 @@ const StyledCreateItem = styled.span`
   }
 `
 
-interface NewEntityProps {
+export interface NewEntityProps {
   disabled?: boolean
+  onNewEntities?: (ops: OperationResponseModel[]) => void
 }
 
-const NewEntity: React.FC<NewEntityProps> = ({ disabled }) => {
+const NewEntity: React.FC<NewEntityProps> = ({ disabled, onNewEntities }) => {
   const {
     entityType,
     setEntityType,
@@ -220,17 +221,24 @@ const NewEntity: React.FC<NewEntityProps> = ({ disabled }) => {
 
   const handleSubmit = async (stayOpen: boolean) => {
     setIsSubmitting(true)
-    await onCreateNew(selectedFolderIds)
-    setIsSubmitting(false)
+    try {
+      const resOperations = await onCreateNew(selectedFolderIds)
 
-    if (stayOpen) {
-      // focus and select the label input
-      if (labelRef.current) {
-        labelRef.current.focus()
-        labelRef.current.select()
+      // callback function
+      onNewEntities?.(resOperations)
+
+      if (stayOpen) {
+        // focus and select the label input
+        if (labelRef.current) {
+          labelRef.current.focus()
+          labelRef.current.select()
+        }
+      } else {
+        handleClose()
       }
-    } else {
-      handleClose()
+    } catch (error) {
+    } finally {
+      setIsSubmitting(false)
     }
   }
 

--- a/src/pages/ProjectOverviewPage/ProjectOverviewPage.tsx
+++ b/src/pages/ProjectOverviewPage/ProjectOverviewPage.tsx
@@ -31,6 +31,8 @@ import OverviewActions from './components/OverviewActions'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { useFiltersWithHierarchy } from '@shared/containers'
 import { useAppSelector } from '@state/store'
+import { OperationResponseModel } from '@shared/api'
+import useExpandAndSelectNewFolders from './hooks/useExpandAndSelectNewFolders'
 
 const searchFilterTypes: FilterFieldType[] = [
   'attributes',
@@ -120,6 +122,14 @@ const ProjectOverviewPage: FC = () => {
     }
   }
 
+  const expandAndSelectNewFolders = useExpandAndSelectNewFolders()
+
+  // select new entities and expand their parents
+  const handleNewEntities = (ops: OperationResponseModel[]) => {
+    // expands to newly created folders and selects them
+    expandAndSelectNewFolders(ops)
+  }
+
   return (
     <main style={{ overflow: 'hidden', gap: 4 }}>
       <Splitter
@@ -136,7 +146,7 @@ const ProjectOverviewPage: FC = () => {
         <SplitterPanel size={88}>
           <Section wrap direction="column" style={{ height: '100%' }}>
             <Toolbar style={{ gap: 8 }}>
-              <NewEntity disabled={!showHierarchy} />
+              <NewEntity disabled={!showHierarchy} onNewEntities={handleNewEntities} />
               <OverviewActions />
               <SearchFilterWrapper
                 filters={filtersWithHierarchy}

--- a/src/pages/ProjectOverviewPage/hooks/useExpandAndSelectNewFolders.ts
+++ b/src/pages/ProjectOverviewPage/hooks/useExpandAndSelectNewFolders.ts
@@ -1,0 +1,58 @@
+import { OperationResponseModel } from '@shared/api'
+import {
+  CellId,
+  getCellId,
+  parseCellId,
+  useProjectTableContext,
+  useSelectedRowsContext,
+  useSelectionCellsContext,
+} from '@shared/containers'
+import { ExpandedState } from '@tanstack/react-table'
+import { useCallback } from 'react'
+
+const useExpandAndSelectNewFolders = () => {
+  const { selectedRows } = useSelectedRowsContext()
+  const { setSelectedCells, setFocusedCellId, selectedCells } = useSelectionCellsContext()
+
+  const { expanded, setExpanded } = useProjectTableContext()
+
+  const expandAndSelectNewFolders = useCallback(
+    (ops: OperationResponseModel[]) => {
+      // clone expanded state
+      const newExpanded: ExpandedState = { ...(expanded as {}) }
+
+      // expand all currently selected rows
+      for (const rowId of selectedRows) {
+        newExpanded[rowId] = true
+      }
+
+      // expand all rows referenced by selected cells
+      for (const cellId of selectedCells) {
+        const rowId = parseCellId(cellId)?.rowId
+        if (rowId) {
+          newExpanded[rowId] = true
+        }
+      }
+
+      setExpanded(newExpanded)
+
+      // build new cell selection for created folders
+      const newSelection = new Set<CellId>()
+      for (const op of ops) {
+        if (!op.entityId) continue
+        if (op.entityType !== 'folder') continue
+        newSelection.add(getCellId(op.entityId, 'name'))
+      }
+
+      if (newSelection.size) {
+        setSelectedCells(newSelection)
+        setFocusedCellId(newSelection.values().next().value || null)
+      }
+    },
+    [selectedRows, selectedCells, expanded, setExpanded, setSelectedCells, setFocusedCellId],
+  )
+
+  return expandAndSelectNewFolders
+}
+
+export default useExpandAndSelectNewFolders


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
- When creating new folders or tasks the selected folders are expanded after creation.
- When new folders are created, they are preselected after creation.
- New workflow of creating multiple new folders and creating tasks inside of them, even with deeply nested sequences.


https://github.com/user-attachments/assets/9f7a1def-230a-48e6-ab4a-f484f38ac7fc






## Technical details
<!-- Please state any technical details such as limitations -->
Required a slight rollback of #1241 to ensure cells can be visible when they are within a collapsed folder, but are still deselected when the data set no longer contains them.


