### PR TITLE
Overview: Enabling stay open for new entity preserves selection

### DIFF
--- a/src/components/NewEntity/NewEntity.tsx
+++ b/src/components/NewEntity/NewEntity.tsx
@@ -76,7 +76,7 @@ const StyledCreateItem = styled.span`
 
 export interface NewEntityProps {
   disabled?: boolean
-  onNewEntities?: (ops: OperationResponseModel[]) => void
+  onNewEntities?: (ops: OperationResponseModel[], stayOpen: boolean) => void
 }
 
 const NewEntity: React.FC<NewEntityProps> = ({ disabled, onNewEntities }) => {
@@ -225,7 +225,7 @@ const NewEntity: React.FC<NewEntityProps> = ({ disabled, onNewEntities }) => {
       const resOperations = await onCreateNew(selectedFolderIds)
 
       // callback function
-      onNewEntities?.(resOperations)
+      onNewEntities?.(resOperations, stayOpen)
 
       if (stayOpen) {
         // focus and select the label input

--- a/src/pages/ProjectOverviewPage/ProjectOverviewPage.tsx
+++ b/src/pages/ProjectOverviewPage/ProjectOverviewPage.tsx
@@ -125,9 +125,9 @@ const ProjectOverviewPage: FC = () => {
   const expandAndSelectNewFolders = useExpandAndSelectNewFolders()
 
   // select new entities and expand their parents
-  const handleNewEntities = (ops: OperationResponseModel[]) => {
+  const handleNewEntities = (ops: OperationResponseModel[], stayOpen: boolean) => {
     // expands to newly created folders and selects them
-    expandAndSelectNewFolders(ops)
+    expandAndSelectNewFolders(ops, { enableSelect: !stayOpen, enableExpand: true })
   }
 
   return (


### PR DESCRIPTION
## Description of changes 
When Stay Open is checked, the selection will stay on the currently selected folder instead of moving to the newly created folder (behaviour when not checked). This is useful when wanted to create lots of different folders in the same parent folder.

![image](https://github.com/user-attachments/assets/12c28067-b8df-4a45-8a69-9cee9b7c7296)

