### PR TITLE
Feature: Add page specific help button in project scope

### DIFF
--- a/shared/src/components/Feedback/FeedbackContext.tsx
+++ b/shared/src/components/Feedback/FeedbackContext.tsx
@@ -378,7 +378,8 @@ export const FeedbackProvider: React.FC<FeedbackProviderProps> = ({ children }) 
         break
       default:
         // Default to showing the main widget
-        win.Featurebase('show')
+        console.error(`Unhandled page: ${page}`)
+        win.Featurebase('show') 
         break
     }
   }

--- a/src/containers/header/AppNavLinks.jsx
+++ b/src/containers/header/AppNavLinks.jsx
@@ -1,111 +1,55 @@
 import { Button, Spacer } from '@ynput/ayon-react-components'
-import React, { useEffect } from 'react'
-import { useSelector } from 'react-redux'
-import { NavLink, useNavigate, useParams, useSearchParams } from 'react-router-dom'
-import * as Styled from './AppNavLinks.styled'
+import { NavLink } from 'react-router-dom'
 import Typography from '@/theme/typography.module.css'
-import { replaceQueryParams } from '@helpers/url'
-import { ayonUrlParam } from '@/constants'
+import * as Styled from './AppNavLinks.styled'
+import { useAppNavLinks } from './hooks/useAppNavLinks'
 
-const AppNavLinks = ({ links = [] }) => {
-  // item = { name: 'name', path: 'path', node: node | 'spacer', accessLevel: [] }
-  const navigate = useNavigate()
-  const { module } = useParams()
-  const [search] = useSearchParams()
-  const isManager = useSelector((state) => state.user.data.isManager)
-  const isAdmin = useSelector((state) => state.user.data.isAdmin)
-  const uri = useSelector((state) => state.context.uri)
-
-  const appendUri = (path, shouldAddUri = true) => {
-    if (!path) return path
-
-    // Get the base path and existing query parameters
-    const [basePath, queryString] = path.split('?')
-
-    // Only add the uri parameter when shouldAddUri is true and uri exists
-    if (shouldAddUri && uri) {
-      search.set(ayonUrlParam, encodeURIComponent(uri))
-    }
-
-    // Rebuild the URL with all parameters
-    const newQueryString = search.toString()
-    return newQueryString ? `${basePath}?${newQueryString}` : basePath
-  }
-
-  const access = {
-    manager: isManager || isAdmin,
-    admin: isAdmin,
-  }
-
-  //   if module is matches an item that has accessLevel that is not in access, redirect to
-  useEffect(() => {
-    const item = links.find((item) => item.module === `${module}`)
-    if (item && item.accessLevels?.length && !item.accessLevels?.every((level) => access[level])) {
-      // find the first item that this user has access
-      const firstItem = links.find((item) => item.accessLevels?.every((level) => access[level]))
-
-      if (firstItem) {
-        navigate(firstItem.path)
-      } else {
-        // last resort, navigate to home
-        navigate('/')
-      }
-    }
-  }, [module, links, access])
+const AppNavLinks = ({ links = [], actions = [] }) => {
+  // linkItem = { name: 'name', path: 'path', node: node | 'spacer', accessLevel: [] }
 
   return (
     <Styled.NavBar className="secondary">
-      <ul>
-        {links.map(
-          (
-            {
-              accessLevels,
-              node,
-              shortcut,
-              path,
-              tooltip,
-              name,
-              enabled = true,
-              startContent,
-              endContent,
-              uriSync,
-              module,
-              ...props
-            } = {},
-            idx,
-          ) => {
-            if (!enabled) return null
-            // if item has restrictions, check if user has access
-            let hasAccess = true
-            if (accessLevels?.length) {
-              hasAccess = accessLevels?.every((restriction) => access[restriction])
-            }
-            if (!hasAccess) return null
-
-            // return spacer if item is a spacer, or just the node
-            if (node) {
-              // if item is a node a spacer, return spacer
-              if (node === 'spacer') {
-                return <Spacer key={idx} />
-              } else return <li key={idx}>{node}</li>
-            }
-
-            return (
-              <Styled.NavItem key={idx} data-shortcut={shortcut} data-tooltip={tooltip} {...props}>
-                <NavLink to={appendUri(path, uriSync)}>
-                  <Button variant="nav" className={Typography.titleSmall} tabIndex={-1}>
-                    {startContent && startContent}
-                    {name}
-                    {endContent && endContent}
-                  </Button>
-                </NavLink>
-              </Styled.NavItem>
-            )
-          },
-        )}
-      </ul>
+      <AppNavLeftLinks links={links} />
+      <AppNavRightActionButtons actions={actions} />
     </Styled.NavBar>
   )
+}
+
+const AppNavLeftLinks = ({ links }) => {
+  const { filteredItems, appendUri } = useAppNavLinks(links)
+
+  return (
+    <Styled.NavLinksContainer>
+      <ul>
+        {filteredItems.map(({ node, enabled = true, ...rest }, idx) => {
+          if (!enabled) return null
+
+          if (node) {
+            if (node === 'spacer') return <Spacer key={idx} />
+            return <li key={idx}>{node}</li>
+          }
+
+          return (
+            <Styled.NavItem key={idx} {...rest}>
+              <NavLink to={appendUri(rest.path, rest.uriSync)}>
+                <Button variant="nav" className={Typography.titleSmall} tabIndex={-1}>
+                  {rest.startContent}
+                  {rest.name}
+                  {rest.endContent}
+                </Button>
+              </NavLink>
+            </Styled.NavItem>
+          )
+        })}
+      </ul>
+    </Styled.NavLinksContainer>
+  )
+}
+
+const AppNavRightActionButtons = ({ actions }) => {
+  if (!actions || actions.length === 0) return null
+
+  return <Styled.NavRightActions>{actions}</Styled.NavRightActions>
 }
 
 export default AppNavLinks

--- a/src/containers/header/AppNavLinks.styled.js
+++ b/src/containers/header/AppNavLinks.styled.js
@@ -5,6 +5,18 @@ export const NavBar = styled.nav`
   border-bottom: 1px solid var(--md-sys-color-outline-variant);
   background-color: var(--panel-background);
   padding: 0 8px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: var(--base-gap-small);
+  /* this hides the border of the navbar by putting the active tab border over it */
+  position: relative;
+  top: 1px;
+  margin-bottom: -1px;
+`
+
+export const NavLinksContainer = styled.div`
+  overflow: hidden;
 
   ul {
     display: flex;
@@ -15,12 +27,6 @@ export const NavBar = styled.nav`
     list-style: none;
     margin: 0;
     padding: 0;
-
-    /* this hides the border of the navbar by putting the active tab border over it */
-    position: relative;
-    top: 1px;
-    margin-bottom: -1px;
-
     /* overflow */
     width: 100%;
     overflow-x: auto;
@@ -31,6 +37,19 @@ export const NavBar = styled.nav`
       display: none;
     }
   }
+`
+
+export const NavRightActions = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: var(--base-gap-small);
+  flex-shrink: 0; /* Prevent shrinking */
+  margin-left: auto; /* Push to the right */
+  /* Ensure action buttons are always visible */
+  z-index: 1;
+  position: relative;
+  padding-left: 4px;
 `
 
 export const NavItem = styled.li`

--- a/src/containers/header/hooks/useAppNavLinks.ts
+++ b/src/containers/header/hooks/useAppNavLinks.ts
@@ -1,0 +1,77 @@
+import { useNavigate, useParams } from 'react-router-dom'
+import { useAppSelector } from '@/features/store'
+import { useEffect, useMemo } from 'react'
+import { ayonUrlParam } from '@/constants'
+
+type AccessLevel = 'manager' | 'admin'
+
+export type NavLinkItem = {
+  name: string
+  path: string
+  module: string
+  uriSync?: boolean
+  enabled?: boolean
+  accessLevels?: AccessLevel[]
+  shortcut?: string
+  tooltip?: string
+  startContent?: React.ReactNode
+  endContent?: React.ReactNode
+}
+
+
+/**
+ * Custom hook for filtering navigation links based on user access levels,
+ * appending URI parameters, and redirecting unauthorized users.
+ */
+export const useAppNavLinks = (items: NavLinkItem[]) => {
+  const navigate = useNavigate()
+  const { module } = useParams<{ module?: string }>()
+  const uri = useAppSelector(state => state.context.uri)
+  const isManager = useAppSelector(state => state.user.data.isManager)
+  const isAdmin = useAppSelector(state => state.user.data.isAdmin)
+
+  // access logic in one place
+ const access = {
+  manager: isManager || isAdmin,
+  admin: isAdmin,
+  }
+
+  // filtered items
+  const filteredItems = useMemo(() => {
+    return items.filter(item => {
+      if (item.enabled === false) return false
+      if (item.accessLevels?.length) {
+        return item.accessLevels.every(level => access[level])
+      }
+      return true
+    })
+  }, [items, access])
+
+  // appendUri helper
+  const appendUri = (path: string, shouldAddUri = true) => {
+    if (!path) return path
+    const [basePath, queryString] = path.split('?')
+    const params = new URLSearchParams(queryString || '')
+    if (shouldAddUri && uri) {
+      params.set(ayonUrlParam, encodeURIComponent(uri))
+    }
+    const newQueryString = params.toString()
+    return newQueryString ? `${basePath}?${newQueryString}` : basePath
+  }
+
+ // redirect effect inside hook
+  useEffect(() => {
+    if (!module) return
+    const current = items.find(item => item.module === module)
+    if (!current) return
+
+    const hasAccess = !current.accessLevels?.length || current.accessLevels.every(level => access[level])
+    if (hasAccess) return
+
+    // Fallback to first accessible item, or home if none
+    const fallback = items.find(item => item.accessLevels?.every(level => access[level]))
+    navigate(fallback?.path || '/', { replace: true })
+  }, [module, items, access, navigate])
+
+  return { filteredItems, appendUri }
+}

--- a/src/pages/ProjectPage/ProjectPage.tsx
+++ b/src/pages/ProjectPage/ProjectPage.tsx
@@ -28,6 +28,7 @@ import { VersionUploadProvider, UploadVersionDialog } from '@shared/components'
 import { productSelected } from '@state/context'
 import useGetBundleAddonVersions from '@hooks/useGetBundleAddonVersions'
 import ProjectReviewsPage from '@pages/ProjectListsPage/ProjectReviewsPage'
+import { useHelpButtonHandler } from './hooks/useHelpButtonHandler'
 
 const ProjectContextInfo = () => {
   /**
@@ -114,12 +115,14 @@ const ProjectPage = () => {
         path: `/projects/${projectName}/overview`,
         module: 'overview',
         uriSync: true,
+        articleId: '7885519',
       },
       {
         name: 'Task progress',
         path: `/projects/${projectName}/tasks`,
         module: 'tasks',
         uriSync: true,
+        articleId: '2408349',
       },
       {
         name: 'Browser',
@@ -131,6 +134,7 @@ const ProjectPage = () => {
         name: 'Lists',
         path: `/projects/${projectName}/lists`,
         module: 'lists',
+        articleId: '7382645',
       },
       {
         name: 'Review',
@@ -165,21 +169,26 @@ const ProjectPage = () => {
           path: `/projects/${projectName}/addon/${addon.name}`,
           module: addon.name,
         })),
-      { node: 'spacer' },
-      {
-        node: (
-          <Button
-            icon="more_horiz"
-            onClick={() => {
-              setShowContextDialog(true)
-            }}
-            variant="text"
-          />
-        ),
-      },
     ],
     [addonsData, projectName, remotePages, matchedAddons],
   )
+
+  const { handleHelpClick } = useHelpButtonHandler(links)
+
+  const actions = [
+  <Button
+    key="help"
+    icon="help"
+    onClick={handleHelpClick}
+    variant="text"
+  />,
+  <Button
+    key="more"
+    icon="more_horiz"
+    onClick={() => setShowContextDialog(true)}
+    variant="text"
+  />,
+]
 
   //
   // Render page
@@ -273,7 +282,7 @@ const ProjectPage = () => {
         {showContextDialog && <ProjectContextInfo />}
       </Dialog>
       {/* @ts-expect-error - AppNavLinks is jsx */}
-      <AppNavLinks links={links} />
+      <AppNavLinks links={links} actions={actions}  />
       <VersionUploadProvider
         projectName={projectName}
         dispatch={dispatch}

--- a/src/pages/ProjectPage/hooks/useHelpButtonHandler.ts
+++ b/src/pages/ProjectPage/hooks/useHelpButtonHandler.ts
@@ -1,0 +1,28 @@
+import { useMemo } from 'react'
+import { useLocation } from 'react-router-dom'
+import { useFeedback } from '@shared/components'
+
+const normalizePath = (path: string) =>
+  path.replace(/\/+$/, '').split('?')[0].toLowerCase()
+
+export const useHelpButtonHandler = (pages: { path: string; name?: string; articleId?: string }[]) => {
+  const location = useLocation()
+  const { openPortal, openSupport } = useFeedback()
+
+  const currentPage = useMemo(() => {
+    return pages.find((page) => normalizePath(page.path) === normalizePath(location.pathname))
+  }, [location.pathname, pages])
+
+  const handleHelpClick = () => {
+    if (currentPage?.articleId) {
+      openPortal('HelpView', currentPage.articleId)
+    } else {
+      openSupport(
+        'NewMessage',
+        `Can you help me know more about the Project ${currentPage?.name} page?`,
+      )
+    }
+  }
+
+  return { handleHelpClick }
+}


### PR DESCRIPTION
Implements #1294
 
## Description of changes 

- Added a page-specific help button in the project scope. 
- Refactored AppNavLinks component.
- Split AppNavLinks to left links and right action buttons. Right part should be always visible when left part overflows.


## Additional context
- On mobile, AppNavLinks supports scrolling.
- On desktop, when links overflow, mouse scrolling is currently broken — this will be addressed in a separate bugfix.