### PR TITLE
Add page specific help button in project scope 

### DIFF
--- a/src/containers/header/AppNavLinks.jsx
+++ b/src/containers/header/AppNavLinks.jsx
@@ -7,7 +7,7 @@ import Typography from '@/theme/typography.module.css'
 import { replaceQueryParams } from '@helpers/url'
 import { ayonUrlParam } from '@/constants'
 
-const AppNavLinks = ({ links = [] }) => {
+const AppNavLinks = ({ links = [], helpButtons = [] }) => {
   // item = { name: 'name', path: 'path', node: node | 'spacer', accessLevel: [] }
   const navigate = useNavigate()
   const { module } = useParams()
@@ -82,14 +82,6 @@ const AppNavLinks = ({ links = [] }) => {
             }
             if (!hasAccess) return null
 
-            // return spacer if item is a spacer, or just the node
-            if (node) {
-              // if item is a node a spacer, return spacer
-              if (node === 'spacer') {
-                return <Spacer key={idx} />
-              } else return <li key={idx}>{node}</li>
-            }
-
             return (
               <Styled.NavItem key={idx} data-shortcut={shortcut} data-tooltip={tooltip} {...props}>
                 <NavLink to={appendUri(path, uriSync)}>
@@ -104,6 +96,9 @@ const AppNavLinks = ({ links = [] }) => {
           },
         )}
       </ul>
+      {helpButtons.map(({ node }, idx) => (
+        <span key={idx}>{node}</span>
+      ))}
     </Styled.NavBar>
   )
 }

--- a/src/containers/header/AppNavLinks.styled.js
+++ b/src/containers/header/AppNavLinks.styled.js
@@ -5,6 +5,11 @@ export const NavBar = styled.nav`
   border-bottom: 1px solid var(--md-sys-color-outline-variant);
   background-color: var(--panel-background);
   padding: 0 8px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--base-gap-small);
 
   ul {
     display: flex;


### PR DESCRIPTION


## Description of changes 

This PR adds page-specific help button to the project navigation bar. The help button opens a relevant support article or a contextual support message based on the current project page. This improves user guidance and support accessibility throughout the project scope. Reference: https://github.com/ynput/ayon-frontend/issues/1294.



## Technical details

- Each project page link can define an articleId for contextual help.

- The help button uses the current module to open a relevant article or support message.

- helpButtons are passed to AppNavLinks and always remain visible.




