### PR TITLE
feat: add help button

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "dev-arc": "yarn setup:arc && concurrently \"yarn watch:arc\" \"vite --port 3000 --force\"",
     "setup:arc": "cd ../ayon-react-components && yarn link && cd - && yarn link @ynput/ayon-react-components",
     "watch:arc": "nodemon --watch ../ayon-react-components/dist --exec \"yarn link @ynput/ayon-react-components\"",
-    "arc-unlink": "yarn unlink @ynput/ayon-react-components && yarn install --force"
+    "arc-unlink": "yarn unlink @ynput/ayon-react-components && yarn install --force",
+    "scrape-help": "node scripts/scrape-help-articles.js"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.0.8",

--- a/scripts/scrape-help-articles.js
+++ b/scripts/scrape-help-articles.js
@@ -1,0 +1,214 @@
+const { chromium } = require('playwright')
+const fs = require('fs')
+const path = require('path')
+
+async function updateHelpArticles() {
+  console.log('🚀 Started scraping the help articles')
+  console.log('📅 Current time:', new Date().toLocaleString())
+  
+  const browser = await chromium.launch({ 
+    headless: true,
+    args: [
+      '--no-sandbox', 
+      '--disable-setuid-sandbox',
+      '--disable-dev-shm-usage',
+      '--disable-gpu',
+      '--no-first-run',
+      '--disable-extensions',
+      '--disable-default-apps'
+    ]
+  })
+  
+  const page = await browser.newPage({
+    userAgent: 'Mozilla/5.0 (Macintosh Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
+  })
+  
+  try {
+    const url = 'https://help.ayon.app/collections/0376560-production-tracking'
+    
+    try {
+      await page.goto(url, {
+        waitUntil: 'domcontentloaded',
+        timeout: 60000
+      })
+      console.log('✅ Page loaded')
+    } catch (error) {
+      console.log('⚠️  domcontentloaded failed')
+      await page.goto(url, {
+        waitUntil: 'load',
+        timeout: 60000
+      })
+    }
+    
+    // Wait a bit for dynamic content
+    await page.waitForTimeout(3000)
+    
+    // Check if page actually loaded
+    const title = await page.title()
+    console.log('📄 Page title:', title)
+    
+    // Try to detect if we're blocked or redirected
+    const currentUrl = page.url()
+    console.log('🔗 Current URL:', currentUrl)
+    
+    if (currentUrl !== url) {
+      throw new Error('⚠️  URL changed')
+    }
+
+    const selectors = [
+      'a[href*="/articles/"]',
+      'a[href*="articles"]',
+    ]
+    
+    let articlesFound = false
+    for (const selector of selectors) {
+      try {
+        await page.waitForSelector(selector, { timeout: 5000 })
+        console.log(`✅ Found elements with a selector: ${selector}`)
+        articlesFound = true
+      } catch (error) {
+        console.log(`❌ Selector ${selector} not found`)
+      }
+    }
+    
+    if (!articlesFound) {
+      // Try to get page content for debugging
+      console.log('🔍 No article links found, checking page content...')
+      const bodyText = await page.evaluate(() => document.body.textContent)
+      console.log('📝 Page content preview:', bodyText.substring(0, 500))
+      
+      // Save screenshot for debugging
+      await page.screenshot({ path: 'debug-screenshot.png' })
+      console.log('📸 Screenshot saved as debug-screenshot.png')
+      
+      throw new Error('No article links found on the page')
+    }
+    
+    console.log('🔍 Extracting article links with multiple selectors')
+    
+    const articles = await page.evaluate(() => {
+      const articleLinks = [
+        ...document.querySelectorAll('a[href*="/articles/"]'),
+        ...document.querySelectorAll('a[href*="articles"]'),
+      ]
+      
+      console.log(`Found ${articleLinks.length} article links total`)
+      
+      const articleMap = {}
+      const foundArticles = []
+      const processedHrefs = new Set()
+      
+      articleLinks.forEach((link) => {
+        const href = link.getAttribute('href')
+        if (!href || processedHrefs.has(href)) {
+          return
+        }
+        
+        processedHrefs.add(href)
+        
+        let title = ''
+        
+        const button = link.querySelector('button')
+        if (button) {
+          title = button.textContent.trim()
+        }
+        
+        title = title.replace(/\s+/g, ' ').trim()
+        
+        // Extract article ID from href
+        const articleIdMatch = href.match(/\/articles\/([^\/\?#]+)/)
+        
+        if (articleIdMatch) {
+
+          const fullArticleId = articleIdMatch[1] // e.g., "2408349-tasks-home-page"
+          
+          const parts = fullArticleId.split('-')
+          const articleId = parts[0] // e.g., "2408349"
+          const articleSlug = parts.slice(1).join('-') // e.g., "tasks-home-page"
+          
+          
+          if (articleSlug) {
+            // Avoid duplicates by adding number if key exists
+            let finalKey = articleSlug
+            let counter = 1
+            while (articleMap[finalKey]) {
+              finalKey = `${articleSlug}${counter}`
+              counter++
+            }
+            
+            articleMap[finalKey] = articleId // Store just the numeric ID
+            foundArticles.push({ key: finalKey, title, id: articleId })
+          }
+         
+        }
+      })
+      
+      return { articleMap, foundArticles }
+    })
+    
+    if (articles.foundArticles.length === 0) {
+      throw new Error('No articles were found and mapped')
+    }
+
+    console.log(`Found ${articles.foundArticles.length} articles`)
+    
+    articles.foundArticles.forEach(article => {
+      console.log(`   ✅ ${article.key}: (${article.id})`)
+    })
+    
+    const scrapedAt = new Date().toISOString()
+    
+    // Generate TypeScript file with types and autocomplete
+    const tsOutputPath = path.join(__dirname, '../src/data/help-articles.ts')
+    const tsContent = generateTypeScriptFile(articles.articleMap, scrapedAt)
+    
+    fs.writeFileSync(tsOutputPath, tsContent)
+    console.log(`💾 Saved TypeScript to: ${tsOutputPath}`)
+    
+    console.log('📝 Files updated:')
+    console.log(`   - ${tsOutputPath}`)
+    
+    return articles.articleMap
+    
+  } catch (error) {
+    console.error('❌ Error updating help articles:', error)
+    throw error
+  } finally {
+    await browser.close()
+  }
+}
+
+function generateTypeScriptFile(articles, scrapedAt) {
+  const articleEntries = Object.entries(articles)
+    .map(([key, value]) => `    "${key}": "${value}"`)
+    .join(',\n')
+  
+  return `// Auto-generated from scraped help articles
+// Last updated: ${scrapedAt}
+// Run 'npm run scrape-help' to update this file
+
+const articles = {
+${articleEntries}
+} as const
+
+export type HelpArticleKey = keyof typeof articles
+
+export const getHelpArticleId = (key: HelpArticleKey): string | undefined => {
+  return articles[key]
+}
+`
+}
+
+if (require.main === module) {
+  updateHelpArticles()
+    .then(() => {
+      console.log('\n✅ Help articles updated successfully!')
+      process.exit(0)
+    })
+    .catch(error => {
+      console.error('\n💥 Failed to update help articles:', error.message)
+      process.exit(1)
+    })
+}
+
+module.exports = { updateHelpArticles }

--- a/src/components/Canvas.jsx
+++ b/src/components/Canvas.jsx
@@ -1,6 +1,5 @@
-import { useEffect, forwardRef } from 'react';
-import styled from 'styled-components';
-
+import { useEffect, forwardRef } from 'react'
+import styled from 'styled-components'
 
 const CanvasContainer = styled.div`
   position: relative;
@@ -16,37 +15,34 @@ const CanvasContainer = styled.div`
   }
 `
 
-const Canvas = forwardRef(({style, onDraw, ...props}, ref) => {
+const Canvas = forwardRef(({ style, onDraw, ...props }, ref) => {
   useEffect(() => {
-    if (!ref.current) return;
-    const canvas = ref.current;
+    if (!ref.current) return
+    const canvas = ref.current
 
     const handleResize = () => {
-      canvas.width = canvas.parentElement.clientWidth;
-      canvas.height = canvas.parentElement.clientHeight;
+      canvas.width = canvas.parentElement.clientWidth
+      canvas.height = canvas.parentElement.clientHeight
       if (onDraw) {
-        onDraw({target: canvas});
+        onDraw({ target: canvas })
       }
     }
 
-    handleResize();
+    handleResize()
 
-    const parentElement = canvas.parentElement;
-    const resizeObserver = new ResizeObserver(handleResize);
-    resizeObserver.observe(parentElement);
+    const parentElement = canvas.parentElement
+    const resizeObserver = new ResizeObserver(handleResize)
+    resizeObserver.observe(parentElement)
 
-    return () => resizeObserver.unobserve(parentElement);
-
-  }, [ref]);
-
+    return () => resizeObserver.unobserve(parentElement)
+  }, [ref])
 
   return (
     <CanvasContainer style={style}>
       <canvas ref={ref} {...props} />
     </CanvasContainer>
-  );
-});
-Canvas.displayName = 'Canvas';
+  )
+})
+Canvas.displayName = 'Canvas'
 
-
-export default Canvas;
+export default Canvas

--- a/src/components/HelpButton/HelpButton.tsx
+++ b/src/components/HelpButton/HelpButton.tsx
@@ -1,0 +1,59 @@
+import React from 'react'
+import { Button } from '@ynput/ayon-react-components'
+import styled from 'styled-components'
+
+import { useFeedback } from '@shared/components'
+
+const StyledHelpButton = styled(Button)`
+  margin-left: auto;
+  flex-shrink: 0;
+`
+
+interface HelpButtonProps {
+  className?: string
+  pageTitle?: string
+  helpArticleId?: string
+}
+
+const HelpButton: React.FC<HelpButtonProps> = ({ className, pageTitle, helpArticleId }) => {
+  const { openSupport, openPortal, messengerVisibility, setMessengerVisibility } = useFeedback()
+
+  const ensureOnlyOneDialogOpen = () => {
+    if (helpArticleId && messengerVisibility) {
+      const win = window as any
+      if (typeof win.Featurebase === 'function') {
+        win.Featurebase('hide')
+        setMessengerVisibility(false)
+      }
+    }
+  }
+
+  const handleHelpClick = () => {
+    ensureOnlyOneDialogOpen()
+
+    setTimeout(() => {
+      if (helpArticleId) {
+        openPortal('HelpView', helpArticleId)
+      } else {
+        if (pageTitle) {
+          const message = `Can you help me know more about the ${pageTitle} page?`
+          openSupport('NewMessage', message)
+        } else {
+          openSupport('Help')
+        }
+      }
+    }, 100)
+  }
+
+  return (
+    <StyledHelpButton
+      icon="help"
+      variant="text"
+      onClick={handleHelpClick}
+      className={className}
+      data-tooltip="Get help for this page"
+    />
+  )
+}
+
+export default HelpButton

--- a/src/components/HelpButton/index.ts
+++ b/src/components/HelpButton/index.ts
@@ -1,0 +1,1 @@
+export { default } from './HelpButton' 

--- a/src/containers/header/AppNavLinks.jsx
+++ b/src/containers/header/AppNavLinks.jsx
@@ -6,6 +6,7 @@ import * as Styled from './AppNavLinks.styled'
 import Typography from '@/theme/typography.module.css'
 import { replaceQueryParams } from '@helpers/url'
 import { ayonUrlParam } from '@/constants'
+import HelpButton from '@components/HelpButton'
 
 const AppNavLinks = ({ links = [] }) => {
   // item = { name: 'name', path: 'path', node: node | 'spacer', accessLevel: [] }
@@ -37,6 +38,10 @@ const AppNavLinks = ({ links = [] }) => {
     admin: isAdmin,
   }
 
+  const currentLink = links.find((link) => link.module === module)
+  const pageTitle = currentLink?.name
+  const helpArticleId = currentLink?.helpArticleId
+
   //   if module is matches an item that has accessLevel that is not in access, redirect to
   useEffect(() => {
     const item = links.find((item) => item.module === `${module}`)
@@ -55,55 +60,60 @@ const AppNavLinks = ({ links = [] }) => {
 
   return (
     <Styled.NavBar className="secondary">
-      <ul>
-        {links.map(
-          (
-            {
-              accessLevels,
-              node,
-              shortcut,
-              path,
-              tooltip,
-              name,
-              enabled = true,
-              startContent,
-              endContent,
-              uriSync,
-              module,
-              ...props
-            } = {},
-            idx,
-          ) => {
-            if (!enabled) return null
-            // if item has restrictions, check if user has access
-            let hasAccess = true
-            if (accessLevels?.length) {
-              hasAccess = accessLevels?.every((restriction) => access[restriction])
-            }
-            if (!hasAccess) return null
+      <Styled.ScrollableNav>
+        <ul>
+          {links.map(
+            (
+              {
+                accessLevels,
+                node,
+                shortcut,
+                path,
+                tooltip,
+                name,
+                enabled = true,
+                startContent,
+                endContent,
+                uriSync,
+                module,
+                ...props
+              } = {},
+              idx,
+            ) => {
+              if (!enabled) return null
+              // if item has restrictions, check if user has access
+              let hasAccess = true
+              if (accessLevels?.length) {
+                hasAccess = accessLevels?.every((restriction) => access[restriction])
+              }
+              if (!hasAccess) return null
 
-            // return spacer if item is a spacer, or just the node
-            if (node) {
-              // if item is a node a spacer, return spacer
-              if (node === 'spacer') {
-                return <Spacer key={idx} />
-              } else return <li key={idx}>{node}</li>
-            }
+              // return spacer if item is a spacer, or just the node
+              if (node) {
+                // if item is a node a spacer, return spacer
+                if (node === 'spacer') {
+                  return <Spacer key={idx} />
+                } else return <li key={idx}>{node}</li>
+              }
 
-            return (
-              <Styled.NavItem key={idx} data-shortcut={shortcut} data-tooltip={tooltip} {...props}>
-                <NavLink to={appendUri(path, uriSync)}>
-                  <Button variant="nav" className={Typography.titleSmall} tabIndex={-1}>
-                    {startContent && startContent}
-                    {name}
-                    {endContent && endContent}
-                  </Button>
-                </NavLink>
-              </Styled.NavItem>
-            )
-          },
-        )}
-      </ul>
+              return (
+                <Styled.NavItem key={idx} data-shortcut={shortcut} data-tooltip={tooltip} {...props}>
+                  <NavLink to={appendUri(path, uriSync)}>
+                    <Button variant="nav" className={Typography.titleSmall} tabIndex={-1}>
+                      {startContent && startContent}
+                      {name}
+                      {endContent && endContent}
+                    </Button>
+                  </NavLink>
+                </Styled.NavItem>
+              )
+            },
+          )}
+        </ul>
+      </Styled.ScrollableNav>
+      <Styled.HelpButtonContainer>
+        <HelpButton pageTitle={pageTitle} helpArticleId={helpArticleId} />
+      </Styled.HelpButtonContainer>
     </Styled.NavBar>
   )
 }

--- a/src/containers/header/AppNavLinks.styled.js
+++ b/src/containers/header/AppNavLinks.styled.js
@@ -5,32 +5,49 @@ export const NavBar = styled.nav`
   border-bottom: 1px solid var(--md-sys-color-outline-variant);
   background-color: var(--panel-background);
   padding: 0 8px;
+  display: flex;
+  align-items: center;
+  gap: var(--base-gap-small);
+`
+
+export const ScrollableNav = styled.div`
+  flex: 1;
+  overflow-x: auto;
+  /* hide scroll bar */
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
 
   ul {
     display: flex;
     flex-direction: row;
     align-items: center;
     gap: var(--base-gap-small);
-    /* reset defaults */
+
     list-style: none;
     margin: 0;
     padding: 0;
 
-    /* this hides the border of the navbar by putting the active tab border over it */
     position: relative;
     top: 1px;
     margin-bottom: -1px;
 
-    /* overflow */
-    width: 100%;
-    overflow-x: auto;
-    /* hide scroll bar */
-    scrollbar-width: none;
-    -ms-overflow-style: none;
-    &::-webkit-scrollbar {
-      display: none;
+    & > li {
+      flex-shrink: 0;
     }
   }
+`
+
+export const HelpButtonContainer = styled.div`
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+
+  position: relative;
+  top: 1px;
+  margin-bottom: -1px;
 `
 
 export const NavItem = styled.li`

--- a/src/context/PasteContext.jsx
+++ b/src/context/PasteContext.jsx
@@ -1,7 +1,6 @@
 import React, { createContext, useContext, useState, useCallback } from 'react'
 import { Button, InputTextarea, Dialog } from '@ynput/ayon-react-components'
 
-
 const PasteContext = createContext()
 
 const PasteProvider = ({ children }) => {

--- a/src/context/WebsocketContext.jsx
+++ b/src/context/WebsocketContext.jsx
@@ -22,7 +22,7 @@ export const SocketProvider = (props) => {
   const [serverRestartingVisible, setServerRestartingVisible] = useState(false)
   const [topics, setTopics] = useState([])
   const [logout] = useLogoutMutation()
-  const [getInfo] = useLazyGetSiteInfoQuery({full:false})
+  const [getInfo] = useLazyGetSiteInfoQuery({ full: false })
 
   const wsOpts = {
     shouldReconnect: () => {

--- a/src/data/help-articles.ts
+++ b/src/data/help-articles.ts
@@ -1,0 +1,24 @@
+// Auto-generated from scraped help articles
+// Last updated: 2025-07-13T12:32:45.766Z
+// Run 'npm run scrape-help' to update this file
+
+const articles = {
+    "tasks-home-page": "2408349",
+    "the-details-panel": "0219162",
+    "the-activity-feed": "8709483",
+    "reviewables": "0359490",
+    "project-overview-page": "7885519",
+    "task-progress-page": "5526719",
+    "inbox-and-notifications": "7870202",
+    "planner-addon": "8736562",
+    "power-features": "7017685",
+    "lists": "7382645",
+    "review-sessions": "8669165",
+    "teams": "6300319"
+} as const
+
+export type HelpArticleKey = keyof typeof articles
+
+export const getHelpArticleId = (key: HelpArticleKey): string | undefined => {
+  return articles[key]
+}

--- a/src/helpers/callbackOnKeyDown.js
+++ b/src/helpers/callbackOnKeyDown.js
@@ -1,9 +1,9 @@
-  const callbackOnKeyDown = (e, { validationPassed, callback}) => {
-    // if enter then submit
-    if (e.key === 'Enter' && (e.ctrlKey || e.metaKey || e.shiftKey) && validationPassed) {
-      e.preventDefault()
-      const closeOnSubmit = e.ctrlKey || e.metaKey
-      callback(closeOnSubmit)
-    }
+const callbackOnKeyDown = (e, { validationPassed, callback }) => {
+  // if enter then submit
+  if (e.key === 'Enter' && (e.ctrlKey || e.metaKey || e.shiftKey) && validationPassed) {
+    e.preventDefault()
+    const closeOnSubmit = e.ctrlKey || e.metaKey
+    callback(closeOnSubmit)
   }
-  export default callbackOnKeyDown
+}
+export default callbackOnKeyDown

--- a/src/pages/ProjectPage/ProjectPage.tsx
+++ b/src/pages/ProjectPage/ProjectPage.tsx
@@ -28,6 +28,7 @@ import { VersionUploadProvider, UploadVersionDialog } from '@shared/components'
 import { productSelected } from '@state/context'
 import useGetBundleAddonVersions from '@hooks/useGetBundleAddonVersions'
 import ProjectReviewsPage from '@pages/ProjectListsPage/ProjectReviewsPage'
+import { getHelpArticleId } from '@/data/help-articles'
 
 const ProjectContextInfo = () => {
   /**
@@ -113,12 +114,14 @@ const ProjectPage = () => {
         name: 'Overview',
         path: `/projects/${projectName}/overview`,
         module: 'overview',
+        helpArticleId: getHelpArticleId('project-overview-page'),
         uriSync: true,
       },
       {
         name: 'Task progress',
         path: `/projects/${projectName}/tasks`,
         module: 'tasks',
+        helpArticleId: getHelpArticleId('task-progress-page'),
         uriSync: true,
       },
       {
@@ -131,6 +134,7 @@ const ProjectPage = () => {
         name: 'Lists',
         path: `/projects/${projectName}/lists`,
         module: 'lists',
+        helpArticleId: getHelpArticleId('lists'),
       },
       {
         name: 'Review',


### PR DESCRIPTION
## Description of Changes

This PR introduces a typed integration of help articles via a HelpButton component, allowing each relevant page to link directly to its documentation. If there is no link for an article, we will display a help dialog with a prefilled message "Can you help me know more about the {{page title}} page?"

It implements the Help button feature ([#1294](https://github.com/ynput/ayon-frontend/issues/1294)) that provides contextual help links throughout the application.

## Implementation Overview
### Article Scraping & Type Safety

- Added `scrape-help-articles.js` script to scrape help articles from the AYON help site automatically
- Generated `help-articles.ts` with typed article mappings and helper functions
- Created `HelpArticleKey` type for compile-time validation of article references
- Implemented `getHelpArticleId()` function for safe article ID retrieval

### Setup & Usage

- First-time setup: Run `yarn playwright install` to install browser dependencies
- Update articles: Run `yarn scrape-help` to refresh article mappings
- The scraper provides detailed console output showing progress and results

### Help Button Component

- Created `HelpButton.tsx` component for consistent help button UI
- Articles are linked with `helpArticleId` - see `ProjectPage.tsx` with `helpArticleId: getHelpArticleId('task-progress-page'))`
- Implemented dialog management with `ensureOnlyOneDialogOpen()` to prevent multiple overlapping dialogs

### UI/UX Improvements
- Updated `AppNavLinks.styled` to ensure help button remains visible even when navigation links overflow

### Key Features

- **Type-safe article references**: No more broken links to help articles
- **Automated article syncing**: Run `npm run scrape-help` to update article mappings
- **Contextual help**: Each page can specify its relevant help article
- **Dialog management**: Only one help dialog can be open at a time to prevent UI conflicts

## Technical details

- The scraping script generates a const assertion (`as const`) for better TypeScript inference
- Dialog management prevents both article dialog and help dialog from being open simultaneously
- If concurrent dialogs are preferred, the `ensureOnlyOneDialogOpen` logic can be removed

## Additional context

- The implementation prioritizes type safety over automatic title-based linking to prevent broken help links and ensure reliable user experience
- Each page that needs contextual help explicitly declares its help article ID using the typed helper function
## Example Console Output
```🚀 Started scraping the help articles
📅 Current time: 7/13/2025, 2:54:26 PM
✅ Page loaded
📄 Page title: Production Tracking - AYON
🔗 Current URL: https://help.ayon.app/collections/0376560-production-tracking
✅ Found elements with a selector: a[href*="/articles/"]
✅ Found elements with a selector: a[href*="articles"]
🔍 Extracting article links with multiple selectors

Found 12 articles
   ✅ tasks-home-page: (2408349)
   ✅ the-details-panel: (0219162)
   ✅ the-activity-feed: (8709483)
   ✅ reviewables: (0359490)
   ✅ project-overview-page: (7885519)
   ✅ task-progress-page: (5526719)
   ✅ inbox-and-notifications: (7870202)
   ✅ planner-addon: (8736562)
   ✅ power-features: (7017685)
   ✅ lists: (7382645)
   ✅ review-sessions: (8669165)
   ✅ teams: (6300319)

💾 Saved TypeScript to: /src/data/help-articles.ts
📝 Files updated:
   - /src/data/help-articles.ts

✅ Help articles updated successfully!
✨  Done in 5.78s.```