### PR TITLE
Bundles: Dev mode: Include `/client` in placeholder path + add tooltip

### DIFF
--- a/src/pages/SettingsPage/Bundles/BundlesAddonList.jsx
+++ b/src/pages/SettingsPage/Bundles/BundlesAddonList.jsx
@@ -251,7 +251,8 @@ const BundlesAddonList = React.forwardRef(
                 <InputText
                   value={addon.dev?.path || ''}
                   style={{ width: '100%' }}
-                  placeholder="/path/to/dev/addon..."
+                  placeholder="/path/to/dev/addon/client"
+                  data-tooltip="Path to the client folder of the addon to run client side code live from source."
                   onChange={(e) =>
                     onDevChange([addon.name], { value: e.target.value, key: 'path' })
                   }


### PR DESCRIPTION
## Description of changes 

Make it clearer that the dev mode folder for addons needs to be the `/client` folder in the addon.

## Technical details

<img width="695" height="266" alt="image" src="https://github.com/user-attachments/assets/3a3c9bd4-ce11-4073-a6c3-f4773fe9b45f" />

## Additional context

Came up internally [here](https://discord.com/channels/517362899170230292/1001811244535259207/1395410994565746730) (private).
