### PR TITLE
main always uses overflow hidden - fixes access groups scroll

### DIFF
--- a/src/pages/AccountPage/DownloadsPage/DownloadsPage.jsx
+++ b/src/pages/AccountPage/DownloadsPage/DownloadsPage.jsx
@@ -46,10 +46,8 @@ const DownloadsPage = () => {
 
   const platforms = ['windows', 'darwin', 'linux']
 
-  console.log(allInstallers)
-
   return (
-    <main style={{ overflow: 'hidden' }}>
+    <main>
       <Section>
         <Styled.Container>
           <Styled.Header>

--- a/src/pages/BrowserPage/BrowserPage.tsx
+++ b/src/pages/BrowserPage/BrowserPage.tsx
@@ -19,7 +19,7 @@ type BrowserPageProps = {
 const BrowserPage: FC<BrowserPageProps> = () => {
   const { onOpenVersionUpload } = useVersionUploadContext()
   return (
-    <main style={{ overflow: 'hidden' }}>
+    <main>
       <Splitter
         layout="horizontal"
         style={{ width: '100%', height: '100%' }}

--- a/src/pages/MarketPage/MarketPage.jsx
+++ b/src/pages/MarketPage/MarketPage.jsx
@@ -397,7 +397,7 @@ const MarketPage = () => {
         onHide={() => setShowConnectDialog(false)}
         redirect={`/market?addon=${selectedItemId}`}
       />
-      <main style={{ flexDirection: 'column', overflow: 'hidden' }}>
+      <main style={{ flexDirection: 'column' }}>
         <Section style={{ overflow: 'hidden', flexDirection: 'row', justifyContent: 'center' }}>
           <MarketFilters
             filterType={filterType}

--- a/src/pages/ProjectListsPage/ProjectListsPage.tsx
+++ b/src/pages/ProjectListsPage/ProjectListsPage.tsx
@@ -241,7 +241,7 @@ const ProjectLists: FC<ProjectListsProps> = ({
   }
 
   return (
-    <main style={{ overflow: 'hidden', gap: 4 }}>
+    <main style={{ gap: 4 }}>
       <Splitter
         layout="horizontal"
         style={{ width: '100%', height: '100%' }}

--- a/src/pages/ProjectOverviewPage/ProjectOverviewPage.tsx
+++ b/src/pages/ProjectOverviewPage/ProjectOverviewPage.tsx
@@ -131,7 +131,7 @@ const ProjectOverviewPage: FC = () => {
   }
 
   return (
-    <main style={{ overflow: 'hidden', gap: 4 }}>
+    <main style={{ gap: 4 }}>
       <Splitter
         layout="horizontal"
         style={{ width: '100%', height: '100%' }}

--- a/src/pages/SchedulerPage/SchedulerPage.tsx
+++ b/src/pages/SchedulerPage/SchedulerPage.tsx
@@ -40,7 +40,7 @@ const SchedulerPage: FC<SchedulerPageProps> = ({}) => {
   }
 
   return (
-    <main style={{ overflow: 'hidden', width: '100%', height: '100%' }}>
+    <main style={{ width: '100%', height: '100%' }}>
       <Splitter
         layout="horizontal"
         style={{ width: '100%', height: '100%' }}

--- a/src/pages/ServicesPage/ServicesPage.jsx
+++ b/src/pages/ServicesPage/ServicesPage.jsx
@@ -212,7 +212,7 @@ const ServicesPage = () => {
   const [ctxMenuShow] = useCreateContextMenu([])
 
   return (
-    <main style={{ overflow: 'hidden' }}>
+    <main>
       {showServiceDialog && (
         <ServiceDialog onHide={handleCloseDialog} editService={editingService} />
       )}

--- a/src/pages/SettingsPage/Bundles/Bundles.jsx
+++ b/src/pages/SettingsPage/Bundles/Bundles.jsx
@@ -395,7 +395,7 @@ const Bundles = () => {
         onCancel={closeCopySettings}
         onFinish={closeCopySettings}
       />
-      <main style={{ overflow: 'hidden' }}>
+      <main>
         <Splitter style={{ width: '100%' }} stateStorage="local" stateKey="bundles-splitter">
           <SplitterPanel style={{ minWidth: 200, width: 400, maxWidth: 800, zIndex: 10 }} size={30}>
             <Section style={{ height: '100%' }}>

--- a/src/pages/TasksProgressPage/TasksProgressPage.tsx
+++ b/src/pages/TasksProgressPage/TasksProgressPage.tsx
@@ -28,7 +28,7 @@ const TasksProgressPage: FC = () => {
   const statuses = useScopedStatuses([projectName], ['task'])
 
   return (
-    <main style={{ overflow: 'hidden' }}>
+    <main>
       <Splitter layout="horizontal" style={{ width: '100%', height: '100%' }}>
         <SplitterPanel size={detailsOpen ? 12 : 18} style={{ minWidth: 100, maxWidth: 500 }}>
           <Section wrap>

--- a/src/pages/UserDashboardPage/UserDashboardPage.jsx
+++ b/src/pages/UserDashboardPage/UserDashboardPage.jsx
@@ -156,7 +156,7 @@ const UserDashboardPage = () => {
   return (
     <>
       <AppNavLinks links={links} />
-      <main style={{ overflow: 'hidden' }}>
+      <main>
         <Section direction="row" wrap style={{ position: 'relative', overflow: 'hidden' }}>
           {showProjectList ? (
             <StyledSplitter stateKey={PROJECTS_LIST_WIDTH_KEY} stateStorage="local">

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -88,6 +88,7 @@ strong {
     flex-grow: 1;
     display: flex;
     flex-direction: row;
+    overflow: hidden;
     gap: var(--base-gap-large);
     padding: 8px;
     position: relative;


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
Fixes an issue where access groups did not overflow properly and couldn't be scrolled.


## Technical details
<!-- Please state any technical details such as limitations -->
main element now has overflow hidden applied always.

