### PR TITLE
Critical: Check status scope is not undefined to prevent home page crash

### DIFF
--- a/shared/src/hooks/useScopedStatuses.ts
+++ b/shared/src/hooks/useScopedStatuses.ts
@@ -15,9 +15,10 @@ export const useScopedStatuses = (projects: string[], entityTypes: string[]) => 
 
   let currentStatuses: EntityStatus[] | undefined
   for (const item of Object.values(response.data) as ProjectModel[]) {
-    const filteredStatuses = item.statuses!.filter((status: EntityStatus) =>
-      entityTypes.every((type) => (!status.scope || status.scope?.includes(type))),
-    )
+    const filteredStatuses =
+      item.statuses?.filter((status: EntityStatus) =>
+        entityTypes.every((type) => !status.scope || status.scope?.includes(type)),
+      ) || []
     if (currentStatuses === undefined) {
       currentStatuses = filteredStatuses
       continue
@@ -35,5 +36,7 @@ export const filterProjectStatuses = (statuses: EntityStatus[], entityTypes: str
     return statusesList
   }
 
-  return statusesList.filter((el) => entityTypes.every((type) => el.scope!.includes(type)))
+  return statusesList.filter((el) =>
+    entityTypes.every((type) => el.scope === undefined || el.scope.includes(type)),
+  )
 }


### PR DESCRIPTION
Legacy projects could have statuses that do not have a scope field (undefined). This check was overwritten to assume scope was defined (when it wasn't). This would cause the home page to crash and make it very hard to recover from.

<img width="307" height="227" alt="image" src="https://github.com/user-attachments/assets/32a87858-5f8c-4423-8cb0-d3091473dda6" />
