### PR TITLE
Overview: Force update virtual columns on size or order change

### DIFF
--- a/shared/src/containers/ProjectTreeTable/ProjectTreeTable.tsx
+++ b/shared/src/containers/ProjectTreeTable/ProjectTreeTable.tsx
@@ -420,6 +420,8 @@ export const ProjectTreeTable = ({
     visibleColumns,
     tableContainerRef,
     columnPinning,
+    columnSizing,
+    columnOrder,
   })
 
   const columnSizeVars = useCustomColumnWidthVars(table, columnSizing)


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
There was a bug that the virtual columns would not re-calculate when the width or order of the columns changed causing weird glitches when scrolling.

