### PR TITLE
Add HelpButton component to ProjectPage

### DIFF
--- a/src/components/HelpButton/HelpButton.tsx
+++ b/src/components/HelpButton/HelpButton.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import { Button } from '@ynput/ayon-react-components'
+import { useFeedback } from '@shared/components'
+import { getHelpForPage } from '@helpers/helpArticles'
+
+interface HelpButtonProps {
+    module: string
+    pageName?: string
+    className?: string
+}
+
+const HelpButton: React.FC<HelpButtonProps> = ({ module, pageName, className }) => {
+    const { openSupport } = useFeedback()
+    const handleHelpClick = () => {
+        const help = getHelpForPage(module, pageName)
+
+        if (help.articleId) {
+            // Open specific help article
+            openSupport('ShowArticle', help.articleId)
+        } else {
+            // Open support with a prefilled message
+            openSupport('NewMessage', help.fallbackMessage)
+        }
+    }
+
+    return (
+        <Button
+            icon="help"
+            variant="text"
+            onClick={handleHelpClick}
+            className={className}
+            data-tooltip="Get help for this page"
+        />
+    )
+}
+
+export default HelpButton

--- a/src/containers/header/AppNavLinks.jsx
+++ b/src/containers/header/AppNavLinks.jsx
@@ -53,7 +53,12 @@ const AppNavLinks = ({ links = [], currentModule, projectName }) => {
       }
     }
   }, [module, links, access])
-
+  
+  const activeModule = currentModule || module
+  const currentPageLink = links.find(link => link.module === activeModule)
+  const currentPageName = currentPageLink?.name
+  
+  
   return (
     <Styled.NavBar className="secondary">
       <ul>

--- a/src/helpers/helpArticles.ts
+++ b/src/helpers/helpArticles.ts
@@ -1,0 +1,29 @@
+export interface HelpArticle {
+    articleId?: string
+    fallbackMessage?: string
+}
+
+export const HELP_ARTICLES: Record<string, HelpArticle> = {
+    overview: {
+        articleId: '7885519',
+    },
+    tasks: {
+        articleId: '5526719',
+    },
+    lists: {
+        articleId: '7382645',
+    }
+}
+
+export const getHelpForPage = (module: string, pageName?: string): HelpArticle => {
+    const help = HELP_ARTICLES[module]
+    if (help) {
+        return help
+    }
+
+
+    const displayName = pageName || module
+    return {
+        fallbackMessage: `Can you help me know more about the ${displayName} page?`,
+    }
+}

--- a/src/pages/ProjectPage/ProjectPage.tsx
+++ b/src/pages/ProjectPage/ProjectPage.tsx
@@ -29,6 +29,7 @@ import { productSelected } from '@state/context'
 import useGetBundleAddonVersions from '@hooks/useGetBundleAddonVersions'
 import ProjectReviewsPage from '@pages/ProjectListsPage/ProjectReviewsPage'
 import { Views, ViewsProvider } from '@shared/containers'
+import HelpButton from "@components/HelpButton/HelpButton.tsx"
 
 type NavLink = {
   name?: string
@@ -182,6 +183,9 @@ const ProjectPage = () => {
         })),
       { node: 'spacer' },
       {
+        node: <HelpButton module={module} />,
+      },
+      {
         node: (
           <Button
             icon="more_horiz"
@@ -193,7 +197,7 @@ const ProjectPage = () => {
         ),
       },
     ],
-    [addonsData, projectName, remotePages, matchedAddons],
+    [addonsData, projectName, remotePages, matchedAddons, module],
   )
   const activeLink = useMemo(() => {
     return links.find((link) => link.module === module) || null


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
Implemented a contextual Help button feature for the ProjectPage. The button uses the useFeedback hook to provide support, either by opening specific help articles or by creating a pre-filled support request based on the current page.

This change involved:

- Creating a new HelpButton React component.
- Adding a helper module (helpArticles.ts) to configure help article IDs and fallback messages.
- Integrating the HelpButton into the ProjectPage navigation.
- Updating AppNavLinks to provide the current page context.


## Technical details
<!-- Please state any technical details such as limitations -->


## Additional context
<!-- Add any other context or screenshots here. -->

