### PR TITLE
1390- Market: Disable and show when addon v is not compatible.

### DIFF
--- a/src/pages/MarketPage/MarketDetails/MarketDetails.styled.ts
+++ b/src/pages/MarketPage/MarketDetails/MarketDetails.styled.ts
@@ -45,7 +45,7 @@ export const Right = styled.div`
   gap: var(--base-gap-large);
   flex: 1;
   max-width: 300px;
-  min-width: 200px;
+  min-width: 250px;
 
   & > button {
     width: 100%;


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 


- Incompatible version detection: Added logic to find newest version by createdAt and check isCompatible flag
- Disabled UI elements: Main download button shows "Update required" with block icon when latest version is incompatible 
- Version dropdown protection: Incompatible versions marked as disabled with block icons and "(server update required)" labels
- Toast error messages: Users get "Addon incompatible with your server version" when attempting incompatible downloads
- Button layout fixes: Fixed width constraints to ensure both download button and version dropdown are visible together



## Technical details
<!-- Please state any technical details such as limitations -->


## Additional context
<!-- Add any other context or screenshots here. -->

