### PR TITLE
Unified list styles in activity feed

### DIFF
--- a/shared/src/containers/Feed/components/CommentInput/CommentInput.styled.ts
+++ b/shared/src/containers/Feed/components/CommentInput/CommentInput.styled.ts
@@ -83,12 +83,24 @@ export const Comment = styled.div`
   }
 
   /* list and check box styles */
-  .ql-editor ol {
+  .ql-editor ol,
+  .ql-editor ul {
     li {
-      :not([data-list='ordered']) {
-        &::before {
-          display: none;
-        }
+      padding-left: 0;
+
+      /* Hide React Quill's ::before pseudo-elements */
+      &::before {
+        content: none;
+      }
+
+      &[data-list='ordered'] {
+        list-style-type: decimal;
+        list-style-position: inside;
+      }
+
+      &[data-list='bullet'] {
+        list-style-type: circle;
+        list-style-position: inside;
       }
 
       /* checkbox data-checked false or true */


### PR DESCRIPTION
## Description of changes 
* There were bad styles for the unordered list
* I tried to make bullets look the same for React Quill and ReactMarkdown


## Additional context
* We should probably make React Quill and React Markdown have the same padding

<img width="473" height="325" alt="Screenshot 2025-08-23 at 8 33 50" src="https://github.com/user-attachments/assets/fdf530c9-83de-48f2-8ac1-ddb938e1a78a" />


