### PR TITLE
Add custom protocol fail message

### DIFF
--- a/shared/src/hooks/useActionTriggers.ts
+++ b/shared/src/hooks/useActionTriggers.ts
@@ -1,6 +1,6 @@
 import { useDispatch } from 'react-redux'
-import customProtocolCheck from 'custom-protocol-check'
 import { api } from '@shared/api'
+import { useCustomProtocolCheck } from './useCustomProtocolCheck'
 
 
 export type ActionTriggersProps = {
@@ -29,17 +29,30 @@ export const useActionTriggers = ({
   onNavigate,
 }: ActionTriggersProps) => {
   const dispatch = useDispatch()
-  const handleActionPayload = (actionType: string, payload: ActionPayload | null): void => {
+  
+  const { checkProtocol } = useCustomProtocolCheck({
+    timeout: 2000,
+    showSuccessMessage: false,
+    showErrorMessage: true,
+    enableFallback: true
+  })
+  
+  const handleActionPayload = async (actionType: string, payload: ActionPayload | null): Promise<void> => {
     if (!payload) return
 
     if (actionType === 'launcher') {
       if (payload?.uri) {
-        customProtocolCheck(
-          payload.uri,
-          () => {},
-          () => {},
-          2000,
-        )
+        try {
+          const success = await checkProtocol(payload.uri)
+          
+          if (!success) {
+            console.log('Protocol launch failed - AYON client may not be running')
+          }
+        } catch (error) {
+          console.error('Protocol launch error:', error)
+        }
+      } else {
+        console.warn('Launcher action has no URI:', payload)
       }
     } else if (actionType === 'query') {
       // Validate it is an object of key:value pairs with value being string

--- a/shared/src/hooks/useCustomProtocolCheck.ts
+++ b/shared/src/hooks/useCustomProtocolCheck.ts
@@ -1,0 +1,70 @@
+import { useCallback } from 'react'
+import customProtocolCheck from 'custom-protocol-check'
+import { toast } from 'react-toastify'
+
+interface UseCustomProtocolCheckOptions {
+  timeout?: number
+  showSuccessMessage?: boolean
+  showErrorMessage?: boolean
+  enableFallback?: boolean
+}
+
+export const useCustomProtocolCheck = (options: UseCustomProtocolCheckOptions = {}) => {
+  const {
+    timeout = 2000,
+    showSuccessMessage = false,
+    showErrorMessage = true,
+    enableFallback = true,
+  } = options
+
+  const checkProtocol = useCallback((uri: string): Promise<boolean> => {
+    return new Promise((resolve) => {
+      let hasResolved = false
+      
+      const resolveOnce = (result: boolean) => {
+        if (hasResolved) return
+        hasResolved = true
+        resolve(result)
+      }
+
+      const timeoutId = setTimeout(() => {
+        resolveOnce(false)
+      }, timeout + 500) // Add a small buffer to the timeout
+
+      try {
+        customProtocolCheck(
+          uri,
+          () => {
+            clearTimeout(timeoutId)
+            
+            // On success: show nothing
+            
+            resolveOnce(true)
+          },
+          () => {
+            clearTimeout(timeoutId)
+            if (showErrorMessage) {
+              toast.error(
+                'AYON client is not running. Please start the AYON client application and try again.',
+                { 
+                  autoClose: 8000,
+                  toastId: 'ayon-client-not-running'
+                }
+              )
+            }
+            resolveOnce(false)
+          },
+          timeout
+        )
+      } catch (error) {
+        clearTimeout(timeoutId)
+        if (showErrorMessage) {
+          toast.error('Failed to launch AYON client action')
+        }
+        resolveOnce(false)
+      }
+    })
+  }, [timeout, showSuccessMessage, showErrorMessage, enableFallback])
+
+  return { checkProtocol }
+}


### PR DESCRIPTION
## Description of changes 
* Added a message on the custom protocol fail
* On success, we do nothing

## Additional context
* There was a tricky part with Firefox, I accidentally opened the ayon + version. It does nothing. I needed to open the ayon, and it worked. Tested on Mac. 
* Safari works

<img width="415" height="370" alt="Screenshot 2025-08-23 at 14 43 25" src="https://github.com/user-attachments/assets/a1f8b6c7-7529-416c-8245-8fc882902cd2" />

