### PR TITLE
1355: Table: Clickable links

### DIFF
--- a/shared/src/containers/ProjectTreeTable/widgets/TextWidget.tsx
+++ b/shared/src/containers/ProjectTreeTable/widgets/TextWidget.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from 'react'
+import { forwardRef, useCallback } from 'react'
 import { TextWidgetInput } from './TextWidgetInput'
 import { WidgetBaseProps } from './CellWidget'
 import styled from 'styled-components'
@@ -15,6 +15,43 @@ const StyledBaseTextWidget = styled.span`
   gap: 4px;
 `
 
+const StyledLink = styled.a`
+  color: var(--md-sys-color-primary, #0066cc);
+  text-decoration: none;
+  cursor: pointer;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  
+  &:hover {
+    text-decoration: underline;
+  }
+`
+
+// Function to check if a string is a valid URL
+const isValidUrl = (text: string): boolean => {
+  try {
+    const url = new URL(text.trim())
+    return url.protocol === 'http:' || url.protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
+// Function to parse text and extract URLs
+const parseTextWithUrls = (text: string) => {
+  // Regex to match HTTP/HTTPS URLs
+  const urlRegex = /(https?:\/\/\S+)/gi
+  const parts = text.split(urlRegex)
+
+  return parts.map((part, index) => {
+    if (isValidUrl(part)) {
+      return { type: 'url', content: part, key: index }
+    }
+    return { type: 'text', content: part, key: index }
+  })
+}
+
 type AttributeType = AttributeData['type']
 export type TextWidgetType = Extract<AttributeType, 'string' | 'integer' | 'float'>
 
@@ -28,10 +65,45 @@ export interface TextWidgetProps
 
 export const TextWidget = forwardRef<HTMLSpanElement, TextWidgetProps>(
   ({ value, option, isEditing, isInherited, onChange, onCancelEdit, style, ...props }, ref) => {
+    const handleLinkClick = useCallback((e: React.MouseEvent, url: string) => {
+      e.stopPropagation()
+      window.open(url, '_blank', 'noopener,noreferrer')
+    }, [])
+
     if (isEditing) {
       return (
         <TextWidgetInput value={value} onChange={onChange} onCancel={onCancelEdit} type={'text'} />
       )
+    }
+
+    const displayText = option?.label || value
+    const textValue = typeof displayText === 'string' ? displayText : String(displayText || '')
+    const hasUrls = !option && textValue.match(/(https?:\/\/\S+)/gi)
+
+    const renderContent = () => {
+      if (hasUrls) {
+        // Text with URLs (handles both single URL and mixed content)
+        const parts = parseTextWithUrls(textValue)
+        return parts.map((part) => {
+          if (part.type === 'url') {
+            return (
+              <StyledLink
+                key={part.key}
+                href={part.content}
+                onClick={(e) => handleLinkClick(e, part.content)}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {part.content}
+              </StyledLink>
+            )
+          }
+          return part.content
+        })
+      } else {
+        // Regular text
+        return textValue
+      }
     }
 
     return (
@@ -44,7 +116,7 @@ export const TextWidget = forwardRef<HTMLSpanElement, TextWidgetProps>(
             }}
           />
         )}
-        {option?.label || value}
+        {renderContent()}
       </StyledBaseTextWidget>
     )
   },


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description

  Added clickable URL support to table cells in ProjectTreeTable

- URL Detection: Automatically detects HTTP/HTTPS URLs in table cell content
- Hyperlink Rendering: URLs are displayed as clickable blue links with hover underline effects
- Mixed Content Support: Handles both pure URLs and text containing URLs (e.g., "Visit https://example.com for details")
- Link Behavior: URLs open in new tab (_blank) with security attributes (noopener noreferrer)
- Text Truncation: Long URLs are truncated with ellipsis (...) to fit cell width

- Cell Editing: Users can still edit cells by clicking on non-URL areas
- Event Handling: Link clicks use stopPropagation() to prevent interference with table selection
- Existing Behavior: Non-URL content remains unchanged with full editing capability


## Technical details

- Modified TextWidget.tsx in shared/src/containers/ProjectTreeTable/widgets/
- Uses regex pattern /(https?:\/\/\S+)/gi for URL detection
- Splits mixed content to render URLs as <a> tags and text as regular content
- Maintains type safety with proper string conversion handling


### Examples:

- "https://example.com" → Clickable blue link
- "Check https://docs.com and https://api.com" → Two clickable links within text
- "Regular text" → Normal editable text (unchanged)

## Additional context
<!-- Add any other context or screenshots here. -->

