### PR TITLE
Add tooltip to dependency package file name

### DIFF
--- a/src/pages/SettingsPage/Bundles/BundleDepPackage.jsx
+++ b/src/pages/SettingsPage/Bundles/BundleDepPackage.jsx
@@ -27,7 +27,7 @@ const BundleDepPackage = ({ children, label, onEdit }) => {
         onClick={onEdit}
         data-tooltip={children ? 'Edit dependency package' : 'Add dependency package'}
       />
-      <span>
+      <span data-tooltip={children || '(NONE)'}>
         {children || '(NONE)'}
         {/* <span> (author)</span> */}
       </span>


### PR DESCRIPTION
<img width="566" height="337" alt="image" src="https://github.com/user-attachments/assets/57acae44-ce3f-4e39-aa7c-b39892b05d02" />


This pull request introduces a small UI improvement to the `BundleDepPackage` component. Now, when displaying the dependency package name, a tooltip is shown with either the package name or "(NONE)" if no package is present.
