### PR TITLE
Prevent closing upload dialog by clicking outside

### DIFF
--- a/src/components/AddonDialog/AddonDialog.jsx
+++ b/src/components/AddonDialog/AddonDialog.jsx
@@ -18,10 +18,6 @@ const AddonDialog = ({ uploadOpen, setUploadOpen, uploadHeader, manager }) => {
   const abortController = useRef(new AbortController())
   const [manageMode, setManageMode] = useState(false)
 
-  const closeHandler = () => {
-    handleAddonInstallFinish()
-    setManageMode(false)
-  }
 
   const handleAddonInstallFinish = () => {
     if (!isUploading) {
@@ -57,9 +53,10 @@ const AddonDialog = ({ uploadOpen, setUploadOpen, uploadHeader, manager }) => {
       isOpen={!!uploadOpen}
       style={{ width: manageMode ? 800 : 400, height: 400, overflow: 'hidden' }}
       header={uploadHeader || 'Upload addon'}
-      onClose={closeHandler}
       size="md"
       tabIndex={-1}
+      hideCancelButton
+
     >
       {uploadOpen && (
         <AddonUpload


### PR DESCRIPTION
This pull request makes a minor update to the `AddonDialog` component, focusing on dialog closing behavior and UI controls. The main change is the removal of the custom close handler and the cancel button from the dialog.