### PR TITLE
Overview: Automatically focus search bar dropdowns

### DIFF
--- a/shared/src/containers/ProjectTreeTable/hooks/useKeyboardNavigation.ts
+++ b/shared/src/containers/ProjectTreeTable/hooks/useKeyboardNavigation.ts
@@ -34,6 +34,7 @@ export default function useKeyboardNavigation() {
       // allow keyboard and up and down only if the player is open
       if (playerOpen && e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return
 
+      // Don't handle keyboard events if we are currently editing a cell
       if (editingCellId) return
 
       // Don't handle keyboard events if we don't have a focused cell

--- a/shared/src/containers/ProjectTreeTable/widgets/EnumWidget.tsx
+++ b/shared/src/containers/ProjectTreeTable/widgets/EnumWidget.tsx
@@ -84,7 +84,7 @@ export const EnumWidget = forwardRef<HTMLDivElement, EnumWidgetProps>(
 
     // when the dropdown is open, focus the first item
     useEffect(() => {
-      if (dropdownOpen) {
+      if (dropdownOpen && !dropdownProps.search) {
         const optionsUlEl = dropdownRef.current?.getOptions() as HTMLUListElement
         const firstItem = optionsUlEl?.querySelector('li')
         if (firstItem) {
@@ -93,7 +93,7 @@ export const EnumWidget = forwardRef<HTMLDivElement, EnumWidgetProps>(
           firstItem.style.outline = 'none'
         }
       }
-    }, [dropdownOpen])
+    }, [dropdownOpen, dropdownProps.search])
 
     const isMultiSelect = !!type?.includes('list')
 

--- a/src/hooks/useCreateEntityShortcuts.ts
+++ b/src/hooks/useCreateEntityShortcuts.ts
@@ -1,6 +1,7 @@
 import { useEffect } from 'react'
 import { NewEntityType } from '@context/NewEntityContext'
 import { useAppSelector } from '@state/store'
+import { useCellEditing } from '@shared/containers'
 
 interface EntityOption {
   label: string
@@ -23,6 +24,7 @@ interface UseCreateEntityShortcutsProps {
  */
 const useCreateEntityShortcuts = ({ options, onOpenNew }: UseCreateEntityShortcutsProps) => {
   const menuOpen = useAppSelector((state) => state.context.menuOpen)
+  const { editingCellId } = useCellEditing()
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       // skip if the menu is open
@@ -37,6 +39,9 @@ const useCreateEntityShortcuts = ({ options, onOpenNew }: UseCreateEntityShortcu
       ) {
         return
       }
+
+      // skip if currently editing a cell
+      if (editingCellId) return
 
       // Skip if key modifiers are pressed
       if (e.ctrlKey || e.metaKey || e.altKey) {
@@ -61,7 +66,7 @@ const useCreateEntityShortcuts = ({ options, onOpenNew }: UseCreateEntityShortcu
     return () => {
       window.removeEventListener('keydown', handleKeyDown)
     }
-  }, [options, onOpenNew])
+  }, [options, onOpenNew, editingCellId])
 }
 
 export default useCreateEntityShortcuts


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
- Disable new entity shortcuts when editing a cell
- Ensure the dropdown search input is auto focused

