### PR TITLE
Handle null values of link nodes

### DIFF
--- a/shared/src/api/queries/links/getEntityLinks.ts
+++ b/shared/src/api/queries/links/getEntityLinks.ts
@@ -128,7 +128,7 @@ const injectedQueries = foldersApi.injectEndpoints({
             result.project?.[resultPath]?.edges?.map(({ node }: { node: any }) => ({
               id: node.id,
               links:
-                node.links.edges?.map((linkEdge: EntityLinkQuery) => ({
+                node.links.edges?.filter((e: EntityLinkQuery | null) =>!!e?.node)?.map((linkEdge: EntityLinkQuery) => ({
                   ...linkEdge,
                   node: {
                     id: linkEdge.node.id,


### PR DESCRIPTION
This pull request introduces a minor improvement to the way entity links are processed in the `getEntityLinks` query. It adds a filter to ensure that only valid link edges with a `node` property are mapped, which helps prevent potential runtime errors when processing data from the API.


This is required by https://github.com/ynput/ayon-backend/pull/718