### PR TITLE
Feed: New version activity date overflow #1470

### DIFF
--- a/shared/src/containers/Feed/components/ActivityDate.tsx
+++ b/shared/src/containers/Feed/components/ActivityDate.tsx
@@ -20,6 +20,11 @@ const DateStyled = styled.span`
   white-space: nowrap;
   display: flex;
   align-items: center;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex-shrink: 3;
+  min-width: 0;
+  max-width: fit-content;
 
   ${theme.bodySmall}
 `

--- a/shared/src/containers/Feed/components/ActivityVersions/ActivityVersions.styled.ts
+++ b/shared/src/containers/Feed/components/ActivityVersions/ActivityVersions.styled.ts
@@ -37,18 +37,43 @@ export const Content = styled.div`
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-
+  align-items: flex-start;
   gap: var(--base-gap-small);
+  overflow: hidden;
+  min-width: 0;
+
+  > div:first-child {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+  }
 `
 
 export const Title = styled.div`
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: var(--base-gap-small);
+  overflow: hidden;
+  flex: 1;
+  min-width: 0;
+
+  /* Product name text that can be truncated */
+  > span:not(.date) {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    flex-shrink: 1;
+    min-width: 0;
+    max-width: 100%;
+  }
 
   .date {
     /* by default hide */
     display: none;
+    flex-shrink: 2;
+    min-width: 0;
+    max-width: 50%;
   }
 `
 
@@ -66,6 +91,14 @@ export const Thumbnail = styled(ThumbnailSimple)`
   img {
     object-fit: cover;
   }
+`
+
+export const VersionName = styled.span`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: block;
+  min-width: 0;
 `
 
 export const Comment = styled.div`

--- a/shared/src/containers/Feed/components/ActivityVersions/ActivityVersions.styled.ts
+++ b/shared/src/containers/Feed/components/ActivityVersions/ActivityVersions.styled.ts
@@ -71,9 +71,7 @@ export const Title = styled.div`
   .date {
     /* by default hide */
     display: none;
-    flex-shrink: 2;
-    min-width: 0;
-    max-width: 50%;
+    flex: 1;
   }
 `
 

--- a/shared/src/containers/Feed/components/ActivityVersions/ActivityVersions.tsx
+++ b/shared/src/containers/Feed/components/ActivityVersions/ActivityVersions.tsx
@@ -69,7 +69,7 @@ const ActivityVersions: React.FC<ActivityVersionsProps> = ({
                     <span>{productName}</span>
                     <ActivityDate date={createdAt} isExact />
                   </Styled.Title>
-                  <span className="version">{name}</span>
+                  <Styled.VersionName className="version">{name}</Styled.VersionName>
                 </div>
                 <Styled.Thumbnail
                   {...{ projectName }}


### PR DESCRIPTION
Feed: New version activity date overflow

<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
  Fixed overflow issue in Feed where date text on version activities would push thumbnails out of their container when the feed width was very small. Implemented proper
  text truncation and flex layout prioritization to ensure content remains within bounds.

## Technical details
<!-- Please state any technical details such as limitations -->
  **Layout Behavior:**
  - Priority order: Product name (highest) → Thumbnail (fixed) → Date (lowest)
  - Space distribution: Text content gets up to 100% width, date limited to 50% when visible
  - Overflow handling: All text elements show ellipsis (...) when truncated
  - Responsive: Layout adapts gracefully from wide to very narrow feed widths

## Additional context
<!-- Add any other context or screenshots here. -->
<img width="292" height="109" alt="Screenshot 2025-09-18 at 17 00 22" src="https://github.com/user-attachments/assets/8abaa01f-d0bf-4889-abbf-3752df7fd2e3" />
<img width="700" height="226" alt="Screenshot 2025-09-18 at 17 03 05" src="https://github.com/user-attachments/assets/b398d59b-3dbc-4231-984b-0534073d9b72" />


