### PR TITLE
Overview: When a enum does not exist we should still show it in dropdown to give option unselect.

### DIFF
--- a/shared/src/containers/ProjectTreeTable/widgets/EnumWidget.tsx
+++ b/shared/src/containers/ProjectTreeTable/widgets/EnumWidget.tsx
@@ -53,22 +53,25 @@ export const EnumWidget = forwardRef<HTMLDivElement, EnumWidgetProps>(
     )
 
     // Check if all values are present in options, if not, add a warning
+    const invalidOptions: AttributeEnumItem[] = []
     valueAsStrings.forEach((val) => {
       if (!options.find((option) => option.value === val)) {
-        selectedOptions = [
-          ...selectedOptions,
-          {
-            label: val,
-            value: val,
-            color: enableCustomValues
-              ? 'var(--md-sys-color-surface-container)'
-              : 'var(--md-sys-color-error)',
-            icon: enableCustomValues ? undefined : 'warning',
-          },
-        ]
+        const invalidOption = {
+          label: val,
+          value: val,
+          color: enableCustomValues
+            ? 'var(--md-sys-color-surface-container)'
+            : 'var(--md-sys-color-error)',
+          icon: enableCustomValues ? undefined : 'warning',
+        }
+        selectedOptions = [...selectedOptions, invalidOption]
+        invalidOptions.push(invalidOption)
       }
     })
     const hasMultipleValues = selectedOptions.length > 1
+
+    // Merge valid options with invalid options for the dropdown
+    const allOptions = [...options, ...invalidOptions]
 
     const dropdownRef = useRef<DropdownRef>(null)
 
@@ -113,7 +116,7 @@ export const EnumWidget = forwardRef<HTMLDivElement, EnumWidgetProps>(
     if (isEditing) {
       return (
         <StyledDropdown
-          options={options}
+          options={allOptions}
           value={valueAsStrings}
           ref={dropdownRef}
           valueTemplate={(_value, selected, isOpen) => (


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

 Fixed enum dropdown to show invalid values as selectable options, allowing users to easily deselect them. Previously, invalid enum values would show with a warning
  triangle but weren't available in the dropdown for removal.

## Technical details
<!-- Please state any technical details such as limitations -->

- Invalid enum values are now collected into a separate invalidOptions array
- Valid and invalid options are merged into allOptions for the dropdown
- Invalid values maintain their warning styling (error color + warning icon) when displayed in the dropdown
- Users can now click on invalid values in the dropdown to deselect and remove them

## Additional context
<!-- Add any other context or screenshots here. -->
<img width="219" height="127" alt="Screenshot 2025-09-19 at 14 27 41" src="https://github.com/user-attachments/assets/cbd8582e-a4ea-4f2f-8f4f-fa2e3f59513b" />
<img width="228" height="134" alt="Screenshot 2025-09-19 at 14 27 57" src="https://github.com/user-attachments/assets/9d7a4de4-ff52-413e-a88e-f2f5885f3bf3" />


