### PR TITLE
Home: Tasks dashboard groupby sorting on enums should use order

### DIFF
--- a/src/pages/UserDashboardPage/UserDashboardTasks/DashboardTasksToolbar/KanBanGroupByOptions.ts
+++ b/src/pages/UserDashboardPage/UserDashboardTasks/DashboardTasksToolbar/KanBanGroupByOptions.ts
@@ -7,7 +7,7 @@ type GroupByOption = {
 
 const groupByOptions: GroupByOption[] = [
   { id: 'folderName', label: 'Folder', sortOrder: true },
-  { id: 'status', label: 'Status', sortOrder: true },
+  { id: 'status', label: 'Status', sortOrder: true, sortByEnumOrder: true },
   { id: 'priority', label: 'Priority', sortOrder: true, sortByEnumOrder: true },
   { id: 'taskType', label: 'Type', sortOrder: true },
   { id: 'projectName', label: 'Project', sortOrder: true },


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
Fixed task dashboard grouping to use enum order instead of alphabetical sorting. When grouping tasks by priority or status, the groups now appear in the order defined by
  the project's anatomy settings rather than alphabetically.

  Before: Groups sorted alphabetically (e.g., "Approved", "In Progress", "Not Ready")
  After: Groups sorted by anatomy order (e.g., "Not Ready" → "Ready to Start" → "In Progress" → "Pending Review" → "Approved" → "On Hold" → "Omitted")


## Technical details
<!-- Please state any technical details such as limitations -->
- Added sortByEnumOrder: true to status in KanBanGroupByOptions.ts (priority already had this)
  - Enhanced list view sorting logic to check for sortByEnumOrder flag and use anatomy arrays when present
  - Handles different property structures: id property for status options, value property for priority options
  - Maintains proper reverse sorting functionality when toggling sort direction
  - List view now matches Kanban view sorting behavior

## Additional context
<!-- Add any other context or screenshots here. -->

Before: 

https://github.com/user-attachments/assets/c1427e71-14b7-48c8-bdab-d5b5bc90cfff

After:

https://github.com/user-attachments/assets/013986fd-29dc-4b5b-b390-ec94a89ba184






