### PR TITLE
Overview: Make thumbnails bigger by increasing the column width

### DIFF
--- a/shared/src/api/generated/views.ts
+++ b/shared/src/api/generated/views.ts
@@ -208,6 +208,7 @@ export type OverviewSettings = {
   sortDesc?: boolean
   filter?: QueryFilter
   columns?: ColumnItemModel[]
+  rowHeight?: number
 }
 export type OverviewViewPostModel = {
   /** Unique identifier for the view within the given scope. */

--- a/shared/src/api/generated/views.ts
+++ b/shared/src/api/generated/views.ts
@@ -237,6 +237,7 @@ export type ListsSettings = {
   sortDesc?: boolean
   filter?: QueryFilter
   columns?: ColumnItemModel[]
+  rowHeight?: number
 }
 export type ListsViewPostModel = {
   /** Unique identifier for the view within the given scope. */

--- a/shared/src/components/ProjectTableSettings/ProjectTableSettings.tsx
+++ b/shared/src/components/ProjectTableSettings/ProjectTableSettings.tsx
@@ -10,6 +10,7 @@ import styled from 'styled-components'
 import { SettingHighlightedId, useSettingsPanel } from '@shared/context'
 import { SettingsPanel, SettingConfig } from '@shared/components/SettingsPanel'
 import ColumnsSettings from './ColumnsSettings'
+import RowHeightSettings from './RowHeightSettings'
 
 const StyledCustomizeButton = styled(Button)`
   min-width: 120px;
@@ -48,7 +49,7 @@ export const ProjectTableSettings: FC<ProjectTableSettingsProps> = ({
   highlighted,
 }) => {
   const { attribFields, projectInfo } = useProjectTableContext()
-  const { columnVisibility } = useColumnSettingsContext()
+  const { columnVisibility, rowHeight = 40 } = useColumnSettingsContext()
 
   const columns = [
     {
@@ -113,6 +114,13 @@ export const ProjectTableSettings: FC<ProjectTableSettingsProps> = ({
       icon: 'view_column',
       preview: `${visibleCount}/${columns.length}`,
       component: <ColumnsSettings columns={columns} highlighted={highlighted} />,
+    },
+    {
+      id: 'row-height',
+      title: 'Row Height',
+      icon: 'height',
+      preview: `${rowHeight}px`,
+      component: <RowHeightSettings />,
     },
   ]
 

--- a/shared/src/components/ProjectTableSettings/ProjectTableSettings.tsx
+++ b/shared/src/components/ProjectTableSettings/ProjectTableSettings.tsx
@@ -115,13 +115,6 @@ export const ProjectTableSettings: FC<ProjectTableSettingsProps> = ({
       preview: `${visibleCount}/${columns.length}`,
       component: <ColumnsSettings columns={columns} highlighted={highlighted} />,
     },
-    {
-      id: 'row-height',
-      title: 'Row Height',
-      icon: 'height',
-      preview: `${rowHeight}px`,
-      component: <RowHeightSettings />,
-    },
   ]
 
   settings.forEach((setting) => defaultSettings.push(setting))

--- a/shared/src/components/ProjectTableSettings/ProjectTableSettings.tsx
+++ b/shared/src/components/ProjectTableSettings/ProjectTableSettings.tsx
@@ -10,7 +10,6 @@ import styled from 'styled-components'
 import { SettingHighlightedId, useSettingsPanel } from '@shared/context'
 import { SettingsPanel, SettingConfig } from '@shared/components/SettingsPanel'
 import ColumnsSettings from './ColumnsSettings'
-import RowHeightSettings from './RowHeightSettings'
 
 const StyledCustomizeButton = styled(Button)`
   min-width: 120px;
@@ -49,7 +48,7 @@ export const ProjectTableSettings: FC<ProjectTableSettingsProps> = ({
   highlighted,
 }) => {
   const { attribFields, projectInfo } = useProjectTableContext()
-  const { columnVisibility, rowHeight = 40 } = useColumnSettingsContext()
+  const { columnVisibility } = useColumnSettingsContext()
 
   const columns = [
     {

--- a/shared/src/components/ProjectTableSettings/RowHeightSettings.tsx
+++ b/shared/src/components/ProjectTableSettings/RowHeightSettings.tsx
@@ -42,7 +42,7 @@ const Slider = styled.input`
   flex: 1;
   height: 4px;
   border-radius: 2px;
-  background: var(--md-sys-color-outline);
+  background: var(--md-sys-color-outline-variant);
   outline: none;
   -webkit-appearance: none;
   appearance: none;
@@ -54,9 +54,12 @@ const Slider = styled.input`
     height: 16px;
     border-radius: 50%;
     background: var(--md-sys-color-primary);
-    cursor: pointer;
-    border: 2px solid var(--md-sys-color-surface);
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+    cursor: grab;
+    box-shadow: var(--box-fill);
+  }
+
+  &:active::-webkit-slider-thumb {
+    cursor: grabbing;
   }
 
   &::-moz-range-thumb {
@@ -64,13 +67,13 @@ const Slider = styled.input`
     height: 16px;
     border-radius: 50%;
     background: var(--md-sys-color-primary);
-    cursor: pointer;
+    cursor: grabbing;
     border: 2px solid var(--md-sys-color-surface);
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
   }
 
   &:hover::-webkit-slider-thumb {
-    background: var(--md-sys-color-primary-container);
+    background: var(--md-sys-color-primary-hover);
   }
 
   &:hover::-moz-range-thumb {
@@ -79,14 +82,17 @@ const Slider = styled.input`
 `
 
 const ValueDisplay = styled.span`
-  font-size: 14px;
   color: var(--md-sys-color-on-surface-variant);
   min-width: 40px;
   text-align: right;
 `
 
 const RowHeightSettings: FC = () => {
-  const { rowHeight: contextRowHeight = 34, updateRowHeight, updateRowHeightWithPersistence } = useColumnSettingsContext()
+  const {
+    rowHeight: contextRowHeight = 34,
+    updateRowHeight,
+    updateRowHeightWithPersistence,
+  } = useColumnSettingsContext()
 
   // Local state for immediate UI updates during slider drag
   const [localRowHeight, setLocalRowHeight] = useState(contextRowHeight)
@@ -123,6 +129,9 @@ const RowHeightSettings: FC = () => {
     updateRowHeightWithPersistence(localRowHeight)
   }, [localRowHeight, updateRowHeightWithPersistence])
 
+  // Calculate the percentage for the gradient fill
+  const fillPercentage = ((localRowHeight - 24) / (200 - 24)) * 100
+
   return (
     <Container>
       <Label htmlFor="row-height-slider">Row height</Label>
@@ -137,6 +146,9 @@ const RowHeightSettings: FC = () => {
           onChange={handleSliderChange}
           onMouseDown={handleSliderStart}
           onMouseUp={handleSliderRelease}
+          style={{
+            background: `linear-gradient(to right, var(--md-sys-color-primary) 0%, var(--md-sys-color-primary) ${fillPercentage}%, var(--md-sys-color-outline-variant) ${fillPercentage}%, var(--md-sys-color-outline-variant) 100%)`,
+          }}
         />
         <ValueDisplay>{localRowHeight}</ValueDisplay>
       </SliderContainer>

--- a/shared/src/components/ProjectTableSettings/RowHeightSettings.tsx
+++ b/shared/src/components/ProjectTableSettings/RowHeightSettings.tsx
@@ -92,7 +92,7 @@ const RowHeightSettings: FC = () => {
   const [localRowHeight, setLocalRowHeight] = useState(contextRowHeight)
 
   // Debounced value for context updates (reduce expensive re-renders)
-  const debouncedRowHeight = useDebounce(localRowHeight, 100) // 150ms delay
+  const debouncedRowHeight = useDebounce(localRowHeight, 70) // 150ms delay
 
   // Update context when debounced value changes
   useEffect(() => {
@@ -113,7 +113,7 @@ const RowHeightSettings: FC = () => {
 
   return (
     <Container>
-      <Label htmlFor="row-height-slider">Row Height</Label>
+      <Label htmlFor="row-height-slider">Row height</Label>
       <SliderContainer>
         <Slider
           id="row-height-slider"
@@ -124,7 +124,7 @@ const RowHeightSettings: FC = () => {
           value={localRowHeight} // Use local state for smooth slider
           onChange={handleChange}
         />
-        <ValueDisplay>{localRowHeight}px</ValueDisplay>
+        <ValueDisplay>{localRowHeight}</ValueDisplay>
       </SliderContainer>
     </Container>
   )

--- a/shared/src/components/ProjectTableSettings/RowHeightSettings.tsx
+++ b/shared/src/components/ProjectTableSettings/RowHeightSettings.tsx
@@ -116,8 +116,15 @@ const RowHeightSettings: FC = () => {
   }, [debouncedRowHeight, updateRowHeight, isDragging])
 
   const handleSliderChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    setLocalRowHeight(parseInt(e.target.value, 10))
-  }, [])
+    const newValue = parseInt(e.target.value, 10)
+    setLocalRowHeight(newValue)
+
+    // If not dragging (e.g., arrow keys), update immediately
+    if (!isDragging) {
+      updateRowHeight(newValue)
+      updateRowHeightWithPersistence(newValue)
+    }
+  }, [isDragging, updateRowHeight, updateRowHeightWithPersistence])
 
   const handleSliderStart = useCallback(() => {
     setIsDragging(true)

--- a/shared/src/components/ProjectTableSettings/RowHeightSettings.tsx
+++ b/shared/src/components/ProjectTableSettings/RowHeightSettings.tsx
@@ -1,0 +1,113 @@
+import { FC } from 'react'
+import styled from 'styled-components'
+import { useColumnSettingsContext } from '@shared/containers/ProjectTreeTable'
+
+const Container = styled.div`
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+`
+
+const Label = styled.label`
+  font-weight: 500;
+  color: var(--md-sys-color-on-surface);
+  font-size: 14px;
+`
+
+const SliderContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+`
+
+const Slider = styled.input`
+  flex: 1;
+  height: 4px;
+  border-radius: 2px;
+  background: var(--md-sys-color-outline);
+  outline: none;
+  -webkit-appearance: none;
+  appearance: none;
+
+  &::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    background: var(--md-sys-color-primary);
+    cursor: pointer;
+    border: 2px solid var(--md-sys-color-surface);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+  }
+
+  &::-moz-range-thumb {
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    background: var(--md-sys-color-primary);
+    cursor: pointer;
+    border: 2px solid var(--md-sys-color-surface);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+  }
+
+  &:hover::-webkit-slider-thumb {
+    background: var(--md-sys-color-primary-container);
+  }
+
+  &:hover::-moz-range-thumb {
+    background: var(--md-sys-color-primary-container);
+  }
+`
+
+const ValueDisplay = styled.span`
+  font-size: 14px;
+  color: var(--md-sys-color-on-surface-variant);
+  min-width: 40px;
+  text-align: right;
+`
+
+const RowHeightSettings: FC = () => {
+  const { rowHeight = 40, updateRowHeight } = useColumnSettingsContext()
+
+  console.log('RowHeightSettings: current rowHeight from context is', rowHeight) // Debug log
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = parseInt(e.target.value, 10)
+    console.log('RowHeightSettings: slider onChange event with', newValue, 'current context rowHeight is', rowHeight) // Debug log
+    updateRowHeight(newValue)
+  }
+
+  const handleMouseUp = (e: React.MouseEvent<HTMLInputElement>) => {
+    const newValue = parseInt(e.currentTarget.value, 10)
+    console.log('RowHeightSettings: slider mouseup event with', newValue, 'current context rowHeight is', rowHeight) // Debug log
+  }
+
+  const handleInput = (e: React.FormEvent<HTMLInputElement>) => {
+    const newValue = parseInt(e.currentTarget.value, 10)
+    console.log('RowHeightSettings: slider input event with', newValue, 'current context rowHeight is', rowHeight) // Debug log
+  }
+
+  return (
+    <Container>
+      <Label htmlFor="row-height-slider">Row Height</Label>
+      <SliderContainer>
+        <Slider
+          id="row-height-slider"
+          type="range"
+          min={30}
+          max={200}
+          step={5}
+          value={rowHeight}
+          onChange={handleChange}
+          onMouseUp={handleMouseUp}
+          onInput={handleInput}
+        />
+        <ValueDisplay>{rowHeight}px</ValueDisplay>
+      </SliderContainer>
+    </Container>
+  )
+}
+
+export default RowHeightSettings

--- a/shared/src/components/SettingsPanel/SettingsPanel.tsx
+++ b/shared/src/components/SettingsPanel/SettingsPanel.tsx
@@ -2,6 +2,7 @@ import { Button, Icon } from '@ynput/ayon-react-components'
 import { FC, ReactNode } from 'react'
 import styled from 'styled-components'
 import { SettingField, useSettingsPanel } from '@shared/context'
+import RowHeightSettings from '@shared/components/ProjectTableSettings/RowHeightSettings'
 
 // Side panel styled components
 const SidePanel = styled.div<{ open: boolean }>`
@@ -118,7 +119,10 @@ export const SettingsPanel: FC<SettingsPanelProps> = ({ settings }) => {
         <PanelTitle>{getPanelTitle()}</PanelTitle>
         <ToolButton variant="text" icon="close" onClick={closePanel} />
       </PanelHeader>
-      <PanelContent>{renderSettingContent()}</PanelContent>
+      <PanelContent>
+        {renderSettingContent()}
+        <RowHeightSettings />
+      </PanelContent>
     </SidePanel>
   )
 }

--- a/shared/src/components/Thumbnail/Thumbnail.styled.ts
+++ b/shared/src/components/Thumbnail/Thumbnail.styled.ts
@@ -6,7 +6,6 @@ export const Card = styled.div`
   height: 52px;
   aspect-ratio: 1.7;
   overflow: hidden;
-  border-radius: var(--border-radius-l);
   margin: auto;
 
   background-color: var(--md-sys-color-surface-container-lowest);
@@ -97,7 +96,6 @@ export const Image = styled.img`
   width: 100%;
   height: 100%;
   object-fit: contain;
-  border-radius: var(--border-radius-m);
   overflow: hidden;
 
   /* ensures it always fills the parent */

--- a/shared/src/components/ThumbnailSimple/ThumbnailSimple.tsx
+++ b/shared/src/components/ThumbnailSimple/ThumbnailSimple.tsx
@@ -22,7 +22,6 @@ const ThumbnailStyled = styled.div`
   max-width: 500px;
   aspect-ratio: 1.77;
   overflow: hidden;
-  border-radius: 3px;
   margin: auto;
   max-width: 250px;
   background-color: var(--md-sys-color-surface-container-lowest);

--- a/shared/src/containers/ProjectTreeTable/ProjectTreeTable.styled.ts
+++ b/shared/src/containers/ProjectTreeTable/ProjectTreeTable.styled.ts
@@ -58,7 +58,6 @@ export const TableCellContent = styled.div`
   width: 100%;
   padding: 0px 8px;
   overflow: hidden;
-  white-space: nowrap;
   border-radius: var(--border-radius-m);
   user-select: none;
   padding-right: 0;

--- a/shared/src/containers/ProjectTreeTable/ProjectTreeTable.styled.ts
+++ b/shared/src/containers/ProjectTreeTable/ProjectTreeTable.styled.ts
@@ -19,6 +19,7 @@ export const TR = styled.tr`
   display: flex;
   position: absolute;
   width: 100%;
+  transition: height 0.2s ease-out;
 
   &:hover {
     // When the row (TR) is hovered...
@@ -231,6 +232,7 @@ export const TableCell = styled.td<TableCellProps>`
   position: relative;
   box-shadow: ${getDefaultShadow(false)};
   background-color: var(--md-sys-color-surface-container-low);
+  transition: height 0.2s ease-out;
 
   &.${DRAG_HANDLE_CLASS} {
     // Styles for the button inside the drag handle cell

--- a/shared/src/containers/ProjectTreeTable/ProjectTreeTable.styled.ts
+++ b/shared/src/containers/ProjectTreeTable/ProjectTreeTable.styled.ts
@@ -19,7 +19,6 @@ export const TR = styled.tr`
   display: flex;
   position: absolute;
   width: 100%;
-  transition: height 0.2s ease-out;
 
   &:hover {
     // When the row (TR) is hovered...
@@ -232,7 +231,6 @@ export const TableCell = styled.td<TableCellProps>`
   position: relative;
   box-shadow: ${getDefaultShadow(false)};
   background-color: var(--md-sys-color-surface-container-low);
-  transition: height 0.2s ease-out;
 
   &.${DRAG_HANDLE_CLASS} {
     // Styles for the button inside the drag handle cell

--- a/shared/src/containers/ProjectTreeTable/ProjectTreeTable.tsx
+++ b/shared/src/containers/ProjectTreeTable/ProjectTreeTable.tsx
@@ -440,7 +440,7 @@ export const ProjectTreeTable = ({
   const columnSizeVars = useCustomColumnWidthVars(table, columnSizing)
 
   // Calculate dynamic row height based on user setting from Customize panel
-  const { getRowHeight, thumbnailRowHeight, defaultRowHeight } = useDynamicRowHeight()
+  const { getRowHeight, defaultRowHeight } = useDynamicRowHeight()
 
   const attribByField = useMemo(() => {
     return attribFields.reduce((acc: Record<string, AttributeEnumItem[]>, attrib) => {

--- a/shared/src/containers/ProjectTreeTable/ProjectTreeTable.tsx
+++ b/shared/src/containers/ProjectTreeTable/ProjectTreeTable.tsx
@@ -938,9 +938,13 @@ const TableBody = ({
 
   const virtualRows = rowVirtualizer.getVirtualItems()
 
-  // Force row virtualizer to recalculate when row height changes
+  // Force row virtualizer to recalculate when row height changes (debounced for performance)
   useEffect(() => {
-    rowVirtualizer.measure()
+    const timeout = setTimeout(() => {
+      rowVirtualizer.measure()
+    }, 100) // Small delay to batch multiple rapid changes
+
+    return () => clearTimeout(timeout)
   }, [defaultRowHeight, rowVirtualizer])
 
   // Memoize the measureElement callback

--- a/shared/src/containers/ProjectTreeTable/ProjectTreeTable.tsx
+++ b/shared/src/containers/ProjectTreeTable/ProjectTreeTable.tsx
@@ -439,8 +439,20 @@ export const ProjectTreeTable = ({
 
   const columnSizeVars = useCustomColumnWidthVars(table, columnSizing)
 
-  // Calculate dynamic row height based on thumbnail column width and row data
-  const { getRowHeight, thumbnailRowHeight, defaultRowHeight } = useDynamicRowHeight(columnSizing)
+  // Get selection context functions for dynamic row height
+  const { isCellSelected: tableIsCellSelected } = useSelectionCellsContext()
+  const { isRowSelected: tableIsRowSelected } = useSelectedRowsContext()
+
+  // Check if thumbnail column is being resized
+  const isResizingThumbnail = table.getState().columnSizingInfo.isResizingColumn === 'thumbnail'
+
+  // Calculate dynamic row height based on thumbnail column width and selection state
+  const { getRowHeight, thumbnailRowHeight, defaultRowHeight } = useDynamicRowHeight(
+    columnSizing,
+    tableIsRowSelected,
+    tableIsCellSelected,
+    isResizingThumbnail,
+  )
 
   const attribByField = useMemo(() => {
     return attribFields.reduce((acc: Record<string, AttributeEnumItem[]>, attrib) => {

--- a/shared/src/containers/ProjectTreeTable/ProjectTreeTable.tsx
+++ b/shared/src/containers/ProjectTreeTable/ProjectTreeTable.tsx
@@ -439,20 +439,8 @@ export const ProjectTreeTable = ({
 
   const columnSizeVars = useCustomColumnWidthVars(table, columnSizing)
 
-  // Get selection context functions for dynamic row height
-  const { isCellSelected: tableIsCellSelected } = useSelectionCellsContext()
-  const { isRowSelected: tableIsRowSelected } = useSelectedRowsContext()
-
-  // Check if thumbnail column is being resized
-  const isResizingThumbnail = table.getState().columnSizingInfo.isResizingColumn === 'thumbnail'
-
-  // Calculate dynamic row height based on thumbnail column width and selection state
-  const { getRowHeight, thumbnailRowHeight, defaultRowHeight } = useDynamicRowHeight(
-    columnSizing,
-    tableIsRowSelected,
-    tableIsCellSelected,
-    isResizingThumbnail,
-  )
+  // Calculate dynamic row height based on user setting from Customize panel
+  const { getRowHeight, thumbnailRowHeight, defaultRowHeight } = useDynamicRowHeight()
 
   const attribByField = useMemo(() => {
     return attribFields.reduce((acc: Record<string, AttributeEnumItem[]>, attrib) => {
@@ -642,7 +630,7 @@ export const ProjectTreeTable = ({
                           width: getColumnWidth(overlayRowInstance.id, cell.column.id),
                           display: 'flex',
                           alignItems: 'center',
-                          height: 40,
+                          height: defaultRowHeight,
                         }
 
                         if (cell.column.id === DRAG_HANDLE_COLUMN_ID) {
@@ -950,6 +938,11 @@ const TableBody = ({
 
   const virtualRows = rowVirtualizer.getVirtualItems()
 
+  // Force row virtualizer to recalculate when row height changes
+  useEffect(() => {
+    rowVirtualizer.measure()
+  }, [defaultRowHeight, rowVirtualizer])
+
   // Memoize the measureElement callback
   const measureRowElement = useCallback(
     (node: HTMLTableRowElement | null) => {
@@ -1224,7 +1217,7 @@ const TableCell = ({
       style={{
         ...getCommonPinningStyles(cell.column),
         width: getColumnWidth(cell.row.id, cell.column.id),
-        height: rowHeight || 40,
+        height: rowHeight,
       }}
       onMouseDown={(e) => {
         // Only process left clicks (button 0), ignore right clicks

--- a/shared/src/containers/ProjectTreeTable/buildTreeTableColumns.tsx
+++ b/shared/src/containers/ProjectTreeTable/buildTreeTableColumns.tsx
@@ -139,7 +139,7 @@ const buildTreeTableColumns = ({
       id: 'thumbnail',
       header: 'Thumbnail',
       size: 63,
-      minSize: 64,
+      minSize: 24,
       enableResizing: true,
       enableSorting: false,
       cell: ({ row, column, table }) => {

--- a/shared/src/containers/ProjectTreeTable/buildTreeTableColumns.tsx
+++ b/shared/src/containers/ProjectTreeTable/buildTreeTableColumns.tsx
@@ -8,7 +8,7 @@ import clsx from 'clsx'
 import { SelectionCell } from './components/SelectionCell'
 import RowSelectionHeader from './components/RowSelectionHeader'
 import { ROW_SELECTION_COLUMN_ID } from './context/SelectionCellsContext'
-import { TableGroupBy, useCellEditing } from './context'
+import { TableGroupBy, useCellEditing, useColumnSettingsContext } from './context'
 import { NEXT_PAGE_ID } from './hooks/useBuildGroupByTableData'
 import LoadMoreWidget from './widgets/LoadMoreWidget'
 import { LinkTypeModel } from '@shared/api'
@@ -179,6 +179,7 @@ const buildTreeTableColumns = ({
         const { value, id, type } = getValueIdType(row, column.id)
         const meta = table.options.meta
         const { isEditing } = useCellEditing()
+        const { rowHeight = 40 } = useColumnSettingsContext()
         const cellId = getCellId(row.id, column.id)
 
         if (row.original.entityType === NEXT_PAGE_ID && row.original.group) {
@@ -228,6 +229,7 @@ const buildTreeTableColumns = ({
                 isExpanded={row.getIsExpanded()}
                 toggleExpandAll={() => meta?.toggleExpandAll?.([row.id])}
                 toggleExpanded={row.getToggleExpandedHandler()}
+                rowHeight={rowHeight}
               />
             )}
             {isEditing(cellId) && (

--- a/shared/src/containers/ProjectTreeTable/context/ColumnSettingsContext.tsx
+++ b/shared/src/containers/ProjectTreeTable/context/ColumnSettingsContext.tsx
@@ -68,6 +68,7 @@ export interface ColumnSettingsContextType {
   // Row height
   rowHeight?: number
   updateRowHeight: (rowHeight: number) => void
+  setRowHeightWithAPI: (rowHeight: number) => void
 
   // Global change
   setColumnsConfig: (config: ColumnsConfig) => void

--- a/shared/src/containers/ProjectTreeTable/context/ColumnSettingsContext.tsx
+++ b/shared/src/containers/ProjectTreeTable/context/ColumnSettingsContext.tsx
@@ -68,7 +68,7 @@ export interface ColumnSettingsContextType {
   // Row height
   rowHeight?: number
   updateRowHeight: (rowHeight: number) => void
-  setRowHeightWithAPI: (rowHeight: number) => void
+  updateRowHeightWithPersistence: (rowHeight: number) => void
 
   // Global change
   setColumnsConfig: (config: ColumnsConfig) => void

--- a/shared/src/containers/ProjectTreeTable/context/ColumnSettingsContext.tsx
+++ b/shared/src/containers/ProjectTreeTable/context/ColumnSettingsContext.tsx
@@ -24,6 +24,7 @@ export type ColumnsConfig = {
   groupByConfig?: {
     showEmpty?: boolean
   }
+  rowHeight?: number
 }
 
 export interface ColumnSettingsContextType {
@@ -63,6 +64,10 @@ export interface ColumnSettingsContextType {
   updateGroupBy: (groupBy: TableGroupBy | undefined) => void
   groupByConfig: GroupByConfig
   updateGroupByConfig: (config: GroupByConfig) => void
+
+  // Row height
+  rowHeight?: number
+  updateRowHeight: (rowHeight: number) => void
 
   // Global change
   setColumnsConfig: (config: ColumnsConfig) => void

--- a/shared/src/containers/ProjectTreeTable/context/ColumnSettingsProvider.tsx
+++ b/shared/src/containers/ProjectTreeTable/context/ColumnSettingsProvider.tsx
@@ -27,6 +27,7 @@ export const ColumnSettingsProvider: React.FC<ColumnSettingsProviderProps> = ({
   const allColumnsRef = React.useRef<string[]>([])
 
   // Internal state for immediate updates (similar to column sizing)
+  const [internalColumnSizing, setInternalColumnSizing] = useState<ColumnSizingState | null>(null)
   const [internalRowHeight, setInternalRowHeight] = useState<number | null>(null)
 
   // Local row height state that persists and doesn't get overridden by API
@@ -144,17 +145,29 @@ export const ColumnSettingsProvider: React.FC<ColumnSettingsProviderProps> = ({
   }
 
   // use internalColumnSizing if it exists, otherwise use the external column sizing
-  const columnSizing = columnsSizingExternal
+  const columnSizing = internalColumnSizing || columnsSizingExternal
 
   const resizingTimeoutRef = React.useRef<NodeJS.Timeout | null>(null)
   const rowHeightTimeoutRef = React.useRef<NodeJS.Timeout | null>(null)
 
   const setColumnSizing = (sizing: ColumnSizingState) => {
+    setInternalColumnSizing(sizing)
 
     // if there is a timeout already set, clear it
     if (resizingTimeoutRef.current) {
       clearTimeout(resizingTimeoutRef.current)
     }
+    // set a timeout that tracks if the column sizing has finished
+    resizingTimeoutRef.current = setTimeout(() => {
+      // we have finished resizing now!
+      // update the external column sizing
+      onChangeWithColumns({
+        ...columnsConfig,
+        columnSizing: sizing,
+      })
+      // reset the internal column sizing to not be used anymore
+      setInternalColumnSizing(null)
+    }, 500)
   }
 
   // SIDE EFFECT UTILITIES
@@ -266,7 +279,7 @@ export const ColumnSettingsProvider: React.FC<ColumnSettingsProviderProps> = ({
     // Debounce API call to avoid excessive requests
     rowHeightTimeoutRef.current = setTimeout(() => {
       // Auto-adjust thumbnail width if needed
-      const currentColumnSizing =  columnsSizingExternal
+      const currentColumnSizing = internalColumnSizing || columnsSizingExternal
       const currentThumbnailWidth = currentColumnSizing.thumbnail || 150
       const shouldUpdateThumbnailWidth = currentThumbnailWidth < newRowHeight
 

--- a/shared/src/containers/ProjectTreeTable/context/ColumnSettingsProvider.tsx
+++ b/shared/src/containers/ProjectTreeTable/context/ColumnSettingsProvider.tsx
@@ -262,7 +262,7 @@ export const ColumnSettingsProvider: React.FC<ColumnSettingsProviderProps> = ({
     setLocalRowHeight(newRowHeight)
   }
 
-  // Update row height and persist to API with thumbnail width adjustment
+  // Update row height and persist to API
   const updateRowHeightWithPersistence = (newRowHeight: number) => {
     // Update UI immediately
     setLocalRowHeight(newRowHeight)
@@ -278,20 +278,10 @@ export const ColumnSettingsProvider: React.FC<ColumnSettingsProviderProps> = ({
 
     // Debounce API call to avoid excessive requests
     rowHeightTimeoutRef.current = setTimeout(() => {
-      // Auto-adjust thumbnail width if needed
-      const currentColumnSizing = internalColumnSizing || columnsSizingExternal
-      const currentThumbnailWidth = currentColumnSizing.thumbnail || 150
-      const shouldUpdateThumbnailWidth = currentThumbnailWidth < newRowHeight
-
-      const updatedColumnSizing = shouldUpdateThumbnailWidth
-        ? { ...currentColumnSizing, thumbnail: newRowHeight }
-        : currentColumnSizing
-
       // Persist to API
       onChangeWithColumns({
         ...columnsConfig,
         rowHeight: newRowHeight,
-        columnSizing: updatedColumnSizing,
       })
 
       // Clean up internal state

--- a/shared/src/containers/ProjectTreeTable/context/ColumnSettingsProvider.tsx
+++ b/shared/src/containers/ProjectTreeTable/context/ColumnSettingsProvider.tsx
@@ -25,13 +25,12 @@ export const ColumnSettingsProvider: React.FC<ColumnSettingsProviderProps> = ({
   onChange,
 }) => {
   const allColumnsRef = React.useRef<string[]>([])
-  const currentRowHeightRef = React.useRef<number>(40) // Track current row height
+  const currentRowHeightRef = React.useRef<number>(24) // Track current row height
 
   const setAllColumns = (allColumnIds: string[]) => {
     allColumnsRef.current = Array.from(new Set(allColumnIds))
   }
   const onChangeWithColumns = (next: ColumnsConfig) => {
-    console.log('ColumnSettingsProvider: onChangeWithColumns called with', next)
     // Update our ref when rowHeight changes
     if (next.rowHeight !== undefined) {
       currentRowHeightRef.current = next.rowHeight
@@ -39,7 +38,6 @@ export const ColumnSettingsProvider: React.FC<ColumnSettingsProviderProps> = ({
     onChange(next, allColumnsRef.current)
   }
   const columnsConfig = config as ColumnsConfig
-  console.log('ColumnSettingsProvider: received config', config) // Debug log
 
   const {
     columnOrder: columnOrderInit = [],
@@ -52,9 +50,8 @@ export const ColumnSettingsProvider: React.FC<ColumnSettingsProviderProps> = ({
     rowHeight: configRowHeight,
   } = columnsConfig || {}
 
-  // Use the rowHeight from config if provided, otherwise use our tracked value, otherwise default to 40
+  // Use the rowHeight from config if provided, otherwise use our tracked value, otherwise default to 24
   const rowHeight = configRowHeight !== undefined ? configRowHeight : currentRowHeightRef.current
-  console.log('ColumnSettingsProvider: extracted rowHeight from config is', configRowHeight, 'using rowHeight', rowHeight) // Debug log
 
   // Update our ref to the current value
   currentRowHeightRef.current = rowHeight
@@ -156,10 +153,6 @@ export const ColumnSettingsProvider: React.FC<ColumnSettingsProviderProps> = ({
     resizingTimeoutRef.current = setTimeout(() => {
       // we have finished resizing now!
       // update the external column sizing
-      console.log('ColumnSettingsProvider: column sizing timeout fired, calling onChangeWithColumns with', {
-        ...columnsConfig,
-        columnSizing: sizing,
-      }) // Debug log
       onChangeWithColumns({
         ...columnsConfig,
         columnSizing: sizing,
@@ -257,15 +250,11 @@ export const ColumnSettingsProvider: React.FC<ColumnSettingsProviderProps> = ({
   }
 
   const updateRowHeight = (newRowHeight: number) => {
-    console.log('ColumnSettingsProvider: updateRowHeight called with', newRowHeight, 'current rowHeight is', rowHeight) // Debug log
-
     // Get current thumbnail column width
     const currentThumbnailWidth = columnSizing.thumbnail || 150 // Default to 150 if not set
-    console.log('ColumnSettingsProvider: current thumbnail width is', currentThumbnailWidth, 'new row height is', newRowHeight) // Debug log
 
     // Only update thumbnail width if current width is smaller than new row height
     const shouldUpdateThumbnailWidth = currentThumbnailWidth < newRowHeight
-    console.log('ColumnSettingsProvider: should update thumbnail width?', shouldUpdateThumbnailWidth) // Debug log
 
     const updatedColumnSizing = shouldUpdateThumbnailWidth
       ? { ...columnSizing, thumbnail: newRowHeight }
@@ -276,7 +265,6 @@ export const ColumnSettingsProvider: React.FC<ColumnSettingsProviderProps> = ({
       rowHeight: newRowHeight,
       columnSizing: updatedColumnSizing,
     }
-    console.log('ColumnSettingsProvider: calling onChangeWithColumns with', updatedConfig) // Debug log
     onChangeWithColumns(updatedConfig)
   }
 

--- a/shared/src/containers/ProjectTreeTable/hooks/useDynamicRowHeight.ts
+++ b/shared/src/containers/ProjectTreeTable/hooks/useDynamicRowHeight.ts
@@ -1,74 +1,25 @@
-import { useMemo, useCallback, useRef, useEffect } from 'react'
-import { ColumnSizingState } from '@tanstack/react-table'
+import { useCallback } from 'react'
 import type { TableRow } from '../types/table'
-import { getCellId } from '../utils/cellUtils'
+import { useColumnSettingsContext } from '../context/ColumnSettingsContext'
 
 const DEFAULT_ROW_HEIGHT = 40
-const THUMBNAIL_PADDING = 8
-const THUMBNAIL_ASPECT_RATIO = 1.77 // 16:9
 
 /**
- * Hook to calculate dynamic row height based on thumbnail column width and selection state
- * Only changes height during column resize, not during selection changes
+ * Hook to provide row height based on user setting from Customize panel
+ * Returns a function that calculates height per row using the configured row height
  */
-const useDynamicRowHeight = (
-  columnSizing: ColumnSizingState,
-  isRowSelected: (rowId: string) => boolean,
-  isCellSelected: (cellId: string) => boolean,
-  isResizing: boolean, // New parameter to track if column is being resized
-) => {
-  const thumbnailRowHeight = useMemo(() => {
-    // Get the current thumbnail column size
-    const thumbnailSize = columnSizing.thumbnail
+const useDynamicRowHeight = () => {
+  const { rowHeight = DEFAULT_ROW_HEIGHT } = useColumnSettingsContext()
 
-    if (!thumbnailSize) {
-      return DEFAULT_ROW_HEIGHT
-    }
+  console.log('useDynamicRowHeight: current rowHeight from context is', rowHeight) // Debug log
 
-    // Calculate the thumbnail display width (column width minus padding)
-    const thumbnailWidth = thumbnailSize - THUMBNAIL_PADDING
+  // Function to calculate height for a specific row - avoid stale closure by not memoizing the function
+  const getRowHeight = (_row: TableRow) => {
+    console.log('useDynamicRowHeight: getRowHeight called, returning', rowHeight) // Debug log
+    return rowHeight
+  }
 
-    // Calculate required height based on aspect ratio and add padding
-    const thumbnailHeight = thumbnailWidth / THUMBNAIL_ASPECT_RATIO
-    const requiredRowHeight = thumbnailHeight + THUMBNAIL_PADDING
-
-    // Ensure minimum row height
-    return Math.max(requiredRowHeight, DEFAULT_ROW_HEIGHT)
-  }, [columnSizing.thumbnail])
-
-  // Track which rows should be expanded based on selection during resize
-  const expandedRowsRef = useRef<Set<string>>(new Set())
-
-  // Update expanded rows only when resizing
-  useEffect(() => {
-    if (isResizing) {
-      // During resize, capture currently selected rows
-      expandedRowsRef.current = new Set()
-      // We can't iterate through all rows here, so we'll check in getRowHeight
-    }
-  }, [isResizing])
-
-  // Function to calculate height for a specific row
-  const getRowHeight = useCallback((row: TableRow) => {
-    // Check if the row is selected or if the thumbnail cell is selected
-    const thumbnailCellId = getCellId(row.id, 'thumbnail')
-    const isRowOrThumbnailSelected = isRowSelected(row.id) || isCellSelected(thumbnailCellId)
-
-    // During resize: update the expanded rows set and apply height changes
-    if (isResizing) {
-      if (isRowOrThumbnailSelected) {
-        expandedRowsRef.current.add(row.id)
-      } else {
-        expandedRowsRef.current.delete(row.id)
-      }
-    }
-
-    // Return expanded height only for rows that were selected during resize AND column is wider than default
-    const shouldExpand = expandedRowsRef.current.has(row.id) && columnSizing.thumbnail && columnSizing.thumbnail > 63
-    return shouldExpand ? thumbnailRowHeight : DEFAULT_ROW_HEIGHT
-  }, [thumbnailRowHeight, isRowSelected, isCellSelected, columnSizing.thumbnail, isResizing])
-
-  return { getRowHeight, thumbnailRowHeight, defaultRowHeight: DEFAULT_ROW_HEIGHT }
+  return { getRowHeight, thumbnailRowHeight: rowHeight, defaultRowHeight: rowHeight }
 }
 
 export default useDynamicRowHeight

--- a/shared/src/containers/ProjectTreeTable/hooks/useDynamicRowHeight.ts
+++ b/shared/src/containers/ProjectTreeTable/hooks/useDynamicRowHeight.ts
@@ -1,0 +1,42 @@
+import { useMemo, useCallback } from 'react'
+import { ColumnSizingState } from '@tanstack/react-table'
+import type { TableRow } from '../types/table'
+
+const DEFAULT_ROW_HEIGHT = 40
+const THUMBNAIL_PADDING = 8
+const THUMBNAIL_ASPECT_RATIO = 1.77 // 16:9
+
+/**
+ * Hook to calculate dynamic row height based on thumbnail column width and row data
+ * Returns a function that calculates height per row based on whether it has thumbnail data
+ */
+const useDynamicRowHeight = (columnSizing: ColumnSizingState) => {
+  const thumbnailRowHeight = useMemo(() => {
+    // Get the current thumbnail column size
+    const thumbnailSize = columnSizing.thumbnail
+
+    if (!thumbnailSize) {
+      return DEFAULT_ROW_HEIGHT
+    }
+
+    // Calculate the thumbnail display width (column width minus padding)
+    const thumbnailWidth = thumbnailSize - THUMBNAIL_PADDING
+
+    // Calculate required height based on aspect ratio and add padding
+    const thumbnailHeight = thumbnailWidth / THUMBNAIL_ASPECT_RATIO
+    const requiredRowHeight = thumbnailHeight + THUMBNAIL_PADDING
+
+    // Ensure minimum row height
+    return Math.max(requiredRowHeight, DEFAULT_ROW_HEIGHT)
+  }, [columnSizing.thumbnail])
+
+  // Function to calculate height for a specific row
+  const getRowHeight = useCallback((_row: TableRow) => {
+    // Return the same height for all rows when thumbnail column is resized
+    return thumbnailRowHeight
+  }, [thumbnailRowHeight])
+
+  return { getRowHeight, thumbnailRowHeight, defaultRowHeight: DEFAULT_ROW_HEIGHT }
+}
+
+export default useDynamicRowHeight

--- a/shared/src/containers/ProjectTreeTable/hooks/useDynamicRowHeight.ts
+++ b/shared/src/containers/ProjectTreeTable/hooks/useDynamicRowHeight.ts
@@ -2,7 +2,7 @@ import { useCallback } from 'react'
 import type { TableRow } from '../types/table'
 import { useColumnSettingsContext } from '../context/ColumnSettingsContext'
 
-const DEFAULT_ROW_HEIGHT = 40
+const DEFAULT_ROW_HEIGHT = 24
 
 /**
  * Hook to provide row height based on user setting from Customize panel
@@ -11,11 +11,8 @@ const DEFAULT_ROW_HEIGHT = 40
 const useDynamicRowHeight = () => {
   const { rowHeight = DEFAULT_ROW_HEIGHT } = useColumnSettingsContext()
 
-  console.log('useDynamicRowHeight: current rowHeight from context is', rowHeight) // Debug log
-
   // Function to calculate height for a specific row - avoid stale closure by not memoizing the function
   const getRowHeight = (_row: TableRow) => {
-    console.log('useDynamicRowHeight: getRowHeight called, returning', rowHeight) // Debug log
     return rowHeight
   }
 

--- a/shared/src/containers/ProjectTreeTable/hooks/useDynamicRowHeight.ts
+++ b/shared/src/containers/ProjectTreeTable/hooks/useDynamicRowHeight.ts
@@ -1,16 +1,22 @@
-import { useMemo, useCallback } from 'react'
+import { useMemo, useCallback, useRef, useEffect } from 'react'
 import { ColumnSizingState } from '@tanstack/react-table'
 import type { TableRow } from '../types/table'
+import { getCellId } from '../utils/cellUtils'
 
 const DEFAULT_ROW_HEIGHT = 40
 const THUMBNAIL_PADDING = 8
 const THUMBNAIL_ASPECT_RATIO = 1.77 // 16:9
 
 /**
- * Hook to calculate dynamic row height based on thumbnail column width and row data
- * Returns a function that calculates height per row based on whether it has thumbnail data
+ * Hook to calculate dynamic row height based on thumbnail column width and selection state
+ * Only changes height during column resize, not during selection changes
  */
-const useDynamicRowHeight = (columnSizing: ColumnSizingState) => {
+const useDynamicRowHeight = (
+  columnSizing: ColumnSizingState,
+  isRowSelected: (rowId: string) => boolean,
+  isCellSelected: (cellId: string) => boolean,
+  isResizing: boolean, // New parameter to track if column is being resized
+) => {
   const thumbnailRowHeight = useMemo(() => {
     // Get the current thumbnail column size
     const thumbnailSize = columnSizing.thumbnail
@@ -30,11 +36,37 @@ const useDynamicRowHeight = (columnSizing: ColumnSizingState) => {
     return Math.max(requiredRowHeight, DEFAULT_ROW_HEIGHT)
   }, [columnSizing.thumbnail])
 
+  // Track which rows should be expanded based on selection during resize
+  const expandedRowsRef = useRef<Set<string>>(new Set())
+
+  // Update expanded rows only when resizing
+  useEffect(() => {
+    if (isResizing) {
+      // During resize, capture currently selected rows
+      expandedRowsRef.current = new Set()
+      // We can't iterate through all rows here, so we'll check in getRowHeight
+    }
+  }, [isResizing])
+
   // Function to calculate height for a specific row
-  const getRowHeight = useCallback((_row: TableRow) => {
-    // Return the same height for all rows when thumbnail column is resized
-    return thumbnailRowHeight
-  }, [thumbnailRowHeight])
+  const getRowHeight = useCallback((row: TableRow) => {
+    // Check if the row is selected or if the thumbnail cell is selected
+    const thumbnailCellId = getCellId(row.id, 'thumbnail')
+    const isRowOrThumbnailSelected = isRowSelected(row.id) || isCellSelected(thumbnailCellId)
+
+    // During resize: update the expanded rows set and apply height changes
+    if (isResizing) {
+      if (isRowOrThumbnailSelected) {
+        expandedRowsRef.current.add(row.id)
+      } else {
+        expandedRowsRef.current.delete(row.id)
+      }
+    }
+
+    // Return expanded height only for rows that were selected during resize AND column is wider than default
+    const shouldExpand = expandedRowsRef.current.has(row.id) && columnSizing.thumbnail && columnSizing.thumbnail > 63
+    return shouldExpand ? thumbnailRowHeight : DEFAULT_ROW_HEIGHT
+  }, [thumbnailRowHeight, isRowSelected, isCellSelected, columnSizing.thumbnail, isResizing])
 
   return { getRowHeight, thumbnailRowHeight, defaultRowHeight: DEFAULT_ROW_HEIGHT }
 }

--- a/shared/src/containers/ProjectTreeTable/widgets/CellWidget.tsx
+++ b/shared/src/containers/ProjectTreeTable/widgets/CellWidget.tsx
@@ -11,6 +11,7 @@ import { isLinkEditable, LinksWidget, LinkWidgetData } from './LinksWidget'
 
 // Contexts
 import { useCellEditing } from '../context/CellEditingContext'
+import { useColumnSettingsContext } from '../context/ColumnSettingsContext'
 
 // Utils
 import { getCellId } from '../utils/cellUtils'
@@ -108,6 +109,7 @@ export const CellWidget: FC<EditorCellProps> = ({
   const { projectName } = useProjectTableContext()
   const { isEditing, setEditingCellId } = useCellEditing()
   const { isCellFocused, gridMap, selectCell, focusCell } = useSelectionCellsContext()
+  const { rowHeight } = useColumnSettingsContext()
   const cellId = getCellId(rowId, columnId)
 
   const isCurrentCellEditing = isEditing(cellId)
@@ -224,6 +226,7 @@ export const CellWidget: FC<EditorCellProps> = ({
               isReadOnly
               hasMultipleValues={enumValue.length > 1}
               isMultiSelect={type?.includes('list')}
+              rowHeight={rowHeight}
             />
           )
         }

--- a/shared/src/containers/ProjectTreeTable/widgets/EntityNameWidget.tsx
+++ b/shared/src/containers/ProjectTreeTable/widgets/EntityNameWidget.tsx
@@ -28,6 +28,7 @@ const StyledContentWrapper = styled.div`
   height: 24px;
   overflow: hidden;
   position: relative;
+  transition: height 0.2s ease-out;
 `
 
 const StyledContentAbsolute = styled.div`
@@ -56,15 +57,25 @@ const StyledContent = styled.div`
   } */
 `
 
-const StyledTextContent = styled.div`
+const StyledTextContent = styled.div<{ $isCompact: boolean }>`
   display: flex;
-  flex-direction: column;
+  flex-direction: ${props => props.$isCompact ? 'row' : 'column'};
+  align-items: ${props => props.$isCompact ? 'center' : 'flex-start'};
+  gap: ${props => props.$isCompact ? '8px' : '0px'};
   overflow: hidden;
+  transition: flex-direction 0.2s ease-out, align-items 0.2s ease-out, gap 0.2s ease-out;
 
   .path {
-    ${theme.labelSmall}
-    margin-bottom: -4px;
+    ${theme.bodyMedium}
+    font-size: 14px;
+    margin-bottom: ${props => props.$isCompact ? '0' : '-4px'};
     color: var(--md-sys-color-outline);
+    transition: margin-bottom 0.2s ease-out;
+  }
+
+  .label {
+    ${theme.bodyMedium}
+    font-size: 14px;
   }
 
   span {
@@ -85,6 +96,7 @@ type EntityNameWidgetProps = {
   isExpanded: boolean
   toggleExpandAll: (id: string) => void
   toggleExpanded: () => void
+  rowHeight?: number
 }
 
 export const EntityNameWidget = ({
@@ -98,7 +110,16 @@ export const EntityNameWidget = ({
   isExpanded,
   toggleExpandAll,
   toggleExpanded,
+  rowHeight = 40,
 }: EntityNameWidgetProps) => {
+  // Determine layout based on row height
+  // < 50px = single line (compact), >= 50px = stacked
+  const isCompact = rowHeight < 50
+
+  // For compact mode, show single line with "path / label"
+  // For stacked mode, show path above label
+  const contentHeight = isCompact ? 24 : (path ? 32 : 24)
+
   return (
     <StyledEntityNameWidget>
       {showHierarchy ? (
@@ -121,12 +142,12 @@ export const EntityNameWidget = ({
           <div style={{ display: 'inline-block', minWidth: 24 }} />
         )
       ) : null}
-      <StyledContentWrapper style={{ height: path ? 32 : 24 }}>
+      <StyledContentWrapper style={{ height: contentHeight }}>
         <StyledContentAbsolute>
           <StyledContent>
             {icon && <Icon icon={icon} />}
-            <StyledTextContent>
-              {path && <span className="path">{path}</span>}
+            <StyledTextContent $isCompact={isCompact}>
+              {path && <span className="path">{path} {isCompact && path && "/"}</span>}
               <span className="label">{label || name}</span>
             </StyledTextContent>
           </StyledContent>

--- a/shared/src/containers/ProjectTreeTable/widgets/EntityNameWidget.tsx
+++ b/shared/src/containers/ProjectTreeTable/widgets/EntityNameWidget.tsx
@@ -1,5 +1,6 @@
 import { Button, Icon, theme } from '@ynput/ayon-react-components'
 import styled from 'styled-components'
+import clsx from 'clsx'
 
 const Expander = styled(Button)`
   &.expander {
@@ -56,50 +57,50 @@ const StyledContent = styled.div`
   } */
 `
 
-const StyledTextContent = styled.div<{ $isCompact: boolean }>`
+const StyledTextContent = styled.div`
   display: flex;
-  flex-direction: ${props => props.$isCompact ? 'row' : 'column'};
-  align-items: ${props => props.$isCompact ? 'center' : 'flex-start'};
-  gap: ${props => props.$isCompact ? '0px' : '0px'};
+  flex-direction: column;
+  align-items: flex-start;
   overflow: hidden;
   flex: 1;
   min-width: 0;
 
+  &.compact {
+    flex-direction: row;
+    align-items: center;
+  }
+
   .path {
     ${theme.bodyMedium}
     font-size: 14px;
-    margin-bottom: ${props => props.$isCompact ? '0' : '-4px'};
+    margin-bottom: -4px;
     color: var(--md-sys-color-outline);
-    ${props => props.$isCompact && 'margin-right: 4px;'}
     white-space: nowrap;
     overflow: hidden;
-    ${props => props.$isCompact ? `
-      text-overflow: unset;
-      flex-shrink: 0 1 auto;
-    ` : `
-      text-overflow: ellipsis;
-    `}
+    text-overflow: ellipsis;
   }
-  
+
+  &.compact .path {
+    margin-bottom: 0;
+    text-overflow: unset;
+    flex-shrink: 0 1 auto;
+  }
 
   .label {
     ${theme.bodyMedium}
     font-size: 14px;
-    ${props => props.$isCompact && 'margin-left: 4px;'}
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
-    flex: 1 1 auto;            /* ✅ allow shrinking so ellipsis can appear */
-    min-width: 0;              /* ✅ critical inside flex to enable ellipsis */
+    flex: 1 1 auto;
+    min-width: 0;
   }
 
   .divider {
     ${theme.bodyMedium}
     font-size: 14px;
     color: var(--md-sys-color-outline);
-    margin: 0 4px;
     flex-shrink: 0;
-  }
   }
 `
 
@@ -134,9 +135,9 @@ export const EntityNameWidget = ({
   // < 50px = single line (compact), >= 50px = stacked
   const isCompact = rowHeight < 50
 
-  // For compact mode, show single line with "path / label"
-  // For stacked mode, show path above label
-  const contentHeight = isCompact ? 24 : (path ? 32 : 24)
+  // Always keep content height at 24px in compact mode or hierarchy mode to prevent jumping
+  // Only allow expansion to 32px in non-hierarchy mode when not compact and path exists
+  const contentHeight = (isCompact || showHierarchy) ? 24 : (path ? 32 : 24)
 
   return (
     <StyledEntityNameWidget>
@@ -164,7 +165,7 @@ export const EntityNameWidget = ({
         <StyledContentAbsolute>
           <StyledContent>
             {icon && <Icon icon={icon} />}
-            <StyledTextContent $isCompact={isCompact}>
+            <StyledTextContent className={clsx({ compact: isCompact })}>
               {path && <span className="path">{path}</span>}
               {isCompact && path && <span className="divider">/</span>}
               <span className="label">{label || name}</span>

--- a/shared/src/containers/ProjectTreeTable/widgets/EntityNameWidget.tsx
+++ b/shared/src/containers/ProjectTreeTable/widgets/EntityNameWidget.tsx
@@ -60,25 +60,46 @@ const StyledTextContent = styled.div<{ $isCompact: boolean }>`
   display: flex;
   flex-direction: ${props => props.$isCompact ? 'row' : 'column'};
   align-items: ${props => props.$isCompact ? 'center' : 'flex-start'};
-  gap: ${props => props.$isCompact ? '8px' : '0px'};
+  gap: ${props => props.$isCompact ? '0px' : '0px'};
   overflow: hidden;
+  flex: 1;
+  min-width: 0;
 
   .path {
     ${theme.bodyMedium}
     font-size: 14px;
     margin-bottom: ${props => props.$isCompact ? '0' : '-4px'};
     color: var(--md-sys-color-outline);
+    ${props => props.$isCompact && 'margin-right: 4px;'}
+    white-space: nowrap;
+    overflow: hidden;
+    ${props => props.$isCompact ? `
+      text-overflow: unset;
+      flex-shrink: 0 1 auto;
+    ` : `
+      text-overflow: ellipsis;
+    `}
   }
+  
 
   .label {
     ${theme.bodyMedium}
     font-size: 14px;
-  }
-
-  span {
+    ${props => props.$isCompact && 'margin-left: 4px;'}
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
+    flex: 1 1 auto;            /* ✅ allow shrinking so ellipsis can appear */
+    min-width: 0;              /* ✅ critical inside flex to enable ellipsis */
+  }
+
+  .divider {
+    ${theme.bodyMedium}
+    font-size: 14px;
+    color: var(--md-sys-color-outline);
+    margin: 0 4px;
+    flex-shrink: 0;
+  }
   }
 `
 
@@ -144,7 +165,8 @@ export const EntityNameWidget = ({
           <StyledContent>
             {icon && <Icon icon={icon} />}
             <StyledTextContent $isCompact={isCompact}>
-              {path && <span className="path">{path} {isCompact && path && "/"}</span>}
+              {path && <span className="path">{path}</span>}
+              {isCompact && path && <span className="divider">/</span>}
               <span className="label">{label || name}</span>
             </StyledTextContent>
           </StyledContent>

--- a/shared/src/containers/ProjectTreeTable/widgets/EntityNameWidget.tsx
+++ b/shared/src/containers/ProjectTreeTable/widgets/EntityNameWidget.tsx
@@ -28,7 +28,6 @@ const StyledContentWrapper = styled.div`
   height: 24px;
   overflow: hidden;
   position: relative;
-  transition: height 0.2s ease-out;
 `
 
 const StyledContentAbsolute = styled.div`
@@ -63,14 +62,12 @@ const StyledTextContent = styled.div<{ $isCompact: boolean }>`
   align-items: ${props => props.$isCompact ? 'center' : 'flex-start'};
   gap: ${props => props.$isCompact ? '8px' : '0px'};
   overflow: hidden;
-  transition: flex-direction 0.2s ease-out, align-items 0.2s ease-out, gap 0.2s ease-out;
 
   .path {
     ${theme.bodyMedium}
     font-size: 14px;
     margin-bottom: ${props => props.$isCompact ? '0' : '-4px'};
     color: var(--md-sys-color-outline);
-    transition: margin-bottom 0.2s ease-out;
   }
 
   .label {

--- a/shared/src/containers/ProjectTreeTable/widgets/EnumCellValue.tsx
+++ b/shared/src/containers/ProjectTreeTable/widgets/EnumCellValue.tsx
@@ -11,12 +11,14 @@ const StyledWidget = styled.div`
   align-items: center;
   width: 100%;
   height: 100%;
-  overflow: hidden;
+  overflow: visible;
   border-radius: var(--border-radius-m);
+  padding: 0 1px;
 
   &.item {
     padding: 4px 2px;
     border-radius: 0;
+    overflow: hidden;
 
     &:hover {
       background-color: var(--md-sys-color-surface-container-hover);
@@ -47,16 +49,12 @@ const StyledValueWrapper = styled.div`
   gap: var(--base-gap-small);
   align-items: center;
 
-  overflow: hidden;
   max-width: 100%;
   min-width: 20px;
 `
 
 const StyledValue = styled.span`
-  overflow: hidden;
-  white-space: nowrap;
   width: 100%;
-  text-overflow: ellipsis;
   text-align: left;
   border-radius: var(--border-radius-m);
   padding: 0px 2px;
@@ -77,13 +75,17 @@ const StyledImg = styled.img`
 `
 
 const StyledExpandButton = styled.div`
-  width: 32px;
-  height: 32px;
+  width: min(32px, 100%);
+  height: min(32px, 100%);
+  min-width: 20px;
+  min-height: 20px;
+  aspect-ratio: 1;
   border-radius: var(--border-radius-m);
   display: flex;
   justify-content: center;
   align-items: center;
   cursor: pointer;
+  flex-shrink: 0;
 
   &:hover {
     background-color: var(--md-sys-color-surface-container-highest-hover);

--- a/shared/src/containers/ProjectTreeTable/widgets/EnumCellValue.tsx
+++ b/shared/src/containers/ProjectTreeTable/widgets/EnumCellValue.tsx
@@ -34,7 +34,7 @@ const StyledWidget = styled.div`
   }
 `
 
-const StyledValuesContainer = styled.div<{ $allowWrap?: boolean }>`
+const StyledValuesContainer = styled.div`
   flex: 1;
   display: flex;
   gap: var(--base-gap-small);
@@ -42,7 +42,11 @@ const StyledValuesContainer = styled.div<{ $allowWrap?: boolean }>`
   overflow: hidden;
   border-radius: var(--border-radius-m);
   padding: 0px 2px;
-  flex-wrap: ${({ $allowWrap }) => ($allowWrap ? 'wrap' : 'nowrap')};
+  flex-wrap: nowrap;
+
+  &.wrap {
+    flex-wrap: wrap;
+  }
 `
 
 const StyledValueWrapper = styled.div`
@@ -174,7 +178,7 @@ export const EnumCellValue = ({
 
   return (
     <StyledWidget className={clsx(className, { selected: isSelected, item: isItem })} {...props}>
-      <StyledValuesContainer $allowWrap={allowWrap}>
+      <StyledValuesContainer className={clsx({ wrap: allowWrap })}>
         {selectedOptions.map((option, i) => (
           <StyledValueWrapper key={option.value.toString() + i}>
             {option.icon && checkForImgSrc(option.icon) ? (

--- a/shared/src/containers/ProjectTreeTable/widgets/EnumCellValue.tsx
+++ b/shared/src/containers/ProjectTreeTable/widgets/EnumCellValue.tsx
@@ -34,7 +34,7 @@ const StyledWidget = styled.div`
   }
 `
 
-const StyledValuesContainer = styled.div`
+const StyledValuesContainer = styled.div<{ $allowWrap?: boolean }>`
   flex: 1;
   display: flex;
   gap: var(--base-gap-small);
@@ -42,6 +42,7 @@ const StyledValuesContainer = styled.div`
   overflow: hidden;
   border-radius: var(--border-radius-m);
   padding: 0px 2px;
+  flex-wrap: ${({ $allowWrap }) => ($allowWrap ? 'wrap' : 'nowrap')};
 `
 
 const StyledValueWrapper = styled.div`
@@ -54,10 +55,13 @@ const StyledValueWrapper = styled.div`
 `
 
 const StyledValue = styled.span`
-  width: 100%;
   text-align: left;
   border-radius: var(--border-radius-m);
   padding: 0px 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
 
   &.placeholder {
     color: var(--md-sys-color-outline);
@@ -75,10 +79,9 @@ const StyledImg = styled.img`
 `
 
 const StyledExpandButton = styled.div`
-  width: min(32px, 100%);
-  height: min(32px, 100%);
-  min-width: 20px;
-  min-height: 20px;
+  width: 32px;
+  height: fit-content;
+  min-height: 32px;
   aspect-ratio: 1;
   border-radius: var(--border-radius-m);
   display: flex;
@@ -109,6 +112,7 @@ export interface EnumTemplateProps extends React.HTMLAttributes<HTMLSpanElement>
   isItem?: boolean
   isSelected?: boolean
   isReadOnly?: boolean
+  rowHeight?: number
   pt?: {
     icon?: Partial<IconProps>
     img?: Partial<React.ImgHTMLAttributes<HTMLImageElement>>
@@ -127,6 +131,7 @@ export const EnumCellValue = ({
   isItem,
   isSelected,
   isReadOnly,
+  rowHeight,
   className,
   pt,
   ...props
@@ -164,9 +169,12 @@ export const EnumCellValue = ({
     ]
   }
 
+  // Allow wrapping when row height is above 100px
+  const allowWrap = rowHeight !== undefined && rowHeight > 100
+
   return (
     <StyledWidget className={clsx(className, { selected: isSelected, item: isItem })} {...props}>
-      <StyledValuesContainer>
+      <StyledValuesContainer $allowWrap={allowWrap}>
         {selectedOptions.map((option, i) => (
           <StyledValueWrapper key={option.value.toString() + i}>
             {option.icon && checkForImgSrc(option.icon) ? (

--- a/shared/src/containers/ProjectTreeTable/widgets/ThumbnailWidget.tsx
+++ b/shared/src/containers/ProjectTreeTable/widgets/ThumbnailWidget.tsx
@@ -6,7 +6,7 @@ import styled from 'styled-components'
 const Wrapper = styled.div`
   position: absolute;
   inset: 0;
-  padding: 6px;
+  padding: 4px;
   display: flex;
 `
 

--- a/shared/src/containers/ProjectTreeTable/widgets/ThumbnailWidget.tsx
+++ b/shared/src/containers/ProjectTreeTable/widgets/ThumbnailWidget.tsx
@@ -13,7 +13,7 @@ const Inner = styled.div`
   position: relative;
   max-height: 100%;
   height: auto;
-  width: 100%;
+  width: calc(100% - 8px);
   aspect-ratio: 1.77;
 
   border-radius: 2px;

--- a/shared/src/containers/ProjectTreeTable/widgets/ThumbnailWidget.tsx
+++ b/shared/src/containers/ProjectTreeTable/widgets/ThumbnailWidget.tsx
@@ -6,9 +6,8 @@ import styled from 'styled-components'
 const Wrapper = styled.div`
   position: absolute;
   inset: 0;
-  padding: 2px 2px 2px 2px;
+  padding: 6px;
   display: flex;
-  align-items: center;
 `
 
 const Inner = styled.div`
@@ -18,7 +17,6 @@ const Inner = styled.div`
   width: 100%;
   //aspect-ratio: 1.77;
 
-  border-radius: 2px;
   overflow: hidden;
 `
 

--- a/shared/src/containers/ProjectTreeTable/widgets/ThumbnailWidget.tsx
+++ b/shared/src/containers/ProjectTreeTable/widgets/ThumbnailWidget.tsx
@@ -6,15 +6,17 @@ import styled from 'styled-components'
 const Wrapper = styled.div`
   position: absolute;
   inset: 0;
-  padding: 4px;
+  padding: 2px 2px 2px 2px;
+  display: flex;
+  align-items: center;
 `
 
 const Inner = styled.div`
   position: relative;
   max-height: 100%;
-  height: auto;
-  width: calc(100% - 8px);
-  aspect-ratio: 1.77;
+  height: 100%;
+  width: 100%;
+  //aspect-ratio: 1.77;
 
   border-radius: 2px;
   overflow: hidden;

--- a/shared/src/util/columnConfigConverter.ts
+++ b/shared/src/util/columnConfigConverter.ts
@@ -13,7 +13,7 @@ import { GroupByConfig } from '@shared/containers/ProjectTreeTable/components/Gr
  * Converts ColumnItemModel array from OverviewSettings to TanStack table states
  */
 export function convertColumnConfigToTanstackStates(settings: OverviewSettings): ColumnsConfig {
-  const { columns = [], groupBy: groupByField, showEmptyGroups, sortBy, sortDesc } = settings || {}
+  const { columns = [], groupBy: groupByField, showEmptyGroups, sortBy, sortDesc, rowHeight } = settings || {}
 
   // Initialize state objects
   const columnVisibility: VisibilityState = {}
@@ -62,6 +62,7 @@ export function convertColumnConfigToTanstackStates(settings: OverviewSettings):
     sorting,
     groupBy,
     groupByConfig,
+    rowHeight: rowHeight ?? 34,
   }
 }
 
@@ -167,6 +168,7 @@ export function convertTanstackStatesToColumnConfig(
     sorting,
     groupBy,
     groupByConfig,
+    rowHeight,
   } = states
 
   // Collect all columns that have any state
@@ -213,6 +215,11 @@ export function convertTanstackStatesToColumnConfig(
       result.sortBy = undefined
       result.sortDesc = undefined
     }
+  }
+
+  // Add row height if present
+  if (rowHeight !== undefined) {
+    result.rowHeight = rowHeight
   }
 
   return result


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
Added dynamic thumbnail resizing functionality to the ProjectTreeTable. When users resize the thumbnail column width, thumbnail images now scale to fit the new width while
  maintaining their 16:9 aspect ratio, and table rows automatically adjust their height to accommodate the scaled thumbnails.


## Technical details
<!-- Please state any technical details such as limitations -->

- **ThumbnailWidget**: Updated to use `width: calc(100% - 8px)` with `aspect-ratio: 1.77` for responsive scaling
- **useDynamicRowHeight hook**: New hook that calculates row height based on thumbnail column width using the formula: `(columnWidth - padding) / aspectRatio + padding`
- **Row virtualizer**: Enhanced to use dynamic `estimateSize` function for variable row heights
- **Table components**: Updated to pass calculated row heights to all table cells and drag handles

  **Limitations:**

- All rows resize uniformly (not just rows with actual thumbnails) to maintain consistent table layout
- Uses TanStack Virtual's row measurement for optimal scrolling performance
- Minimum row height enforced to prevent layout issues with very narrow columns

## Additional context
<!-- Add any other context or screenshots here. -->

https://github.com/user-attachments/assets/9f9e9ad6-279f-4b7d-96ba-ee3fde49af58



