### PR TITLE
Task Progress: Folder status icon does not show

### DIFF
--- a/shared/src/hooks/useScopedStatuses.ts
+++ b/shared/src/hooks/useScopedStatuses.ts
@@ -17,7 +17,7 @@ export const useScopedStatuses = (projects: string[], entityTypes: string[]) => 
   for (const item of Object.values(response.data) as ProjectModel[]) {
     const filteredStatuses =
       item.statuses?.filter((status: EntityStatus) =>
-        !status.scope || entityTypes.some((type) => status.scope?.includes(type)),
+        entityTypes.every((type) => !status.scope || status.scope?.includes(type)),
       ) || []
     if (currentStatuses === undefined) {
       currentStatuses = filteredStatuses

--- a/src/containers/TasksProgress/TasksProgress.tsx
+++ b/src/containers/TasksProgress/TasksProgress.tsx
@@ -59,7 +59,8 @@ export type Operation = {
 }
 
 interface TasksProgressProps {
-  statuses?: Status[]
+  taskStatuses?: Status[]
+  folderStatuses?: Status[]
   taskTypes?: TaskType[]
   folderTypes?: FolderType[]
   priorities?: AttributeEnumItem[]
@@ -67,7 +68,8 @@ interface TasksProgressProps {
 }
 
 const TasksProgress: FC<TasksProgressProps> = ({
-  statuses = [],
+  taskStatuses = [],
+  folderStatuses = [],
   taskTypes = [],
   folderTypes = [],
   priorities = [],
@@ -248,9 +250,10 @@ const TasksProgress: FC<TasksProgressProps> = ({
     () =>
       formatTaskProgressForTable(foldersTasksData, collapsedParents, {
         folderTypes,
-        statuses,
+        taskStatuses,
+        folderStatuses,
       }),
-    [foldersTasksData, collapsedParents],
+    [foldersTasksData, collapsedParents, taskStatuses, folderStatuses],
   )
 
   const [updateEntities] = useUpdateEntitiesMutation()
@@ -434,7 +437,8 @@ const TasksProgress: FC<TasksProgressProps> = ({
               isLoading={isFetchingTasks}
               activeTask={activeTask}
               selectedAssignees={selectedAssignees}
-              statuses={statuses} // status icons etc.
+              taskStatuses={taskStatuses} // task status icons etc.
+              folderStatuses={folderStatuses} // folder status icons etc.
               taskTypes={taskTypes} // for tasks icon etc.
               priorities={priorities} // for priority icons and colors
               users={users}

--- a/src/containers/TasksProgress/components/TasksProgressTable/TasksProgressTable.tsx
+++ b/src/containers/TasksProgress/components/TasksProgressTable/TasksProgressTable.tsx
@@ -62,7 +62,8 @@ interface TasksProgressTableProps
   isLoading: boolean
   activeTask: string | null
   selectedAssignees: string[]
-  statuses: Status[]
+  taskStatuses: Status[]
+  folderStatuses: Status[]
   taskTypes: TaskType[]
   priorities: AttributeEnumItem[]
   users: Assignees
@@ -92,7 +93,8 @@ export const TasksProgressTable = ({
   isLoading,
   activeTask,
   selectedAssignees = [],
-  statuses = [], // project statuses schema
+  taskStatuses = [], // project task statuses schema
+  folderStatuses = [], // project folder statuses schema
   taskTypes = [], // project task types schema
   priorities = [], // project priorities schema
   users = [], // users in the project
@@ -390,7 +392,7 @@ export const TasksProgressTable = ({
                 id: row.__folderId,
                 name: row._folder,
                 icon: row.__folderIcon,
-                status: statuses.find((s) => s.name === row.__folderStatus),
+                status: folderStatuses.find((s) => s.name === row.__folderStatus),
                 updatedAt: row.__folderUpdatedAt,
               }}
               isSelected={
@@ -427,7 +429,7 @@ export const TasksProgressTable = ({
           resizeable
           header={<TaskColumnHeader taskType={taskTypeKey} />}
           sortable
-          sortFunction={(e) => sortFolderFunction(e, taskStatusSortFunction(statuses))}
+          sortFunction={(e) => sortFolderFunction(e, taskStatusSortFunction(taskStatuses))}
           pt={{
             bodyCell: { style: { padding: 0 } },
             headerCell: { onContextMenu: (e) => handleColumnHeaderContextMenu(e, taskTypeKey) },
@@ -440,7 +442,7 @@ export const TasksProgressTable = ({
             if (rowData.__isParent) {
               const taskCellData = rowData[taskTypeKey] as TaskTypeStatusBar
 
-              return <TaskStatusBar statuses={statuses} statusCounts={taskCellData} />
+              return <TaskStatusBar statuses={taskStatuses} statusCounts={taskCellData} />
             }
 
             const taskCellData = rowData[taskTypeKey] as TaskTypeRow
@@ -522,7 +524,7 @@ export const TasksProgressTable = ({
                               assigneeOptions={assigneeOptions}
                               isExpanded={isExpanded}
                               taskIcon={taskType?.icon || ''}
-                              statuses={statuses}
+                              statuses={taskStatuses}
                               priorities={priorities}
                               onChange={onChange}
                             />

--- a/src/containers/TasksProgress/helpers/formatTaskProgressForTable.ts
+++ b/src/containers/TasksProgress/helpers/formatTaskProgressForTable.ts
@@ -50,7 +50,10 @@ const getParentKey = (parent: FolderGroup['parent']) =>
 export const formatTaskProgressForTable = (
   data: FolderTask[],
   collapsedFolders: string[] = [],
-  { folderTypes, statuses }: { folderTypes: FolderType[]; statuses: Status[] },
+  {
+    folderTypes,
+    taskStatuses,
+  }: { folderTypes: FolderType[]; taskStatuses: Status[]; folderStatuses: Status[] },
 ): FolderRow[] => {
   // TODO: try using a map instead of an array to easily lookup parent folders
   const rows = new Map<string, FolderRow>()
@@ -123,7 +126,7 @@ export const formatTaskProgressForTable = (
 
         const updateCompleted = () => {
           const status = task.status
-          const statusType = statuses.find((s) => s.name === status)
+          const statusType = taskStatuses.find((s) => s.name === status)
           const statusState = statusType?.state
           const completed = statusState === 'done'
           const toAdd = completed ? taskFraction : 0

--- a/src/pages/TasksProgressPage/TasksProgressPage.tsx
+++ b/src/pages/TasksProgressPage/TasksProgressPage.tsx
@@ -25,7 +25,8 @@ const TasksProgressPage: FC = () => {
   // Get attributes so we can use priority
   const { data: priorityAttrib } = useGetAttributeConfigQuery({ attributeName: 'priority' })
   const priorities = getPriorityOptions(priorityAttrib, 'task')
-  const statuses = useScopedStatuses([projectName], ['task', 'folder'])
+  const taskStatuses = useScopedStatuses([projectName], ['task'])
+  const folderStatuses = useScopedStatuses([projectName], ['folder'])
 
   return (
     <main>
@@ -43,7 +44,8 @@ const TasksProgressPage: FC = () => {
           >
             <SplitterPanel size={60} style={{ overflow: 'hidden' }}>
               <TasksProgress
-                statuses={statuses}
+                taskStatuses={taskStatuses}
+                folderStatuses={folderStatuses}
                 taskTypes={projectInfo?.taskTypes}
                 folderTypes={projectInfo?.folderTypes}
                 priorities={priorities}


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

1. Include both 'task' and 'folder' scopes when fetching statuses for the Task Progress page
2. Changed the filtering logic from .every() to .some() so statuses with ANY of the specified entity types are included, not requiring ALL of them

## Technical details
<!-- Please state any technical details such as limitations -->
Update filtering logic to use `some` instead of `every` and include 'folder' in task statuses.

## Additional context
<!-- Add any other context or screenshots here. -->

