### PR TITLE
Task Progress: Expanded selected folders glitch

### DIFF
--- a/src/containers/TasksProgress/components/FolderBody/FolderBody.styled.ts
+++ b/src/containers/TasksProgress/components/FolderBody/FolderBody.styled.ts
@@ -99,6 +99,12 @@ export const Path = styled.span`
       background-color: var(--md-sys-color-primary-hover);
     }
   }
+
+  &.expanded {
+    opacity: 0;
+    width: 0;
+    padding: 0;
+  }
 `
 
 export const ExpandButton = styled(Button)`

--- a/src/containers/TasksProgress/components/FolderBody/FolderBody.tsx
+++ b/src/containers/TasksProgress/components/FolderBody/FolderBody.tsx
@@ -77,7 +77,7 @@ export const FolderBody: FC<FolderBodyProps> = ({
         </Styled.ThumbnailCard>
         <Styled.Path
           onClick={() => onFolderOpen?.(folder.id)}
-          className={clsx({ selected: isSelected })}
+          className={clsx({ selected: isSelected, expanded: isExpanded })}
         >
           <span className="small-title">{folder.name}</span>
         </Styled.Path>


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
  When a folder row is both selected and expanded, the Path component (which displays the selected background color) will now be hidden, preventing it from overflowing
  behind the thumbnail image.

## Technical details
<!-- Please state any technical details such as limitations -->
Fixed the background overflow issue. Here's what I changed:

1. FolderBody.tsx:80 - Added expanded class to the Path component
2. FolderBody.styled.ts:103-107 - Added CSS rule to hide the Path component when expanded

## Additional context
Before:
<img width="322" height="203" alt="Screenshot 2025-09-30 at 14 48 05" src="https://github.com/user-attachments/assets/8d56b543-8e36-48b9-b87d-06d2045acc84" />
After fix:
<img width="1095" height="326" alt="Screenshot 2025-09-30 at 14 47 27" src="https://github.com/user-attachments/assets/efbc698b-ab24-40c7-9e3a-2f9fa2f43122" />



