### PR TITLE
Show archived menu for lists and projects

### DIFF
--- a/src/components/Menu/MenuComponents/MenuItem.jsx
+++ b/src/components/Menu/MenuComponents/MenuItem.jsx
@@ -23,6 +23,7 @@ const MenuItem = forwardRef(
       shortcut,
       disabled,
       powerFeature,
+      active,
       ...props
     },
     ref,
@@ -60,6 +61,7 @@ const MenuItem = forwardRef(
             {shortcut}
           </ShortcutTag>
         )}
+        {active && <Icon icon="check" style={{ marginLeft: 'auto' }} />}
 
         {!!items.length && <Icon icon="arrow_right" className="more" />}
       </Styled.Item>

--- a/src/components/Menu/MenuComponents/MenuList.jsx
+++ b/src/components/Menu/MenuComponents/MenuList.jsx
@@ -97,6 +97,7 @@ const MenuList = ({
               selected,
               disabled,
               powerFeature,
+              active,
               ...props
             } = item
 
@@ -116,7 +117,17 @@ const MenuList = ({
               <MenuItem
                 tabIndex={0}
                 key={`${id}-${i}`}
-                {...{ label, icon, img, highlighted, items, selected, disabled, powerFeature }}
+                {...{
+                  label,
+                  icon,
+                  img,
+                  highlighted,
+                  items,
+                  selected,
+                  disabled,
+                  powerFeature,
+                  active,
+                }}
                 isLink={link}
                 onClick={(e) =>
                   isPowerFeature

--- a/src/containers/ProjectsList/hooks/useProjectsListMenuItems.ts
+++ b/src/containers/ProjectsList/hooks/useProjectsListMenuItems.ts
@@ -140,6 +140,7 @@ const useProjectsListMenuItems = ({
           [command ? 'command' : 'onClick']: onShowArchivedToggle,
           selected: showArchived,
           active: showArchived,
+          hidden: command, // hide on context menu
         },
         { id: 'divider', label: '' },
         {

--- a/src/containers/ProjectsList/hooks/useProjectsListMenuItems.ts
+++ b/src/containers/ProjectsList/hooks/useProjectsListMenuItems.ts
@@ -11,6 +11,7 @@ type Hidden = {
   'select-all'?: boolean
   'archive-project'?: boolean
   'delete-project'?: boolean
+  'show-archived'?: boolean
 }
 
 interface MenuItemProps {
@@ -19,6 +20,7 @@ interface MenuItemProps {
   onNewProject?: () => void
   pinned: string[]
   multiSelect?: boolean
+  showArchived?: boolean
   onPin?: (pinned: string[]) => void
   onSearch?: () => void
   onManage?: (name: string) => void
@@ -26,6 +28,7 @@ interface MenuItemProps {
   onSelectAll?: () => void
   onArchive?: (projectName: string, active: boolean) => void
   onDelete?: (projectName: string) => void
+  onShowArchivedToggle?: () => void
 }
 
 type BuildMenuItems = (
@@ -40,6 +43,8 @@ type BuildMenuItems = (
   link?: string
   disabled?: boolean
   danger?: boolean
+  selected?: boolean
+  active?: boolean
 }[]
 
 const useProjectsListMenuItems = ({
@@ -47,6 +52,7 @@ const useProjectsListMenuItems = ({
   projects,
   pinned,
   multiSelect,
+  showArchived = false,
   onNewProject,
   onSearch,
   onPin,
@@ -55,6 +61,7 @@ const useProjectsListMenuItems = ({
   onSelectAll,
   onArchive,
   onDelete,
+  onShowArchivedToggle,
 }: MenuItemProps): BuildMenuItems => {
   // Remove allPinned, singleProject from hook scope, move to buildMenuItems
   const handlePin = (allPinned: boolean, selection: string[]) => {
@@ -126,6 +133,14 @@ const useProjectsListMenuItems = ({
           icon: 'settings',
           [command ? 'command' : 'onClick']: () => singleProject && onManage?.(singleProject.name),
         },
+        {
+          id: 'show-archived',
+          label: 'Show archived',
+          icon: 'inventory_2',
+          [command ? 'command' : 'onClick']: onShowArchivedToggle,
+          selected: showArchived,
+          active: showArchived,
+        },
         { id: 'divider', label: '' },
         {
           id: 'pin-project',
@@ -170,9 +185,11 @@ const useProjectsListMenuItems = ({
       pinned,
       projects,
       multiSelect,
+      showArchived,
       isMenuItemEnabled,
       onArchive,
       onDelete,
+      onShowArchivedToggle,
     ],
   )
 

--- a/src/pages/ProjectListsPage/components/ListFolderFormDialog/ListFolderForm.tsx
+++ b/src/pages/ProjectListsPage/components/ListFolderFormDialog/ListFolderForm.tsx
@@ -34,7 +34,7 @@ export interface ListFolderFormData {
   label: string
   icon?: string
   color?: string
-  scope?: ('generic' | 'review-session')[]
+  scope?: string[]
   parentId?: string
 }
 

--- a/src/pages/ProjectListsPage/components/ListsTable/ListsTableHeader.tsx
+++ b/src/pages/ProjectListsPage/components/ListsTable/ListsTableHeader.tsx
@@ -1,4 +1,5 @@
 import { useListsContext } from '@pages/ProjectListsPage/context'
+import { useListsDataContext } from '@pages/ProjectListsPage/context/ListsDataContext'
 import { Header, HeaderButton } from '@shared/containers/SimpleTable'
 import { theme } from '@ynput/ayon-react-components'
 import { FC } from 'react'
@@ -98,6 +99,8 @@ interface MenuItemDefinition {
   className?: string
   hiddenButtonType?: ButtonType
   powerFeature?: string
+  selected?: boolean
+  active?: boolean
 }
 
 interface ListsTableHeaderProps {
@@ -126,6 +129,8 @@ const ListsTableHeader: FC<ListsTableHeaderProps> = ({
     setListsFiltersOpen,
     selectAllLists,
   } = useListsContext()
+
+  const { showArchived, setShowArchived } = useListsDataContext()
 
   const { menuOpen, toggleMenuOpen } = useMenuContext()
 
@@ -222,6 +227,15 @@ const ListsTableHeader: FC<ListsTableHeaderProps> = ({
       hiddenButtonType: 'add' as ButtonType,
     },
     { id: 'divider' },
+    {
+      id: 'show-archived',
+      label: 'Show archived',
+      icon: 'inventory_2',
+      onClick: () => setShowArchived(!showArchived),
+      isPinned: false,
+      selected: showArchived,
+      active: showArchived,
+    },
     ...(!isReview
       ? [
           {

--- a/src/pages/ProjectListsPage/context/ListsDataContext.tsx
+++ b/src/pages/ProjectListsPage/context/ListsDataContext.tsx
@@ -3,7 +3,7 @@ import { EntityList, EntityListFolderModel, useGetEntityListFoldersQuery } from 
 import { useProjectDataContext } from '@shared/containers/ProjectTreeTable'
 import { SimpleTableRow } from '@shared/containers/SimpleTable'
 import { Filter } from '@ynput/ayon-react-components'
-import { useQueryArgumentChangeLoading, useUserProjectConfig } from '@shared/hooks'
+import { useQueryArgumentChangeLoading, useUserProjectConfig, useLocalStorage } from '@shared/hooks'
 import useGetListsData from '../hooks/useGetListsData'
 import { buildListsTableData } from '../util'
 import { usePowerpack } from '@shared/context'
@@ -22,6 +22,9 @@ interface ListsDataContextValue {
   // filters
   listsFilters: Filter[]
   setListsFilters: (filters: Filter[]) => Promise<void>
+  // show archived
+  showArchived: boolean
+  setShowArchived: (show: boolean) => void
 }
 
 const ListsDataContext = createContext<ListsDataContextValue | undefined>(undefined)
@@ -75,6 +78,8 @@ export const ListsDataProvider = ({
     await updatePageConfig({ listsFilters: filters })
   }
 
+  const [showArchived, setShowArchived] = useLocalStorage<boolean>('lists-show-archived', false)
+
   const {
     data: listsData,
     isLoading: isLoadingLists,
@@ -94,8 +99,8 @@ export const ListsDataProvider = ({
 
   // convert listsData into tableData
   const listsTableData = useMemo(
-    () => buildListsTableData(listsData, listFolders, true, powerLicense),
-    [listsData, listFolders, powerLicense],
+    () => buildListsTableData(listsData, listFolders, true, powerLicense, showArchived),
+    [listsData, listFolders, powerLicense, showArchived],
   )
 
   return (
@@ -117,6 +122,9 @@ export const ListsDataProvider = ({
         // filters
         listsFilters,
         setListsFilters,
+        // show archived
+        showArchived,
+        setShowArchived,
       }}
     >
       {children}

--- a/src/pages/ProjectListsPage/context/ListsProvider.tsx
+++ b/src/pages/ProjectListsPage/context/ListsProvider.tsx
@@ -371,10 +371,10 @@ export const ListsProvider = ({ children, isReview }: ListsProviderProps) => {
         // info dialog
         listDetailsOpen,
         setListDetailsOpen,
-        // lists filters dialog
+        // Lists filters dialog
         listsFiltersOpen,
         setListsFiltersOpen,
-        // list folders dialog
+        // List folders dialog
         listFolderOpen,
         setListFolderOpen,
         onOpenFolderList, // helper function to open folder dialog in edit/create mode

--- a/src/pages/ProjectListsPage/util/buildListsTableData.ts
+++ b/src/pages/ProjectListsPage/util/buildListsTableData.ts
@@ -18,6 +18,7 @@ export const buildListsTableData = (
   folders: EntityListFolderModel[],
   showEmptyFolders: boolean = true,
   powerLicense: boolean = false,
+  showArchived: boolean = false,
 ): SimpleTableRow[] => {
   // Create lookup maps
   const foldersMap = new Map<string, EntityListFolderModel>()
@@ -62,10 +63,13 @@ export const buildListsTableData = (
     }
   }
 
+  // Filter out archived lists if showArchived is false
+  const filteredLists = showArchived ? listsData : listsData.filter((list) => list.active)
+
   // Assign lists to their folders and mark folders as having lists
   const rootLists: EntityList[] = []
 
-  for (const list of listsData) {
+  for (const list of filteredLists) {
     const listFolderId = list.entityListFolderId
 
     if (powerLicense && listFolderId && folderNodes.has(listFolderId)) {

--- a/src/pages/ProjectManagerPage/ProjectManagerPageContainer.jsx
+++ b/src/pages/ProjectManagerPage/ProjectManagerPageContainer.jsx
@@ -15,7 +15,6 @@ const ProjectManagerPageContainer = ({
   onNoProject,
   ...props
 }) => {
-
   // for each child, add the project list react node with the props
   const childrenWithProps = React.Children.map(children, (child) => {
     if (React.isValidElement(child)) {
@@ -33,7 +32,6 @@ const ProjectManagerPageContainer = ({
               onNoProjectSelected={onNoProject}
               onSelect={onSelect}
               multiSelect={false}
-              showInactive={true}
             />
           </>
         ),

--- a/src/pages/UserDashboardPage/UserDashboardPage.jsx
+++ b/src/pages/UserDashboardPage/UserDashboardPage.jsx
@@ -71,14 +71,17 @@ const UserDashboardPage = () => {
       module: addon.name,
     })
   }
-    links.push({ node: 'spacer' })
-    links.push({
-        node: <HelpButton module={addonName || (module === 'overview' ? 'dashboard overview' : module) || 'tasks'} />,
-    })
-  
+  links.push({ node: 'spacer' })
+  links.push({
+    node: (
+      <HelpButton
+        module={addonName || (module === 'overview' ? 'dashboard overview' : module) || 'tasks'}
+      />
+    ),
+  })
+
   const title = useTitle(addonName || module, links, 'AYON', '')
-  
-  
+
   const addonData = addonsData.find((addon) => addon.name === addonName)
 
   const addonModule = addonData ? (
@@ -169,7 +172,6 @@ const UserDashboardPage = () => {
     return <GuestUserPageLocked />
   }
 
-
   return (
     <>
       <DocumentTitle title={title} />
@@ -180,7 +182,6 @@ const UserDashboardPage = () => {
             <StyledSplitter stateKey={PROJECTS_LIST_WIDTH_KEY} stateStorage="local">
               <SplitterPanel size={15}>
                 <ProjectsList
-                  showInactive={module === 'overview'}
                   multiSelect={isProjectsMultiSelect}
                   selection={selectedProjects}
                   onSelect={setSelectedProjects}


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
You can now toggle to show/hide archived projects and lists in the table dropdown menu.

This state saves for your current session (local storage).

