### PR TITLE
Lists: Filter by tags

### DIFF
--- a/src/pages/ProjectListsPage/components/ListsFiltersDialog/ListsFiltersDialog.tsx
+++ b/src/pages/ProjectListsPage/components/ListsFiltersDialog/ListsFiltersDialog.tsx
@@ -58,21 +58,11 @@ const ListsFiltersDialog: FC<ListsFiltersDialogProps> = ({}) => {
       },
     ]
 
-    // Add tags option if there are any tags in the lists
-    const allTags = new Set<string>()
-    listsData.forEach((list) => {
-      if (list.tags && Array.isArray(list.tags)) {
-        list.tags.forEach((tag) => allTags.add(tag))
-      }
-    })
+    // Add tags option based on project anatomy
+    const projectTags = projectInfo?.tags || []
 
-    if (allTags.size > 0) {
-      // Get tag anatomy from project info
-      const tagsAnatomy = new Map(
-        projectInfo?.tags?.map((tag) => [tag.name, tag]) || [],
-      )
-
-      // Create tag option values with counts
+    if (projectTags.length > 0) {
+      // Create tag count map from current lists
       const tagCounts = new Map<string, number>()
       listsData.forEach((list) => {
         if (list.tags && Array.isArray(list.tags)) {
@@ -82,18 +72,15 @@ const ListsFiltersDialog: FC<ListsFiltersDialogProps> = ({}) => {
         }
       })
 
-      const tagValues = Array.from(allTags)
-        .map((tag) => {
-          const tagData = tagsAnatomy.get(tag)
-          return {
-            id: tag,
-            label: tag,
-            type: 'string' as const,
-            values: [],
-            color: tagData?.color || null,
-            count: tagCounts.get(tag) || 0,
-          }
-        })
+      const tagValues = projectTags
+        .map((tag) => ({
+          id: tag.name,
+          label: tag.name,
+          type: 'string' as const,
+          values: [],
+          color: tag.color || null,
+          count: tagCounts.get(tag.name) || 0,
+        }))
         .sort((a, b) => b.count - a.count)
 
       opts.push({

--- a/src/pages/ProjectListsPage/components/ListsFiltersDialog/ListsFiltersDialog.tsx
+++ b/src/pages/ProjectListsPage/components/ListsFiltersDialog/ListsFiltersDialog.tsx
@@ -5,6 +5,8 @@ import { entityTypeOptions } from '../NewListDialog/NewListDialog'
 import { createPortal } from 'react-dom'
 import styled from 'styled-components'
 import { useListsContext } from '@pages/ProjectListsPage/context'
+import { useProjectDataContext } from '@shared/containers/ProjectTreeTable'
+import { getAttributeIcon } from '@shared/util'
 
 const Dialog = styled.div`
   position: fixed;
@@ -25,8 +27,9 @@ const Dialog = styled.div`
 interface ListsFiltersDialogProps {}
 
 const ListsFiltersDialog: FC<ListsFiltersDialogProps> = ({}) => {
-  const { listsFilters, setListsFilters } = useListsDataContext()
+  const { listsFilters, setListsFilters, listsData } = useListsDataContext()
   const { listsFiltersOpen, setListsFiltersOpen } = useListsContext()
+  const { projectInfo } = useProjectDataContext()
 
   const filtersRef = useRef<SearchFilterRef>(null)
 
@@ -44,8 +47,8 @@ const ListsFiltersDialog: FC<ListsFiltersDialogProps> = ({}) => {
     setFilters(listsFilters)
   }, [listsFilters, setFilters])
 
-  const options = useMemo<Option[]>(
-    () => [
+  const options = useMemo<Option[]>(() => {
+    const opts: Option[] = [
       {
         id: 'entityType',
         label: 'Entity Type',
@@ -53,9 +56,59 @@ const ListsFiltersDialog: FC<ListsFiltersDialogProps> = ({}) => {
         icon: 'check_circle',
         values: entityTypeOptions.map((option) => ({ ...option, id: option.value })),
       },
-    ],
-    [],
-  )
+    ]
+
+    // Add tags option if there are any tags in the lists
+    const allTags = new Set<string>()
+    listsData.forEach((list) => {
+      if (list.tags && Array.isArray(list.tags)) {
+        list.tags.forEach((tag) => allTags.add(tag))
+      }
+    })
+
+    if (allTags.size > 0) {
+      // Get tag anatomy from project info
+      const tagsAnatomy = new Map(
+        projectInfo?.tags?.map((tag) => [tag.name, tag]) || [],
+      )
+
+      // Create tag option values with counts
+      const tagCounts = new Map<string, number>()
+      listsData.forEach((list) => {
+        if (list.tags && Array.isArray(list.tags)) {
+          list.tags.forEach((tag) => {
+            tagCounts.set(tag, (tagCounts.get(tag) || 0) + 1)
+          })
+        }
+      })
+
+      const tagValues = Array.from(allTags)
+        .map((tag) => {
+          const tagData = tagsAnatomy.get(tag)
+          return {
+            id: tag,
+            label: tag,
+            type: 'string' as const,
+            values: [],
+            color: tagData?.color || null,
+            count: tagCounts.get(tag) || 0,
+          }
+        })
+        .sort((a, b) => b.count - a.count)
+
+      opts.push({
+        id: 'tags',
+        label: 'Tags',
+        type: 'list_of_strings',
+        icon: getAttributeIcon('tags'),
+        operator: 'OR',
+        values: tagValues,
+        allowsCustomValues: true,
+      })
+    }
+
+    return opts
+  }, [listsData, projectInfo])
 
   //   on keydown, close the dialog
   useEffect(() => {

--- a/src/pages/ProjectListsPage/components/ListsTable/ListsTableHeader.tsx
+++ b/src/pages/ProjectListsPage/components/ListsTable/ListsTableHeader.tsx
@@ -130,7 +130,7 @@ const ListsTableHeader: FC<ListsTableHeaderProps> = ({
     selectAllLists,
   } = useListsContext()
 
-  const { showArchived, setShowArchived } = useListsDataContext()
+  const { showArchived, setShowArchived, listsFilters } = useListsDataContext()
 
   const { menuOpen, toggleMenuOpen } = useMenuContext()
 
@@ -244,6 +244,8 @@ const ListsTableHeader: FC<ListsTableHeaderProps> = ({
             icon: 'filter_list',
             onClick: () => setListsFiltersOpen(true),
             isPinned: false,
+            selected: listsFilters.length > 0,
+            active: listsFilters.length > 0,
           },
         ]
       : []),


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
Adds dynamic tag-based filtering capability to the Lists Filters Dialog. Users can now filter lists by tags, with the filter options dynamically generated based on tags
  present in existing lists.


## Technical details
<!-- Please state any technical details such as limitations -->

- Dynamically generates tag filter options from all tags found across lists in listsData
- Integrates with project tag anatomy to display tag colors from projectInfo
- Shows tag counts (number of lists with each tag) and sorts by count (most used first)
- Tag filter only appears when at least one list has tags
- Uses OR operator for tag filtering (shows lists with any of the selected tags)
- Supports custom tag values in the filter

## Additional context

<img width="635" height="388" alt="Screenshot 2025-10-02 at 12 36 14" src="https://github.com/user-attachments/assets/11f5ba3b-5826-48bb-ad99-5b7eed760e73" />

<img width="615" height="193" alt="Screenshot 2025-10-02 at 12 36 37" src="https://github.com/user-attachments/assets/041103d4-51e2-422a-a638-a83d855aeb12" />

