### PR TITLE
Overview: Row height not loading properly

### DIFF
--- a/shared/src/containers/ProjectTreeTable/ProjectTreeTable.styled.ts
+++ b/shared/src/containers/ProjectTreeTable/ProjectTreeTable.styled.ts
@@ -70,12 +70,8 @@ export const TableCellContent = styled.div`
     margin: 0px 5px;
     padding: 0 !important;
     width: calc(100% - 10px);
-    height: 28px;
+    height: calc(100% - 6px);
     margin-top: 3px;
-
-    &:not(.hierarchy) {
-      height: 32px;
-    }
   }
 
   &:focus-visible {

--- a/shared/src/containers/ProjectTreeTable/ProjectTreeTable.tsx
+++ b/shared/src/containers/ProjectTreeTable/ProjectTreeTable.tsx
@@ -940,15 +940,6 @@ const TableBody = ({
 
   const virtualRows = rowVirtualizer.getVirtualItems()
 
-  // Force row virtualizer to recalculate when row height changes (debounced for performance)
-  useEffect(() => {
-    const timeout = setTimeout(() => {
-      rowVirtualizer.measure()
-    }, 100) // Small delay to batch multiple rapid changes
-
-    return () => clearTimeout(timeout)
-  }, [defaultRowHeight, rowVirtualizer])
-
   // Memoize the measureElement callback
   const measureRowElement = useCallback(
     (node: HTMLTableRowElement | null) => {


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
Fixed multiple bugs in the row height adjustment feature:
- Row height now persists correctly after page refresh
- Slider moves smoothly without lagging behind cursor
- Skeleton loading states now scale properly with row height in all cells


## Technical details
<!-- Please state any technical details such as limitations -->

- Simplified state management from triple-state (internal/local/config) to dual-state (internal/config)
- Removed broken initialization logic that only ran once, preventing external updates
- `internalRowHeight` now properly falls back to `configRowHeight` for seamless synchronization

## Additional context
<!-- Add any other context or screenshots here. -->

