### PR TITLE
Fix settings search

### DIFF
--- a/src/containers/AddonSettings/AddonSettings.jsx
+++ b/src/containers/AddonSettings/AddonSettings.jsx
@@ -726,7 +726,10 @@ const AddonSettings = ({ projectName, showSites = false, bypassPermissions = fal
     setCurrentSelection(null)
   }
 
+
   const onUpdateAddonSchema = (addonName, schema) => {
+    // TODO: Rewrite this to not rely on `settings` in addon settings list
+    // as it requires addon list to load the entire payload, which is not optimal
     const settings = selectedAddons.find((el) => el.name == addonName).settings
     const hydratedObject = attachLabels(settings, schema, schema)
     setSearchTree((prev) => {

--- a/src/services/addonSettings.js
+++ b/src/services/addonSettings.js
@@ -25,7 +25,11 @@ const addonSettings = api.injectEndpoints({
       query: ({ variant, projectName, siteId, bundleName, projectBundleName }) => {
         // this should prevent passing null/undefined values to the query
         // params once and for all (until we have typescript)
-        const params = {summary: true}
+
+        // TODO: we would normally use 'summary: true' here to reduce the payload,
+        // but fulltext search in settings actually neeed the data
+        // so for now we leave it out
+        const params = {}//{summary: true}
         if (variant) params.variant = variant
         if (projectName) params.project_name = projectName
         if (siteId) params.site_id = siteId


### PR DESCRIPTION
* In `src/services/addonSettings.js`, the query for addon settings no longer uses the `summary: true` parameter, ensuring that full data is retrieved to support full-text search in settings. This change temporarily increases the payload size but is necessary for search functionality.
* In `src/containers/AddonSettings/AddonSettings.jsx`, a TODO comment was added to the `onUpdateAddonSchema` function, highlighting the need to refactor the logic so that it doesn't rely on the full settings payload from the addon list, which is currently suboptimal for performance.