### PR TITLE
Overview: Multi-select items should fill row height

### DIFF
--- a/shared/src/containers/ProjectTreeTable/widgets/CellWidget.tsx
+++ b/shared/src/containers/ProjectTreeTable/widgets/CellWidget.tsx
@@ -226,7 +226,6 @@ export const CellWidget: FC<EditorCellProps> = ({
               isReadOnly
               hasMultipleValues={enumValue.length > 1}
               isMultiSelect={type?.includes('list')}
-              rowHeight={rowHeight}
             />
           )
         }
@@ -237,7 +236,6 @@ export const CellWidget: FC<EditorCellProps> = ({
             type={type}
             onOpen={() => setEditingCellId(cellId)}
             enableCustomValues={enableCustomValues}
-            rowHeight={rowHeight}
             {...sharedProps}
             {...pt?.enum}
           />

--- a/shared/src/containers/ProjectTreeTable/widgets/EnumCellValue.tsx
+++ b/shared/src/containers/ProjectTreeTable/widgets/EnumCellValue.tsx
@@ -32,9 +32,22 @@ const StyledWidget = styled.div`
       background-color: var(--md-sys-color-primary-container-hover);
     }
   }
+
+  /* when value container is higher than 55px, wrap the contents */
+  &:not(.item) {
+    container-type: size;
+
+    @container (min-height: 55px) {
+      .values {
+        flex-wrap: wrap;
+        align-items: flex-start;
+        max-height: 100%;
+      }
+    }
+  }
 `
 
-const StyledValuesContainer = styled.div<{ $maxHeight: number| undefined} >`
+const StyledValuesContainer = styled.div`
   flex: 1;
   display: flex;
   gap: var(--base-gap-small);
@@ -44,12 +57,6 @@ const StyledValuesContainer = styled.div<{ $maxHeight: number| undefined} >`
   border-radius: var(--border-radius-m);
   padding: 0px 2px;
   flex-wrap: nowrap;
-  
-  &.wrap {
-    flex-wrap: wrap;
-    align-items: flex-start;
-    max-height: ${({ $maxHeight }) => ($maxHeight ? `${$maxHeight- 10}px` : 'unset')};
-  }
 `
 
 const StyledValueWrapper = styled.div`
@@ -67,7 +74,6 @@ const StyledValue = styled.span`
   padding: 0px 2px;
   white-space: nowrap;
   overflow: hidden;
-  text-overflow: ellipsis;
   max-width: 100%;
 
   &.placeholder {
@@ -119,7 +125,6 @@ export interface EnumTemplateProps extends React.HTMLAttributes<HTMLSpanElement>
   isItem?: boolean
   isSelected?: boolean
   isReadOnly?: boolean
-  rowHeight?: number
   pt?: {
     icon?: Partial<IconProps>
     img?: Partial<React.ImgHTMLAttributes<HTMLImageElement>>
@@ -138,7 +143,6 @@ export const EnumCellValue = ({
   isItem,
   isSelected,
   isReadOnly,
-  rowHeight,
   className,
   pt,
   ...props
@@ -176,13 +180,9 @@ export const EnumCellValue = ({
     ]
   }
 
-  // Allow wrapping when row height is above 40px (allowing multi-row display)
-  const allowWrap = rowHeight !== undefined && rowHeight > 60
-
-
   return (
     <StyledWidget className={clsx(className, { selected: isSelected, item: isItem })} {...props}>
-      <StyledValuesContainer className={clsx({ wrap: allowWrap })} $maxHeight={rowHeight}>
+      <StyledValuesContainer className="values">
         {selectedOptions.map((option, i) => (
           <StyledValueWrapper key={option.value.toString() + i}>
             {option.icon && checkForImgSrc(option.icon) ? (

--- a/shared/src/containers/ProjectTreeTable/widgets/EnumWidget.tsx
+++ b/shared/src/containers/ProjectTreeTable/widgets/EnumWidget.tsx
@@ -20,7 +20,6 @@ export interface EnumWidgetProps
   autoOpen?: boolean
   isReadOnly?: boolean
   enableCustomValues?: boolean
-  rowHeight?: number
   pt?: {
     template?: Partial<EnumTemplateProps>
   }
@@ -38,7 +37,6 @@ export const EnumWidget = forwardRef<HTMLDivElement, EnumWidgetProps>(
       autoOpen = true,
       isReadOnly,
       enableCustomValues,
-      rowHeight,
       onOpen,
       onChange,
       onCancelEdit,
@@ -130,7 +128,6 @@ export const EnumWidget = forwardRef<HTMLDivElement, EnumWidgetProps>(
               isOpen={isOpen}
               isReadOnly={isReadOnly}
               isMultiSelect={isMultiSelect}
-              rowHeight={rowHeight}
               {...pt?.template}
               placeholder={dropdownProps.placeholder}
               className={clsx('enum-dropdown-value', pt?.template?.className)}
@@ -168,7 +165,6 @@ export const EnumWidget = forwardRef<HTMLDivElement, EnumWidgetProps>(
         hasMultipleValues={hasMultipleValues}
         isMultiSelect={isMultiSelect}
         isReadOnly={isReadOnly}
-        rowHeight={rowHeight}
         {...pt?.template}
         placeholder={dropdownProps.placeholder}
         className={clsx('enum-value', pt?.template?.className, dropdownProps.className)}


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
Fixed multi-select enum tags stretching to full width when wrapping is enabled in multi-row cells. Tags now maintain their natural width.

## Technical details
<!-- Please state any technical details such as limitations -->

- Added $maxHeight prop to StyledValuesContainer to constrain height when wrapping
- Applied max-height only when .wrap class is active (row height > 60px)
- Subtracted 10px from $maxHeight to account for padding and prevent overflow
- Changed wrap threshold from 40px to 60px row height for better UX

## Additional context
<!-- Add any other context or screenshots here. -->
The flex-wrap: wrap; property enables the multi-row layout, but there is an issue with tag widths — the CSS doesn’t know it should shrink the tags to a min-width of 20px and display ellipses.

<img width="620" height="163" alt="Screenshot 2025-10-15 at 13 00 57" src="https://github.com/user-attachments/assets/d4b97e33-04ae-42e7-b5d6-a29d50a58477" />
<img width="544" height="90" alt="Screenshot 2025-10-15 at 13 56 11" src="https://github.com/user-attachments/assets/fd19a565-ba29-4645-9eee-94f09e8c72c5" />


