### PR TITLE
Fix row height when switching between custom views

### DIFF
--- a/shared/src/components/ProjectTableSettings/RowHeightSettings.tsx
+++ b/shared/src/components/ProjectTableSettings/RowHeightSettings.tsx
@@ -80,17 +80,20 @@ const RowHeightSettings: FC = () => {
 
   const [isDragging, setIsDragging] = useState(false)
   const [localValue, setLocalValue] = useState(contextRowHeight)
+  const [isUserAdjusting, setIsUserAdjusting] = useState(false)
 
-  // Sync local value when context changes and we're not dragging
+  // Sync local value when context changes and we're not dragging or adjusting
   useEffect(() => {
-    if (!isDragging) {
+    if (!isDragging && !isUserAdjusting) {
       setLocalValue(contextRowHeight)
     }
-  }, [contextRowHeight, isDragging])
+  }, [contextRowHeight, isDragging, isUserAdjusting])
 
   const handleSliderChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     const newValue = parseInt(e.target.value, 10)
 
+    // Mark that user is actively adjusting
+    setIsUserAdjusting(true)
     // Update local state immediately for responsive slider
     setLocalValue(newValue)
   }, [])
@@ -98,10 +101,12 @@ const RowHeightSettings: FC = () => {
   // Debounce the local value to avoid too many updates
   const debouncedValue = useDebounce(localValue, 25)
 
-  // Update context when debounced value changes
+  // Update context when debounced value changes, but only if user is adjusting
   useEffect(() => {
-    updateRowHeight(localValue)
-  }, [debouncedValue, updateRowHeight])
+    if (isUserAdjusting) {
+      updateRowHeight(localValue)
+    }
+  }, [debouncedValue, updateRowHeight, isUserAdjusting, localValue])
 
   const handleSliderStart = useCallback(() => {
     setIsDragging(true)
@@ -109,6 +114,7 @@ const RowHeightSettings: FC = () => {
 
   const handleSliderRelease = useCallback(() => {
     setIsDragging(false)
+    setIsUserAdjusting(false)
     // Persist to API when user finishes adjusting
     updateRowHeightWithPersistence(localValue)
   }, [localValue, updateRowHeightWithPersistence])


### PR DESCRIPTION


<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
Fixed rowHeight not persisting correctly when switching between views in the Overview page. Users can now save different rowHeight values for different views (e.g., Large, Medium, Small), and the correct rowHeight will be
  applied when switching between them.

  **Before:**
  - When switching views, the table would display the previous view's rowHeight instead of the selected view's rowHeight
  - Flickering occurred when switching between views with different rowHeight values

  **After:**
  - Each view correctly loads and displays its saved rowHeight
  - No flickering when switching between views
  - Smooth transitions between different view configurations



## Technical details
<!-- Please state any technical details such as limitations -->
  ### Root Cause
  The issue was caused by stale state in the `ColumnSettingsProvider` and `RowHeightSettings` components:

  1. `internalRowHeight` state was persisting across view changes
  2. The slider component was calling `updateRowHeight` even when the context changed externally (view switch)

## Additional context
<!-- Add any other context or screenshots here. -->

