### PR TITLE
Inbox: Comments not highlighting and therefore not being scrolled to

### DIFF
--- a/shared/src/context/DetailsPanelContext.tsx
+++ b/shared/src/context/DetailsPanelContext.tsx
@@ -180,7 +180,9 @@ export const DetailsPanelProvider: React.FC<DetailsPanelProviderProps> = ({
   // close the slide out
   const closeSlideOut = useCallback(() => {
     setSlideOut(null)
-    setHighlightedActivities([])
+    if (slideOut) {
+      setHighlightedActivities([])
+    }
   }, [])
 
   const [pip, setPip] = useState<DetailsPanelPip | null>(null)


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Fixed inbox comments not highlighting and scrolling when clicking on inbox items. The issue was caused by highlightedActivities being cleared immediately after being set.

## Technical details
<!-- Please state any technical details such as limitations -->
Modified `closeSlideOut() `in `DetailsPanelContext.tsx` to only clear `highlightedActivities` when there's actually a slide-out open (when `slideOut` exists). This prevents clearing highlights when entities change in the main inbox panel, while still properly clearing them when actually closing a slide-out.

## Additional context
<!-- Add any other context or screenshots here. -->

