### PR TITLE
Project Access: Filtering broken

### DIFF
--- a/src/pages/ProjectManagerPage/Users/hooks.ts
+++ b/src/pages/ProjectManagerPage/Users/hooks.ts
@@ -1,11 +1,10 @@
 import { $Any } from '@types'
 import { useState } from 'react'
 import { SelectionStatus } from './types'
-import { Filter } from '@components/SearchFilter/types'
-import { useAppSelector } from '@state/store'
 import { useSetFrontendPreferencesMutation, useGetCurrentUserQuery } from '@shared/api'
 import { useUpdateAccessGroupsMutation } from '@queries/accessGroups/updateAccessGroups'
 import { useGetProjectsAccessQuery } from '@queries/accessGroups/getAccessGroups'
+import { Filter } from '@ynput/ayon-react-components'
 
 const useProjectAccessGroupData = (selectedProject: string) => {
   const [selectedProjects, setSelectedProjects] = useState<string[]>(
@@ -151,8 +150,9 @@ const useUserPreferencesExpandedPanels = (): [
 ] => {
   const pageId = 'project.settings.user.access_groups'
   const [updateUserPreferences] = useSetFrontendPreferencesMutation()
-  const userName = useAppSelector((state) => state.user.name)
-  const frontendPreferences = useAppSelector((state) => state.user.data.frontendPreferences)
+  const { data: user } = useGetCurrentUserQuery()
+  const userName = user?.name as string
+  const { data: { frontendPreferences = {} } = {} } = user || {}
   const pageExpandedAccessGroups: {
     [pageId: string]: {}
   } = frontendPreferences?.expandedAccessGroups


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
Fixed an issue where user filters in the Project Manager > Users page were not updating in real-time within the running application. Filters would only persist and display correctly after a page refresh.


## Technical details
<!-- Please state any technical details such as limitations -->
 The `useUserPageFilters` hook was reading `frontendPreferences` from the Redux state slice using `useAppSelector()`. When filters were updated, the
  `setFrontendPreferences` mutation performed an optimistic update to the RTK Query cache, but this update wasn't reflected in the Redux state selector until the next page
  load/refetch.

  ### Solution
  Changed the data source from Redux state selector to RTK Query's `useGetCurrentUserQuery()` hook. This allows the component to:

1. Subscribe directly to the RTK Query cache
2. Receive optimistic updates immediately when preferences are saved
3. Follow the same pattern used elsewhere in the codebase (e.g., `useProjectListUserPreferences`)

## Additional context
<!-- Add any other context or screenshots here. -->

