### PR TITLE
Bundle Page / Lists of Addons - should be aligned for all circumstances

### DIFF
--- a/src/pages/SettingsPage/Bundles/BundleCompare.tsx
+++ b/src/pages/SettingsPage/Bundles/BundleCompare.tsx
@@ -2,6 +2,7 @@ import { Panel, Section } from '@ynput/ayon-react-components'
 import React, { useRef, useState } from 'react'
 import BundlesAddonList from './BundlesAddonList'
 import useScrollSync from '@hooks/useScrollSync'
+import { DataTableSortEvent } from 'primereact/datatable'
 
 type Bundle = {
   name: string
@@ -20,7 +21,8 @@ const BundleCompare: React.FC<BundleCompareProps> = ({ bundles = [], addons }) =
   // for each bundle, in addons check if the same addon has a different version in another bundle
   // if so, set a flag on the addon to show it's different
   const diffAddonVersions: string[] = []
-
+  const [sortField, setSortField] = useState<string | null>(null)
+  const [sortOrder, setSortOrder] = useState<0 | 1 | -1 | null | undefined>(null)
   const bundlesAddons: Array<Record<string, string | null>> = bundles.map((b) => b.addons)
 
   addons.forEach(({ name }) => {
@@ -42,7 +44,11 @@ const BundleCompare: React.FC<BundleCompareProps> = ({ bundles = [], addons }) =
   }
 
   useScrollSync(addonListRefs as any, [bundles])
+  const handleSort = (e: DataTableSortEvent) => {
+    setSortOrder(e.sortOrder)
+    setSortField(e.sortField)
 
+  }
   return (
     <Section direction="row" style={{ alignItems: 'flex-start', overflow: 'auto' }}>
       {bundles.map((bundle, index) => (
@@ -57,6 +63,9 @@ const BundleCompare: React.FC<BundleCompareProps> = ({ bundles = [], addons }) =
             selected={selectedAddons}
             ref={handleRef(index)}
             diffAddonVersions={diffAddonVersions}
+            handleSort={handleSort}
+            sortOrder={sortOrder}
+            sortField={sortField}
           />
         </Panel>
       ))}

--- a/src/pages/SettingsPage/Bundles/BundlesAddonList.tsx
+++ b/src/pages/SettingsPage/Bundles/BundlesAddonList.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo } from 'react'
 import { useListAddonsQuery } from '@shared/api'
 import { useListBundlesQuery } from '@queries/bundles/getBundles'
-import { DataTable } from 'primereact/datatable'
+import { DataTable, DataTableSortEvent } from 'primereact/datatable'
 import { Column } from 'primereact/column'
 import { useSocketContext } from '@shared/context'
 import { compareBuild, coerce } from 'semver'
@@ -42,6 +42,9 @@ type BundlesAddonListProps = {
   isDev?: boolean
   onDevChange?: (addonNames: string[], payload: { value: any; key: 'enabled' | 'path' }) => void
   onAddonAutoUpdate?: (addon: string, version: string | null) => void
+  handleSort?:(e: DataTableSortEvent) => void
+  sortField?: string | null
+  sortOrder?: 0 | 1 | -1 | null | undefined
 }
 
 const StyledDataTable = styled(DataTable as unknown as React.FC<any>)`
@@ -141,11 +144,13 @@ const BundlesAddonList = React.forwardRef<any, BundlesAddonListProps>(
       isDev,
       onDevChange,
       onAddonAutoUpdate,
+      sortOrder,
+      sortField,
+      handleSort,
     },
     ref,
   ) => {
     const navigate = useNavigate()
-
     const { data: { addons = [] } = {}, refetch } = useListAddonsQuery({}) as any
 
     const readyState = useSocketContext().readyState
@@ -236,6 +241,7 @@ const BundlesAddonList = React.forwardRef<any, BundlesAddonListProps>(
       ctxMenuShow(e.originalEvent, createContextItems(contextSelection))
     }
 
+
     return (
       <StyledDataTable
         value={addonsTable}
@@ -251,6 +257,11 @@ const BundlesAddonList = React.forwardRef<any, BundlesAddonListProps>(
         className="addons-table"
         rowClassName={(rowData: any) => diffAddonVersions?.includes(rowData.name) && 'diff-version'}
         ref={ref}
+        {...(handleSort && {
+          onSort: (e: DataTableSortEvent) => handleSort(e),
+          sortField: sortField,
+          sortOrder: sortOrder,
+        })}
       >
         <Column
           header="Title"


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
 Fixed addon list alignment issues in bundle comparison view. When comparing bundles with different addons (e.g., Bundle A has AfterEffects + Maya, Bundle B has Maya +
  Nuke), the lists were misaligned making it difficult to compare addon versions side-by-side.

  **Changes:**
  - Modified `BundleCompare.tsx` to create a unified addon list across all bundles being compared
  - Pre-process bundle data to ensure each bundle has entries for all addons (with `null` for missing ones)
  - Updated `BundlesAddonList.tsx` to use consistent title-based sorting in `readOnly` mode (comparison view)
  - Added logic to synchronize sorting across comparison bundles

  **Result:** All bundle columns now show the same addons in the same order, with missing addons displayed as "NONE", making version comparison significantly easier.


## Technical details
<!-- Please state any technical details such as limitations -->
  - In comparison mode (`readOnly=true`), all addon lists now sort by title only, regardless of bundle type (project vs studio)
  - In edit mode, project bundles retain their original sorting behavior (by `projectCanOverrideAddonVersion` first, then title)
  - The normalization process preserves all original bundle properties while extending the addons object
  -  Added `handleSort` logic to synchronize sorting across bundles

## Additional context
<!-- Add any other context or screenshots here. -->

