### PR TITLE
NewServiceDialog: configurable service environment

### DIFF
--- a/src/pages/ServicesPage/NewServiceDialog.jsx
+++ b/src/pages/ServicesPage/NewServiceDialog.jsx
@@ -75,6 +75,7 @@ const ServiceDialog = ({ onHide, editService = null }) => {
   const [settingsVariant, setSettingsVariant] = useState('production')
   const [storages, setStorages] = useState('')
   const [ports, setPorts] = useState('')
+  const [envVars, setEnvVars] = useState('')
 
   const { data: addonData = [] } = useGetServiceAddonsQuery({})
   const { data: hostsData } = useListHostsQuery()
@@ -109,8 +110,12 @@ const ServiceDialog = ({ onHide, editService = null }) => {
       if (ports && ports.length) {
         setPorts(ports.join('\n'))
       }
-        
 
+      // Set envVars if available
+      const envVars = editService.data?.env
+      if (envVars && Object.keys(envVars).length) {
+        setEnvVars(Object.entries(envVars).map(([key, value]) => `${key}=${value}`).join('\n'))
+      }
     }
   }, [isEditMode, editService, addonData])
 
@@ -181,6 +186,16 @@ const ServiceDialog = ({ onHide, editService = null }) => {
 
     if (ports) {
       serviceConfig.ports = ports.split('\n').map((s) => s.trim())
+    }
+
+    if (envVars) {
+      serviceConfig.env = envVars.split('\n').reduce((acc, line) => {
+        const [key, value] = line.split('=')
+        if (key && value) {
+          acc[key.trim()] = value.trim()
+        }
+        return acc
+      }, {})
     }
 
     const serviceData = {
@@ -363,6 +378,15 @@ const ServiceDialog = ({ onHide, editService = null }) => {
             placeholder="8080:8080"
           />
           Add multiple ports by adding them on a new line.
+        </FormRow>
+        <FormRow label="Environment">
+          <InputTextarea
+            value={envVars}
+            style={{ minHeight: 40 }}
+            onChange={(e) => setEnvVars(e.target.value)}
+            placeholder="LOGLEVEL=INFO"
+          />
+          Add multiple environment variables by adding them on a new line.
         </FormRow>
       </FormLayout>
     </Dialog>


### PR DESCRIPTION
## Description of changes 
This PR adds a new FormRow that lets users set environment variables for the containers spawned by ash.

## Additional context
This is the modified Form
<img width="575" height="627" alt="image" src="https://github.com/user-attachments/assets/0aaf11d8-18ea-4d6c-a6df-0293643f1769" />
And here's an example of the sg-leecher running with debug logging enabled
<img width="755" height="598" alt="Screenshot 2025-10-23 at 17 14 43" src="https://github.com/user-attachments/assets/ded46961-23d8-41ef-9b05-524d10cd79ab" />


