### PR TITLE
New Entity: Changing type resets label when it should not

### DIFF
--- a/src/components/NewEntity/NewEntity.tsx
+++ b/src/components/NewEntity/NewEntity.tsx
@@ -13,11 +13,11 @@ import {
 import styled from 'styled-components'
 import TypeEditor from './TypeEditor'
 import {
-  checkLabel,
   checkName,
+  checkLabel,
+  parseAndFormatName,
   getPlatformShortcutKey,
   KeyMode,
-  parseAndFormatName,
 } from '@shared/util'
 import ShortcutWidget from '@components/ShortcutWidget'
 import {


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
Implemented proper label update logic when changing entity types in the Create Entity dialog. The label now only updates when changing type if:

1. The label has **not** been manually edited by the user, AND
2. The label still matches the **original type's name** (the type that was active when the label was first edited)


## Technical details
<!-- Please state any technical details such as limitations -->
  - Added `originalTypeWhenLabelEdited` state to store the entity type that was active when the user first manually edited the
  label
  - Modified `handleChange` to check if current label matches the **stored original type** rather than just checking if it was
  manually edited
  - Added logic to reset tracking flags when user changes label back to match current type
  - Ensured proper cleanup of stored original type in `handleClose` and `handleSubmit`

## Additional context
<!-- Add any other context or screenshots here. -->


https://github.com/user-attachments/assets/0f17400f-b78e-4a0b-bc67-4a998160a408

