### PR TITLE
Access Groups: Use same naming validation on server

### DIFF
--- a/src/pages/SettingsPage/AccessGroups/NewAccessGroup.jsx
+++ b/src/pages/SettingsPage/AccessGroups/NewAccessGroup.jsx
@@ -27,8 +27,7 @@ const NewAccessGroup = ({ onClose, accessGroupList }) => {
   let error = null
   if (accessGroupNames.includes(accessGroupName.toLowerCase()))
     error = 'This access group already exists'
-  else if (!accessGroupName.match('^[a-zA-Z_]{2,20}$')) error = 'Invalid access group name'
-
+  else if (!accessGroupName.match('^[a-zA-Z0-9_]([a-zA-Z0-9_.\\-]*[a-zA-Z0-9_])?$')) error = 'Invalid access group name'
   const handleKeyDown = (e) => {
     e?.stopPropagation()
     const isEnter = e.key === 'Enter'


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Updated frontend access group name validation regex to match backend pattern, allowing numbers, dots, and hyphens in names.

## Technical details
<!-- Please state any technical details such as limitations -->

- Changed regex from `^[a-zA-Z_]{2,20}$` to `^[a-zA-Z0-9_]([a-zA-Z0-9_.\-]*[a-zA-Z0-9_])?$`
- Now matches the backend pattern defined in `ayon_server/types.py:71`
- Allows alphanumeric characters, underscores, dots (.), and hyphens (-) in middle positions
- Removes arbitrary 20-character frontend limit

## Additional context
<!-- Add any other context or screenshots here. -->

