### PR TITLE
Projects: Ensure projects cannot be selected in the background (archived)

### DIFF
--- a/src/containers/ProjectsList/ProjectsList.tsx
+++ b/src/containers/ProjectsList/ProjectsList.tsx
@@ -162,6 +162,30 @@ const ProjectsList: FC<ProjectsListProps> = ({
     // I don't like the setTimeout, but it is legacy code and I do not want to break existing stuffs
     setTimeout(() => dispatch((_, getState) => navigate(getState)(link)), 0)
   }
+  const onArchive = (projectName: string, active: boolean) => {
+    onActivateProject?.(projectName, active)
+
+    if (!active && !showArchived) {
+      const newSelection = selection.filter((p) => p !== projectName)
+      if (newSelection.length === 0 && projects.length > 0) {
+        const firstAvailable = projects.find((p) => p.name !== projectName)
+        if (firstAvailable) {
+          onSelect([firstAvailable.name])
+        } else {
+          onSelect([])
+        }
+      } else {
+        onSelect(newSelection)
+      }
+    }
+  }
+  const onShowArchivedToggle = () => {
+    if (showArchived) {
+      const activeProjects = projects.filter((p) => p.active)
+      onSelect(selection.filter((s) => activeProjects.some((p) => p.name === s)))
+    }
+    setShowArchived(!showArchived)
+  }
 
   // Generate menu items used in both header and context menu
   const buildMenuItems = useProjectsListMenuItems({
@@ -178,11 +202,11 @@ const ProjectsList: FC<ProjectsListProps> = ({
     onSearch: () => setClientSearch(''),
     onPin: (pinned) => onRowPinningChange({ top: pinned }),
     onSelectAll: toggleSelectAll,
-    onArchive: onActivateProject,
+    onArchive,
     onDelete: onDeleteProject,
     onOpen: onOpenProject,
     onManage: onOpenProjectManage,
-    onShowArchivedToggle: () => setShowArchived(!showArchived),
+    onShowArchivedToggle,
   })
 
   // attach context menu

--- a/src/containers/ProjectsList/hooks/useProjectsListMenuItems.ts
+++ b/src/containers/ProjectsList/hooks/useProjectsListMenuItems.ts
@@ -162,7 +162,7 @@ const useProjectsListMenuItems = ({
           label: `${singleActive ? 'Deactivate to delete' : 'Delete'}`,
           icon: 'delete',
           [command ? 'command' : 'onClick']: () => handleDelete(singleProject, selection),
-          disabled: selection.length !== 1 || singleActive || !singleProject,
+          disabled: selection.length !== 1 || singleActive !== false,
           danger: true,
         },
       ]


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
 Fixed issue where archived projects could be deleted when hidden from the list after toggling "Show archived" off while the project remained selected.


## Technical details
<!-- Please state any technical details such as limitations -->
 Added `!singleProject` check to delete button disabled condition in `useProjectsListMenuItems.ts:165`. This ensures the selected project exists in the currently visible projects list before allowing deletion.

## Additional context
<!-- Add any other context or screenshots here. -->

