### PR TITLE
Kanban: Details panel could become stuck closed after hitting enter

### DIFF
--- a/src/pages/UserDashboardPage/UserDashboardTasks/UserDashboardKanBan.jsx
+++ b/src/pages/UserDashboardPage/UserDashboardTasks/UserDashboardKanBan.jsx
@@ -189,7 +189,13 @@ const UserDashboardKanBan = ({
 
   // DND Stuff
   const touchSensor = useSensor(TouchSensor)
-  const keyboardSensor = useSensor(KeyboardSensor)
+  const keyboardSensor = useSensor(KeyboardSensor, {
+    keyboardCodes: {
+      start: ['Enter'],
+      cancel: ['Escape'],
+      end: ['Enter'],
+    },
+  })
   const pointerSensor = useSensor(PointerSensor, {
     activationConstraint: {
       distance: 1,
@@ -221,6 +227,11 @@ const UserDashboardKanBan = ({
       const task = tasks.find((t) => t.id === event.active.id)
       setSelectedTasks([event.active.id], [task.taskType], [task])
     }
+  }
+
+  const handleDragCancel = (event) => {
+    dispatch(onDraggingEnd())
+    setActiveDraggingId(null)
   }
 
   const handleDragEnd = async (event) => {
@@ -280,6 +291,7 @@ const UserDashboardKanBan = ({
           <DndContext
             sensors={sensors}
             onDragEnd={handleDragEnd}
+            onDragCancel={handleDragCancel}
             onDragStart={handleDragStart}
             autoScroll={false}
           >


### PR DESCRIPTION
This pull request improves the drag-and-drop (DND) functionality in the `UserDashboardKanBan` component, focusing on keyboard accessibility and proper handling of drag cancellation events. 

**Accessibility and Drag Event Handling Improvements:**

* Updated the initialization of `KeyboardSensor` to specify which keyboard keys start, cancel, and end a drag operation, improving keyboard accessibility for DND.
* Added a new `handleDragCancel` function to reset the dragging state and dispatch the appropriate Redux action when a drag is cancelled.
* Registered the new `handleDragCancel` function with the `DndContext` to handle drag cancellation events.