### PR TITLE
Overview: Failed update should not add to history stack

### DIFF
--- a/shared/src/api/queries/overview/updateOverview.ts
+++ b/shared/src/api/queries/overview/updateOverview.ts
@@ -513,6 +513,11 @@ const operationsApiEnhancedInjected = operationsEnhanced.injectEndpoints({
         try {
           const result = await dispatch(operationsEnhanced.endpoints.operations.initiate(arg))
 
+          // Check if the network request itself failed (offline, timeout, etc.)
+          if (result.error) {
+            return { error: result.error as FetchBaseQueryError }
+          }
+
           const data = result.data
           // check for any errors in the result
           const uniqueErrors = new Set()

--- a/shared/src/containers/ProjectTreeTable/context/CellEditingProvider.tsx
+++ b/shared/src/containers/ProjectTreeTable/context/CellEditingProvider.tsx
@@ -20,11 +20,12 @@ export const CellEditingProvider: React.FC<{ children: ReactNode }> = ({ childre
 
   // Get history functions
   const history = useHistory()
-  const { pushHistory, undo: undoHistory, redo: redoHistory, canUndo, canRedo } = history
+  const { pushHistory, undo: undoHistory, redo: redoHistory, canUndo, canRedo, removeHistoryEntries } = history
 
   const { selectedCells } = useSelectionCellsContext()
   const { updateEntities: updateOverviewEntities, inheritFromParent } = useUpdateTableData({
     pushHistory,
+    removeHistoryEntries,
   })
   const { attribFields, getEntityById } = useProjectTableContext()
 

--- a/shared/src/containers/ProjectTreeTable/hooks/useUpdateTableData.ts
+++ b/shared/src/containers/ProjectTreeTable/hooks/useUpdateTableData.ts
@@ -46,10 +46,11 @@ export type OperationWithRowId = OperationModel & { rowId: string; meta?: Record
 
 interface UseUpdateTableDataProps {
   pushHistory?: UseHistoryReturn['pushHistory']
+  removeHistoryEntries?: UseHistoryReturn['removeHistoryEntries']
 }
 
 const useUpdateTableData = (props?: UseUpdateTableDataProps) => {
-  const { pushHistory } = props || {}
+  const { pushHistory, removeHistoryEntries } = props || {}
   const { projectName } = useProjectContext()
   const {
     getEntityById,
@@ -248,6 +249,10 @@ const useUpdateTableData = (props?: UseUpdateTableDataProps) => {
       } catch (error: any) {
         console.error('Error updating entities:', error)
         toast.error('Failed to update entities: ' + error?.error)
+        // Remove the failed update from history stack
+        if (pushHistory && pushToHistory && removeHistoryEntries) {
+          removeHistoryEntries(1)
+        }
       }
     },
     [
@@ -256,6 +261,7 @@ const useUpdateTableData = (props?: UseUpdateTableDataProps) => {
       getEntityById,
       getInheritedDependents,
       pushHistory,
+      removeHistoryEntries,
     ],
   )
 
@@ -476,6 +482,10 @@ const useUpdateTableData = (props?: UseUpdateTableDataProps) => {
         })
       } catch (error) {
         toast.error('Failed to update entities')
+        // Remove the failed update from history stack
+        if (pushToHistory && pushHistory && removeHistoryEntries) {
+          removeHistoryEntries(1)
+        }
       }
     },
     [
@@ -484,6 +494,7 @@ const useUpdateTableData = (props?: UseUpdateTableDataProps) => {
       getInheritedDependents,
       findInheritedValueFromAncestors,
       pushHistory,
+      removeHistoryEntries,
     ],
   )
 


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
 - Added network error detection in `updateOverview` queryFn
  - Extended `useUpdateTableData` to accept and call `removeHistoryEntries` on API failures
  - Updated `CellEditingProvider` to pass `removeHistoryEntries` callback

## Technical details
<!-- Please state any technical details such as limitations -->
  When an update fails (network error, validation error, etc.), the catch blocks now call `removeHistoryEntries(1)` to prevent users from undoing changes that were never
  persisted.

## Additional context
<!-- Add any other context or screenshots here. -->
Closes #1123 

