### PR TITLE
YN-0212: product name filter on Products page

### DIFF
--- a/shared/src/components/SearchFilter/useBuildFilterOptions.tsx
+++ b/shared/src/components/SearchFilter/useBuildFilterOptions.tsx
@@ -683,10 +683,10 @@ const getOptionRoot = (
       break
     case 'productName':
       rootOption = {
-        id: getRootIdWithPrefix(`name`),
+        id: getRootIdWithPrefix(`productNames`),
         type: 'string',
         label: formatLabelWithScope(`Product Name`),
-        icon: getAttributeIcon('product'),
+        icon: getAttributeIcon('productName', 'string'),
         inverted: false,
         operator: 'OR',
         values: [],

--- a/src/pages/ProjectOverviewPage/containers/SearchFilterWrapper.tsx
+++ b/src/pages/ProjectOverviewPage/containers/SearchFilterWrapper.tsx
@@ -26,11 +26,13 @@ interface SearchFilterWrapperProps
   scopes?: ScopeWithFilterTypes[]
   queryFilters?: QueryFilter
   onChange?: (queryFilters: QueryFilter) => void
+  data: BuildFilterOptions['data']
 }
 
 const SearchFilterWrapper: FC<SearchFilterWrapperProps> = ({
   queryFilters,
   onChange,
+  data: customData,
   filterTypes,
   projectNames,
   disabledFilters,
@@ -59,6 +61,7 @@ const SearchFilterWrapper: FC<SearchFilterWrapperProps> = ({
     assignees: allAssignees,
     tags: projectInfo?.tags?.map((t) => t.name) || [],
     productTypes: projectInfo?.productTypes,
+    ...customData
     // TODO: find a way of getting all attribute values when all tasks are not loaded
   }
 

--- a/src/pages/VersionsProductsPage/components/VPToolbar/VPSearchFilter.tsx
+++ b/src/pages/VersionsProductsPage/components/VPToolbar/VPSearchFilter.tsx
@@ -10,7 +10,7 @@ interface VPSearchFilterProps {}
 const VPSearchFilter: FC<VPSearchFilterProps> = ({}) => {
   const { projectName, ...projectInfo } = useProjectContext()
   const { filters, onUpdateFilters } = useVPViewsContext()
-  const { productsMap } = useVersionsDataContext()
+  const { productsMap, versionsMap } = useVersionsDataContext()
 
   const scopesConfig: ScopeWithFilterTypes[] = [
     {
@@ -35,16 +35,17 @@ const VPSearchFilter: FC<VPSearchFilterProps> = ({}) => {
     },
   ]
 
-  // Extract product names for filtering
-  const productNames = useMemo(() => {
-    return Array.from(productsMap.values()).map((product) => product.name)
-  }, [productsMap])
-
   const data = useMemo(
     () => ({
-      productNames,
+      productNames: [
+        ...new Set(
+          productsMap.size
+            ? Array.from(productsMap.values()).map((product) => product.name)
+            : Array.from(versionsMap.values()).map((version) => version.product.name),
+        ),
+      ],
     }),
-    [productNames],
+    [productsMap, versionsMap],
   )
 
   return (
@@ -56,6 +57,9 @@ const VPSearchFilter: FC<VPSearchFilterProps> = ({}) => {
       projectNames={[projectName]}
       projectInfo={projectInfo}
       data={data}
+      config={{
+        keys: { productName: 'name' },
+      }}
       enableGlobalSearch={false}
     />
   )


### PR DESCRIPTION


<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
Added a product name filter to the Products page (VersionsProductsPage) allowing users to filter products by typing their names.


## Technical details
<!-- Please state any technical details such as limitations -->

- Added new `'productName'` filter type to `FilterFieldType` union in `useBuildFilterOptions.tsx`
- Created filter option with `allowsCustomValues: true` to enable free text input with suggestions
- Filter is scoped to the `'product'` scope only
- Product names are extracted from `productsMap` in `VPSearchFilter.tsx` and passed as suggestions
- Filter ID is set to `'name'` (maps to the product's `name` field in GraphQL)

## Additional context
<!-- Add any other context or screenshots here. -->

