### PR TITLE
Project-level schemas for permission model

### DIFF
--- a/shared/src/api/generated/access.ts
+++ b/shared/src/api/generated/access.ts
@@ -2,7 +2,10 @@ import { api } from '@shared/api/base'
 const injectedRtkApi = api.injectEndpoints({
   endpoints: (build) => ({
     getAccessGroupSchema: build.query<GetAccessGroupSchemaApiResponse, GetAccessGroupSchemaApiArg>({
-      query: () => ({ url: `/api/accessGroups/_schema` }),
+      query: (queryArg) => ({ 
+        url: `/api/accessGroups/_schema`, 
+        params: { project_name: queryArg.projectName } 
+      }),
     }),
     getAccessGroups: build.query<GetAccessGroupsApiResponse, GetAccessGroupsApiArg>({
       query: (queryArg) => ({ url: `/api/accessGroups/${queryArg.projectName}` }),
@@ -41,7 +44,9 @@ const injectedRtkApi = api.injectEndpoints({
 })
 export { injectedRtkApi as api }
 export type GetAccessGroupSchemaApiResponse = /** status 200 Successful Response */ any
-export type GetAccessGroupSchemaApiArg = void
+export type GetAccessGroupSchemaApiArg = {
+  projectName?: string
+} 
 export type GetAccessGroupsApiResponse = /** status 200 Successful Response */ AccessGroupObject[]
 export type GetAccessGroupsApiArg = {
   projectName: string

--- a/src/pages/SettingsPage/AccessGroups/AccessGroupDetail.jsx
+++ b/src/pages/SettingsPage/AccessGroups/AccessGroupDetail.jsx
@@ -34,7 +34,9 @@ const AccessGroupDetail = ({ projectName, accessGroupName }) => {
     },
     { skip: !accessGroupName },
   )
-  const { data: schema } = useGetAccessGroupSchemaQuery()
+  const { data: schema } = useGetAccessGroupSchemaQuery(
+    projectName ? { projectName } : {},
+  )
 
   const { data: accessGroupList = [] } = useGetAccessGroupsQuery({
     projectName: projectName || '_',


### PR DESCRIPTION
Requirement for https://github.com/ynput/ayon-backend/pull/816

This pull request updates how the access group schema is fetched in the `AccessGroupDetail` component. Now, the schema query includes the `projectName` as a parameter when available, ensuring the schema returned is specific to the selected project.
