### PR TITLE
AY-6854_GUI: Settings tab always defaults to Production

### DIFF
--- a/src/containers/AddonSettings/AddonSettings.jsx
+++ b/src/containers/AddonSettings/AddonSettings.jsx
@@ -727,7 +727,6 @@ const AddonSettings = ({ projectName, showSites = false, bypassPermissions = fal
     setCurrentSelection(null)
   }
 
-
   const onUpdateAddonSchema = (addonName, schema) => {
     // TODO: Rewrite this to not rely on `settings` in addon settings list
     // as it requires addon list to load the entire payload, which is not optimal

--- a/src/containers/AddonSettings/VariantSelector.tsx
+++ b/src/containers/AddonSettings/VariantSelector.tsx
@@ -47,8 +47,6 @@ const VariantSelector = ({
       ? (['production', 'staging', 'dev'] as const)
       : (['production', 'staging'] as const)
 
-
-
   const handleOnChange = (variant: (typeof buttons)[number]) => {
     if (variant === 'dev') {
       // find dev bundle that belongs to the user
@@ -63,7 +61,6 @@ const VariantSelector = ({
     }
   }
 
-  console.log("variant: ", {buttons, variant})
   return (
     <ButtonContainer>
       {buttons.map((variantType) => (


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

 - Replaced `useState` with `useLocalStorage` for persisting selected bundle variant (`production`/`staging`/`dev`) across sessions
  - Removed unnecessary `selectedBundle` and `selectedType` logic
  - Simplified button active state to directly compare with `variant` prop


## Technical details
<!-- Please state any technical details such as limitations -->

The `selectedType` calculation checked bundle flags in order (`isProduction` → `isStaging` → `isDev`), which could incorrectly return `'production'` even when
   staging was selected.

  **After:** Button highlighting now directly compares `variantType === variant`, which is simpler and always correct.

  **localStorage key:** `'variant-type'` - stores the selected variant for Studio Settings page

## Additional context
<!-- Add any other context or screenshots here. -->
This PR fixing the #831 issue
