### PR TITLE
Links: When linking to a specific comment ensure "all activity" tab selected

### DIFF
--- a/shared/src/context/DetailsPanelContext.tsx
+++ b/shared/src/context/DetailsPanelContext.tsx
@@ -1,16 +1,15 @@
 import React, {
   createContext,
-  useContext,
-  useCallback,
   ReactNode,
-  useState,
+  useCallback,
+  useContext,
   useEffect,
+  useState,
 } from 'react'
 import { useLocalStorage } from '@shared/hooks'
-import { DetailsPanelEntityType } from '@shared/api'
 import type { UserModel } from '@shared/api'
-import { useLocation, useNavigate, useParams } from 'react-router-dom'
-import { useSearchParams } from 'react-router-dom'
+import { DetailsPanelEntityType } from '@shared/api'
+import { useLocation, useNavigate, useParams, useSearchParams } from 'react-router-dom'
 import { SavedAnnotationMetadata } from '@shared/containers'
 import { PowerpackFeature, usePowerpack } from './PowerpackContext'
 import { useGlobalContext } from './GlobalContext'
@@ -129,12 +128,12 @@ export interface DetailsPanelProviderProps extends DetailsPanelContextProps {
 }
 
 export const DetailsPanelProvider: React.FC<DetailsPanelProviderProps> = ({
-                                                                            children,
-                                                                            defaultTab = 'activity',
-                                                                            hasLicense: hasLicenseProp,
-                                                                            debug = {},
-                                                                            ...forwardedProps
-                                                                          }) => {
+  children,
+  defaultTab = 'activity',
+  hasLicense: hasLicenseProp,
+  debug = {},
+  ...forwardedProps
+}) => {
   // get current user
   const { user: currentUser } = useGlobalContext()
   const isDeveloperMode =


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Fixed syntax error and implemented automatic 'activity' tab selection when DetailPanel opens from shared URLs. When users share entity/comment links (introduced in #1658 ), clicking these links now automatically opens the DetailPanel on the 'activity' tab, ensuring the shared content is immediately visible.

- Added currentScope state tracking in DetailsPanelContext to identify which scope is active
- Updated URL parameter handling to set tab to 'activity' for the current scope when ?project=...&type=...&id=... params are present

## Technical details
<!-- Please state any technical details such as limitations -->

  - Uses currentScope state registered by useScopedDetailsPanel hook to determine which scope's tab to update
  - Only updates tab setting for the active scope, preserving tab preferences for other scopes
  - Changes persist in localStorage via details/tabs-by-scope key

## Additional context
<!-- Add any other context or screenshots here. -->

