### PR TITLE
YN-0228: copying text breaks when cells selected

### DIFF
--- a/shared/src/containers/ProjectTreeTable/context/ClipboardContext.tsx
+++ b/shared/src/containers/ProjectTreeTable/context/ClipboardContext.tsx
@@ -690,27 +690,17 @@ export const ClipboardProvider: React.FC<ClipboardProviderProps> = ({
     const handleKeyDown = async (e: KeyboardEvent) => {
       // Copy functionality (Ctrl+C or Command+C)
       if ((e.ctrlKey || e.metaKey) && e.key === 'c') {
-        // Check if user has text selected elsewhere or focus is in an input/textarea/contentEditable
+
         const activeEl = document.activeElement as HTMLElement | null
-        const selection = window.getSelection()
-        const hasTextSelection = selection && selection.toString().length > 0
 
-        // Skip table copy if:
-        // 1. There's a text selection (user is selecting text to copy)
-        // 2. Focus is in an input, textarea, or content-editable element
-        if (
-          hasTextSelection ||
-          (activeEl &&
-            (activeEl.tagName === 'INPUT' ||
-              activeEl.tagName === 'TEXTAREA' ||
-              activeEl.isContentEditable))
-        ) {
-          // Allow default browser copy behavior
-          return
-        }
+        // Check if the active element is part of the table (td, th, table elements)
+        const isTableFocused =
+          activeEl?.closest('table') !== null ||
+          activeEl?.closest('.table-container') !== null ||
+          activeEl?.tagName === 'TD' ||
+          activeEl?.tagName === 'TH'
 
-        // Only copy from table if there are selected cells and no text selection
-        if (selectedCells.size > 0) {
+        if (isTableFocused && selectedCells.size > 0) {
           copyToClipboard()
         }
       }


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
This PR significantly **improves the reliability** of the `copyToClipboard` functionality across various browsers and contexts.

The implementation now utilizes a **robust, multi-stage copying mechanism**:
1.  **Primary Attempt:** Use the modern, asynchronous **`navigator.clipboard.writeText`** API.
2.  **Automatic Fallback:** If the modern API fails (e.g., due to permission issues, secure context requirements, or focus problems), it automatically reverts to the proven **legacy method** using a hidden `<textarea>` and **`document.execCommand('copy')`**.

This ensures that clipboard operations are successful even in environments or scenarios where the modern API is restricted or unreliable.


## Technical details
<!-- Please state any technical details such as limitations -->


## Additional context
<!-- Add any other context or screenshots here. -->

