### PR TITLE
Products: Ensure filtering by product name stays as filter

### DIFF
--- a/shared/src/containers/ProjectTreeTable/hooks/useQueryFilters.ts
+++ b/shared/src/containers/ProjectTreeTable/hooks/useQueryFilters.ts
@@ -7,6 +7,9 @@ import { QueryFilter, QueryCondition } from '../types/operations'
 interface UseQueryFiltersProps {
   queryFilters: QueryFilter
   sliceFilter?: Filter | null
+  config?: {
+    searchKey?: string
+  }
 }
 
 interface QueryFiltersResult {
@@ -20,6 +23,7 @@ interface QueryFiltersResult {
 export const useQueryFilters = ({
   queryFilters,
   sliceFilter,
+  config: { searchKey } = {},
 }: UseQueryFiltersProps): QueryFiltersResult => {
   return useMemo(() => {
     let combinedQueryFilter = queryFilters
@@ -61,13 +65,25 @@ export const useQueryFilters = ({
         }
 
         // Extract name filter (can be scoped like 'task_name' or 'folder_name' or just 'name')
-        if (queryCondition.key === 'name' || queryCondition.key?.endsWith('_name')) {
+        if (
+          (searchKey && queryCondition.key === searchKey) ||
+          queryCondition.key?.endsWith('_' + 'searchKey')
+        ) {
           const val = queryCondition.value
           // Name filters use 'like' operator with wildcards, extract the actual search term
           if (val !== undefined && val !== null) {
-            const searchTerm = String(val).replace(/%/g, '').trim()
-            if (searchTerm) {
-              searchValues.push(searchTerm)
+            if (Array.isArray(val)) {
+              val.forEach((v) => {
+                const searchTerm = String(v).replace(/%/g, '').trim()
+                if (searchTerm) {
+                  searchValues.push(searchTerm)
+                }
+              })
+            } else {
+              const searchTerm = String(val).replace(/%/g, '').trim()
+              if (searchTerm) {
+                searchValues.push(searchTerm)
+              }
             }
           }
           return false // remove name condition

--- a/src/pages/ProjectOverviewPage/context/ProjectOverviewContext.tsx
+++ b/src/pages/ProjectOverviewPage/context/ProjectOverviewContext.tsx
@@ -118,16 +118,19 @@ export const ProjectOverviewProvider = ({ children, modules }: ProjectOverviewPr
   const combinedTaskFilter = useQueryFilters({
     queryFilters: taskFilter,
     sliceFilter: slicerTaskFilter,
+    config: { searchKey: 'name' },
   })
   const combinedFolderFilter = useQueryFilters({
     queryFilters: folderFilter,
     sliceFilter: slicerFolderFilter,
+    config: { searchKey: 'name' },
   })
 
   // Use the shared hook to handle filter logic (for backward compatibility)
   const queryFiltersResult = useQueryFilters({
     queryFilters,
     sliceFilter,
+    config: { searchKey: 'name' },
   })
 
   const selectedFolders = useSelectedFolders({


### PR DESCRIPTION
There was an issue where any filter that was called name would be extracted out as a search string. In this case it should have stayed as a filter. This is fixed by requiring what the search string should be, in this case `undefined`.