### PR TITLE
Default Views: Optimistic Updates Not Working

### DIFF
--- a/shared/src/api/queries/views/updateViews.ts
+++ b/shared/src/api/queries/views/updateViews.ts
@@ -1,5 +1,6 @@
 import { ViewListItemModel } from '@shared/api/generated'
 import { getScopeTag, getViewsApi } from './getViews'
+import { v4 as uuidv4 } from 'uuid'
 
 const updateViewsApi = getViewsApi.enhanceEndpoints({
   endpoints: {
@@ -81,7 +82,7 @@ const updateViewsApi = getViewsApi.enhanceEndpoints({
 
         if (payload.label === '__base__') {
           const newBaseView = {
-            id: `optimistic-base-${Date.now()}`,
+            id: uuidv4(),
             ...payload,
             working: false,
             scope: arg.projectName ? 'project' : 'studio',

--- a/shared/src/containers/Views/ViewsMenuContainer/BaseViewsTags.tsx
+++ b/shared/src/containers/Views/ViewsMenuContainer/BaseViewsTags.tsx
@@ -13,9 +13,8 @@ const BaseViewsTagContainer: FC = () => {
     projectBaseView,
     studioBaseView,
     onCreateBaseView,
-    onUpdateBaseView,
     onDeleteBaseView,
-    onUpdateWorkingView,
+    onLoadBaseView,
   } = useViewsContext()
 
   const { powerLicense, setPowerpackDialog } = usePowerpack()
@@ -43,8 +42,8 @@ const BaseViewsTagContainer: FC = () => {
           },
         })
       } else {
-        // update the existing base view with current working settings
-        await onUpdateBaseView(existingBase.id as string, isStudioScope)
+        // load the base view settings into working view
+        await onLoadBaseView(isStudioScope)
       }
     } else {
       // create new base view

--- a/shared/src/containers/Views/context/ViewsContext.tsx
+++ b/shared/src/containers/Views/context/ViewsContext.tsx
@@ -76,6 +76,7 @@ export interface ViewsContextValue {
   onCreateBaseView: (isStudioScope: boolean) => Promise<void>
   onUpdateBaseView: (baseViewId: string, isStudioScope: boolean) => Promise<void>
   onDeleteBaseView: (baseViewId: string, isStudioScope: boolean) => Promise<void>
+  onLoadBaseView: (isStudioScope: boolean) => Promise<void>
 
   // Actions (shared)
   resetWorkingView: () => Promise<void>
@@ -231,10 +232,11 @@ export const ViewsProvider: FC<ViewsProviderProps> = ({
   })
 
   // Base view mutations
-  const { onCreateBaseView, onUpdateBaseView, onDeleteBaseView } = useBaseViewMutations({
+  const { onCreateBaseView, onUpdateBaseView, onDeleteBaseView, onLoadBaseView } = useBaseViewMutations({
     viewType: viewType as string,
     projectName,
     workingSettings,
+    workingView,
     dispatch,
   })
 
@@ -314,6 +316,7 @@ export const ViewsProvider: FC<ViewsProviderProps> = ({
     onCreateBaseView,
     onUpdateBaseView,
     onDeleteBaseView,
+    onLoadBaseView,
     editingViewId,
     viewMenuItems,
     isLoadingViews,

--- a/shared/src/containers/Views/hooks/useBaseViewMutations.ts
+++ b/shared/src/containers/Views/hooks/useBaseViewMutations.ts
@@ -3,17 +3,20 @@ import {
   useCreateViewMutation,
   useUpdateViewMutation,
   useDeleteViewMutation,
+  useSetDefaultViewMutation,
   viewsQueries,
+  ViewListItemModel,
 } from '@shared/api'
 import { toast } from 'react-toastify'
 import { getScopeTag } from '@shared/api/queries/views/getViews'
 import { BASE_VIEW_ID } from './useBuildViewMenuItems'
-import { ViewSettings } from '../context/ViewsContext'
+import { ViewSettings } from '@shared/containers'
 
 type Props = {
   viewType?: string
   projectName?: string
   workingSettings?: ViewSettings
+  workingView?: ViewListItemModel
   dispatch?: any
 }
 
@@ -21,17 +24,20 @@ export type UseBaseViewMutations = {
   onCreateBaseView: (isStudioScope: boolean) => Promise<void>
   onUpdateBaseView: (baseViewId: string, isStudioScope: boolean) => Promise<void>
   onDeleteBaseView: (baseViewId: string, isStudioScope: boolean) => Promise<void>
+  onLoadBaseView: (isStudioScope: boolean) => Promise<void>
 }
 
 export const useBaseViewMutations = ({
   viewType,
   projectName,
   workingSettings,
+  workingView,
   dispatch,
 }: Props): UseBaseViewMutations => {
   const [createViewMutation] = useCreateViewMutation()
   const [updateViewMutation] = useUpdateViewMutation()
   const [deleteViewMutation] = useDeleteViewMutation()
+  const [setDefaultViewMutation] = useSetDefaultViewMutation()
 
   const onCreateBaseView = useCallback(
     async (isStudioScope: boolean) => {
@@ -124,9 +130,67 @@ export const useBaseViewMutations = ({
     [deleteViewMutation, viewType, projectName, dispatch],
   )
 
+  const onLoadBaseView = useCallback(
+    async (isStudioScope: boolean) => {
+      try {
+        if (!workingView?.id) {
+          throw new Error('No working view available to update')
+        }
+
+        // Fetch the specific base view (project or studio)
+        const baseViewPromise = dispatch(
+          viewsQueries.endpoints.getBaseView.initiate(
+            {
+              viewType: viewType as string,
+              projectName: isStudioScope ? undefined : projectName,
+            },
+            { subscribe: false, forceRefetch: true }
+          )
+        )
+        const baseViewResult = await baseViewPromise
+        const baseView = baseViewResult.data
+
+        if (!baseView || !baseView.settings) {
+          throw new Error('Base view not found or has no settings')
+        }
+
+        // Update the working view with the base view settings
+        await updateViewMutation({
+          viewId: workingView.id,
+          viewType: viewType as string,
+          projectName,
+          payload: { settings: baseView.settings },
+        }).unwrap()
+
+        // Set the working view as the default view
+        await setDefaultViewMutation({
+          viewType: viewType as string,
+          projectName,
+          setDefaultViewRequestModel: { viewId: workingView.id },
+        }).unwrap()
+
+        const scope = isStudioScope ? 'Studio' : 'Project'
+        toast.success(`Loaded ${scope} default view to working view`)
+      } catch (error: any) {
+        const scope = isStudioScope ? 'studio' : 'project'
+        console.error(`Failed to load ${scope} base view:`, error)
+        toast.error(`Failed to load ${scope} base view: ${error?.message || error}`)
+      }
+    },
+    [
+      workingView,
+      updateViewMutation,
+      setDefaultViewMutation,
+      viewType,
+      projectName,
+      dispatch,
+    ],
+  )
+
   return {
     onCreateBaseView,
     onUpdateBaseView,
     onDeleteBaseView,
+    onLoadBaseView,
   }
 }

--- a/shared/src/containers/Views/hooks/useViewsMutations.ts
+++ b/shared/src/containers/Views/hooks/useViewsMutations.ts
@@ -231,8 +231,8 @@ export const useViewsMutations = ({
 
         if (notify) {
           const message =
-            baseViewSource === 'project' ? 'View reset to project base view' :
-            baseViewSource === 'studio' ? 'View reset to studio base view' :
+            baseViewSource === 'project' ? 'View reset to project default view' :
+            baseViewSource === 'studio' ? 'View reset to studio default view' :
             'View reset to default settings'
           toast.success(message)
         }


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
This PR fixes two related issues around **default (base) views**:

1. **Optimistic updates for base views were unreliable**
   - In some cases, base view optimistic updates were skipped or left the cache in an inconsistent state.
   - Rollback logic was incomplete, causing stale cache data after failed mutations.

2. **Base view updates only worked on the Overview page**
   - Updating the base view on other pages appeared to work but was not persisted correctly.
   - The logic mixed working view updates with base view persistence, causing the base view state to desync across pages.

The changes ensure that base view updates behave consistently and predictably across the application.



## Technical details
<!-- Please state any technical details such as limitations -->
- Simplified optimistic update logic for `getBaseView`
  - Removed duplicated conditional update paths
  - Applied optimistic updates only when the cache is initialized
  - Ensured proper rollback (`undo`) handling for base view updates

- Refactored `BaseViewsTags`
  - Centralized base view updates via `onUpdateBaseView`
  - Separated working view selection from base view persistence
  - Fixed base view updates not being saved outside the Overview page

## Additional context
<!-- Add any other context or screenshots here. -->

