### PR TITLE
Links: Admins show unknown instead of restricted and make removable

### DIFF
--- a/shared/src/components/LinksManager/LinkManagerItem.tsx
+++ b/shared/src/components/LinksManager/LinkManagerItem.tsx
@@ -11,6 +11,7 @@ export interface LinkManagerItemProps {
   isSelected?: boolean
   onEntityClick?: (entityId: string, entityType: string) => void
   onRemove: (e: React.MouseEvent<HTMLButtonElement>, link: LinkEntity) => void
+  isManager?: boolean
 }
 
 export const LinkManagerItem: FC<LinkManagerItemProps> = ({
@@ -18,6 +19,7 @@ export const LinkManagerItem: FC<LinkManagerItemProps> = ({
   isSelected = false,
   onEntityClick,
   onRemove,
+  isManager = false,
 }) => {
   const entityTypeSupported = detailsPanelEntityTypes.includes(link.entityType as any)
   const isClickable = entityTypeSupported && !link.isRestricted
@@ -28,22 +30,23 @@ export const LinkManagerItem: FC<LinkManagerItemProps> = ({
       onClick={() => isClickable && onEntityClick?.(link.entityId, link.entityType)}
       data-tooltip={
         link.isRestricted
-          ? "Access Restricted - Insufficient Permissions to Entity"
+          ? isManager
+            ? 'Unknown Link - Entity not found'
+            : 'Access Restricted - Insufficient Permissions to Entity'
           : link.parents.join('/') + '/' + link.label
       }
       className={clsx({
         clickable: isClickable,
         selected: isSelected,
-        restricted: link.isRestricted,
+        restricted: link.isRestricted && !isManager,
+        unknown: link.isRestricted && isManager,
       })}
     >
       {link.icon ? <Icon icon={link.icon} /> : <Icon icon={getEntityTypeIcon(link.entityType)} />}
 
       <span className="title">
         {link.isRestricted ? (
-          <span className="label">
-            Access Restricted
-          </span>
+          <span className="label">{isManager ? 'Unknown' : 'Access Restricted'}</span>
         ) : (
           <>
             {link.parents?.map((part, index) => (
@@ -56,7 +59,7 @@ export const LinkManagerItem: FC<LinkManagerItemProps> = ({
           </>
         )}
       </span>
-      { !link.isRestricted &&
+      {(!link.isRestricted || isManager) && (
         <Button
           icon={'link_off'}
           variant="text"
@@ -64,8 +67,7 @@ export const LinkManagerItem: FC<LinkManagerItemProps> = ({
           onClick={(e) => onRemove(e, link)}
           data-tooltip={'Remove link'}
         />
-      }
-
+      )}
     </Styled.LinkItem>
   )
 }

--- a/shared/src/components/LinksManager/LinksManager.styled.ts
+++ b/shared/src/components/LinksManager/LinksManager.styled.ts
@@ -75,7 +75,8 @@ export const LinkItem = styled.li`
     }
   }
 
-  &.restricted {
+  &.restricted,
+  &.unknown {
     opacity: 0.5;
     font-style: italic;
   }

--- a/shared/src/components/LinksManager/LinksManager.tsx
+++ b/shared/src/components/LinksManager/LinksManager.tsx
@@ -7,6 +7,7 @@ import { EntityPickerDialog, PickerEntityType } from '@shared/containers/EntityP
 import { upperFirst } from 'lodash'
 import { LinkManagerItem } from './LinkManagerItem'
 import { Button } from '@ynput/ayon-react-components'
+import { useGlobalContext } from '@shared/context'
 
 export type LinkEntity = {
   linkId: string
@@ -47,6 +48,9 @@ export const LinksManager: FC<LinksManagerProps> = ({
   onClose,
   onEntityClick,
 }) => {
+  const { user } = useGlobalContext()
+  const isManager = user?.data?.isAdmin || user?.data?.isManager
+
   const linksUpdater = useUpdateLinks({
     projectName,
     direction,
@@ -92,6 +96,7 @@ export const LinksManager: FC<LinksManagerProps> = ({
               isSelected={selectedEntityIds.includes(link.entityId)}
               onEntityClick={onEntityClick}
               onRemove={handleRemove}
+              isManager={isManager}
             />
           ))}
           {links.length === 0 && <Styled.SubHeader>No links yet</Styled.SubHeader>}

--- a/shared/src/containers/ProjectTreeTable/widgets/LinksWidget.tsx
+++ b/shared/src/containers/ProjectTreeTable/widgets/LinksWidget.tsx
@@ -7,7 +7,7 @@ import { useDetailsPanelEntityContext } from '../context/DetailsPanelEntityConte
 import { useSelectedRowsContext } from '../context/SelectedRowsContext'
 import { Container } from '@shared/components/LinksManager/LinksManager.styled'
 import { isEntityRestricted } from '../utils/restrictedEntity'
-import { Icon } from '@ynput/ayon-react-components'
+import { useGlobalContext } from '@shared/context'
 
 export const sortEntityLinksByPath = (links: LinkEntity[]) => {
   return [...links].sort((a, b) => {
@@ -62,6 +62,9 @@ export const LinksWidget: FC<LinksWidgetProps> = ({
   onChange: _onChange, // not used in this widget
   onCancelEdit,
 }) => {
+  const { user } = useGlobalContext()
+  const isManager = user?.data?.isAdmin || user?.data?.isManager
+
   // Try to get the contexts, but they might not exist in all environments
   let setSelectedEntity:
     | ((entity: { entityId: string; entityType: 'folder' | 'task' }) => void)
@@ -116,11 +119,13 @@ export const LinksWidget: FC<LinksWidgetProps> = ({
       <Chips
         values={
           sortedLinks.map((v) => ({
-            label: v.isRestricted ? 'Restricted' : v.label,
+            label: v.isRestricted ? (isManager ? 'Unknown' : 'Restricted') : v.label,
             tooltip: v.isRestricted
-              ? "Access Restricted - Insufficient Permissions to Entity"
+              ? isManager
+                ? 'Unknown Link - Entity not found'
+                : 'Access Restricted - Insufficient Permissions to Entity'
               : v.parents.join('/') + '/' + v.label,
-            icon: v.isRestricted ? "lock": undefined,
+            icon: v.isRestricted ? (isManager ? 'help' : 'lock') : undefined,
           })) || []
         }
         pt={{ chip: { className: EDIT_TRIGGER_CLASS } }}


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
Not sure how a link can ever get into this state, but if it does then it's possible to remove now.

<img width="295" height="224" alt="image" src="https://github.com/user-attachments/assets/276dc503-54a4-407c-9450-3d892ccfe05b" />



## Technical details
<!-- Please state any technical details such as limitations -->


## Additional context
<!-- Add any other context or screenshots here. -->

