### PR TITLE
Tooltips for webactions

### DIFF
--- a/shared/src/containers/Actions/Actions.tsx
+++ b/shared/src/containers/Actions/Actions.tsx
@@ -152,7 +152,9 @@ export const Actions = ({
         label: action.groupLabel ? action.groupLabel + ' ' + action.label : action.label,
         icon: action.icon,
         hasConfig: !!action.configFields,
+        description: action.description,
       }))
+
 
       options.push(...groupOptions)
     })

--- a/shared/src/containers/Actions/ActionsDropdown/ActionsDropdown.tsx
+++ b/shared/src/containers/Actions/ActionsDropdown/ActionsDropdown.tsx
@@ -33,6 +33,7 @@ type ActionsDropdownItemProps = {
   icon?: IconModel
   header?: boolean
   hasConfig?: boolean
+  description?: string
   onConfig?: (value: string) => void
 }
 
@@ -42,6 +43,7 @@ export const ActionsDropdownItem = ({
   icon,
   header,
   hasConfig,
+  description,
   onConfig,
 }: ActionsDropdownItemProps) => {
   if (header) return <DropdownHeader>{upperFirst(label)}</DropdownHeader>
@@ -54,7 +56,7 @@ export const ActionsDropdownItem = ({
 
   return (
     <DropdownItem>
-      <ActionItemContainer>
+      <ActionItemContainer data-tooltip={description || ''} data-tooltip-delay={0}>
         <ActionIcon icon={icon} />
         <span>{label}</span>
         <Spacer />
@@ -93,7 +95,6 @@ export const ActionsDropdown = ({
     dropdownRef.current?.close()
     onConfig(e)
   }
-
   return (
     <StyledDropdown
       ref={dropdownRef}

--- a/src/hooks/Tooltip/Tooltip.styled.js
+++ b/src/hooks/Tooltip/Tooltip.styled.js
@@ -2,7 +2,7 @@ import styled from 'styled-components'
 
 export const TooltipWidget = styled.div`
   position: fixed;
-  z-index: 3000;
+  z-index: 10001;
 
   transition: opacity 300ms;
   /* how far up the tooltip us */


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
 Added tooltip support for web actions in the actions dropdown. Action descriptions are now displayed as tooltips when hovering over action items, allowing users to see additional context without   
  making action names bloated.    

  - Pass action description property through to dropdown items                                                                                                                                         
  - Display description as tooltip on hover with no delay                                                                                                                                              
  - Fixed tooltip z-index (3000 → 10001) to ensure tooltips appear above dropdown menus  

## Technical details
<!-- Please state any technical details such as limitations -->
 - The description field from the action manifest is now utilized in the frontend                                                                                                                     
  - Tooltips use the existing data-tooltip attribute system                                                                                                                                            
  - Z-index adjustment ensures proper layering: tooltips now render above dropdown menus (which typically use z-index ~10000)      

## Additional context

We need to test if `tooltip z-index (3000 → 10001)` doesn't break some UI


<img width="489" height="389" alt="Screenshot 2026-01-23 at 11 54 46" src="https://github.com/user-attachments/assets/b5096151-5cd8-440e-901c-646167f46e1c" />



