### PR TITLE
Project folders cleanup

### DIFF
--- a/src/pages/UserDashboardPage/UserDashboardPage.tsx
+++ b/src/pages/UserDashboardPage/UserDashboardPage.tsx
@@ -15,6 +15,7 @@ import { confirmDelete } from '@shared/util'
 import { useGetDashboardAddonsQuery } from '@shared/api'
 import DashboardAddon from '@pages/ProjectDashboard/DashboardAddon'
 import ProjectsList, { PROJECTS_LIST_WIDTH_KEY } from '@containers/ProjectsList/ProjectsList'
+import { parseProjectFolderRowId } from '@containers/ProjectsList/buildProjectsTableData'
 import { Splitter, SplitterPanel } from 'primereact/splitter'
 import GuestUserPageLocked from '@components/GuestUserPageLocked'
 import styled from 'styled-components'
@@ -92,10 +93,16 @@ const UserDashboardPage: React.FC = () => {
   const selectedProjects = useAppSelector((state: any) => state.dashboard.selectedProjects)
   const setSelectedProjects = (projects: string[]) => dispatch(onProjectSelected(projects))
 
+  // Filter out folder IDs from selection - only actual project names should be used for API queries
+  const selectedProjectNames = useMemo(
+    () => selectedProjects.filter((id: string) => !parseProjectFolderRowId(id)),
+    [selectedProjects],
+  )
+
   // get all the info required for the projects selected, like status icons and colours
   const { data: projectsInfo = {}, isFetching: isLoadingInfo } = useGetProjectsInfoQuery(
-    { projects: selectedProjects },
-    { skip: !selectedProjects?.length },
+    { projects: selectedProjectNames },
+    { skip: !selectedProjectNames?.length },
   )
 
   // get projects list
@@ -153,7 +160,7 @@ const UserDashboardPage: React.FC = () => {
         path: '/dashboard/dashboard',
         module: 'dashboard',
         accessLevels: [],
-        component: <ProjectDashboard projectName={selectedProjects[0]} />,
+        component: <ProjectDashboard projectName={selectedProjectNames[0]} />,
         showProjectList: true,
         isMultiSelect: false,
       },
@@ -208,6 +215,7 @@ const UserDashboardPage: React.FC = () => {
       projectsInfoWithProjects,
       isLoadingInfo,
       selectedProjects,
+      selectedProjectNames,
       isAdmin,
       isManager,
       addonName,

--- a/src/pages/UserDashboardPage/UserDashboardTasks/UserTasksContainer.jsx
+++ b/src/pages/UserDashboardPage/UserDashboardTasks/UserTasksContainer.jsx
@@ -9,6 +9,7 @@ import { filterProjectStatuses } from '@shared/hooks'
 import { getPriorityOptions } from '@shared/util'
 import { useScopedDetailsPanel } from '@shared/context'
 import { EmptyPlaceholder } from '@shared/components'
+import { parseProjectFolderRowId } from '@containers/ProjectsList/buildProjectsTableData'
 
 import UserDashboardKanBan from './UserDashboardKanBan'
 import { useEffect, useMemo } from 'react'
@@ -53,6 +54,11 @@ export const getThumbnailUrl = ({ entityId, entityType, thumbnailId, updatedAt, 
 const UserTasksContainer = ({ projectsInfo = {}, isLoadingInfo }) => {
   const dispatch = useDispatch()
   const selectedProjects = useSelector((state) => state.dashboard.selectedProjects)
+  // Filter out folder IDs - only actual project names should be used for API queries
+  const selectedProjectNames = useMemo(
+    () => selectedProjects.filter((id) => !parseProjectFolderRowId(id)),
+    [selectedProjects],
+  )
   let { isOpen: isPanelOpen } = useScopedDetailsPanel('dashboard')
 
   const user = useSelector((state) => state.user)
@@ -102,8 +108,8 @@ const UserTasksContainer = ({ projectsInfo = {}, isLoadingInfo }) => {
     isError,
     error,
   } = useGetKanbanQuery(
-    { assignees: assignees, projects: selectedProjects },
-    { skip: !assignees.length || !selectedProjects?.length },
+    { assignees: assignees, projects: selectedProjectNames },
+    { skip: !assignees.length || !selectedProjectNames?.length },
   )
 
   // get priority attribute so we know the colors and icons for each priority
@@ -163,8 +169,8 @@ const UserTasksContainer = ({ projectsInfo = {}, isLoadingInfo }) => {
 
   const { data: projectUsers = [], isLoading: isLoadingProjectUsers } =
     useGetKanbanProjectUsersQuery(
-      { projects: selectedProjects },
-      { skip: !selectedProjects?.length },
+      { projects: selectedProjectNames },
+      { skip: !selectedProjectNames?.length },
     )
 
   // for selected projects, make sure user is on all


### PR DESCRIPTION
… `UserTasksContainer` by filtering `selectedProjects`

<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
 Fixes an issue where selecting a folder in project folders on the Dashboard caused invalid API calls. The client was treating folder IDs (e.g., folder-abc123) as project names and attempting to fetch project anatomy, kanban tasks, and project 
  users for non-existent projects.      


## Technical details
<!-- Please state any technical details such as limitations -->
                                                                                                                                                                                                                                                     
  Root cause: When a folder is selected in ProjectsList, the folder ID (prefixed with folder-) was being passed directly to API queries that expected project names.                                                                                 
            
 Solution: Added filtering in UserDashboardPage.tsx and UserTasksContainer.jsx to separate visual selection state from API query parameters:                                                                                                        
                                                                                                                                                                                                                                                     
  - selectedProjects - raw selection from Redux, includes both project names and folder IDs (used for visual selection in ProjectsList)                                                                                                              
  - selectedProjectNames - filtered to only include actual project names (used for all API queries)                                                  

## Additional context
<!-- Add any other context or screenshots here. -->
 The folder ID prefix system was already in place (buildProjectsTableData.ts), but the filtering wasn't applied before passing selections to API consumers.       

