### PR TITLE
Project Folders: Cannot delete multiple folders at once

### DIFF
--- a/src/containers/ProjectsList/hooks/useProjectFolderActions.ts
+++ b/src/containers/ProjectsList/hooks/useProjectFolderActions.ts
@@ -67,9 +67,9 @@ export const useProjectFolderActions = ({
   )
 
   const onDeleteFolder = useCallback(
-    async (folderId: string) => {
+    async (folderIds: string[]) => {
       await handleDeleteFolders({
-        folderIds: folderId,
+        folderIds: folderIds,
         folders,
         deleteMutation: (id) => deleteProjectFolder({ folderId: id }).unwrap(),
         onSelect,

--- a/src/containers/ProjectsList/hooks/useProjectsListMenuItems.ts
+++ b/src/containers/ProjectsList/hooks/useProjectsListMenuItems.ts
@@ -41,7 +41,7 @@ interface MenuItemProps {
   onPutProjectsInFolder?: (projectNames: string[], projectFolderId?: string) => Promise<void>
   onPutFolderInFolder?: (folderId: string, projectFolderId?: string) => Promise<void>
   onRemoveProjectsFromFolder?: (projectNames: string[]) => Promise<void>
-  onDeleteFolder?: (folderId: string) => void
+  onDeleteFolder?: (folderId: string[]) => void
   onRenameFolder?: (folderId: string) => void
   onEditFolder?: (folderId: string) => void
 }
@@ -118,11 +118,11 @@ const useProjectsListMenuItems = ({
     }
   }
   const handleDeleteFolder = (selection: string[]) => {
-    if (selection.length === 1) {
-      const folderId = parseProjectFolderRowId(selection[0])
-      if (folderId) {
-        onDeleteFolder?.(folderId)
-      }
+    const folderIds = selection
+      .map((folder) => parseProjectFolderRowId(folder))
+      .filter((id): id is string => id !== null)
+    if (folderIds.length > 0) {
+      onDeleteFolder?.(folderIds)
     }
   }
 


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

  Fixed an issue where deleting multiple project folders at once was not possible. Users can now select multiple folders and delete them all in a single action.

## Technical details
<!-- Please state any technical details such as limitations -->
 Two bugs were preventing multi-folder deletion:                                                                                                                               
                                                                                                                                                                                
  1. useProjectsListMenuItems.ts - The handleDeleteFolder function had a condition selection.length === 1 that blocked the delete action when multiple folders were selected.   
  Also fixed the filter condition from folderIds.length >= 0 (always true) to > 0.                                                                                              
  2. useProjectFolderActions.ts - The deleteMutation callback was incorrectly passing the entire folderIds array to the API instead of individual IDs. Changed from:            
  deleteMutation: () => deleteProjectFolder({ folderIds }).unwrap()                                                                                                             
  2. to:                                                                                                                                                                        
  deleteMutation: (id) => deleteProjectFolder({ folderId: id }).unwrap()                                                                                                        
                                                                                                                                                                                
  The underlying handleDeleteFolders utility already supported array deletion via Promise.all, so only the UI layer needed fixing.      

## Additional context
<!-- Add any other context or screenshots here. -->

The confirmation dialog, correctly shows "X folders" when multiple folders are selected for deletion. 