### PR TITLE
Project folders: Spacebar shortcut conflict

### DIFF
--- a/src/pages/ProjectManagerPage/components/ProjectFolderFormDialog/ProjectFolderFormDialog.tsx
+++ b/src/pages/ProjectManagerPage/components/ProjectFolderFormDialog/ProjectFolderFormDialog.tsx
@@ -224,6 +224,7 @@ export const ProjectFolderFormDialog: FC<ProjectFolderFormDialogProps> = ({
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
+      e.stopPropagation()
       if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
         handleSave()
       } else if (e.key === 'Escape') {


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
 Prevent spacebar from opening the review dialog when the folder creation dialog is open and the user is typing in the input field.                   


## Technical details
<!-- Please state any technical details such as limitations -->
 Added e.stopPropagation() to the handleKeyDown in ProjectFolderFormDialog to prevent keyboard events from bubbling up to parent components when the dialog is open.           
                     

## Additional context
<!-- Add any other context or screenshots here. -->
Previously, when creating a folder on the UserDashboard page with a task selected, pressing spacebar while typing the folder label would also trigger the review dialog to    
  open.  
  
  

https://github.com/user-attachments/assets/01c61e4e-2b36-4ec8-98e9-052d6e563fe6


  
  
