### PR TITLE
Feed: Minor activities username not showing when no fullName

### DIFF
--- a/shared/src/containers/Feed/components/ActivityAssigneeChange/ActivityAssigneeChange.tsx
+++ b/shared/src/containers/Feed/components/ActivityAssigneeChange/ActivityAssigneeChange.tsx
@@ -8,6 +8,7 @@ interface ActivityData {
 
 export interface ActivityAssigneeChangeProps {
   activity: {
+    authorName: string
     authorFullName?: string
     createdAt?: string
     activityData?: ActivityData
@@ -17,10 +18,10 @@ export interface ActivityAssigneeChangeProps {
 }
 
 const ActivityAssigneeChange: React.FC<ActivityAssigneeChangeProps> = ({ activity, isAdding }) => {
-  const { authorFullName, createdAt, activityData } = activity || {}
+  const { authorFullName, createdAt, activityData, authorName } = activity || {}
   const { assignee } = activityData || {}
 
-  let fullText = authorFullName
+  let fullText = authorFullName || authorName
   fullText += isAdding ? ' added ' : ' removed '
   fullText += 'assignee: ' + assignee
 

--- a/shared/src/containers/Feed/components/ActivityItem.tsx
+++ b/shared/src/containers/Feed/components/ActivityItem.tsx
@@ -11,6 +11,7 @@ interface ActivityItemProps {
     activityType: string
     items?: any[]
     [key: string]: any
+    authorName: string
   }
   fromGroup?: boolean
   projectInfo: Record<string, any>

--- a/shared/src/containers/Feed/components/ActivityStatusChange/ActivityStatusChange.tsx
+++ b/shared/src/containers/Feed/components/ActivityStatusChange/ActivityStatusChange.tsx
@@ -13,6 +13,7 @@ interface StatusInfo {
 interface ActivityStatusChangeProps {
   entityType?: string
   activity: {
+    authorName?: string
     authorFullName?: string
     createdAt?: string
     oldStatus?: StatusInfo
@@ -25,13 +26,13 @@ const ActivityStatusChange: React.FC<ActivityStatusChangeProps> = ({
   entityType,
   activity = {},
 }) => {
-  const { authorFullName, createdAt, oldStatus = {}, newStatus = {} } = activity
+  const { authorName, authorFullName, createdAt, oldStatus = {}, newStatus = {} } = activity
   const tagList = useGetContextParents(activity, entityType)
 
   return (
     <Styled.StatusChange>
       <Styled.Body>
-        <Styled.Text>{authorFullName}</Styled.Text>
+        <Styled.Text>{authorFullName || authorName}</Styled.Text>
         <Styled.Text>- {tagList.join(' / ')} -</Styled.Text>
         {oldStatus.icon && <Icon icon={oldStatus.icon} style={{ color: oldStatus.color }} />}
         <Styled.Text>{oldStatus.name}</Styled.Text>


### PR DESCRIPTION

<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
 Fallback to `name` when `fullName` is not set in minor activities.   
                                                                                                                                                                                                          


## Technical details
<!-- Please state any technical details such as limitations -->
  - Updated `ActivityAssigneeChange.tsx` to use `authorFullName || authorName`                                                                                                                            
  - Updated `ActivityStatusChange.tsx` to use `authorFullName || authorName`                                                                                                                              
  - Both `authorName` and `authorFullName` are already available on the activity object from the GraphQL transformation in `activitiesHelpers.ts`

## Additional context
<!-- Add any other context or screenshots here. -->

<img width="251" height="300" alt="Screenshot 2026-01-27 at 16 41 59" src="https://github.com/user-attachments/assets/2db4485f-1e2f-4d61-a425-ea89b5c01f2d" />

