### PR TITLE
Details: Clicking links doesn't open the link

### DIFF
--- a/shared/src/components/DetailsPanelAttributes/DetailsPanelAttributesEditor.tsx
+++ b/shared/src/components/DetailsPanelAttributes/DetailsPanelAttributesEditor.tsx
@@ -182,8 +182,11 @@ export const DetailsPanelAttributesEditor: FC<DetailsPanelAttributesEditorProps>
               <FieldValue
                 className={clsx({ editing: isEditing, readonly: isReadOnly })}
                 onClick={(e) => {
+                  // Allow links to work normally - don't intercept clicks on anchor elements
+                  if ((e.target as HTMLElement).closest('a')) {
+                    return
+                  }
                   e.preventDefault()
-                  e.stopPropagation()
                   if (!isEditing && !isReadOnly && field.data.type !== 'boolean') {
                     handleStartEditing(field.name)
                   }


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Fixed an issue in the details panel where clicking on links within attribute fields would not open the link. Instead, it would trigger edit mode for the field.


## Technical details
<!-- Please state any technical details such as limitations -->

 The `onClick` handler on `FieldValue` in `DetailsPanelAttributesEditor.tsx` was calling `e.preventDefault()` unconditionally, which blocked the browser's default action for anchor tags.                                                                                                                                                                                 
                                                                                                                                                                                        
Added an early return check using `closest('a')` to detect if the click target is an anchor element. If so, the handler exits early and lets the browser handle the link click normally.
## Additional context
<!-- Add any other context or screenshots here. -->


https://github.com/user-attachments/assets/a57dfba9-d17b-451b-a425-fd801bc973ff



