### PR TITLE
Project Folders: Pinning should not affect projects order

### DIFF
--- a/src/containers/ProjectsList/ProjectsList.tsx
+++ b/src/containers/ProjectsList/ProjectsList.tsx
@@ -70,12 +70,6 @@ const ProjectsList: FC<ProjectsListProps> = ({
   // sort projects by active pinned, active, inactive (active=false) and then alphabetically
   const projects = useMemo(() => {
     return [...data].sort((a, b) => {
-      // Sort by pinned AND active first
-      const aPinnedActive = rowPinning.includes(a.name) && a.active
-      const bPinnedActive = rowPinning.includes(b.name) && b.active
-      if (aPinnedActive && !bPinnedActive) return -1
-      if (!aPinnedActive && bPinnedActive) return 1
-      // Then by active
       if (a.active && !b.active) return -1
       if (!a.active && b.active) return 1
       return a.name.localeCompare(b.name)


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Pinned projects no longer automatically move to the top of the projects list when pinned. They now maintain their alphabetical position within their active/inactive group.     


## Technical details
<!-- Please state any technical details such as limitations -->
Removed the pinned sorting priority logic in `ProjectsList.tsx` that was sorting pinned+active projects to the top of the list. The sorting now only considers:
1. Active vs inactive status
2. Alphabetical order by name

## Additional context
<!-- Add any other context or screenshots here. -->

https://github.com/user-attachments/assets/9cb8bcce-8c4c-4965-a26f-c6601dee03a0


