### PR TITLE
Details: Always include the search bar for dropdowns

### DIFF
--- a/shared/src/components/DetailsPanelAttributes/components/RenderFieldWidget.tsx
+++ b/shared/src/components/DetailsPanelAttributes/components/RenderFieldWidget.tsx
@@ -148,7 +148,7 @@ const RenderFieldWidget: FC<RenderFieldWidgetProps> = ({
           align="right"
           isReadOnly={isReadOnly}
           enableCustomValues={field.enableCustomValues ?? false}
-          search={field.enableSearch ?? false}
+          search={field.enableSearch ?? enumOptions.length>=5}
           sortBySelected={!enumOptions}
           {...widgetCommonProps}
         />


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
Automatically enable search bar for enum/dropdown fields when there are 5 or more options, improving usability for longer lists. The field's explicit `enableSearch` setting still takes precedence if defined


## Technical details
<!-- Please state any technical details such as limitations -->
- Uses nullish coalescing (`??`) to check `field.enableSearch` first                                                                                                                  - Falls back to `enumOptions.length >= 5` threshold when not explicitly set  

## Additional context
<!-- Add any other context or screenshots here. -->

