### PR TITLE
fix: display numeric 0 correctly in the TextWidget

### DIFF
--- a/shared/src/containers/ProjectTreeTable/widgets/TextWidget.tsx
+++ b/shared/src/containers/ProjectTreeTable/widgets/TextWidget.tsx
@@ -114,7 +114,7 @@ export const TextWidget = forwardRef<HTMLSpanElement, TextWidgetProps>(
     }
 
     const displayText = option?.label || value
-    const textValue = typeof displayText === 'string' ? displayText : String(displayText || '')
+    const textValue = typeof displayText === 'string' ? displayText : String(displayText ?? '')
     const isDescriptionColumn = columnId === 'attrib_description' || columnId === 'description'
     // does the content contain only regular text?
     const isRegularText =

--- a/shared/src/containers/ProjectTreeTable/widgets/TextWidgetInput.tsx
+++ b/shared/src/containers/ProjectTreeTable/widgets/TextWidgetInput.tsx
@@ -43,7 +43,7 @@ export const TextWidgetInput = forwardRef<HTMLInputElement, TextWidgetInputProps
       // convert inputValue to string for consistent processing
       const inputStr =
         inputValue !== undefined && inputValue !== null ? String(inputValue).trim() : ''
-      if (!inputValue) return ''
+      if (inputValue === undefined || inputValue === null) return ''
 
       // Handle empty values
       if (inputStr === '') {


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
Fixed numeric value  0  rendering and updating in table cells. When a number cell contained the value  0 , it previously appeared blank instead of displaying  "0" , and updates to  0  were not correctly persisted.


## Technical details
<!-- Please state any technical details such as limitations -->

Rendering:
Rationale:  ||  treated  0  as falsy and converted it to an empty string, while  ??  preserves  0  and only falls back for  null  and undefined .
  
  Updating the the value:
  
Previous logic treated falsy values as empty, which incorrectly handled  0 .
`if (inputValue === undefined || inputValue === null) return '';`
This ensures  0  is preserved as a valid value while still mapping  null / undefined  to an empty string.
  

## Additional context
<!-- Add any other context or screenshots here. -->

