### PR TITLE
Slicer: Searching folders matching improvements

### DIFF
--- a/shared/src/containers/SimpleTable/SimpleTable.tsx
+++ b/shared/src/containers/SimpleTable/SimpleTable.tsx
@@ -22,7 +22,7 @@ import { useVirtualizer } from '@tanstack/react-virtual'
 import clsx from 'clsx'
 import useRowKeydown, { RowKeyboardEvent } from './hooks/useRowKeydown'
 
-import { RankingInfo, rankItem, compareItems } from '@tanstack/match-sorter-utils'
+import { RankingInfo, rankItem, compareItems, rankings } from '@tanstack/match-sorter-utils'
 import { useSimpleTableContext } from './context/SimpleTableContext'
 import { SimpleTableCellTemplate, SimpleTableCellTemplateProps } from './SimpleTableRowTemplate'
 import { EmptyPlaceholder } from '@shared/components'
@@ -67,8 +67,9 @@ const fuzzyFilter: FilterFn<any> = (row, columnId, searchValue, addMeta) => {
     )
   }
 
-  // Rank the item
-  const itemRank = rankItem(searchString, searchValue)
+  // Rank the item with CONTAINS threshold to avoid overly permissive fuzzy matches
+  // This ensures the search term must be a substring, not just scattered characters
+  const itemRank = rankItem(searchString, searchValue, { threshold: rankings.CONTAINS })
 
   // Store the itemRank info
   addMeta({


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
Fixed overly permissive fuzzy search in the Slicer component. Previously, searching for "read" would match unrelated items like "approved" because the fuzzy algorithm matched scattered characters (r-e-a-d found anywhere in the string).

Now the search requires the search term to be an actual substring (CONTAINS threshold), making results much more relevant and predictable.

## Technical details
<!-- Please state any technical details such as limitations -->
- Added `rankings` import from `@tanstack/match-sorter-utils`                                                                                                                                                                    
- Added `{ threshold: rankings.CONTAINS }` option to `rankItem()` in the `fuzzyFilter` function                                                                                                                                  
- This changes the minimum match level from `MATCHES` (scattered characters) to `CONTAINS` (substring match)

## Additional context
<!-- Add any other context or screenshots here. -->

https://github.com/user-attachments/assets/93983b05-f0ec-48e1-9a34-4ed56da9c701



