### PR TITLE
YN-0466: Downloading reviewables broken

### DIFF
--- a/shared/src/components/ReviewablesList/ReviewablesList.tsx
+++ b/shared/src/components/ReviewablesList/ReviewablesList.tsx
@@ -166,26 +166,22 @@ const ReviewablesList: FC<ReviewablesListProps> = ({
 
   const incompatibleMessage = `File type not supported at this time. Please contact support for further assistance.`
 
-  const handleDownloadFile = async (fileId: string, fileName: string = '') => {
-    const url = `/api/projects/${projectName}/files/${fileId}`
+  const handleDownloadFile = (fileId: string, fileName: string = '') => {
+    let url = `/api/projects/${projectName}/files/${fileId}`
 
-    try {
-      const response = await fetch(url)
-      if (!response.ok) throw new Error(`Download failed: ${response.statusText}`)
+    // if (codec) url += `.${codec}`
 
-      const blob = await response.blob()
-      const blobUrl = URL.createObjectURL(blob)
-      const a = document.createElement('a')
-      a.href = blobUrl
-      a.download = fileName || `${fileId}`
-      document.body.appendChild(a)
-      a.click()
-      document.body.removeChild(a)
+    // Create an invisible anchor element
+    const a = document.createElement('a')
+    a.href = url
+    a.target = "_blank"
+    document.body.appendChild(a)
 
-      URL.revokeObjectURL(blobUrl)
-    } catch (error) {
-      toast.error('Failed to download file')
-    }
+    // Trigger a click event on the anchor element
+    a.click()
+
+    // Remove the anchor element from the document
+    document.body.removeChild(a)
   }
 
   const [deleteReviewable] = useDeleteReviewableMutation()


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Changed reviewable file download behavior to open files in a new browser tab instead of forcing a direct download. This allows users to preview the file (video, image, etc.) in the browser first and then choose to download it manually if needed.


## Technical details
<!-- Please state any technical details such as limitations -->
  Removed the download attribute from the dynamically created anchor element in handleDownloadFile. Previously, the download attribute forced an immediate file download, bypassing browser preview. Now with only target="_blank", the file opens in a new tab where the browser can render it natively.

## Additional context

<!-- Add any other context or screenshots here. -->

