### PR TITLE
YN-0381: Player fix version switching issues

### DIFF
--- a/src/containers/VideoPlayer/VideoOverlay.jsx
+++ b/src/containers/VideoPlayer/VideoOverlay.jsx
@@ -1,24 +1,19 @@
-import React, { useEffect, useRef } from 'react'
+import React, { useLayoutEffect, useRef } from 'react'
 
 const VideoOverlay = ({ videoWidth, videoHeight, showOverlay, showStill, videoRef }) => {
   const canvasRef = useRef(null)
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const canvas = canvasRef.current
     const ctx = canvas.getContext('2d')
 
     const drawOverlay = () => {
       const width = canvas.width
       const height = canvas.height
-      ctx.clearRect(0, 0, width, height)
 
       if (showStill) {
-        // Draw still frame
+        ctx.clearRect(0, 0, width, height)
         ctx.drawImage(videoRef.current, 0, 0, width, height)
-        // please let this here for now (debugging)
-        // ctx.fillStyle = 'red'
-        // ctx.rect(100, 100, 20, 20)
-        // ctx.fill()
       }
 
       if (!showOverlay) return


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
Fixes frame glitch when switching between versions with the same duration in the video player. Previously, clicking a different version while on a specific frame (e.g., frame 24) would cause both the video and the timeline to briefly flash to frame 0 before returning to the correct frame.


## Technical details
<!-- Please state any technical details such as limitations -->

1. **Video glitch** — The still overlay (which hides the video during source transitions) was removed in `handleCanPlay` immediately after initiating the seek, before the seek actually completed. The new video was briefly visible at frame 0. Fixed by waiting for the `seeked` event before removing the overlay.

 2. **Timeline glitch** — `requestVideoFrameCallback` reported `mediaTime = 0` from the freshly loaded video, updating `currentTime` state and causing the trackbar to jump to frame 0. Fixed by introducing an `isTransitioning` ref that freezes `currentTime` updates during the version switch and pins the trackbar to the previous frame position (`initialPosition.current`).
 
`seekPreferredInitialPosition` now returns a boolean indicating whether an async seek was initiated, allowing `handleCanPlay` to decide whether to wait for `seeked` or remove the overlay immediately.

## Additional context
<!-- Add any other context or screenshots here. -->



https://github.com/user-attachments/assets/ad1b3d47-40b9-415e-811f-2dcf914b0ca2



