### PR TITLE
Table: Sorting folders does not respect label special characters

### DIFF
--- a/shared/src/containers/ProjectTreeTable/buildTreeTableColumns.tsx
+++ b/shared/src/containers/ProjectTreeTable/buildTreeTableColumns.tsx
@@ -43,11 +43,12 @@ const withLoadingStateSort = (sortFn: SortingFn<any>): SortingFn<any> => {
   }
 }
 
+const naturalSortCollator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' })
+
 const pathSort: SortingFn<any> = (rowA, rowB) => {
-  const labelA = rowA.original.path || rowA.original.name || ''
-  const labelB = rowB.original.path || rowB.original.name || ''
-  // sort alphabetically by label
-  return labelA.localeCompare(labelB)
+  const labelA = rowA.original.label || rowA.original.path || rowA.original.name || ''
+  const labelB = rowB.original.label || rowB.original.path || rowB.original.name || ''
+  return naturalSortCollator.compare(labelA, labelB)
 }
 
 const valueLengthSort: SortingFn<any> = (rowA, rowB, columnId) => {
@@ -519,6 +520,7 @@ const buildTreeTableColumns = ({
       accessorKey: 'folder',
       header: 'Folder name',
       minSize: COLUMN_MIN_SIZE,
+      sortingFn: withLoadingStateSort(pathSort),
       enableSorting: canSort('folderName'),
       enableResizing: true,
       enablePinning: true,


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

  Implement natural sort order for the project tree table that follows standard Unicode priority while remaining human-readable:                                                
              
  - **Special Characters/Symbols** sorted first (e.g., #, $, @)
  - **Numbers** sorted numerically (1, 2, 10 rather than 1, 10, 2)
  - **Letters** sorted case-insensitively (A and a grouped together)
  
  Additionally, sorting now uses the `label` field (what is displayed in the UI) instead of `name`/`path`.

## Technical details
<!-- Please state any technical details such as limitations -->
  - Replaced `String.localeCompare()` with a shared `Intl.Collator` instance using `{ numeric: true, sensitivity: 'base' }` in the `pathSort` comparator
  - Added missing `sortingFn` to the folder column, which previously had no sort function defined and fell back to TanStack's default string comparison
  - Updated `pathSort` fallback chain from `path → name` to `label → path → name` to sort by the displayed value
  - These changes only affect **client-side sorting**, which is used exclusively in the **Project Overview page with hierarchy mode enabled**. All other pages/modes (Project Overview flat view, Versions & Products, Project Lists) use server-side sorting and are unaffected.
## Additional context
<!-- Add any other context or screenshots here. -->

