### PR TITLE
Feed: Missing post text input

### DIFF
--- a/shared/src/containers/Feed/Feed.tsx
+++ b/shared/src/containers/Feed/Feed.tsx
@@ -93,9 +93,15 @@ export const Feed = ({
   const isVersionsFilter = feedFilter.conditions?.some(
     (c) => 'key' in c && c.key === 'versions' && c.value === true,
   )
+  const hasActiveFilters = feedFilter.conditions?.some(
+    (c) => 'key' in c && ['comments', 'checklists', 'versions', 'updates'].includes(c.key) && c.value === true,
+  )
+  const hasCommentLikeFilter = feedFilter.conditions?.some(
+    (c) => 'key' in c && (c.key === 'comments' || c.key === 'checklists') && c.value === true,
+  )
 
   // hide comment input for specific filters
-  const hideCommentInput = isVersionsFilter
+  const hideCommentInput = hasActiveFilters && !hasCommentLikeFilter
 
   const activitiesWithMergedAnnotations = useMemo(
     () => mergeAnnotationAttachments(activitiesData),


### PR DESCRIPTION

<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
 When all feed activity type filters are selected at once, the comment input field disappears. The input should remain visible whenever a comment-like filter (comments or checklists) is active, and only hide when exclusively non-comment filters (versions, updates) are selected.  

- Introduced `hasActiveFilters` and `hasCommentLikeFilter` to handle conditional checks.
- Updated `hideCommentInput` to account for multiple filter types, improving UI consistency.

## Technical details
<!-- Please state any technical details such as limitations -->
The previous logic only checked for `isVersionsFilter` to decide whether to hide the comment input. This failed when multiple filters were active simultaneously — e.g. `{checklists: true, versions: true, updates: true}` would hide the input because versions was active, even though checklists (a comment-like type) was also active.

 New logic:
  - `hasActiveFilters` — checks if any known activity type filter is enabled
  - `hasCommentLikeFilter` — checks if `comments` or `checklists` filter is enabled
  - `hideCommentInput = hasActiveFilters && !hasCommentLikeFilter` — only hides the input when there are active filters but none of them are comment-like

## Additional context
<!-- Add any other context or screenshots here. -->

