### PR TITLE
Table: Sorting should always fallback to label alphabetical

### DIFF
--- a/shared/src/containers/ProjectTreeTable/buildTreeTableColumns.tsx
+++ b/shared/src/containers/ProjectTreeTable/buildTreeTableColumns.tsx
@@ -45,6 +45,16 @@ const withLoadingStateSort = (sortFn: SortingFn<any>): SortingFn<any> => {
 
 const naturalSortCollator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' })
 
+const withNameTieBreaker = (sortFn: SortingFn<any>): SortingFn<any> => {
+  return (rowA, rowB, ...args) => {
+    const result = sortFn(rowA, rowB, ...args)
+    if (result !== 0) return result
+    const labelA = rowA.original.label || rowA.original.name || ''
+    const labelB = rowB.original.label || rowB.original.name || ''
+    return naturalSortCollator.compare(labelA, labelB)
+  }
+}
+
 const pathSort: SortingFn<any> = (rowA, rowB) => {
   const labelA = rowA.original.label || rowA.original.path || rowA.original.name || ''
   const labelB = rowB.original.label || rowB.original.path || rowB.original.name || ''
@@ -68,7 +78,7 @@ const attribSort: AttribSortingFn = (rowA, rowB, columnId, attrib) => {
   if (attrib && attrib.enum) {
     const indexA = attrib.enum.findIndex((o) => o.value === valueA)
     const indexB = attrib.enum.findIndex((o) => o.value === valueB)
-    return indexB - indexA < 0 ? 1 : -1
+    return indexA - indexB
   } else if (attrib?.type === 'datetime') {
     return sortingFns.datetime(rowA, rowB, columnId)
   } else if (attrib?.type === 'boolean') {
@@ -324,9 +334,9 @@ const buildTreeTableColumns = ({
       accessorKey: 'status',
       minSize: COLUMN_MIN_SIZE,
       header: 'Status',
-      sortingFn: withLoadingStateSort((a, b, c) =>
+      sortingFn: withLoadingStateSort(withNameTieBreaker((a, b, c) =>
         attribSort(a, b, c, { enum: options.status, type: 'string' }),
-      ),
+      )),
       sortDescFirst: true,
       enableSorting: canSort('status'),
       enableResizing: true,
@@ -384,7 +394,7 @@ const buildTreeTableColumns = ({
       enableResizing: true,
       enablePinning: true,
       enableHiding: true,
-      sortingFn: withLoadingStateSort(sortingFns.alphanumeric),
+      sortingFn: withLoadingStateSort(withNameTieBreaker(sortingFns.alphanumeric)),
       cell: ({ row, column, table }) => {
         const { value, id, type } = getValueIdType(row, column.id)
         if (['group', NEXT_PAGE_ID].includes(type) || row.original.metaType) return null
@@ -413,9 +423,9 @@ const buildTreeTableColumns = ({
       enableResizing: true,
       enablePinning: true,
       enableHiding: true,
-      sortingFn: withLoadingStateSort((a, b, c) =>
+      sortingFn: withLoadingStateSort(withNameTieBreaker((a, b, c) =>
         attribSort(a, b, c, { enum: [...options.folderType, ...options.taskType], type: 'string' }),
-      ),
+      )),
       cell: ({ row, column, table }) => {
         const { value, id, type } = getValueIdType(row, column.id)
         if (['group', NEXT_PAGE_ID].includes(type) || row.original.metaType) return null
@@ -480,7 +490,7 @@ const buildTreeTableColumns = ({
       enableResizing: true,
       enablePinning: true,
       enableHiding: true,
-      sortingFn: withLoadingStateSort(valueLengthSort),
+      sortingFn: withLoadingStateSort(withNameTieBreaker(valueLengthSort)),
       cell: ({ row, column, table }) => {
         const meta = table.options.meta
         const { value, id, type } = getValueIdType(row, column.id)
@@ -663,7 +673,7 @@ const buildTreeTableColumns = ({
       enableResizing: true,
       enablePinning: true,
       enableHiding: true,
-      sortingFn: withLoadingStateSort(valueLengthSort),
+      sortingFn: withLoadingStateSort(withNameTieBreaker(valueLengthSort)),
       cell: ({ row, column, table }) => {
         const meta = table.options.meta
         const { value, id, type } = getValueIdType(row, column.id)
@@ -701,7 +711,7 @@ const buildTreeTableColumns = ({
       enableResizing: true,
       enablePinning: true,
       enableHiding: true,
-      sortingFn: withLoadingStateSort(sortingFns.datetime),
+      sortingFn: withLoadingStateSort(withNameTieBreaker(sortingFns.datetime)),
       cell: ({ row, column }) => {
         const { value, id, type } = getValueIdType(row, column.id)
         if (['group', NEXT_PAGE_ID].includes(type) || row.original.metaType) return null
@@ -731,7 +741,7 @@ const buildTreeTableColumns = ({
       enableResizing: true,
       enablePinning: true,
       enableHiding: true,
-      sortingFn: withLoadingStateSort(sortingFns.datetime),
+      sortingFn: withLoadingStateSort(withNameTieBreaker(sortingFns.datetime)),
       cell: ({ row, column }) => {
         const { value, id, type } = getValueIdType(row, column.id)
         if (['group', NEXT_PAGE_ID].includes(type) || row.original.metaType) return null
@@ -808,7 +818,7 @@ const buildTreeTableColumns = ({
         header: attrib.data.title || attrib.name,
         minSize: COLUMN_MIN_SIZE,
         filterFn: 'fuzzy' as FilterFnOption<TableRow>,
-        sortingFn: withLoadingStateSort((a, b, c) => attribSort(a, b, c, attrib.data)),
+        sortingFn: withLoadingStateSort(withNameTieBreaker((a, b, c) => attribSort(a, b, c, attrib.data))),
         enableSorting: canSort(attrib.name) && canSort('attrib'),
         enableResizing: true,
         enablePinning: true,


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
When sorting by columns with repeating values (Status, Folder Type, Priority, etc.), items within the same group appeared in random/unstable order. This fix ensures that when two or more entities share the same value in the sorted column, they automatically fall back to alphabetical sorting by name/label

**Before:** `matchmove, anim, fxxxxx, lighting, roto, compositing` (random)
**After:** `anim, compositing, fxxxxx, lighting, matchmove, roto` (alphabetical)

## Technical details
<!-- Please state any technical details such as limitations -->
The `attribSort` enum comparator (`indexB - indexA < 0 ? 1 : -1`) never returned `0` for equal values — it always returned `-1`, violating the comparator contract and producing contradictory results that caused unpredictable ordering.


Added `withNameTieBreaker` higher-order function (same wrapper pattern as existing `withLoadingStateSort`) that falls back to alphabetical name comparison when the primary sort returns `0` (equal). Applied to all non-name columns: Status, EntityType, SubType, Assignees, Tags, CreatedAt, UpdatedAt, and custom attribute columns.
## Additional context
<!-- Add any other context or screenshots here. -->
**Before:** 
<img width="481" height="210" alt="Screenshot 2026-02-17 at 11 58 17" src="https://github.com/user-attachments/assets/309cdd90-8ea1-4a24-9a1a-042ac1bc5f5b" />
**After:**

<img width="476" height="210" alt="Screenshot 2026-02-17 at 11 58 52" src="https://github.com/user-attachments/assets/f66c0299-73ce-4a55-85ff-6ccad3ba0ca8" />
