### PR TITLE
Player: Switching versions breaks playback

### DIFF
--- a/src/containers/VideoPlayer/VideoOverlay.jsx
+++ b/src/containers/VideoPlayer/VideoOverlay.jsx
@@ -6,14 +6,16 @@ const VideoOverlay = ({ videoWidth, videoHeight, showOverlay, showStill, videoRe
   useLayoutEffect(() => {
     const canvas = canvasRef.current
     const ctx = canvas.getContext('2d')
+    const dpr = window.devicePixelRatio || 1
+
+    canvas.width = videoWidth * dpr
+    canvas.height = videoHeight * dpr
+    ctx.scale(dpr, dpr)
 
     const drawOverlay = () => {
-      const width = canvas.width
-      const height = canvas.height
-
-      ctx.clearRect(0, 0, width, height)
+      ctx.clearRect(0, 0, videoWidth, videoHeight)
       if (showStill) {
-        ctx.drawImage(videoRef.current, 0, 0, width, height)
+        ctx.drawImage(videoRef.current, 0, 0, videoWidth, videoHeight)
       }
 
       if (!showOverlay) return
@@ -24,10 +26,10 @@ const VideoOverlay = ({ videoWidth, videoHeight, showOverlay, showStill, videoRe
       ctx.strokeStyle = '#cccccc'
       ctx.lineWidth = 1
       ctx.strokeRect(
-        width * safeMargin,
-        height * safeMargin,
-        width * (1 - 2 * safeMargin),
-        height * (1 - 2 * safeMargin),
+        videoWidth * safeMargin,
+        videoHeight * safeMargin,
+        videoWidth * (1 - 2 * safeMargin),
+        videoHeight * (1 - 2 * safeMargin),
       )
 
       // Draw center cross
@@ -35,10 +37,10 @@ const VideoOverlay = ({ videoWidth, videoHeight, showOverlay, showStill, videoRe
       ctx.strokeStyle = '#cccccc'
       ctx.lineWidth = 1
       ctx.beginPath()
-      ctx.moveTo(width / 2, 0)
-      ctx.lineTo(width / 2, height)
-      ctx.moveTo(0, height / 2)
-      ctx.lineTo(width, height / 2)
+      ctx.moveTo(videoWidth / 2, 0)
+      ctx.lineTo(videoWidth / 2, videoHeight)
+      ctx.moveTo(0, videoHeight / 2)
+      ctx.lineTo(videoWidth, videoHeight / 2)
       ctx.stroke()
     }
 
@@ -48,13 +50,13 @@ const VideoOverlay = ({ videoWidth, videoHeight, showOverlay, showStill, videoRe
   return (
     <canvas
       ref={canvasRef}
-      width={videoWidth}
-      height={videoHeight}
       style={{
         outline: showOverlay ? '1px solid #cccccc' : 'none',
         position: 'absolute',
         top: 0,
         left: 0,
+        width: videoWidth,
+        height: videoHeight,
       }}
     />
   )

--- a/src/containers/VideoPlayer/VideoPlayer.jsx
+++ b/src/containers/VideoPlayer/VideoPlayer.jsx
@@ -231,7 +231,6 @@ const VideoPlayer = ({ src, frameRate, aspectRatio, autoplay, onPlay, reviewable
       setIsPlaying(false)
     }
     if (videoRef.current?.duration < currentTime) {
-      console.log('resetting current time to 0')
       setCurrentTime(0)
     }
     setBufferedRanges([])
@@ -283,62 +282,27 @@ const VideoPlayer = ({ src, frameRate, aspectRatio, autoplay, onPlay, reviewable
     }
     const video = videoRef.current
     if (!video) return
-    
-    // Cancel previous callback if it exists and is a function
-    if (frameCallbackRef.current && typeof frameCallbackRef.current === 'function') {
-      try {
-        frameCallbackRef.current()
-      } catch (error) {
-        console.warn('Error canceling previous video frame callback:', error)
-      }
+
+    if (typeof frameCallbackRef.current === 'function') {
+      frameCallbackRef.current()
     }
-    
-    try {
-      const cancelCallback = video.requestVideoFrameCallback(updateCurrentTime)
-      if (typeof cancelCallback === 'function') {
-        frameCallbackRef.current = cancelCallback
-      } else {
-        console.warn('requestVideoFrameCallback did not return a cancel function')
-        frameCallbackRef.current = null
-      }
-    } catch (error) {
-      console.error('Error setting up video frame callback:', error)
-      frameCallbackRef.current = null
-    }
+
+    frameCallbackRef.current = video.requestVideoFrameCallback(updateCurrentTime)
   }
 
   useEffect(() => {
     if (!videoRef.current) return
     const video = videoRef.current
-    
-    if (frameCallbackRef.current && typeof frameCallbackRef.current === 'function') {
-      try {
-        frameCallbackRef.current()
-      } catch (error) {
-        console.warn('Error canceling previous video frame callback:', error)
-      }
+
+    if (typeof frameCallbackRef.current === 'function') {
+      frameCallbackRef.current()
     }
-    
-    try {
-      const cancelCallback = video.requestVideoFrameCallback(updateCurrentTime)
-      if (typeof cancelCallback === 'function') {
-        frameCallbackRef.current = cancelCallback
-      } else {
-        console.warn('requestVideoFrameCallback did not return a cancel function')
-        frameCallbackRef.current = null
-      }
-    } catch (error) {
-      console.error('Error setting up video frame callback:', error)
-      frameCallbackRef.current = null
-    }
-    
+
+    frameCallbackRef.current = video.requestVideoFrameCallback(updateCurrentTime)
+
     return () => {
-      if (frameCallbackRef.current && typeof frameCallbackRef.current === 'function') {
-        try {
-          frameCallbackRef.current()
-        } catch (error) {
-          console.warn('Error canceling video frame callback on cleanup:', error)
-        }
+      if (typeof frameCallbackRef.current === 'function') {
+        frameCallbackRef.current()
         frameCallbackRef.current = null
       }
     }
@@ -499,7 +463,6 @@ const VideoPlayer = ({ src, frameRate, aspectRatio, autoplay, onPlay, reviewable
               width={videoDimensions.width}
               height={videoDimensions.height}
               src={actualSource}
-              style={{ opacity: showStill ? 0 : 1 }}
               onProgress={handleProgress}
               onEnded={handleEnded}
               onPlay={handleOnPlay}


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
Fix video flickering and visual glitches when switching versions during playback. The player now uses a canvas overlay to seamlessly transition between video sources — the current frame is captured before the source swap, and the new video is only revealed once a frame is fully decoded and ready to display.

## Technical details
<!-- Please state any technical details such as limitations -->
- **Canvas overlay as transition mask**: On version switch, the current video frame is captured to a canvas that sits on top of the `<video>` element. The video source swaps behind it, and the canvas clears only after the new video has a decoded frame ready (`requestVideoFrameCallback`).
- **Retina-aware canvas rendering**: The canvas buffer is now scaled by `devicePixelRatio` to match the video's rendering sharpness on HiDPI displays, eliminating the visible blur during transitions.
- **Removed `opacity: 0/1` hack on video element**: Some browsers discard GPU textures for invisible elements, causing a flash when opacity changes. The canvas overlayalone handles visibility — no opacity trick needed.
- **Fixed `requestVideoFrameCallback` polyfill**: The polyfill now correctly fires for paused videos (`lastTime = -1` so the initial frame always triggers), gates on `readyState >= 2` to ensure frame data is available, and uses one-shot behavior matching the native API. - **Moved `ctx.clearRect()` outside `showStill` condition** in `VideoOverlay` so the canvas clears unconditionally on every draw, preventing stale frames from persisting.

## Additional context
<!-- Add any other context or screenshots here. -->

