### PR TITLE
YN-0510: Pinned columns are lost sometimes

### DIFF
--- a/shared/src/containers/ProjectTreeTable/context/ColumnSettingsProvider.tsx
+++ b/shared/src/containers/ProjectTreeTable/context/ColumnSettingsProvider.tsx
@@ -12,18 +12,7 @@ import { ROW_SELECTION_COLUMN_ID } from './SelectionCellsContext'
 import { DRAG_HANDLE_COLUMN_ID } from '../ProjectTreeTable'
 import { ColumnsConfig, ColumnSettingsContext, TableGroupBy } from './ColumnSettingsContext'
 import { GroupByConfig } from '../components/GroupSettingsFallback'
-
-const isEqualArray = (a: any[], b: any[]): boolean => {
-  if (a.length !== b.length) return false
-  return a.every((val, i) => val === b[i])
-}
-
-const isEqualRecord = (a: Record<string, any>, b: Record<string, any>): boolean => {
-  const keysA = Object.keys(a)
-  const keysB = Object.keys(b)
-  if (keysA.length !== keysB.length) return false
-  return keysA.every((key) => a[key] === b[key])
-}
+import { isEqual } from 'lodash'
 
 interface ColumnSettingsProviderProps {
   children: ReactNode
@@ -353,37 +342,31 @@ export const ColumnSettingsProvider: React.FC<ColumnSettingsProviderProps> = ({
   // ON-CHANGE HANDLERS (TanStack-compatible)
   const columnVisibilityOnChange: OnChangeFn<VisibilityState> = (updater) => {
     const newVisibility = functionalUpdate(updater, columnVisibility)
-    if (isEqualRecord(newVisibility, columnVisibility)) return
+    if (isEqual(newVisibility, columnVisibility)) return
     setColumnVisibility(newVisibility)
   }
 
   const columnPinningOnChange: OnChangeFn<ColumnPinningState> = (updater) => {
     const newPinning = functionalUpdate(updater, columnPinning)
-    if (
-      isEqualArray(newPinning.left || [], columnPinning.left || []) &&
-      isEqualArray(newPinning.right || [], columnPinning.right || [])
-    ) return
+    if (isEqual(newPinning, columnPinning)) return
     setColumnPinning(newPinning)
   }
 
   const columnOrderOnChange: OnChangeFn<ColumnOrderState> = (updater) => {
     const newOrder = functionalUpdate(updater, columnOrder)
-    if (isEqualArray(newOrder, columnOrder)) return
+    if (isEqual(newOrder, columnOrder)) return
     setColumnOrder(newOrder)
   }
 
   const columnSizingOnChange: OnChangeFn<ColumnSizingState> = (updater) => {
     const newSizing = functionalUpdate(updater, columnSizing)
-    if (isEqualRecord(newSizing, columnSizing)) return
+    if (isEqual(newSizing, columnSizing)) return
     setColumnSizing(newSizing)
   }
 
   const sortingOnChange: OnChangeFn<SortingState> = (updater) => {
     const newSorting = functionalUpdate(updater, sorting)
-    if (
-      newSorting.length === sorting.length &&
-      newSorting.every((s, i) => s.id === sorting[i].id && s.desc === sorting[i].desc)
-    ) return
+    if (isEqual(newSorting, sorting)) return
     updateSorting(newSorting)
   }
 


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
Fixes a bug where pinned columns (and other view settings like filters, column order) could be silently overwritten on app load without user interaction. 

## Technical details
<!-- Please state any technical details such as limitations -->

- Added shallow equality checks to all 5 onChange handlers in ColumnSettingsProvider — if the new value matches the current value, the update is skipped
- Added a guard in viewUpdateHelper to skip updates when viewSettings is undefined (prevents overwrite during initial data fetch)

## Additional context
<!-- Add any other context or screenshots here. -->

