### PR TITLE
Version Upload: Product types not showing for users

### DIFF
--- a/shared/src/api/queries/project/getProject.ts
+++ b/shared/src/api/queries/project/getProject.ts
@@ -33,7 +33,6 @@ export const {
   useGetProjectQuery,
   useListProjectsQuery,
   useGetProjectAnatomyQuery,
-  useGetProductTypesQuery,
 } = enhancedProject
 
 export default enhancedProject

--- a/shared/src/components/EntityPanelUploader/EntityPanelUploader.tsx
+++ b/shared/src/components/EntityPanelUploader/EntityPanelUploader.tsx
@@ -139,6 +139,7 @@ export const EntityPanelUploader = ({
         folderId: folderId,
         name: sanitizedName,
         productType: 'review', // default product type for uploaded files
+        productBaseType: 'review',
       })
 
       // Close dialog and proceed with version upload

--- a/shared/src/components/VersionUploader/context/VersionUploadContext.tsx
+++ b/shared/src/components/VersionUploader/context/VersionUploadContext.tsx
@@ -200,6 +200,7 @@ export const VersionUploadProvider: React.FC<VersionUploadProviderProps> = ({
               folderId,
               name: data.name,
               productType: data.productType || 'review',
+              productBaseType: data.productType || 'review',
             },
             {
               version: data.version,

--- a/shared/src/util/versionUploadHelpers.ts
+++ b/shared/src/util/versionUploadHelpers.ts
@@ -5,6 +5,7 @@ export interface ProductCreationData {
   folderId: string
   name: string
   productType: string
+  productBaseType?: string
 }
 
 export interface VersionCreationData {

--- a/src/pages/VersionsProductsPage/hooks/useVPContextMenu.tsx
+++ b/src/pages/VersionsProductsPage/hooks/useVPContextMenu.tsx
@@ -187,7 +187,6 @@ export const useVPContextMenu = (callbacks?: {
       } else if (entity.entityType === 'version' && 'product' in entity) {
         productId = (entity as any).product?.id
         folderId = (entity as any).product?.folder?.id
-        latestVersionNumber = (entity as any).version
         linkedTask = (entity as any).task
       }
 


### PR DESCRIPTION


<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Send `productBaseType` alongside `productType` when creating products via version upload and entity panel drag & drop upload. Since product types now come from `anatomy.product_base_types.definitions`, the selected product type name is the base type name, so `productBaseType` is set to match `productType`.

## Technical details
<!-- Please state any technical details such as limitations -->
 - Added `productBaseType?: string` to the `ProductCreationData` interface
  - Pass `productBaseType` in both creation paths:
    - Version upload dialog: `productBaseType: data.productType || 'review'`
    - Entity panel upload: `productBaseType: 'review'`
  - The `ProductPostModel` REST API already supports `productBaseType` — no backend changes needed

## Additional context
<!-- Add any other context or screenshots here. -->

