### PR TITLE
Users: Fix batching deleting users dialog styling

### DIFF
--- a/src/pages/SettingsPage/UsersSettings/DeleteUserDialog.styled.ts
+++ b/src/pages/SettingsPage/UsersSettings/DeleteUserDialog.styled.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import { InputText } from '@ynput/ayon-react-components'
+import { InputText, Dialog } from '@ynput/ayon-react-components'
 
 export const FooterContainer = styled.div`
   display: flex;
@@ -20,4 +20,21 @@ export const FooterActions = styled.div`
 export const ConfirmInput = styled(InputText)`
   width: 100%;
   margin-bottom: 16px;
+`
+
+export const StyledDialog = styled(Dialog)`
+  .body {
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+  }
+`
+
+export const UserList = styled.div`
+  overflow-y: auto;
+  flex: 1;
+  min-height: 0;
+  padding: 8px;
+  border-radius: var(--border-radius-m);
+  background-color: var(--md-sys-color-surface-container-lowest);
 `

--- a/src/pages/SettingsPage/UsersSettings/DeleteUserDialog.tsx
+++ b/src/pages/SettingsPage/UsersSettings/DeleteUserDialog.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { FormLayout, Dialog, Button } from '@ynput/ayon-react-components'
+import { Button } from '@ynput/ayon-react-components'
 import InfoMessage from '@components/InfoMessage'
 import * as Styled from './DeleteUserDialog.styled'
 
@@ -27,7 +27,7 @@ const DeleteUserDialog = ({ onHide, selectedUsers, onDelete, onDisable }: Delete
     : `Delete ${selectedUsers.length} Users`
 
   return (
-    <Dialog
+    <Styled.StyledDialog
       size="md"
       header={header}
       footer={
@@ -55,20 +55,19 @@ const DeleteUserDialog = ({ onHide, selectedUsers, onDelete, onDisable }: Delete
       isOpen={true}
       onClose={onHide}
     >
-      <FormLayout>
-        <InfoMessage
-          variant="warning"
-          message="Deleting users can have unintended consequences. Consider deactivating the user instead?"
-        />
-        {!isSingle && (
-          <div>
-            {selectedUsers.map((user) => (
-              <div key={user}>{user}</div>
-            ))}
-          </div>
-        )}
-      </FormLayout>
-    </Dialog>
+      <InfoMessage
+        style={{ marginBottom: 16 }}
+        variant="warning"
+        message="Deleting users can have unintended consequences. Consider deactivating the user instead?"
+      />
+      {!isSingle && (
+        <Styled.UserList>
+          {selectedUsers.map((user) => (
+            <div key={user}>{user}</div>
+          ))}
+        </Styled.UserList>
+      )}
+    </Styled.StyledDialog>
   )
 }
 


### PR DESCRIPTION

<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
 - Fix delete users confirmation dialog overflowing when 100+ users are selected
  - Show user count in header instead of listing all names                                                       
  - Display full user list in scrollable dialog body
  - Move confirm input to dialog footer


## Technical details
<!-- Please state any technical details such as limitations -->
- Replaced inline styles with styled-components in new `DeleteUserDialog.styled.ts`
  - For single user: header shows username, confirm input requires typing the username                           
  - For multiple users: header shows count (e.g. "Delete 150 Users"), confirm input requires typing "delete      
  selected"                                                                                                      
  - Dialog body scrolls the user list while footer with confirm input stays fixed

## Additional context
<!-- Add any other context or screenshots here. -->

