### PR TITLE
Bundles: Show warning higher version icon for server bundles

### DIFF
--- a/src/pages/SettingsPage/Bundles/BundlesAddonList.tsx
+++ b/src/pages/SettingsPage/Bundles/BundlesAddonList.tsx
@@ -115,14 +115,12 @@ const AddonListItem: React.FC<{
         placeholder="NONE"
         onChange={(e: string[]) => setVersion(e[0] || null)}
       />
-      {showLatestIcon && (
-        <LatestIcon
-          data-tooltip-delay={0}
-          style={{marginLeft:3}}
-          data-tooltip={'Latest installed version: ' + latestVersion}
-          icon="info"
-        />
-      )}
+      <LatestIcon
+        data-tooltip-delay={0}
+        style={{ marginLeft: 3, visibility: showLatestIcon ? 'visible' : 'hidden' }}
+        data-tooltip={showLatestIcon ? 'Latest installed version: ' + latestVersion : undefined}
+        icon="info"
+      />
     </>
   )
 }


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Show the "i" info icon (latest version indicator) next to the version dropdown selector in bundles. Previously, the icon was only visible in read-only mode for pipeline addons and would disappear when the version dropdown was shown. Now the icon appears alongside the dropdown, so users can still see when a higher version of an addon is available while editing.

## Technical details
<!-- Please state any technical details such as limitations -->

- Added `latestVersion` prop to `AddonListItem` component
- Renders `LatestIcon` next to `VersionSelect` when the selected version is not the latest installed version
- Reuses the same `LatestIcon` component and tooltip ("Latest installed version: X") as the read-only `AddonItem` for consistency

## Additional context
<!-- Add any other context or screenshots here. -->

