### PR TITLE
Review: ensure all remote modules loaded before rendering Cards view

### DIFF
--- a/src/pages/ProjectListsPage/ProjectListsPage.tsx
+++ b/src/pages/ProjectListsPage/ProjectListsPage.tsx
@@ -234,6 +234,7 @@ const ProjectLists: FC<ProjectListsProps> = ({
     ReviewSessionCardsControlsLeft,
     ReviewSessionCardsControlsRight,
     outdated: reviewSessionCardsOutdated,
+    allModulesLoaded: reviewModulesLoaded,
   } = useReviewSessionCardsModules({ skip: !isReview })
 
   const handleOpenPlayer = useTableOpenViewer({ projectName: projectName })
@@ -314,7 +315,7 @@ const ProjectLists: FC<ProjectListsProps> = ({
                     disabled={listItemsData.length === 0}
                   />
                   {
-                    view === "cards" && (
+                    reviewModulesLoaded && view === "cards" && (
                       <ReviewSessionCardsControlsLeft />
                     )
                   }
@@ -328,7 +329,7 @@ const ProjectLists: FC<ProjectListsProps> = ({
                     )
                   }
                   {
-                    isReview && (
+                    isReview && reviewModulesLoaded && (
                       <>
                         <Spacer />
                         <ReviewSessionCardsControlsRight groupingDisabled={view === "table"} />
@@ -381,7 +382,7 @@ const ProjectLists: FC<ProjectListsProps> = ({
                     <SplitterPanel size={70}>
                       {
                         selectedList && isReview && view === "cards"
-                        ? <ReviewSessionCards />
+                        ? (reviewModulesLoaded && <ReviewSessionCards />)
                         : (
                           <ListItemsTable
                             extraColumns={extraColumns}


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Adds checks to make sure the remote `<ReviewCards*>` components don't render until all remotes have loaded - specifically, the provider component must be rendered, otherwise a certain network response order can lead to runtime errors.

## Technical details

## Additional context
<!-- Add any other context or screenshots here. -->

