### PR TITLE
Review: if using new server but outdated Review addon, show the old table view

### DIFF
--- a/src/pages/ProjectListsPage/ProjectListsPage.tsx
+++ b/src/pages/ProjectListsPage/ProjectListsPage.tsx
@@ -1,5 +1,5 @@
 import { parseCellId, ProjectDataProvider, ROW_SELECTION_COLUMN_ID, useSelectionCellsContext } from '@shared/containers/ProjectTreeTable'
-import { FC, useMemo, useState } from 'react'
+import { FC, useEffect, useMemo, useState } from 'react'
 import { ListsProvider, useListsContext } from './context'
 import { Splitter, SplitterPanel } from 'primereact/splitter'
 import { Section, Spacer, Toolbar } from '@ynput/ayon-react-components'
@@ -219,7 +219,6 @@ const ProjectLists: FC<ProjectListsProps> = ({
     setAnchorCell,
     clearSelection
   } = useSelectionCellsContext()
-  const [view, setView] = useState<ReviewPageView>(isReview ? "cards" : "table")
 
   const handleGoToCustomAttrib = (attrib: string) => {
     // open settings panel and highlig the attribute
@@ -238,18 +237,13 @@ const ProjectLists: FC<ProjectListsProps> = ({
   } = useReviewSessionCardsModules({ skip: !isReview })
 
   const handleOpenPlayer = useTableOpenViewer({ projectName: projectName })
+  const [view, setView] = useState<ReviewPageView>(isReview ? "cards" : "table")
 
-  if (reviewSessionCardsOutdated) {
-    return (
-      <EmptyPlaceholder
-        message={
-          `The Review addon version (${reviewSessionCardsOutdated.current}) is out of date.`
-        }
-      >
-        Please update to version {reviewSessionCardsOutdated.required} or newer.
-      </EmptyPlaceholder>
-    )
-  }
+  // if the addon is outdated, make sure we land in table view
+  useEffect(() => {
+    if (!reviewSessionCardsOutdated) return
+    setView("table")
+  }, [reviewSessionCardsOutdated])
 
   return (
     <main style={{ gap: 4 }}>
@@ -355,7 +349,7 @@ const ProjectLists: FC<ProjectListsProps> = ({
                     align="right"
                   />
                   {
-                    isReview && (
+                    !reviewSessionCardsOutdated && isReview && (
                       <TableGridSwitch
                         showGrid={view === "cards"}
                         onChange={(showGrid) => setView(showGrid ? "cards" : "table")}
@@ -386,7 +380,7 @@ const ProjectLists: FC<ProjectListsProps> = ({
                         : (
                           <ListItemsTable
                             extraColumns={extraColumns}
-                            isReview={isReview}
+                            isReview={isReview && !reviewSessionCardsOutdated}
                             dndActiveId={dndActiveId} // Pass prop
                             viewOnly={(selectedList?.accessLevel || 0) < 20}
                           />


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

For users who update their AYON version but haven't updated the Review addon to 0.3.0, we don't have the necessary components to show the Cards view, but we can still show the old Table view by default. 

## Technical details
<!-- Please state any technical details such as limitations -->


## Additional context
<!-- Add any other context or screenshots here. -->

