### PR TITLE
Version detail: JSON viewer displays incorrect text selection

### DIFF
--- a/shared/src/components/DetailsDialog/DetailsDialog.tsx
+++ b/shared/src/components/DetailsDialog/DetailsDialog.tsx
@@ -40,7 +40,6 @@ export const DetailsDialog = ({
     try {
       return JSON.stringify(data, null, 2)
     } catch {
-      // Fallback to string representation
       return String(data)
     }
   }, [data])
@@ -48,9 +47,6 @@ export const DetailsDialog = ({
   // Keep the early return after hooks to ensure hooks are called on every render in the same order
   if (!visible || (Array.isArray(data) ? data.length < 1 : false)) return null
 
-  // TODO: Create a dedicate CodeBlock component that allows to pick the
-  //  code language (or a Markdown component that supports code blocks
-  //  with language syntax highlighting)
   return (
     <Dialog
       isOpen={true}
@@ -63,16 +59,16 @@ export const DetailsDialog = ({
         .details-dialog__code { position: relative; }
         .details-dialog__copy { position: absolute; right: 12px; top: 24px; z-index: 10; background: rgba(0,0,0,0.5); border-radius: 4px; padding: 6px; cursor: pointer; display: none; align-items: center; justify-content: center; }
         .details-dialog__code:hover .details-dialog__copy, .details-dialog__code:focus-within .details-dialog__copy { display: flex; }
-          .w-tc-editor .token.property { color: #c9a5f7 !important; }
-          .w-tc-editor .token.string { color: #6bc985 !important; }
-          .w-tc-editor .token.number { color: #e5a66b !important; }
-          .w-tc-editor .token.boolean { color: #e5a66b !important; }
-          .w-tc-editor .token.null { color: #7a8a99 !important; }
-          .w-tc-editor .token.punctuation { color: #b0bec5 !important; }
-          .w-tc-editor .token.operator { color: #b0bec5 !important; }
+        .w-tc-editor .token.property { color: #c9a5f7 !important; }
+        .w-tc-editor .token.string { color: #6bc985 !important; }
+        .w-tc-editor .token.number { color: #e5a66b !important; }
+        .w-tc-editor .token.boolean { color: #e5a66b !important; }
+        .w-tc-editor .token.null { color: #7a8a99 !important; }
+        .w-tc-editor .token.punctuation { color: #b0bec5 !important; }
+        .w-tc-editor .token.operator { color: #b0bec5 !important; }
+        .details-dialog__code .w-tc-editor textarea { display: none !important; }
       `}</style>
       <div className="details-dialog__code">
-        {/* If loading or error, render plain text */}
         {isLoading || isError ? (
           <pre>{isLoading ? 'loading...' : 'error...'}</pre>
         ) : (


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
Fix text selection rendering glitch in the entity details dialog (product/version detail). When selecting text in the JSON view, the text appeared doubled/overlapping  due to the @uiw/react-textarea-code-editor component overlaying a transparent` <textarea> `on top of a syntax-highlighted `<pre>`.         


## Technical details
<!-- Please state any technical details such as limitations -->
 The CodeEditor component renders two layers: a` <textarea>` for input and a `<pre>` for syntax highlighting. Since this dialog is read-only, the textarea is unnecessary and was causing the selection highlight to misalign with the visible text. Fix: hide the textarea with display: none, letting users select text directly from the `<pre>.`

## Additional context
<!-- Add any other context or screenshots here. -->


Before:
<img width="701" height="473" alt="image" src="https://github.com/user-attachments/assets/83e4f12f-de5a-44e7-aaa8-db264c80e1ba" />

After:
<img width="928" height="460" alt="Screenshot_2026-03-12_at_10 22 28" src="https://github.com/user-attachments/assets/f450ad7e-0053-4469-a4ed-ee9b9c32dbde" />


