### PR TITLE
Review: refetch GraphQL list queries when the session grid items changes

### DIFF
--- a/src/pages/ProjectListsPage/ProjectListsPage.tsx
+++ b/src/pages/ProjectListsPage/ProjectListsPage.tsx
@@ -3,7 +3,7 @@ import { FC, useEffect, useMemo, useState } from 'react'
 import { ListsProvider, useListsContext } from './context'
 import { Splitter, SplitterPanel } from 'primereact/splitter'
 import { Section, Spacer, Toolbar } from '@ynput/ayon-react-components'
-import { ListsDataProvider } from './context/ListsDataContext'
+import { ListsDataProvider, useListsDataContext } from './context/ListsDataContext'
 import ListsTable from './components/ListsTable/ListsTable'
 import ListsFiltersDialog from './components/ListsFiltersDialog/ListsFiltersDialog'
 import { ListItemsDataProvider, useListItemsDataContext } from './context/ListItemsDataContext'
@@ -210,7 +210,12 @@ const ProjectLists: FC<ProjectListsProps> = ({
   const { projectName } = useProjectContext()
   const { isPanelOpen, selectSetting, highlightedSetting } = useSettingsPanel()
   const { selectedList } = useListsContext()
-  const { listItemsData, deleteListItemAction } = useListItemsDataContext()
+  const { refetch: refetchLists } = useListsDataContext()
+  const {
+    listItemsData,
+    deleteListItemAction,
+    refetch: refetchListItems,
+  } = useListItemsDataContext()
 
   const {
     selectedCells,
@@ -300,6 +305,10 @@ const ProjectLists: FC<ProjectListsProps> = ({
               }}
               onOpenInViewer={(state) => {
                 handleOpenPlayer(state, { quickView: true })
+              }}
+              onItemsChanged={() => {
+                refetchListItems()
+                refetchLists()
               }}
             >
               {selectedList && (

--- a/src/pages/ProjectListsPage/context/ListItemsDataContext.tsx
+++ b/src/pages/ProjectListsPage/context/ListItemsDataContext.tsx
@@ -50,6 +50,7 @@ export interface ListItemsDataContextValue {
   reorderListItem: UseReorderListItemReturn['reorderListItem']
   // reset filters
   resetFilters: () => void
+  refetch: () => void
 }
 
 const ListItemsDataContext = createContext<ListItemsDataContextValue | undefined>(undefined)
@@ -101,6 +102,7 @@ export const ListItemsDataProvider = ({ children }: ListItemsDataProviderProps) 
     isFetchingNextPage,
     isError,
     fetchNextPage,
+    refetch,
   } = useGetListItemsData({
     projectName,
     entityType: selectedList?.entityType,
@@ -200,6 +202,7 @@ export const ListItemsDataProvider = ({ children }: ListItemsDataProviderProps) 
         // reorder list item
         reorderListItem,
         resetFilters,
+        refetch,
       }}
     >
       {children}

--- a/src/pages/ProjectListsPage/context/ListsDataContext.tsx
+++ b/src/pages/ProjectListsPage/context/ListsDataContext.tsx
@@ -24,6 +24,7 @@ interface ListsDataContextValue {
   // show archived
   showArchived: boolean
   setShowArchived: (show: boolean) => void
+  refetch: () => void
 }
 
 const ListsDataContext = createContext<ListsDataContextValue | undefined>(undefined)
@@ -85,6 +86,7 @@ export const ListsDataProvider = ({
     isFetchingNextPage,
     isError,
     fetchNextPage,
+    refetch,
   } = useGetListsData({
     projectName,
     filters: listsFilters,
@@ -124,6 +126,7 @@ export const ListsDataProvider = ({
         // show archived
         showArchived,
         setShowArchived,
+        refetch,
       }}
     >
       {children}

--- a/src/pages/ProjectListsPage/hooks/useGetListItemsData.ts
+++ b/src/pages/ProjectListsPage/hooks/useGetListItemsData.ts
@@ -30,6 +30,7 @@ export interface UseGetListItemsDataReturn {
   isFetchingNextPage: boolean
   isError: boolean
   fetchNextPage: () => void
+  refetch: () => void
 }
 
 const useGetListItemsData = ({
@@ -71,6 +72,7 @@ const useGetListItemsData = ({
     fetchNextPage,
     hasNextPage,
     isError,
+    refetch,
   } = useGetListItemsInfiniteInfiniteQuery(
     {
       projectName,
@@ -184,6 +186,7 @@ const useGetListItemsData = ({
     isFetchingNextPage,
     isError,
     fetchNextPage: handleFetchNextPage,
+    refetch,
   }
 }
 

--- a/src/pages/ProjectListsPage/hooks/useGetListsData.ts
+++ b/src/pages/ProjectListsPage/hooks/useGetListsData.ts
@@ -15,6 +15,7 @@ export interface UseGetListsDataReturn {
   isFetchingNextPage: boolean
   isError: boolean
   fetchNextPage: () => void
+  refetch: () => void
 }
 
 const useGetListsData = ({
@@ -45,6 +46,7 @@ const useGetListsData = ({
     fetchNextPage,
     hasNextPage,
     isError,
+    refetch,
   } = useGetListsInfiniteInfiniteQuery(
     {
       projectName,
@@ -85,6 +87,7 @@ const useGetListsData = ({
     isFetchingNextPage,
     isError,
     fetchNextPage: handleFetchNextPage,
+    refetch,
   }
 }
 

--- a/src/pages/ProjectListsPage/hooks/useReviewSessionCardsModules.tsx
+++ b/src/pages/ProjectListsPage/hooks/useReviewSessionCardsModules.tsx
@@ -5,6 +5,7 @@ import { createContext, PropsWithChildren, useContext } from "react"
 function FallbackReviewCardsProvider({ children }: RemoteAddonProjectProps & PropsWithChildren & {
   onSelectionChange: (versionIds: string[]) => void
   onOpenDetails: (versionId: string) => void
+  onItemsChanged?: () => void
   onOpenInViewer?: (state: {
     versionId: string
     productId: string


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Ensured entity lists and list items data are refreshed if the user adds/removes review session items in the Grid View. This means the Details Panel will work correctly, the items will immediately be visible in the Table view and the number of items in the list (as shown in the left panel) will be updated accordingly.

## Technical details
<!-- Please state any technical details such as limitations -->

For both the `ListsDataContext` and `ListItemsDataContext`, we expose the `refetch` function and trigger it if the Review addon's provider tells us the items have changed.

## Additional context
<!-- Add any other context or screenshots here. -->

