### PR TITLE
List: Fix folder row IDs leaking into list selection lookup

### DIFF
--- a/src/pages/ProjectListsPage/context/ListsProvider.tsx
+++ b/src/pages/ProjectListsPage/context/ListsProvider.tsx
@@ -22,10 +22,13 @@ import { usePowerpack, useProjectContext } from '@shared/context'
 const RowSelectionParam: QueryParamConfig<RowSelectionState> = {
   encode: (rowSelection: RowSelectionState | null | undefined) => {
     if (!rowSelection || Object.keys(rowSelection).length === 0) return undefined
-    // Convert to array of selected row ids
+    // Convert to array of selected row ids, excluding folder row IDs
+    // to prevent folder IDs from leaking into URL params where addons may read them as session IDs
     const selectedIds = Object.entries(rowSelection)
       .filter(([_, selected]) => selected)
+      .filter(([id]) => !parseListFolderRowId(id))
       .map(([id]) => id)
+    if (selectedIds.length === 0) return undefined
     return selectedIds.join(',')
   },
   decode: (input: string | (string | null)[] | null | undefined) => {


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
  - Filter out folder row IDs (folder-{id}) from selectedRows before looking them up in listsMap in ListsProvider
  - Without this, selecting a list folder could pass a folder ID to the review session endpoint, causing a malformed query

## Technical details
<!-- Please state any technical details such as limitations -->


## Additional context
<!-- Add any other context or screenshots here. -->

