### PR TITLE
Comments: Adding over 6 attachments causes formating issues

### DIFF
--- a/shared/src/containers/Feed/components/ActivityComment/ActivityComment.styled.ts
+++ b/shared/src/containers/Feed/components/ActivityComment/ActivityComment.styled.ts
@@ -65,6 +65,7 @@ export const Body = styled.div`
   padding: var(--padding-m);
   padding: 12px 10px;
   position: relative;
+  min-width: 0;
 
   /* remove first and last margins */
   /* + * because tools is actual first */

--- a/shared/src/containers/Feed/components/FilesGrid/FilesGrid.styled.ts
+++ b/shared/src/containers/Feed/components/FilesGrid/FilesGrid.styled.ts
@@ -5,9 +5,9 @@ export const Grid = styled.div`
   grid-template-columns: repeat(auto-fill, minmax(125px, 1fr));
   gap: var(--base-gap-large);
   padding: var(--padding-s);
+  min-width: 0;
 
   &.compact {
-    height: calc(100% + 80px);
     grid-template-columns: repeat(auto-fill, minmax(90px, 1fr));
     gap: var(--base-gap-small);
   }


### PR DESCRIPTION


<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Fix formatting overflow when adding more than 6 attachments to a comment.

## Technical details
<!-- Please state any technical details such as limitations -->
1. **`Body` container missing `min-width: 0`** — As a flex child, it defaulted to `min-width: auto`, allowing the inner CSS Grid (`FilesGrid`) to push it wider than its parent.

2. **`FilesGrid` compact mode had `height: calc(100% + 80px)`** — The parent (`Body`) has no explicit height, so `100%` resolved unpredictably. This fought against the existing `max-height` + `overflow: auto` that already handles scrolling. Removed the explicit height and added `min-width: 0` to thegrid as well.

## Additional context
<!-- Add any other context or screenshots here. -->

