### PR TITLE
Filters: Remove confusing radio button icons for boolean filters

### DIFF
--- a/shared/src/components/SearchFilter/useBuildFilterOptions.tsx
+++ b/shared/src/components/SearchFilter/useBuildFilterOptions.tsx
@@ -423,13 +423,11 @@ export const useBuildFilterOptions = ({
             id: 'true',
             label: 'Yes',
             values: [],
-            icon: 'radio_button_checked',
           },
           {
             id: 'false',
             label: 'No',
             values: [],
-            icon: 'radio_button_unchecked',
           },
         ]
         hasReviewablesOption.values?.push(...options_list)
@@ -504,13 +502,11 @@ export const useBuildFilterOptions = ({
               id: 'true',
               label: 'Yes',
               values: [],
-              icon: 'radio_button_checked',
             },
             {
               id: 'false',
               label: 'No',
               values: [],
-              icon: 'radio_button_unchecked',
             },
           ]
           optionValues.push(...options)
@@ -583,10 +579,10 @@ const getSubTypes = (
             values: [],
             allowsCustomValues: false,
             pt: {
-              style:{
-                color: 'inherit'
-              }
-            }
+              style: {
+                color: 'inherit',
+              },
+            },
           })
         }
       })
@@ -607,10 +603,10 @@ const getSubTypes = (
             values: [],
             allowsCustomValues: false,
             pt: {
-              style:{
-                color: 'inherit'
-              }
-            }
+              style: {
+                color: 'inherit',
+              },
+            },
           })
         }
       })
@@ -884,9 +880,9 @@ const getAttributeOptions = (
         values: [],
         icon: enumItem.icon,
         color: enumItem.color,
-        pt:{
-          style:{color:'inherit'}
-        }
+        pt: {
+          style: { color: 'inherit' },
+        },
       })
     })
   }

--- a/src/pages/ProjectListsPage/components/ListsFiltersDialog/ListsFiltersDialog.tsx
+++ b/src/pages/ProjectListsPage/components/ListsFiltersDialog/ListsFiltersDialog.tsx
@@ -200,12 +200,10 @@ const ListsFiltersDialog: FC<ListsFiltersDialogProps> = ({}) => {
             {
               id: 'true',
               label: 'Yes',
-              icon: 'radio_button_checked',
             },
             {
               id: 'false',
               label: 'No',
-              icon: 'radio_button_unchecked',
             },
           ]
         } else {


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes

The radio icons looked like the current state of the filter. Removing them ensures the user selects which boolean state they want.

<img width="760" height="226" alt="image" src="https://github.com/user-attachments/assets/c373e618-bf67-4c83-a4b8-d8db175de0e8" />

