### PR TITLE
Table: Fix sorting column showing on pinned columns

### DIFF
--- a/shared/src/containers/ProjectTreeTable/ProjectTreeTable.styled.ts
+++ b/shared/src/containers/ProjectTreeTable/ProjectTreeTable.styled.ts
@@ -122,9 +122,10 @@ export const HeaderCell = styled.th`
 
     .actions {
       display: flex !important;
-      background-color: var(--md-sys-color-surface-container-lowest-hover); 
+      background-color: var(--md-sys-color-surface-container-lowest-hover);
     }
 
+    .actions .sort-button,
     .actions .header-menu {
       display: flex !important;
     }
@@ -198,8 +199,15 @@ export const HeaderButtons = styled.div<{ $isOpen: boolean }>`
     display: flex !important;
   }
 
+  .sort-button {
+    display: none !important;
+  }
+
   .sort-button.visible,
-  .sort-button.selected,
+  .sort-button.selected {
+    display: flex !important;
+  }
+
   .pin-button.visible,
   .pin-button.selected {
     display: flex !important;


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
Fix pinned columns incorrectly displaying the sorting icon even when no sorting is active.


## Technical details
<!-- Please state any technical details such as limitations -->

The sort button inside `HeaderButtons` was visible whenever the container was shown (e.g. when a pin button was present) because the `.action` class on the button set `display: flex`, overriding the parent's visibility control.

 **Fix:** Hide `.sort-button` by default (`display: none !important`) inside `HeaderButtons`, and explicitly show it on header hover (alongside `.header-menu`) or when it has `.visible`/`.selected` classes (i.e. when sorting is actually active).
## Additional context
<!-- Add any other context or screenshots here. -->

  Closes #1886 