### PR TITLE
Side Panel: Details tab would cause error

### DIFF
--- a/shared/src/containers/ProjectTreeTable/widgets/CellWidget.tsx
+++ b/shared/src/containers/ProjectTreeTable/widgets/CellWidget.tsx
@@ -115,7 +115,7 @@ export const CellWidget: FC<EditorCellProps> = ({
   const type = attributeData?.type
 
   const { projectName } = useProjectContext()
-  const { isEditing, setEditingCellId } = useCellEditing()
+  const { isEditing, setEditingCellId, getEditingDraft, setEditingDraft } = useCellEditing()
   const { isCellFocused, gridMap, selectCell, focusCell } = useSelectionCellsContext()
   const cellId = getCellId(rowId, columnId)
 
@@ -248,6 +248,10 @@ export const CellWidget: FC<EditorCellProps> = ({
                 value={enumValue.join(', ')}
                 isInherited={isInherited}
                 columnId={columnId}
+                cellId={cellId}
+                onRequestEdit={setEditingCellId}
+                getDraftValue={getEditingDraft}
+                setDraftValue={setEditingDraft}
                 {...sharedProps}
                 {...pt?.text}
               />
@@ -285,6 +289,9 @@ export const CellWidget: FC<EditorCellProps> = ({
             columnId={columnId}
             cellId={cellId}
             type={type as TextWidgetType}
+            onRequestEdit={setEditingCellId}
+            getDraftValue={getEditingDraft}
+            setDraftValue={setEditingDraft}
             {...sharedProps}
             {...pt?.text}
           />

--- a/shared/src/containers/ProjectTreeTable/widgets/TextWidget.tsx
+++ b/shared/src/containers/ProjectTreeTable/widgets/TextWidget.tsx
@@ -12,7 +12,7 @@ import clsx from 'clsx'
 import { parseHtmlToPlainTextWithLinks } from '@shared/util'
 import { TextContentWidget } from './TextContentWidget'
 import { CellEditingDialog } from '@shared/components/LinksManager/CellEditingDialog'
-import { useCellEditing } from '../context/CellEditingContext'
+import { CellId } from '../utils/cellUtils'
 
 // ── Styled components ──────────────────────────────────────────────
 
@@ -144,6 +144,9 @@ export interface TextWidgetProps
   type?: TextWidgetType
   columnId?: string
   cellId?: string
+  onRequestEdit?: (id: CellId | null) => void
+  getDraftValue?: () => string | null
+  setDraftValue?: (value: string | null) => void
 }
 
 export const TextWidget = forwardRef<HTMLSpanElement, TextWidgetProps>(
@@ -159,12 +162,17 @@ export const TextWidget = forwardRef<HTMLSpanElement, TextWidgetProps>(
       type,
       columnId,
       cellId,
+      onRequestEdit,
+      getDraftValue,
+      setDraftValue,
       className,
       ...props
     },
     ref,
   ) => {
-    const { setEditingCellId, getEditingDraft, setEditingDraft } = useCellEditing()
+    const requestEdit = onRequestEdit || (() => undefined)
+    const getCurrentDraft = getDraftValue || (() => null)
+    const setCurrentDraft = setDraftValue || (() => undefined)
 
     const [isHoveredOnCell, setIsHoveredOnCell] = useState(false)
     const [isHoveredOnPreview, setIsHoveredOnPreview] = useState(false)
@@ -285,8 +293,8 @@ export const TextWidget = forwardRef<HTMLSpanElement, TextWidgetProps>(
     // ── Preview click → start editing
     const handlePreviewClick = useCallback(() => {
       updatePreview(false)
-      if (cellId) setEditingCellId(cellId)
-    }, [cellId, setEditingCellId, updatePreview])
+      if (cellId) requestEdit(cellId)
+    }, [cellId, requestEdit, updatePreview])
 
     // For description columns, Ctrl+Enter should save and close — not jump to next row.
     // Remap 'Enter' → 'Click' so CellWidget doesn't call moveToNextRow.
@@ -432,8 +440,8 @@ export const TextWidget = forwardRef<HTMLSpanElement, TextWidgetProps>(
             onChange={handleDescriptionChange}
             onCancelEdit={onCancelEdit}
             onDismissWithoutSave={onCancelEdit}
-            draftValue={getEditingDraft()}
-            onEditingDraftChange={setEditingDraft}
+            draftValue={getCurrentDraft()}
+            onEditingDraftChange={setCurrentDraft}
           />
         )}
 


### PR DESCRIPTION
This pull request refactors how cell editing state is managed and passed between `CellWidget` and `TextWidget` components in the project tree table. The main goal is to make the editing logic more flexible and decoupled by passing editing-related handlers and values as props, rather than relying on context within `TextWidget`.

**Refactoring and Prop Drilling for Editing State:**

* [`CellWidget.tsx`](diffhunk://#diff-5535199b9e6bdc3655bd1d85caa353bcfb790f36049eebe4dd67a519c3604722L118-R118): Passes `setEditingCellId`, `getEditingDraft`, and `setEditingDraft` as props to `TextWidget`, enabling parent-driven control of editing state. [[1]](diffhunk://#diff-5535199b9e6bdc3655bd1d85caa353bcfb790f36049eebe4dd67a519c3604722L118-R118) [[2]](diffhunk://#diff-5535199b9e6bdc3655bd1d85caa353bcfb790f36049eebe4dd67a519c3604722R251-R254) [[3]](diffhunk://#diff-5535199b9e6bdc3655bd1d85caa353bcfb790f36049eebe4dd67a519c3604722R292-R294)
* [`TextWidget.tsx`](diffhunk://#diff-ba26177a8f37613806bbcaddef3a780c6cca698b1d00198f66de8622015798f3R147-R149): Updates `TextWidgetProps` to accept `onRequestEdit`, `getDraftValue`, and `setDraftValue` props, removing its direct dependency on the cell editing context.
* [`TextWidget.tsx`](diffhunk://#diff-ba26177a8f37613806bbcaddef3a780c6cca698b1d00198f66de8622015798f3R165-R175): Uses the new props in place of context methods, ensuring that editing actions and draft management are handled via the provided functions. [[1]](diffhunk://#diff-ba26177a8f37613806bbcaddef3a780c6cca698b1d00198f66de8622015798f3R165-R175) [[2]](diffhunk://#diff-ba26177a8f37613806bbcaddef3a780c6cca698b1d00198f66de8622015798f3L288-R297) [[3]](diffhunk://#diff-ba26177a8f37613806bbcaddef3a780c6cca698b1d00198f66de8622015798f3L435-R444)

**Code Cleanup:**

* [`TextWidget.tsx`](diffhunk://#diff-ba26177a8f37613806bbcaddef3a780c6cca698b1d00198f66de8622015798f3L15-R15): Removes the unused import of `useCellEditing` and instead imports `CellId` for type safety.