### PR TITLE
YN-0582: Overview: Tasks "Folder name" column is empty when grouping tasks

### DIFF
--- a/shared/src/containers/ProjectTreeTable/ProjectTreeTable.tsx
+++ b/shared/src/containers/ProjectTreeTable/ProjectTreeTable.tsx
@@ -374,6 +374,7 @@ export const ProjectTreeTable = ({
     excludedColumns,
     excludedSorting,
     sortableRows,
+    groupBy,
   ])
 
   // Keep ColumnSettingsProvider's allColumns ref up to date

--- a/shared/src/containers/ProjectTreeTable/hooks/useBuildGroupByTableData.ts
+++ b/shared/src/containers/ProjectTreeTable/hooks/useBuildGroupByTableData.ts
@@ -108,6 +108,7 @@ const defaultEntityToGroupRow = (
     entityId: task.id,
     entityType: entityType,
     parentId: task.folderId,
+    folderId: task.folderId,
     name: task.name || '',
     label: task.label || task.name || '',
     icon: typeData?.icon || null,
@@ -121,7 +122,10 @@ const defaultEntityToGroupRow = (
     attrib: task.attrib,
     ownAttrib: task.ownAttrib,
     parents: task.parents || [],
+    folder: task.parents?.[task.parents.length - 1] || undefined,
+    createdAt: task.createdAt,
     updatedAt: task.updatedAt,
+    hasReviewables: task.hasReviewables || false,
     links: linksToTableData(task.links, entityType, {
       folderTypes: project?.folderTypes || [],
       productTypes: Object.values(project.productTypes) || [],


### PR DESCRIPTION


<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
Fixes issue #1880 (YN-0582) where the FolderName column was empty when grouping tasks in the Overview page.                                                                   
              
  ### Bugs Fixed:
  1. **Empty FolderName Column When Grouping** — Tasks were missing folder hierarchy data in the FolderName column when any grouping was applied
  2. **Column Header Visibility** — Column headers would sometimes disappear when toggling between grouped and flat views


## Technical details
<!-- Please state any technical details such as limitations -->
The root cause was two-fold:
  1. The `defaultEntityToGroupRow()` function was creating group rows but wasn't populating all required fields from the original entity data
  2. The columns memo wasn't invalidating when `groupBy` changed, causing outdated column definitions to persist even though the grouping state had changed

## Additional context
<!-- Add any other context or screenshots here. -->

