### PR TITLE
Attributes: Delete attribute at top of page does nothing

### DIFF
--- a/src/pages/SettingsPage/Attributes.jsx
+++ b/src/pages/SettingsPage/Attributes.jsx
@@ -158,7 +158,7 @@ const Attributes = () => {
               label="Delete attribute"
               icon="delete"
               disabled={selectedAttribute?.builtin}
-              onClick={onDelete}
+              onClick={() => onDelete(selectedAttribute)}
             />
             <InputText
               style={{ width: '200px' }}


### PR DESCRIPTION
## Description of changes 

Fix Delete Attributes button on the top of the Attributes tab doing nothing at all

Note: The context menu "Delete" action was working fine

## Technical details

- `onClick={onDelete}` passes the React synthetic click event as the argument instead of `selectedAttribute`. The `onDelete` guard if `(!selected?.name)` catches it silently and returns. The context menu path worked fine because it explicitly calls `() => onDelete(selected)`.


## Additional context

Found this out here: https://github.com/ynput/ayon-backend/pull/898#issuecomment-4165360371
