### PR TITLE
Sort "Copy Settings from" addon version lists by semver

### DIFF
--- a/src/containers/CopySettings/AddonDropdown.jsx
+++ b/src/containers/CopySettings/AddonDropdown.jsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react'
 import { toast } from 'react-toastify'
 import { Dropdown } from '@ynput/ayon-react-components'
 import { useListAddonsQuery } from '@shared/api'
+import { compareBuild, coerce } from 'semver'
 
 const AddonDropdown = ({ addonName, addonVersion, setAddonVersion, disabled }) => {
   const { data: { addons = [] } = {}, isLoading, isError } = useListAddonsQuery({})
@@ -15,10 +16,9 @@ const AddonDropdown = ({ addonName, addonVersion, setAddonVersion, disabled }) =
       return []
     }
 
-    const result = []
-    for (const version in addon.versions) {
-      result.push({ value: version, label: `${addon.title} ${version}` })
-    }
+    const result = Object.keys(addon.versions)
+      .sort((a, b) => -1 * compareBuild(coerce(a) ?? a, coerce(b) ?? b))
+      .map((version) => ({ value: version, label: `${addon.title} ${version}` }))
 
     return result
   }, [addons, isLoading, isError, addonName])


### PR DESCRIPTION
## Description of changes 

Sort "Copy Settings from" addon version lists by semver

This is on e.g. Studio Settings or Project Settings when using the context menu on one or multiple addons.

<img width="467" height="229" alt="image" src="https://github.com/user-attachments/assets/1972bdc1-4f52-455f-8709-d3475281b032" />


## Technical details

- Before: versions were iterated from the `addon.versions` object with no sorting (arbitrary JS object key order)
- After: versions are sorted descending by semver using `compareBuild(coerce(a), coerce(b)` — exactly the same pattern used by the Bundles page (`BundlesAddonList.tsx`), with `coerce()` to gracefully handle non-standard version strings

## Additional context

Before:

<img width="267" height="242" alt="image" src="https://github.com/user-attachments/assets/4cba8a30-afd3-434a-976c-2ce15a7a49da" />


After:

<img width="275" height="250" alt="image" src="https://github.com/user-attachments/assets/5424996d-222e-4612-b46f-9e136a5546a6" />

