### PR TITLE
Comments: Properly fix and style empty lines

### DIFF
--- a/shared/src/containers/Feed/components/ActivityComment/ActivityComment.styled.ts
+++ b/shared/src/containers/Feed/components/ActivityComment/ActivityComment.styled.ts
@@ -67,10 +67,8 @@ export const Body = styled.div`
   position: relative;
   min-width: 0;
 
-  /* remove first and last margins */
-  /* + * because tools is actual first */
-  & > *:nth-child(2) + * {
-    margin-top: 8px;
+  p {
+    margin: 0;
   }
 
   & > *:not(.tools):not(h1) {
@@ -89,6 +87,12 @@ export const Body = styled.div`
     word-break: break-word;
     .reference {
       top: 5px;
+    }
+
+    /* target empty lines with &nbsp; or br */
+    &.empty-line {
+      height: 20px;
+      margin: 0;
     }
   }
 

--- a/shared/src/containers/Feed/components/ActivityComment/ActivityComment.tsx
+++ b/shared/src/containers/Feed/components/ActivityComment/ActivityComment.tsx
@@ -30,6 +30,7 @@ import { useDetailsPanelContext } from '@shared/context'
 import { useBlendedCategoryColor } from '../CommentInput/hooks/useBlendedCategoryColor'
 import { CategoryTag } from '../ActivityCategorySelect/CategoryTag'
 import ActivityCommentMenu from './ActivityCommentMenu'
+import { checkForEmptyLine } from '../CommentInput/InputMarkdownConvert'
 
 type Props = {
   activity: any
@@ -321,6 +322,14 @@ const ActivityComment = ({
                           {props.children}
                         </ActivityStatus>
                       )
+                    },
+                    p: (props) => {
+                      // check for empty paragraphs
+                      const text = props.children
+                      if (typeof text === 'string' && checkForEmptyLine(text)) {
+                        return <p className="empty-line"></p>
+                      }
+                      return <p>{props.children}</p>
                     },
                   }}
                 >

--- a/shared/src/containers/Feed/components/CommentInput/CommentInput.styled.ts
+++ b/shared/src/containers/Feed/components/CommentInput/CommentInput.styled.ts
@@ -387,6 +387,7 @@ export const Comment = styled.div<CommentProps>`
 
       .ql-editor {
         padding: 8px;
+        padding-top: 0px;
       }
     }
   }

--- a/shared/src/containers/Feed/components/CommentInput/InputMarkdownConvert.tsx
+++ b/shared/src/containers/Feed/components/CommentInput/InputMarkdownConvert.tsx
@@ -35,7 +35,23 @@ const convertStringToBlockquotes = (text: string) =>
 
 type ParagraphProps = ComponentProps<'p'> & { node?: unknown }
 
-const Paragraph = ({ node: _node, ...props }: ParagraphProps) => <p {...props} />
+export const checkForEmptyLine = (text: string) => {
+  return text.trim() === '' || text.includes('&nbsp;') || text.includes('<br>')
+}
+
+const Paragraph = ({ node: _node, ...props }: ParagraphProps) => {
+  // ensure empty lines are preserved by checking if the text is empty or contains only &nbsp; or <br>
+  // @ts-expect-error
+  const text = props.children?.[0]
+  if (typeof text === 'string' && checkForEmptyLine(text)) {
+    return (
+      <p className="empty-line">
+        <br></br>
+      </p>
+    )
+  }
+  return <p {...props} />
+}
 
 // Preserve multiple blank lines by replacing sequences of 3+ newlines
 // with interleaved <br> tags so ReactMarkdown renders empty paragraphs.

--- a/shared/src/containers/Feed/components/CommentInput/quillToMarkdown.tsx
+++ b/shared/src/containers/Feed/components/CommentInput/quillToMarkdown.tsx
@@ -17,7 +17,7 @@ turndownService.addRule('emptyParagraph', {
     return childNode?.nodeName === 'BR'
   },
   replacement: function () {
-    return `\n\n<br>\n\n`
+    return `&nbsp;`
   },
 })
 


### PR DESCRIPTION
- Empty lines in comments and description are now stored as `&nbsp;` instead of `<br>`.
- Comments now render `&nbsp;` and `<br>` content as an empty `<p></p>` that has a fixed height.]
- Margins are removed from `p` elements so they match the editor line spacing. 

<img width="526" height="252" alt="image" src="https://github.com/user-attachments/assets/31bcf109-f55c-4300-8c69-31bcfd3a257f" />

<img width="523" height="219" alt="image" src="https://github.com/user-attachments/assets/dbc87619-756b-4b93-9204-0c757b4589a1" />


