### PR TITLE
YN-0649: Kanban: Add group by Parent Folder

### DIFF
--- a/src/pages/UserDashboardPage/UserDashboardTasks/DashboardTasksToolbar/KanBanGroupByOptions.ts
+++ b/src/pages/UserDashboardPage/UserDashboardTasks/DashboardTasksToolbar/KanBanGroupByOptions.ts
@@ -7,6 +7,7 @@ type GroupByOption = {
 
 const groupByOptions: GroupByOption[] = [
   { id: 'folderName', label: 'Folder', sortOrder: true },
+  { id: 'parentFolder', label: 'Parent Folder', sortOrder: true },
   { id: 'status', label: 'Status', sortOrder: true, sortByEnumOrder: true },
   { id: 'priority', label: 'Priority', sortOrder: true, sortByEnumOrder: true },
   { id: 'taskType', label: 'Type', sortOrder: true },

--- a/src/pages/UserDashboardPage/UserDashboardTasks/KanBanCard/KanBanCard.tsx
+++ b/src/pages/UserDashboardPage/UserDashboardTasks/KanBanCard/KanBanCard.tsx
@@ -35,8 +35,9 @@ const KanBanCard = forwardRef<HTMLDivElement, KanBanCardProps>(
     if (!inView && inView !== undefined && !isLoading)
       return <div style={{ minHeight: 'var(--min-height)' }}></div>
 
-    // get second last part of folder path
-    const parent = task.folderPath?.split('/').slice(-3, -1)[0]
+    // get parent folder from path (second to last segment)
+    const pathParts = task.folderPath?.split('/').filter(Boolean) || []
+    const parent = pathParts.length >= 2 ? pathParts[pathParts.length - 2] : undefined
 
     return (
       <>

--- a/src/pages/UserDashboardPage/UserDashboardTasks/KanBanCard/KanBanCard.tsx
+++ b/src/pages/UserDashboardPage/UserDashboardTasks/KanBanCard/KanBanCard.tsx
@@ -35,9 +35,7 @@ const KanBanCard = forwardRef<HTMLDivElement, KanBanCardProps>(
     if (!inView && inView !== undefined && !isLoading)
       return <div style={{ minHeight: 'var(--min-height)' }}></div>
 
-    // get parent folder from path (second to last segment)
-    const pathParts = task.folderPath?.split('/').filter(Boolean) || []
-    const parent = pathParts.length >= 2 ? pathParts[pathParts.length - 2] : undefined
+    const parent = task.parentFolder === 'Root' ? undefined : task.parentFolder
 
     return (
       <>

--- a/src/pages/UserDashboardPage/UserDashboardTasks/transformKanbanTasks.ts
+++ b/src/pages/UserDashboardPage/UserDashboardTasks/transformKanbanTasks.ts
@@ -23,6 +23,7 @@ type ExtraInfo = {
 
 export interface TransformedKanbanTask extends KanbanNode, ExtraInfo {
   thumbnailUrl: string | null
+  parentFolder: string
 }
 
 const transformKanbanTasks = (
@@ -52,12 +53,16 @@ const transformKanbanTasks = (
       (priorityItem) => priorityItem.value === task.priority,
     )
 
+    const pathParts = task.folderPath?.split('/').filter(Boolean) || []
+    const parentFolder = pathParts.length >= 2 ? pathParts[pathParts.length - 2] : 'Root'
+
     return {
       ...task,
       thumbnailUrl: `/api/projects/${task.projectName}/tasks/${task.id}/thumbnail?updatedAt=${task.updatedAt}`,
       statusInfo,
       taskInfo,
       priorityInfo,
+      parentFolder,
     }
   })
 }


### PR DESCRIPTION

<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

  Adds a new "Parent Folder" group by option to the Kanban view on the Dashboard, and fixes an off-by-one bug in the card path display.                             
              
  - **Parent Folder groupBy**: Groups tasks by the immediate parent of their folder (e.g., for `/episodes/ep113/ep113sq008/ep113sq008sh150`, the group is `ep113sq008`). This is distinct from the existing "Folder" groupBy which groups by the task's direct folder.
  - **Card path fix**: The small path text above the folder name on Kanban cards was showing the grandparent folder instead of the parent. Fixed by correctly parsing `folderPath` with `filter(Boolean)` to handle the leading `/`.

## Technical details
<!-- Please state any technical details such as limitations -->
 - `parentFolder` is computed from `folderPath` in `transformKanbanTasks.ts` and read dynamically by `getGroupedTasks` via `task[groupBy.id]`
 - Tasks in folders with no parent (single-level paths) fall back to `'Root'`, though this case shouldn't occur in practice since tasks always require a folder.


## Additional context
<!-- Add any other context or screenshots here. -->

