### PR TITLE
Add a Staging Mode for the frontend

### DIFF
--- a/shared/src/containers/Actions/Actions.tsx
+++ b/shared/src/containers/Actions/Actions.tsx
@@ -9,6 +9,7 @@ import ActionIcon from './ActionIcon'
 import { ActionTriggersProps, useActionTriggers } from '@shared/hooks'
 import { ActionConfigDialog } from './ActionConfigDialog'
 import { InteractiveActionDialog, InteractiveForm } from './InteractiveActionDialog'
+import { FrontendBundleMode, getFrontendBundleVariant } from '@shared/util'
 
 const placeholder = {
   identifier: 'placeholder',
@@ -25,7 +26,7 @@ interface ActionsProps extends ActionTriggersProps {
   isLoadingEntity: boolean
   projectActionsProjectName?: string
   featuredCount?: number
-  isDeveloperMode: boolean
+  frontendBundleMode: FrontendBundleMode
   align?: ActionsDropdownProps['align']
   pt?: {
     dropdown?: Partial<ActionsDropdownProps>
@@ -40,12 +41,13 @@ export const Actions = ({
   projectActionsProjectName,
   searchParams,
   featuredCount = 2,
-  isDeveloperMode,
+  frontendBundleMode,
   onNavigate,
   onSetSearchParams,
   align,
   pt,
 }: ActionsProps) => {
+  const actionVariant = getFrontendBundleVariant(frontendBundleMode)
   // special triggers the actions can make to perform stuff on the client
   const { handleActionPayload } = useActionTriggers({ onNavigate, onSetSearchParams, searchParams })
   const [actionBeingConfigured, setActionBeingConfigured] = useState<any>(null)
@@ -93,7 +95,7 @@ export const Actions = ({
   }, [context])
 
   const { data, isFetching: isFetchingActions } = useGetActionsFromContextQuery(
-    { mode: 'simple', actionContext: context as ActionContext },
+    { mode: 'simple', variant: actionVariant, actionContext: context as ActionContext },
     { skip: !context },
   )
 
@@ -218,7 +220,7 @@ export const Actions = ({
     const params = {
       addonName: action.addonName as string,
       addonVersion: action.addonVersion as string,
-      variant: action.variant,
+      variant: action.variant || actionVariant,
       identifier: action.identifier,
     }
 
@@ -326,7 +328,7 @@ export const Actions = ({
         isLoading={isLoading && featuredCount > 0}
         onAction={handleExecuteAction}
         onConfig={handleConfigureAction}
-        isDeveloperMode={isDeveloperMode}
+        frontendBundleMode={frontendBundleMode}
         align={align}
         {...pt?.dropdown}
       />

--- a/shared/src/containers/Actions/ActionsDropdown/ActionsDropdown.styled.ts
+++ b/shared/src/containers/Actions/ActionsDropdown/ActionsDropdown.styled.ts
@@ -49,7 +49,7 @@ export const StyledDropdown = styled(Dropdown)`
     }
   }
 
-  &.developer {
+  &.dev {
     button {
       background-color: var(--color-hl-developer-container);
       .icon {

--- a/shared/src/containers/Actions/ActionsDropdown/ActionsDropdown.styled.ts
+++ b/shared/src/containers/Actions/ActionsDropdown/ActionsDropdown.styled.ts
@@ -28,8 +28,28 @@ export const StyledDropdown = styled(Dropdown)`
     }
   }
 
-  /* developer mode */
-  &.dev {
+  &.staging {
+    button {
+      background-color: color-mix(
+        in srgb,
+        var(--color-hl-staging) 18%,
+        var(--md-sys-color-surface-container-high)
+      );
+      .icon {
+        color: var(--color-hl-staging);
+      }
+
+      &:hover {
+        background-color: color-mix(
+          in srgb,
+          var(--color-hl-staging) 24%,
+          var(--md-sys-color-surface-container-high)
+        );
+      }
+    }
+  }
+
+  &.developer {
     button {
       background-color: var(--color-hl-developer-container);
       .icon {

--- a/shared/src/containers/Actions/ActionsDropdown/ActionsDropdown.tsx
+++ b/shared/src/containers/Actions/ActionsDropdown/ActionsDropdown.tsx
@@ -12,6 +12,7 @@ import { upperFirst } from 'lodash'
 import ActionIcon from '../ActionIcon'
 import styled from 'styled-components'
 import { IconModel } from '@shared/api'
+import { FrontendBundleMode, getFrontendBundleModeLabel } from '@shared/util'
 
 const ActionItemContainer = styled.div`
   display: flex;
@@ -82,7 +83,7 @@ export const ActionsDropdownItem = ({
 export interface ActionsDropdownProps extends Omit<DropdownProps, 'value'> {
   options: ActionsDropdownItemProps[]
   isLoading?: boolean
-  isDeveloperMode: boolean
+  frontendBundleMode: FrontendBundleMode
   onAction: (value: string) => void
   onConfig: (e: any) => void
 }
@@ -90,7 +91,7 @@ export interface ActionsDropdownProps extends Omit<DropdownProps, 'value'> {
 export const ActionsDropdown = ({
   options,
   isLoading,
-  isDeveloperMode,
+  frontendBundleMode,
   onAction,
   onConfig,
   ...props
@@ -105,7 +106,10 @@ export const ActionsDropdown = ({
     <StyledDropdown
       ref={dropdownRef}
       disabled={isLoading}
-      className={clsx('more', { dev: isDeveloperMode })}
+      className={clsx('more', {
+        staging: frontendBundleMode === 'staging',
+        developer: frontendBundleMode === 'developer',
+      })}
       options={options}
       maxOptionsShown={100}
       value={[]}
@@ -115,7 +119,10 @@ export const ActionsDropdown = ({
       onChange={(v) => onAction(v[0])}
       buttonProps={{
         // @ts-expect-error
-        ['data-tooltip']: isDeveloperMode ? 'Actions (dev bundle)' : 'Actions',
+        ['data-tooltip']:
+          frontendBundleMode === 'production'
+            ? 'Actions'
+            : `Actions (${getFrontendBundleModeLabel(frontendBundleMode)})`,
         ['data-tooltip-delay']: 0,
       }}
       {...props}

--- a/shared/src/containers/Actions/ActionsDropdown/ActionsDropdown.tsx
+++ b/shared/src/containers/Actions/ActionsDropdown/ActionsDropdown.tsx
@@ -108,7 +108,7 @@ export const ActionsDropdown = ({
       disabled={isLoading}
       className={clsx('more', {
         staging: frontendBundleMode === 'staging',
-        developer: frontendBundleMode === 'developer',
+        dev: frontendBundleMode === 'developer',
       })}
       options={options}
       maxOptionsShown={100}

--- a/shared/src/containers/DetailsPanel/components/DetailsPanelHeader/DetailsPanelHeader.tsx
+++ b/shared/src/containers/DetailsPanel/components/DetailsPanelHeader/DetailsPanelHeader.tsx
@@ -57,7 +57,7 @@ const DetailsPanelHeader = ({
   onOpenViewer,
   onEntityFocus,
 }: DetailsPanelHeaderProps) => {
-  const { useSearchParams, useNavigate, isDeveloperMode } = useDetailsPanelContext()
+  const { useSearchParams, useNavigate, frontendBundleMode } = useDetailsPanelContext()
   const navigate = useNavigate()
   const [searchParams, setSearchParams] = useSearchParams()
   const tagsSelectRef = useRef<DropdownRef>(null)
@@ -266,7 +266,7 @@ const DetailsPanelHeader = ({
             entitySubTypes={entitySubTypes}
             isLoadingEntity={!!isFetching || !!isLoading}
             searchParams={searchParams}
-            isDeveloperMode={isDeveloperMode}
+            frontendBundleMode={frontendBundleMode}
             onSetSearchParams={setSearchParams}
             onNavigate={navigate}
           />

--- a/shared/src/context/DetailsPanelContext.tsx
+++ b/shared/src/context/DetailsPanelContext.tsx
@@ -13,6 +13,7 @@ import { PowerpackFeature, usePowerpack } from './PowerpackContext'
 import { useURIContext } from './UriContext'
 import { useLocalStorage } from '@shared/hooks'
 import type { SubtasksManagerProps } from '@shared/components'
+import { FrontendBundleMode, getFrontendBundleMode } from '@shared/util'
 
 // High-level tabs for the details panel
 export type DetailsPanelTab = 'feed' | 'subtasks' | 'details' | 'files'
@@ -80,6 +81,7 @@ export interface DetailsPanelContextProps {
   // debugging used to simulate different values
   debug?: {
     isDeveloperMode?: boolean
+    frontendBundleMode?: FrontendBundleMode
     isGuest?: boolean
     hasLicense?: boolean
   }
@@ -88,6 +90,7 @@ export interface DetailsPanelContextProps {
 // Interface for our simplified context
 export interface DetailsPanelContextType extends DetailsPanelContextProps {
   // user
+  frontendBundleMode: FrontendBundleMode
   isDeveloperMode: boolean
   isGuest: boolean
   // Open state for the panel by scope
@@ -143,10 +146,16 @@ export const DetailsPanelProvider: React.FC<DetailsPanelProviderProps> = ({
   ...forwardedProps
 }) => {
   const user = forwardedProps.user
+  const frontendBundleMode =
+    'frontendBundleMode' in debug && debug.frontendBundleMode
+      ? debug.frontendBundleMode
+      : 'isDeveloperMode' in debug && debug.isDeveloperMode
+        ? 'developer'
+        : getFrontendBundleMode(user)
   const isDeveloperMode =
     'isDeveloperMode' in debug
       ? (debug.isDeveloperMode as boolean)
-      : user?.attrib?.developerMode ?? false
+      : frontendBundleMode === 'developer'
   const isGuest = 'isGuest' in debug ? (debug.isGuest as boolean) : user?.data?.isGuest
 
   // get license from powerpack or forwarded down from props
@@ -339,6 +348,7 @@ export const DetailsPanelProvider: React.FC<DetailsPanelProviderProps> = ({
     setEntities,
     feedAnnotations,
     setFeedAnnotations,
+    frontendBundleMode,
     isDeveloperMode,
     isGuest,
     hasLicense,

--- a/shared/src/util/frontendBundleMode.ts
+++ b/shared/src/util/frontendBundleMode.ts
@@ -1,0 +1,50 @@
+import type { UserModel } from '@shared/api'
+
+export type FrontendBundleMode = 'production' | 'staging' | 'developer'
+
+type UserLike = Pick<UserModel, 'attrib' | 'data'> | null | undefined
+
+const FRONTEND_BUNDLE_MODES: FrontendBundleMode[] = ['production', 'staging', 'developer']
+
+export const isFrontendBundleMode = (value: unknown): value is FrontendBundleMode =>
+  typeof value === 'string' && FRONTEND_BUNDLE_MODES.includes(value as FrontendBundleMode)
+
+export const getFrontendBundleMode = (user?: UserLike): FrontendBundleMode => {
+  const preferredMode = user?.data?.frontendPreferences?.frontendBundleMode
+  const isDeveloper = !!user?.data?.isDeveloper
+
+  if (preferredMode === 'developer') {
+    return isDeveloper ? 'developer' : 'production'
+  }
+
+  if (preferredMode === 'staging') {
+    return 'staging'
+  }
+
+  if (isFrontendBundleMode(preferredMode)) {
+    return preferredMode
+  }
+
+  return 'production'
+}
+
+export const getFrontendBundleVariant = (
+  mode: FrontendBundleMode,
+): 'production' | 'staging' | undefined => {
+  if (mode === 'developer') {
+    return undefined
+  }
+
+  return mode
+}
+
+export const getFrontendBundleModeLabel = (mode: FrontendBundleMode) => {
+  switch (mode) {
+    case 'staging':
+      return 'staging bundle'
+    case 'developer':
+      return 'developer bundle'
+    default:
+      return 'production bundle'
+  }
+}

--- a/shared/src/util/index.ts
+++ b/shared/src/util/index.ts
@@ -22,6 +22,7 @@ export * from './keyboardShortcuts'
 export * from './buildHierarchicalTableRows'
 export * from './folderHierarchy'
 export * from './folderOperations'
+export * from './frontendBundleMode'
 
 import isHTMLElement from './isHTMLElement'
 export { isHTMLElement }

--- a/src/containers/AddonSettings/AddonSettings.jsx
+++ b/src/containers/AddonSettings/AddonSettings.jsx
@@ -53,6 +53,7 @@ import PerProjectBundleConfig, {
 } from '../../components/PerProjectBundleConfig/PerProjectBundleConfig'
 import { useLocalStorage } from '@shared/hooks'
 import InfoMessage from '@components/InfoMessage'
+import { getFrontendBundleMode } from '@shared/util'
 
 /*
  * key is {addonName}|{addonVersion}|{variant}|{siteId}|{projectKey}
@@ -106,6 +107,7 @@ const AddonSettings = ({ projectName, showSites = false, bypassPermissions = fal
   //const navigate = useNavigate()
   const user = useSelector((state) => state.user)
   const developerMode = useMemo(() => user?.attrib?.developerMode, [JSON.stringify(user?.attrib)])
+  const frontendBundleMode = useMemo(() => getFrontendBundleMode(user), [user])
   const userName = useSelector((state) => state.user.name)
 
   const [showHelp, setShowHelp] = useState(false)
@@ -170,10 +172,9 @@ const AddonSettings = ({ projectName, showSites = false, bypassPermissions = fal
     return bundles.filter((bundle) => bundle.isDev && bundle.activeUser === userName)
   }, [bundles, userName])
 
-  // Update selectedBundle when developer mode changes
+  // Keep bundle defaults aligned with the current frontend bundle mode.
   useEffect(() => {
-    if (developerMode) {
-      // Switch to dev bundle when entering developer mode
+    if (frontendBundleMode === 'developer') {
       const devBundle = devBundles.find((bundle) => bundle.isDev && bundle.activeUser === userName)
       if (devBundle) {
         setSelectedBundle({
@@ -182,16 +183,15 @@ const AddonSettings = ({ projectName, showSites = false, bypassPermissions = fal
           projectBundleName: undefined,
         })
       }
-      // If no dev bundle found, stay on current variant (don't switch)
-    } else {
-      // Switch back to production when leaving developer mode
-      setSelectedBundle({
-        variant: 'production',
-        bundleName: null,
-        projectBundleName: undefined,
-      })
+      return
     }
-  }, [developerMode, JSON.stringify(devBundles), userName])
+
+    setSelectedBundle({
+      variant: frontendBundleMode,
+      bundleName: null,
+      projectBundleName: undefined,
+    })
+  }, [frontendBundleMode, JSON.stringify(devBundles), userName])
 
   const onSettingsLoad = (addonName, addonVersion, variant, siteId, data) => {
     const key = `${addonName}|${addonVersion}|${variant}|${siteId}|${projectKey}`

--- a/src/containers/header/AppHeader.tsx
+++ b/src/containers/header/AppHeader.tsx
@@ -65,7 +65,7 @@ const getBundleModeHoverBackgroundColor = (frontendBundleMode: FrontendBundleMod
 }
 
 const FrontendBundleModeDropdown = styled(Dropdown)<{ $mode: FrontendBundleMode }>`
-  height: 36px;
+  height: 32px;
   min-width: 180px;
   margin: 4px 0;
   z-index: 10;
@@ -75,8 +75,8 @@ const FrontendBundleModeDropdown = styled(Dropdown)<{ $mode: FrontendBundleMode 
     color: ${({ $mode }) => getBundleModeTextColor($mode)};
     border: none;
     border-radius: var(--border-radius-l);
-    padding: 4px 8px;
-    min-height: 36px;
+    padding: 2px 8px;
+    min-height: 32px;
     transition: background-color 0.2s;
 
     &:hover {

--- a/src/containers/header/AppHeader.tsx
+++ b/src/containers/header/AppHeader.tsx
@@ -10,6 +10,7 @@ import HeaderButton from './HeaderButton'
 import AppMenu from '@components/Menu/Menus/AppMenu'
 import ProjectMenu from '../ProjectMenu/projectMenu'
 import { useAppDispatch, useAppSelector } from '@state/store'
+import { useListBundlesQuery } from '@queries/bundles/getBundles'
 import InstallerDownloadPrompt from '@components/InstallerDownload/InstallerDownloadPrompt'
 import { useMenuContext } from '@shared/context/MenuContext'
 import { HelpMenu, UserMenu } from '@components/Menu'
@@ -162,6 +163,8 @@ const Header: React.FC = () => {
   // Get developer states
   const isDeveloper = (user?.data as any)?.isDeveloper
   const frontendBundleMode = getFrontendBundleMode(user)
+  const { data: { stagingBundle } = {} } = useListBundlesQuery({ archived: false })
+  const hasActiveStagingBundle = !!stagingBundle
 
   // BUTTON REFS used to attach menu to buttons
   const helpButtonRef = useRef<HTMLButtonElement>(null)
@@ -198,21 +201,31 @@ const Header: React.FC = () => {
   const [updateUser] = useUpdateUserMutation()
   const frontendBundleModeOptions = useMemo<BundleModeOption[]>(
     () =>
-      (isDeveloper
-        ? ['production', 'staging', 'developer']
-        : ['production', 'staging']
+      (
+        isDeveloper
+          ? ([
+              'production',
+              ...(hasActiveStagingBundle ? (['staging'] as const) : []),
+              'developer',
+            ] as const)
+          : (['production', ...(hasActiveStagingBundle ? (['staging'] as const) : [])] as const)
       ).map((value) => ({
         value: value as FrontendBundleMode,
         label: FRONTEND_BUNDLE_MODE_LABELS[value as FrontendBundleMode],
       })),
-    [isDeveloper],
+    [hasActiveStagingBundle, isDeveloper],
   )
+  const visibleFrontendBundleMode = frontendBundleModeOptions.some(
+    ({ value }) => value === frontendBundleMode,
+  )
+    ? frontendBundleMode
+    : 'production'
 
   const renderFrontendBundleMode = (
     frontendBundleModeValue?: FrontendBundleMode,
     isActive?: boolean,
   ) => {
-    const mode = frontendBundleModeValue || frontendBundleMode
+    const mode = frontendBundleModeValue || visibleFrontendBundleMode
 
     return (
       <FrontendBundleModeOptionRow $isActive={isActive}>
@@ -291,21 +304,23 @@ const Header: React.FC = () => {
       <FlexWrapperEnd id="header-menu-right">
         <InstallerDownloadPrompt />
         <ReleaseInstallerPrompt isAdmin={user.data.isAdmin} />
-        <FrontendBundleModeDropdown
-          $mode={frontendBundleMode}
-          value={[frontendBundleMode]}
-          options={frontendBundleModeOptions}
-          onChange={handleBundleModeChange}
-          widthExpand
-          valueTemplate={(value) => (
-            <FrontendBundleModeValue>
-              {renderFrontendBundleMode(value?.[0] as FrontendBundleMode)}
-            </FrontendBundleModeValue>
-          )}
-          itemTemplate={(option, isActive) =>
-            renderFrontendBundleMode(option.value as FrontendBundleMode, isActive)
-          }
-        />
+        {frontendBundleModeOptions.length > 1 && (
+          <FrontendBundleModeDropdown
+            $mode={visibleFrontendBundleMode}
+            value={[visibleFrontendBundleMode]}
+            options={frontendBundleModeOptions}
+            onChange={handleBundleModeChange}
+            widthExpand
+            valueTemplate={(value) => (
+              <FrontendBundleModeValue>
+                {renderFrontendBundleMode(value?.[0] as FrontendBundleMode)}
+              </FrontendBundleModeValue>
+            )}
+            itemTemplate={(option, isActive) =>
+              renderFrontendBundleMode(option.value as FrontendBundleMode, isActive)
+            }
+          />
+        )}
 
         {!user.data.isGuest && (
           <>

--- a/src/containers/header/AppHeader.tsx
+++ b/src/containers/header/AppHeader.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 import type { MouseEvent } from 'react'
 import { Link, useLocation, useNavigate } from 'react-router-dom'
-import { InputSwitch } from '@ynput/ayon-react-components'
+import { Dropdown } from '@ynput/ayon-react-components'
 import { UserImage } from '@shared/components'
 import { useUpdateUserMutation } from '@shared/api'
 
@@ -15,13 +15,14 @@ import { useMenuContext } from '@shared/context/MenuContext'
 import { HelpMenu, UserMenu } from '@components/Menu'
 import { MenuContainer } from '@shared/components'
 import { toast } from 'react-toastify'
-import { toggleDevMode } from '@state/user'
+import { updateUserPreferences } from '@state/user'
 import styled from 'styled-components'
 import { useRestart } from '@context/RestartContext'
 import clsx from 'clsx'
 import InboxNotificationIcon from './InboxNotification'
 import ReleaseInstallerPrompt from '@containers/ReleaseInstallerDialog/ReleaseInstallerPrompt/ReleaseInstallerPrompt'
 import ChatBubbleButton from './ChatBubbleButton'
+import { FrontendBundleMode, getFrontendBundleMode } from '@shared/util'
 
 const FlexWrapper = styled.div`
   display: flex;
@@ -34,53 +35,105 @@ const FlexWrapperEnd = styled.div`
   justify-content: end;
 `
 
-const DeveloperSwitch = styled.div`
-  display: flex;
-  align-items: center;
-  gap: var(--base-gap-small);
-  border-radius: var(--border-radius-l);
-  padding: 4px 4px 4px 8px;
+interface BundleModeOption {
+  value: FrontendBundleMode
+  label: string
+}
+
+const FRONTEND_BUNDLE_MODE_LABELS: Record<FrontendBundleMode, string> = {
+  production: 'Production',
+  staging: 'Staging',
+  developer: 'Developer mode',
+}
+
+const getBundleModeTextColor = (frontendBundleMode: FrontendBundleMode) => {
+  if (frontendBundleMode === 'staging') return 'black'
+  if (frontendBundleMode === 'developer') return 'var(--color-hl-developer)'
+  return 'var(--md-sys-color-on-surface)'
+}
+
+const getBundleModeBackgroundColor = (frontendBundleMode: FrontendBundleMode) => {
+  if (frontendBundleMode === 'staging') return 'var(--color-hl-staging)'
+  if (frontendBundleMode === 'developer') return 'var(--color-hl-developer-container)'
+  return 'var(--md-sys-color-surface-container-highest)'
+}
+
+const getBundleModeHoverBackgroundColor = (frontendBundleMode: FrontendBundleMode) => {
+  if (frontendBundleMode === 'staging') return 'var(--color-hl-staging-hover)'
+  if (frontendBundleMode === 'developer') return 'var(--color-hl-developer-container-hover)'
+  return 'var(--md-sys-color-surface-container-highest-hover)'
+}
+
+const FrontendBundleModeDropdown = styled(Dropdown)<{ $mode: FrontendBundleMode }>`
+  height: 36px;
+  min-width: 180px;
   margin: 4px 0;
-  cursor: pointer;
   z-index: 10;
-  transition: background-color 0.2s;
-  background-color: var(--md-sys-color-surface-container-highest);
 
-  & > span {
-    user-select: none;
-  }
-
-  &:hover {
-    background-color: var(--md-sys-color-surface-container-highest-hover);
-  }
-
-  &.active {
-    background-color: var(--color-hl-developer-container);
-
-    & > span {
-      color: var(--color-hl-developer);
-    }
+  button {
+    background-color: ${({ $mode }) => getBundleModeBackgroundColor($mode)};
+    color: ${({ $mode }) => getBundleModeTextColor($mode)};
+    border: none;
+    border-radius: var(--border-radius-l);
+    padding: 4px 8px;
+    min-height: 36px;
+    transition: background-color 0.2s;
 
     &:hover {
-      background-color: var(--color-hl-developer-container-hover);
+      background-color: ${({ $mode }) => getBundleModeHoverBackgroundColor($mode)};
+    }
+
+    .template-value {
+      border: none;
+      background: transparent;
+      padding: 0;
     }
   }
 `
 
-const StyledSwitch = styled(InputSwitch)`
-  pointer-events: none;
+const FrontendBundleModeValue = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--base-gap-small);
+  min-width: 0;
+`
 
-  .switch-body input:checked + .slider {
-    background-color: var(--color-hl-developer);
-    border-color: var(--color-hl-developer);
+const FrontendBundleModeLabel = styled.span`
+  user-select: none;
+  white-space: nowrap;
+`
 
-    &,
-    &:hover {
-      &::before {
-        background-color: var(--color-hl-developer-container);
-      }
-    }
-  }
+const FrontendBundleModeBadge = styled.span<{ $mode: FrontendBundleMode }>`
+  border-radius: 999px;
+  padding: 2px 6px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  line-height: 1;
+  white-space: nowrap;
+  color: ${({ $mode }) => ($mode === 'developer' ? 'var(--color-hl-developer)' : 'black')};
+  background-color: ${({ $mode }) =>
+    $mode === 'staging'
+      ? 'var(--color-hl-staging)'
+      : $mode === 'developer'
+        ? 'var(--color-hl-developer-container-hover)'
+        : 'var(--color-hl-production)'};
+`
+
+const FrontendBundleModeOptionRow = styled.div<{ $isActive?: boolean }>`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--base-gap-small);
+  padding: 4px 8px;
+  flex: 1;
+
+  ${({ $isActive }) =>
+    $isActive &&
+    `
+      background-color: var(--md-sys-color-primary-container);
+      color: var(--md-sys-color-on-primary-container);
+    `}
 `
 
 const ProjectsButton = styled(HeaderButton)`
@@ -108,7 +161,7 @@ const Header: React.FC = () => {
 
   // Get developer states
   const isDeveloper = (user?.data as any)?.isDeveloper
-  const developerMode = user?.attrib.developerMode
+  const frontendBundleMode = getFrontendBundleMode(user)
 
   // BUTTON REFS used to attach menu to buttons
   const helpButtonRef = useRef<HTMLButtonElement>(null)
@@ -143,26 +196,65 @@ const Header: React.FC = () => {
 
   // UPDATE USER DATA
   const [updateUser] = useUpdateUserMutation()
-  const handleDeveloperMode = async () => {
+  const frontendBundleModeOptions = useMemo<BundleModeOption[]>(
+    () =>
+      (isDeveloper
+        ? ['production', 'staging', 'developer']
+        : ['production', 'staging']
+      ).map((value) => ({
+        value: value as FrontendBundleMode,
+        label: FRONTEND_BUNDLE_MODE_LABELS[value as FrontendBundleMode],
+      })),
+    [isDeveloper],
+  )
+
+  const renderFrontendBundleMode = (
+    frontendBundleModeValue?: FrontendBundleMode,
+    isActive?: boolean,
+  ) => {
+    const mode = frontendBundleModeValue || frontendBundleMode
+
+    return (
+      <FrontendBundleModeOptionRow $isActive={isActive}>
+        <FrontendBundleModeLabel>{FRONTEND_BUNDLE_MODE_LABELS[mode]}</FrontendBundleModeLabel>
+        {mode !== 'production' && (
+          <FrontendBundleModeBadge $mode={mode}>
+            {mode === 'staging' ? 'Staging' : 'Dev'}
+          </FrontendBundleModeBadge>
+        )}
+      </FrontendBundleModeOptionRow>
+    )
+  }
+
+  const handleBundleModeChange = async (value: string[]) => {
     try {
-      const newDeveloperMode = !developerMode
-      // optimistic update the switch
-      dispatch(toggleDevMode(newDeveloperMode))
+      const newFrontendBundleMode =
+        value?.[0] === 'staging' ? 'staging' : value?.[0] === 'developer' && isDeveloper ? 'developer' : 'production'
+      if (newFrontendBundleMode === frontendBundleMode) return
+
+      const updatedFrontendPreferences = {
+        ...(user.data?.frontendPreferences || {}),
+        frontendBundleMode: newFrontendBundleMode,
+      }
+
+      dispatch(updateUserPreferences({ frontendBundleMode: newFrontendBundleMode }))
 
       await updateUser({
         name: user.name,
         patch: {
-          attrib: { developerMode: newDeveloperMode },
+          attrib: { developerMode: newFrontendBundleMode === 'developer' },
+          data: {
+            ...user.data,
+            frontendPreferences: updatedFrontendPreferences,
+          },
         },
       }).unwrap()
 
-      // if the request fails, revert the switch
     } catch (error) {
       console.error(error)
       const errorMessage = (error as any)?.details || 'Unknown error'
-      toast.error('Unable to update developer mode: ' + errorMessage)
-      // reset switch on error
-      dispatch(toggleDevMode(developerMode))
+      toast.error('Unable to update frontend bundle mode: ' + errorMessage)
+      dispatch(updateUserPreferences({ frontendBundleMode }))
     }
   }
 
@@ -199,15 +291,21 @@ const Header: React.FC = () => {
       <FlexWrapperEnd id="header-menu-right">
         <InstallerDownloadPrompt />
         <ReleaseInstallerPrompt isAdmin={user.data.isAdmin} />
-        {isDeveloper && (
-          <DeveloperSwitch
-            className={clsx({ active: developerMode })}
-            onClick={handleDeveloperMode}
-          >
-            <span>Developer Mode</span>
-            <StyledSwitch checked={developerMode} readOnly />
-          </DeveloperSwitch>
-        )}
+        <FrontendBundleModeDropdown
+          $mode={frontendBundleMode}
+          value={[frontendBundleMode]}
+          options={frontendBundleModeOptions}
+          onChange={handleBundleModeChange}
+          widthExpand
+          valueTemplate={(value) => (
+            <FrontendBundleModeValue>
+              {renderFrontendBundleMode(value?.[0] as FrontendBundleMode)}
+            </FrontendBundleModeValue>
+          )}
+          itemTemplate={(option, isActive) =>
+            renderFrontendBundleMode(option.value as FrontendBundleMode, isActive)
+          }
+        />
 
         {!user.data.isGuest && (
           <>

--- a/src/features/user.js
+++ b/src/features/user.js
@@ -1,6 +1,51 @@
 import { createSlice } from '@reduxjs/toolkit'
 import axios from 'axios'
 
+const FRONTEND_BUNDLE_MODES = {
+  production: 'production',
+  staging: 'staging',
+  developer: 'developer',
+}
+
+const DEFAULT_FRONTEND_PREFERENCES = {
+  notifications: false,
+  notificationSound: false,
+  pinnedProjects: [],
+  expandedAccessGroups: {},
+  filters: {},
+  columnSizes: {},
+  pageSettings: {},
+  frontendBundleMode: FRONTEND_BUNDLE_MODES.production,
+}
+
+const sanitizeFrontendBundleMode = (frontendBundleMode, isDeveloper = false) => {
+  if (frontendBundleMode === FRONTEND_BUNDLE_MODES.staging) return FRONTEND_BUNDLE_MODES.staging
+  if (frontendBundleMode === FRONTEND_BUNDLE_MODES.developer && isDeveloper) {
+    return FRONTEND_BUNDLE_MODES.developer
+  }
+
+  return FRONTEND_BUNDLE_MODES.production
+}
+
+const syncFrontendBundleMode = (state) => {
+  if (!state.data) return
+
+  const frontendBundleMode = sanitizeFrontendBundleMode(
+    state.data?.frontendPreferences?.frontendBundleMode,
+    state.data?.isDeveloper,
+  )
+
+  state.data.frontendPreferences = {
+    ...DEFAULT_FRONTEND_PREFERENCES,
+    ...(state.data?.frontendPreferences || {}),
+    frontendBundleMode,
+  }
+
+  if (state.attrib) {
+    state.attrib.developerMode = frontendBundleMode === FRONTEND_BUNDLE_MODES.developer
+  }
+}
+
 const userSlice = createSlice({
   name: 'user',
   initialState: {
@@ -9,15 +54,7 @@ const userSlice = createSlice({
     avatarKey: '',
     uiExposureLevel: 0,
     data: {
-      frontendPreferences: {
-        notifications: false,
-        notificationSound: false,
-        pinnedProjects: [],
-        expandedAccessGroups: {},
-        filters: {},
-        columnSizes: {},
-        pageSettings: {},
-      },
+      frontendPreferences: DEFAULT_FRONTEND_PREFERENCES,
       isAdmin: false,
       isManager: false,
       isUser: true,
@@ -38,13 +75,31 @@ const userSlice = createSlice({
         document.cookie = `accessToken=${action.payload.accessToken}; path=/; max-age=86400`
       }
 
-      const user = { ...action.payload.user, data: { ...action.payload.user?.data } }
+      const user = {
+        ...action.payload.user,
+        data: {
+          ...action.payload.user?.data,
+          frontendPreferences: {
+            ...DEFAULT_FRONTEND_PREFERENCES,
+            ...(action.payload.user?.data?.frontendPreferences || {}),
+          },
+        },
+        attrib: { ...(action.payload.user?.attrib || {}) },
+      }
       // set if isUser
       let isUser = true
       if (user.data) {
         if (user.data.isAdmin || user.data.isManager) isUser = false
         user.data.isUser = isUser
       }
+
+      const frontendBundleMode = sanitizeFrontendBundleMode(
+        user.data?.frontendPreferences?.frontendBundleMode,
+        user.data?.isDeveloper,
+      )
+
+      user.data.frontendPreferences.frontendBundleMode = frontendBundleMode
+      user.attrib.developerMode = frontendBundleMode === FRONTEND_BUNDLE_MODES.developer
 
       if (action.payload.redirectUrl) {
         user.redirectUrl = action.payload.redirectUrl
@@ -65,17 +120,16 @@ const userSlice = createSlice({
     updateUserData: (state, action) => {
       if (!state.data) return
       state.data = { ...state.data, ...action.payload }
-    },
-    toggleDevMode: (state, action) => {
-      if (!state.attrib) return
-      state.attrib.developerMode = action.payload
+      syncFrontendBundleMode(state)
     },
     updateUserPreferences: (state, action) => {
       if (!state.data) return
       state.data.frontendPreferences = {
+        ...DEFAULT_FRONTEND_PREFERENCES,
         ...(state.data?.frontendPreferences || {}),
         ...action.payload,
       }
+      syncFrontendBundleMode(state)
     },
     updateAvatarKey: (state) => {
       state.avatarKey = `?${Date.now()}`
@@ -89,7 +143,6 @@ export const {
   updateUserAttribs,
   updateUserData,
   updateUserPreferences,
-  toggleDevMode,
   updateAvatarKey,
 } = userSlice.actions
 export default userSlice.reducer

--- a/src/hooks/useGetBundleAddonVersions.ts
+++ b/src/hooks/useGetBundleAddonVersions.ts
@@ -1,17 +1,27 @@
 import { useListBundlesQuery } from '@queries/bundles/getBundles'
+import { useGlobalContext } from '@shared/context'
+import { getFrontendBundleMode } from '@shared/util'
 
 type Props = {
   addons: string[]
 }
 
 export const useGetBundleAddonVersions = ({ addons }: Props) => {
+  const { user } = useGlobalContext()
+  const frontendBundleMode = getFrontendBundleMode(user)
   const { data: { bundles, productionBundle, stagingBundle } = {}, isFetching } =
     useListBundlesQuery({})
 
   if (isFetching) return { isLoading: true, addonVersions: new Map<string, string>() }
 
-  // get production, staging, dev, latest bundle
-  const bundleName = productionBundle || stagingBundle
+  const userName = user?.name
+  const activeDevBundle = bundles?.find((bundle) => bundle.isDev && bundle.activeUser === userName)?.name
+  const bundleName =
+    frontendBundleMode === 'developer'
+      ? activeDevBundle || stagingBundle || productionBundle
+      : frontendBundleMode === 'staging'
+        ? stagingBundle || productionBundle
+        : productionBundle || stagingBundle
   const bundleDetails = bundles?.find((b) => b.name === bundleName)
 
   // always return a map, even if no bundle details are found

--- a/src/pages/ProjectListsPage/ProjectListsPage.tsx
+++ b/src/pages/ProjectListsPage/ProjectListsPage.tsx
@@ -54,6 +54,7 @@ import ReviewCardsSettings from './components/ReviewCardsSettings/ReviewCardsSet
 import { ReviewCardsSettingsProvider, useReviewCardsSettingsContext } from './context/ReviewCardsSettingsContext.tsx'
 import ProjectListsDetailsPanels from './components/ProjectListsDetailsPanels/ProjectListsDetailsPanels.tsx'
 import { getCellIdForColumn } from './util/cellIds.ts'
+import { getFrontendBundleMode } from '@shared/util'
 
 type ProjectListsPageProps = {
   projectName: string
@@ -203,8 +204,8 @@ const ProjectLists: FC<ProjectListsProps> = ({
   isReview,
   dndActiveId, // Destructure new prop
 }) => {
-  const user = useAppSelector((state) => state.user?.attrib)
-  const isDeveloperMode = user?.developerMode ?? false
+  const user = useAppSelector((state) => state.user)
+  const frontendBundleMode = getFrontendBundleMode(user)
   const navigate = useNavigate()
   const [searchParams, setSearchParams] = useSearchParams()
   const { projectName } = useProjectContext()
@@ -354,7 +355,7 @@ const ProjectLists: FC<ProjectListsProps> = ({
                     onSetSearchParams={setSearchParams}
                     searchParams={searchParams}
                     featuredCount={0}
-                    isDeveloperMode={isDeveloperMode}
+                    frontendBundleMode={frontendBundleMode}
                     align="right"
                   />
                   {

--- a/src/pages/ProjectOverviewPage/ProjectOverviewPage.tsx
+++ b/src/pages/ProjectOverviewPage/ProjectOverviewPage.tsx
@@ -31,6 +31,7 @@ import useExpandAndSelectNewFolders from './hooks/useExpandAndSelectNewFolders'
 import { QueryFilter } from '@shared/containers/ProjectTreeTable/types/operations'
 import DetailsPanelSplitter from '@components/DetailsPanelSplitter'
 import useGoToEntity from '../../hooks/useGoToEntity'
+import { getFrontendBundleMode } from '@shared/util'
 
 // Configure scope-specific filter types for the search filter
 const scopesConfig: ScopeWithFilterTypes[] = [
@@ -71,7 +72,7 @@ const GroupByDropdown = styled(SortingDropdown)<{
 
 const ProjectOverviewPage: FC = () => {
   const { user } = useGlobalContext()
-  const isDeveloperMode = user?.attrib?.developerMode ?? false
+  const frontendBundleMode = getFrontendBundleMode(user)
 
   const [searchParams, setSearchParams] = useSearchParams()
   const navigate = useNavigate()
@@ -236,7 +237,7 @@ const ProjectOverviewPage: FC = () => {
                 onNavigate={navigate}
                 onSetSearchParams={setSearchParams}
                 searchParams={searchParams}
-                isDeveloperMode={isDeveloperMode}
+                frontendBundleMode={frontendBundleMode}
                 align="right"
               />
               <CustomizeButton />


### PR DESCRIPTION
## Description of changes 

Similar to Developer Mode for developers, you can now run the frontend (as any user) in Staging mode instead of only Production. Setting the mode to Staging allows to run the web actions and applications in staging, from the web frontend.

## Technical details

Refactor ActionsDropdown and related components to use frontendBundleMode instead of isDeveloperMode for improved clarity and flexibility in handling different bundle modes

## Additional context

Replaces the old "Developer mode" checkbox:

<img width="178" height="44" alt="image" src="https://github.com/user-attachments/assets/9d3b3121-810e-472d-9d3f-83cc7855ea3d" />

With dropdown to pick the frontend mode:

<img width="346" height="185" alt="image" src="https://github.com/user-attachments/assets/e08e4ce5-641b-42fe-9527-bf16292269b3" />

<img width="490" height="610" alt="image" src="https://github.com/user-attachments/assets/54297eed-3496-4499-bd6e-9df66a0d466b" />

<img width="515" height="535" alt="image" src="https://github.com/user-attachments/assets/455b44be-b876-4ecb-b6fc-0241b06b41a4" />

Fix https://github.com/ynput/ayon-frontend/issues/1925
