### PR TITLE
Add a project-wide search for folders, tasks or products

### DIFF
--- a/shared/src/api/generated/graphqlLinks.ts
+++ b/shared/src/api/generated/graphqlLinks.ts
@@ -1575,7 +1575,7 @@ export type GetFolderLinkDataQueryVariables = Exact<{
 }>;
 
 
-export type GetFolderLinkDataQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', folder?: { __typename: 'FolderNode', label?: string | null, id: string, name: string, parents: Array<string>, subType: string } | null } };
+export type GetFolderLinkDataQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', folder?: { __typename: 'FolderNode', label?: string | null, id: string, name: string, parents: Array<string>, subType: string, thumbnailId?: string | null, thumbnail?: { __typename?: 'ThumbnailInfo', id: string, relation?: string | null, sourceEntityId?: string | null, sourceEntityType?: string | null } | null } | null } };
 
 export type GetProductLinkDataQueryVariables = Exact<{
   projectName: Scalars['String']['input'];
@@ -1583,7 +1583,7 @@ export type GetProductLinkDataQueryVariables = Exact<{
 }>;
 
 
-export type GetProductLinkDataQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', product?: { __typename: 'ProductNode', id: string, name: string, parents: Array<string> } | null } };
+export type GetProductLinkDataQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', product?: { __typename: 'ProductNode', id: string, name: string, parents: Array<string>, featuredVersion?: { __typename?: 'VersionNode', id: string, thumbnailId?: string | null, thumbnail?: { __typename?: 'ThumbnailInfo', id: string, relation?: string | null, sourceEntityId?: string | null, sourceEntityType?: string | null } | null } | null } | null } };
 
 export type GetRepresentationLinkDataQueryVariables = Exact<{
   projectName: Scalars['String']['input'];
@@ -1599,7 +1599,7 @@ export type GetTaskLinkDataQueryVariables = Exact<{
 }>;
 
 
-export type GetTaskLinkDataQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', task?: { __typename: 'TaskNode', label?: string | null, id: string, name: string, parents: Array<string>, subType: string } | null } };
+export type GetTaskLinkDataQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', task?: { __typename: 'TaskNode', label?: string | null, updatedAt: string, id: string, name: string, parents: Array<string>, subType: string, thumbnailId?: string | null, thumbnail?: { __typename?: 'ThumbnailInfo', id: string, relation?: string | null, sourceEntityId?: string | null, sourceEntityType?: string | null } | null } | null } };
 
 export type GetVersionLinkDataQueryVariables = Exact<{
   projectName: Scalars['String']['input'];
@@ -1607,7 +1607,7 @@ export type GetVersionLinkDataQueryVariables = Exact<{
 }>;
 
 
-export type GetVersionLinkDataQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', version?: { __typename: 'VersionNode', id: string, name: string, parents: Array<string> } | null } };
+export type GetVersionLinkDataQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', version?: { __typename: 'VersionNode', updatedAt: string, id: string, name: string, parents: Array<string> } | null } };
 
 export type GetWorkfileLinkDataQueryVariables = Exact<{
   projectName: Scalars['String']['input'];
@@ -1717,7 +1717,7 @@ export type GetSearchedFoldersQueryVariables = Exact<{
 }>;
 
 
-export type GetSearchedFoldersQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', name: string, folders: { __typename?: 'FoldersConnection', pageInfo: { __typename?: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean }, edges: Array<{ __typename?: 'FolderEdge', cursor?: string | null, node: { __typename: 'FolderNode', label?: string | null, id: string, name: string, parents: Array<string>, subType: string } }> } } };
+export type GetSearchedFoldersQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', name: string, folders: { __typename?: 'FoldersConnection', pageInfo: { __typename?: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean }, edges: Array<{ __typename?: 'FolderEdge', cursor?: string | null, node: { __typename: 'FolderNode', label?: string | null, thumbnailId?: string | null, id: string, name: string, parents: Array<string>, subType: string, thumbnail?: { __typename?: 'ThumbnailInfo', id: string, relation?: string | null, sourceEntityId?: string | null, sourceEntityType?: string | null } | null } }> } } };
 
 export type GetSearchedProductsQueryVariables = Exact<{
   projectName: Scalars['String']['input'];
@@ -1730,7 +1730,7 @@ export type GetSearchedProductsQueryVariables = Exact<{
 }>;
 
 
-export type GetSearchedProductsQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', name: string, products: { __typename?: 'ProductsConnection', pageInfo: { __typename?: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean }, edges: Array<{ __typename?: 'ProductEdge', cursor?: string | null, node: { __typename: 'ProductNode', id: string, name: string, parents: Array<string>, subType: string } }> } } };
+export type GetSearchedProductsQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', name: string, products: { __typename?: 'ProductsConnection', pageInfo: { __typename?: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean }, edges: Array<{ __typename?: 'ProductEdge', cursor?: string | null, node: { __typename: 'ProductNode', id: string, name: string, parents: Array<string>, subType: string, featuredVersion?: { __typename?: 'VersionNode', id: string, thumbnailId?: string | null, thumbnail?: { __typename?: 'ThumbnailInfo', id: string, relation?: string | null, sourceEntityId?: string | null, sourceEntityType?: string | null } | null } | null } }> } } };
 
 export type GetSearchedRepresentationsQueryVariables = Exact<{
   projectName: Scalars['String']['input'];
@@ -1756,7 +1756,7 @@ export type GetSearchedTasksQueryVariables = Exact<{
 }>;
 
 
-export type GetSearchedTasksQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', name: string, tasks: { __typename?: 'TasksConnection', pageInfo: { __typename?: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean }, edges: Array<{ __typename?: 'TaskEdge', cursor?: string | null, node: { __typename: 'TaskNode', label?: string | null, id: string, name: string, parents: Array<string>, subType: string } }> } } };
+export type GetSearchedTasksQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', name: string, tasks: { __typename?: 'TasksConnection', pageInfo: { __typename?: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean }, edges: Array<{ __typename?: 'TaskEdge', cursor?: string | null, node: { __typename: 'TaskNode', label?: string | null, updatedAt: string, thumbnailId?: string | null, id: string, name: string, parents: Array<string>, subType: string, thumbnail?: { __typename?: 'ThumbnailInfo', id: string, relation?: string | null, sourceEntityId?: string | null, sourceEntityType?: string | null } | null } }> } } };
 
 export type GetSearchedVersionsQueryVariables = Exact<{
   projectName: Scalars['String']['input'];
@@ -1769,7 +1769,7 @@ export type GetSearchedVersionsQueryVariables = Exact<{
 }>;
 
 
-export type GetSearchedVersionsQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', name: string, versions: { __typename?: 'VersionsConnection', pageInfo: { __typename?: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean }, edges: Array<{ __typename?: 'VersionEdge', cursor?: string | null, node: { __typename: 'VersionNode', id: string, name: string, parents: Array<string> } }> } } };
+export type GetSearchedVersionsQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', name: string, versions: { __typename?: 'VersionsConnection', pageInfo: { __typename?: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean }, edges: Array<{ __typename?: 'VersionEdge', cursor?: string | null, node: { __typename: 'VersionNode', updatedAt: string, id: string, name: string, parents: Array<string> } }> } } };
 
 export type GetSearchedWorkfilesQueryVariables = Exact<{
   projectName: Scalars['String']['input'];
@@ -1846,6 +1846,13 @@ export const GetFolderLinkDataDocument = `
   project(name: $projectName) {
     folder(id: $folderId) {
       ...OverviewEntityLinkNodeFragment
+      thumbnailId
+      thumbnail {
+        id
+        relation
+        sourceEntityId
+        sourceEntityType
+      }
     }
   }
 }
@@ -1855,6 +1862,16 @@ export const GetProductLinkDataDocument = `
   project(name: $projectName) {
     product(id: $productId) {
       ...OverviewEntityLinkNodeFragment
+      featuredVersion {
+        id
+        thumbnailId
+        thumbnail {
+          id
+          relation
+          sourceEntityId
+          sourceEntityType
+        }
+      }
     }
   }
 }
@@ -1873,6 +1890,14 @@ export const GetTaskLinkDataDocument = `
   project(name: $projectName) {
     task(id: $taskId) {
       ...OverviewEntityLinkNodeFragment
+      updatedAt
+      thumbnailId
+      thumbnail {
+        id
+        relation
+        sourceEntityId
+        sourceEntityType
+      }
     }
   }
 }
@@ -1882,6 +1907,7 @@ export const GetVersionLinkDataDocument = `
   project(name: $projectName) {
     version(id: $versionId) {
       ...OverviewEntityLinkNodeFragment
+      updatedAt
     }
   }
 }
@@ -2027,6 +2053,13 @@ export const GetSearchedFoldersDocument = `
           ...OverviewEntityLinkNodeFragment
           subType: folderType
           label
+          thumbnailId
+          thumbnail {
+            id
+            relation
+            sourceEntityId
+            sourceEntityType
+          }
         }
       }
     }
@@ -2057,6 +2090,16 @@ export const GetSearchedProductsDocument = `
         node {
           ...OverviewEntityLinkNodeFragment
           subType: productType
+          featuredVersion {
+            id
+            thumbnailId
+            thumbnail {
+              id
+              relation
+              sourceEntityId
+              sourceEntityType
+            }
+          }
         }
       }
     }
@@ -2116,6 +2159,14 @@ export const GetSearchedTasksDocument = `
           ...OverviewEntityLinkNodeFragment
           label
           subType: taskType
+          updatedAt
+          thumbnailId
+          thumbnail {
+            id
+            relation
+            sourceEntityId
+            sourceEntityType
+          }
         }
       }
     }
@@ -2144,6 +2195,7 @@ export const GetSearchedVersionsDocument = `
         cursor
         node {
           ...OverviewEntityLinkNodeFragment
+          updatedAt
         }
       }
     }

--- a/shared/src/api/queries/links/getLinks.ts
+++ b/shared/src/api/queries/links/getLinks.ts
@@ -1,12 +1,19 @@
 import { FetchBaseQueryError } from '@reduxjs/toolkit/query'
 import {
+  GetFolderLinkDataQuery,
   GetSearchedFoldersQuery,
   GetSearchedProductsQuery,
   GetSearchedRepresentationsQuery,
   GetSearchedTasksQuery,
   GetSearchedVersionsQuery,
   GetSearchedWorkfilesQuery,
+  GetTaskLinkDataQuery,
+  GetProductLinkDataQuery,
+  GetVersionLinkDataQuery,
+  ResolvedEntityModel,
+  ResolvedUriModel,
   gqlLinksApi,
+  uRIsApi,
 } from '@shared/api/generated'
 import { PubSub } from '@shared/util'
 
@@ -17,14 +24,26 @@ type EntitySearchPageParam = {
   cursor: string
 }
 
+export type SearchEntityThumbnail = {
+  id: string
+  relation?: string
+  sourceEntityId?: string
+  sourceEntityType?: string
+}
+
 export type SearchEntityLink = {
   id: string
   name: string
   entityType: string
   parents: string[]
   label: string
-  icon: string | undefined
+  icon?: string
   subType: string | undefined
+  updatedAt?: string
+  thumbnail?: SearchEntityThumbnail
+  thumbnailId?: string
+  targetEntityType?: string
+  targetEntityId?: string
 }
 
 export type GetSearchedEntitiesLinksResult = {
@@ -54,9 +73,260 @@ type SearchedVersionNode = GetSearchedVersionsQuery['project']['versions']['edge
 type SearchedRepresentationNode =
   GetSearchedRepresentationsQuery['project']['representations']['edges'][0]['node']
 type SearchedWorkfileNode = GetSearchedWorkfilesQuery['project']['workfiles']['edges'][0]['node']
+type ExactEntityType = 'folder' | 'product' | 'task' | 'version'
+type ExactFolderNode = NonNullable<GetFolderLinkDataQuery['project']['folder']>
+type ExactProductNode = NonNullable<GetProductLinkDataQuery['project']['product']>
+type ExactTaskNode = NonNullable<GetTaskLinkDataQuery['project']['task']>
+type ExactVersionNode = NonNullable<GetVersionLinkDataQuery['project']['version']>
+type ExactEntityNode = ExactFolderNode | ExactProductNode | ExactTaskNode | ExactVersionNode
+
+export type GetExactEntityLinkDataArgs = {
+  projectName: string
+  uri: string
+}
+
+const exactEntityTypes = ['folder', 'product', 'task', 'version'] as const
+const exactEntityPriority: Record<ExactEntityType, number> = {
+  folder: 0,
+  task: 1,
+  product: 2,
+  version: 3,
+}
+const resolvedEntityIdKeyByType: Record<ExactEntityType, keyof ResolvedEntityModel> = {
+  folder: 'folderId',
+  product: 'productId',
+  task: 'taskId',
+  version: 'versionId',
+}
+
+const mapSearchEntityThumbnail = (
+  thumbnail?: {
+    id: string
+    relation?: string | null
+    sourceEntityId?: string | null
+    sourceEntityType?: string | null
+  } | null,
+): SearchEntityThumbnail | undefined =>
+  thumbnail
+    ? {
+        id: thumbnail.id,
+        relation: thumbnail.relation || undefined,
+        sourceEntityId: thumbnail.sourceEntityId || undefined,
+        sourceEntityType: thumbnail.sourceEntityType || undefined,
+      }
+    : undefined
+
+const mapEntityNodeToSearchEntityLink = (
+  entityType: SearchEntityLink['entityType'],
+  node:
+    | SearchedTaskNode
+    | SearchedFolderNode
+    | SearchedProductNode
+    | SearchedVersionNode
+    | SearchedRepresentationNode
+    | SearchedWorkfileNode
+    | ExactEntityNode,
+): SearchEntityLink | null => {
+  switch (entityType) {
+    case 'task': {
+      const taskNode = node as SearchedTaskNode | ExactTaskNode
+      return {
+        entityType: 'task',
+        id: taskNode.id,
+        name: taskNode.name,
+        label: taskNode.label || taskNode.name,
+        parents: taskNode.parents || [],
+        subType: taskNode.subType,
+        updatedAt: 'updatedAt' in taskNode ? taskNode.updatedAt : undefined,
+        thumbnail: mapSearchEntityThumbnail('thumbnail' in taskNode ? taskNode.thumbnail : undefined),
+        thumbnailId:
+          ('thumbnailId' in taskNode ? taskNode.thumbnailId : undefined) ??
+          ('thumbnail' in taskNode ? taskNode.thumbnail?.id : undefined),
+      }
+    }
+    case 'folder': {
+      const folderNode = node as SearchedFolderNode | ExactFolderNode
+      return {
+        entityType: 'folder',
+        id: folderNode.id,
+        name: folderNode.name,
+        label: folderNode.label || folderNode.name,
+        parents: folderNode.parents || [],
+        subType: folderNode.subType,
+        thumbnail: mapSearchEntityThumbnail(
+          'thumbnail' in folderNode ? folderNode.thumbnail : undefined,
+        ),
+        thumbnailId:
+          ('thumbnailId' in folderNode ? folderNode.thumbnailId : undefined) ??
+          ('thumbnail' in folderNode ? folderNode.thumbnail?.id : undefined),
+      }
+    }
+    case 'product': {
+      const productNode = node as SearchedProductNode | ExactProductNode
+      const featuredVersion =
+        'featuredVersion' in productNode ? productNode.featuredVersion : undefined
+      return {
+        entityType: 'product',
+        id: productNode.id,
+        name: productNode.name,
+        label: productNode.name,
+        parents: productNode.parents || [],
+        subType: 'subType' in productNode ? productNode.subType : undefined,
+        thumbnail: mapSearchEntityThumbnail(featuredVersion?.thumbnail),
+        thumbnailId: featuredVersion?.thumbnailId || featuredVersion?.thumbnail?.id || undefined,
+        targetEntityType: featuredVersion?.id ? 'version' : 'product',
+        targetEntityId: featuredVersion?.id || productNode.id,
+      }
+    }
+    case 'version': {
+      const versionNode = node as SearchedVersionNode | ExactVersionNode
+      return {
+        entityType: 'version',
+        id: versionNode.id,
+        name: versionNode.name,
+        label: versionNode.name,
+        parents: versionNode.parents || [],
+        updatedAt: 'updatedAt' in versionNode ? versionNode.updatedAt : undefined,
+      }
+    }
+    case 'representation': {
+      const representationNode = node as SearchedRepresentationNode
+      return {
+        entityType: 'representation',
+        id: representationNode.id,
+        name: representationNode.name,
+        label: representationNode.name,
+        parents: representationNode.parents || [],
+      }
+    }
+    case 'workfile': {
+      const workfileNode = node as SearchedWorkfileNode
+      return {
+        entityType: 'workfile',
+        id: workfileNode.id,
+        name: workfileNode.name,
+        label: workfileNode.name,
+        parents: workfileNode.parents || [],
+      }
+    }
+    default:
+      return null
+  }
+}
+
+const getResolvedExactEntity = (
+  resolvedUris: ResolvedUriModel[],
+  projectName: string,
+): { entityType: ExactEntityType; entityId: string } | null => {
+  const matchedEntities = resolvedUris.flatMap((resolvedUri) =>
+    (resolvedUri.entities || []).filter((entity) => {
+      if (!entity.target || !exactEntityTypes.includes(entity.target)) {
+        return false
+      }
+
+      if (entity.projectName && entity.projectName !== projectName) {
+        return false
+      }
+
+      const entityId = entity[resolvedEntityIdKeyByType[entity.target]]
+      return Boolean(entityId)
+    }),
+  )
+
+  const deepestEntity = matchedEntities.sort(
+    (left, right) => exactEntityPriority[right.target!] - exactEntityPriority[left.target!],
+  )[0]
+
+  if (!deepestEntity?.target) {
+    return null
+  }
+
+  const entityId = deepestEntity[resolvedEntityIdKeyByType[deepestEntity.target]]
+  return entityId ? { entityType: deepestEntity.target, entityId } : null
+}
+
+const getExactEntityNode = async (
+  entityType: ExactEntityType,
+  entityId: string,
+  projectName: string,
+  dispatch: any,
+): Promise<ExactEntityNode | null> => {
+  switch (entityType) {
+    case 'task': {
+      const result = await dispatch(
+        gqlLinksApi.endpoints.GetTaskLinkData.initiate(
+          { projectName, taskId: entityId },
+          { forceRefetch: true },
+        ),
+      ).unwrap()
+      return result?.project.task || null
+    }
+    case 'folder': {
+      const result = await dispatch(
+        gqlLinksApi.endpoints.GetFolderLinkData.initiate(
+          { projectName, folderId: entityId },
+          { forceRefetch: true },
+        ),
+      ).unwrap()
+      return result?.project.folder || null
+    }
+    case 'product': {
+      const result = await dispatch(
+        gqlLinksApi.endpoints.GetProductLinkData.initiate(
+          { projectName, productId: entityId },
+          { forceRefetch: true },
+        ),
+      ).unwrap()
+      return result?.project.product || null
+    }
+    case 'version': {
+      const result = await dispatch(
+        gqlLinksApi.endpoints.GetVersionLinkData.initiate(
+          { projectName, versionId: entityId },
+          { forceRefetch: true },
+        ),
+      ).unwrap()
+      return result?.project.version || null
+    }
+  }
+}
 
 const injectedQueries = gqlLinksApi.injectEndpoints({
   endpoints: (build) => ({
+    getExactEntityLinkData: build.query<SearchEntityLink | null, GetExactEntityLinkDataArgs>({
+      queryFn: async ({ projectName, uri }, api) => {
+        try {
+          if (!uri.trim().toLowerCase().startsWith('ayon+entity://')) {
+            return { data: null }
+          }
+
+          const resolvedUris = await api
+            .dispatch(uRIsApi.endpoints.resolveUris.initiate({ resolveRequestModel: { uris: [uri] } }))
+            .unwrap()
+
+          const resolvedEntity = getResolvedExactEntity(resolvedUris, projectName)
+          if (!resolvedEntity) {
+            return { data: null }
+          }
+
+          const entityNode = await getExactEntityNode(
+            resolvedEntity.entityType,
+            resolvedEntity.entityId,
+            projectName,
+            api.dispatch,
+          )
+
+          return {
+            data: entityNode
+              ? mapEntityNodeToSearchEntityLink(resolvedEntity.entityType, entityNode)
+              : null,
+          }
+        } catch (error: any) {
+          console.warn('Error resolving exact entity link data:', error)
+          return { data: null }
+        }
+      },
+    }),
     getSearchedEntitiesLinks: build.infiniteQuery<
       GetSearchedEntitiesLinksResult,
       GetSearchedEntitiesLinksArgs,
@@ -161,69 +431,7 @@ const injectedQueries = gqlLinksApi.injectEndpoints({
 
           // Transform entity data to search link format
           const entities: SearchEntityLink[] = entityData?.edges
-            ?.map(({ node }: any) => {
-              switch (entityType) {
-                case 'task':
-                  const taskNode = node as SearchedTaskNode
-                  return {
-                    entityType: 'task',
-                    id: taskNode.id,
-                    name: taskNode.name,
-                    label: taskNode.label || taskNode.name,
-                    parents: taskNode.parents || [],
-                    subType: taskNode.subType,
-                  }
-                case 'folder':
-                  const folderNode = node as SearchedFolderNode
-                  return {
-                    entityType: 'folder',
-                    id: folderNode.id,
-                    name: folderNode.name,
-                    label: folderNode.label || folderNode.name,
-                    parents: folderNode.parents || [],
-                    subType: folderNode.subType,
-                  }
-                case 'product':
-                  const productNode = node as SearchedProductNode
-                  return {
-                    entityType: 'product',
-                    id: productNode.id,
-                    name: productNode.name,
-                    label: productNode.name,
-                    parents: productNode.parents || [],
-                    subType: productNode.subType,
-                  }
-                case 'version':
-                  const versionNode = node as SearchedVersionNode
-                  return {
-                    entityType: 'version',
-                    id: versionNode.id,
-                    name: versionNode.name,
-                    label: versionNode.name,
-                    parents: versionNode.parents || [],
-                  }
-                case 'representation':
-                  const representationNode = node as SearchedRepresentationNode
-                  return {
-                    entityType: 'representation',
-                    id: representationNode.id,
-                    name: representationNode.name,
-                    label: representationNode.name,
-                    parents: representationNode.parents || [],
-                  }
-                case 'workfile':
-                  const workfileNode = node as SearchedWorkfileNode
-                  return {
-                    entityType: 'workfile',
-                    id: workfileNode.id,
-                    name: workfileNode.name,
-                    label: workfileNode.name,
-                    parents: workfileNode.parents || [],
-                  }
-                default:
-                  return null
-              }
-            })
+            ?.map(({ node }: any) => mapEntityNodeToSearchEntityLink(entityType, node))
             .filter(Boolean) as SearchEntityLink[] // Remove nulls, ensure correct type
 
           if (!entityData) {
@@ -283,4 +491,5 @@ const injectedQueries = gqlLinksApi.injectEndpoints({
   }),
 })
 
-export const { useGetSearchedEntitiesLinksInfiniteQuery } = injectedQueries
+export const { useGetExactEntityLinkDataQuery, useGetSearchedEntitiesLinksInfiniteQuery } =
+  injectedQueries

--- a/shared/src/api/queries/links/gql/LinksGetEntityLinkData.graphql
+++ b/shared/src/api/queries/links/gql/LinksGetEntityLinkData.graphql
@@ -2,6 +2,13 @@ query GetFolderLinkData($projectName: String!, $folderId: String!) {
   project(name: $projectName) {
     folder(id: $folderId) {
       ...OverviewEntityLinkNodeFragment
+      thumbnailId
+      thumbnail {
+        id
+        relation
+        sourceEntityId
+        sourceEntityType
+      }
     }
   }
 }
@@ -10,6 +17,16 @@ query GetProductLinkData($projectName: String!, $productId: String!) {
   project(name: $projectName) {
     product(id: $productId) {
       ...OverviewEntityLinkNodeFragment
+      featuredVersion {
+        id
+        thumbnailId
+        thumbnail {
+          id
+          relation
+          sourceEntityId
+          sourceEntityType
+        }
+      }
     }
   }
 }
@@ -26,6 +43,14 @@ query GetTaskLinkData($projectName: String!, $taskId: String!) {
   project(name: $projectName) {
     task(id: $taskId) {
       ...OverviewEntityLinkNodeFragment
+      updatedAt
+      thumbnailId
+      thumbnail {
+        id
+        relation
+        sourceEntityId
+        sourceEntityType
+      }
     }
   }
 }
@@ -34,6 +59,7 @@ query GetVersionLinkData($projectName: String!, $versionId: String!) {
   project(name: $projectName) {
     version(id: $versionId) {
       ...OverviewEntityLinkNodeFragment
+      updatedAt
     }
   }
 }

--- a/shared/src/api/queries/links/gql/LinksGetSearchedEntity.graphql
+++ b/shared/src/api/queries/links/gql/LinksGetSearchedEntity.graphql
@@ -29,6 +29,13 @@ query GetSearchedFolders(
           ...OverviewEntityLinkNodeFragment
           subType: folderType
           label
+          thumbnailId
+          thumbnail {
+            id
+            relation
+            sourceEntityId
+            sourceEntityType
+          }
         }
       }
     }
@@ -67,6 +74,16 @@ query GetSearchedProducts(
         node {
           ...OverviewEntityLinkNodeFragment
           subType: productType
+          featuredVersion {
+            id
+            thumbnailId
+            thumbnail {
+              id
+              relation
+              sourceEntityId
+              sourceEntityType
+            }
+          }
         }
       }
     }
@@ -103,6 +120,7 @@ query GetSearchedRepresentations(
         cursor
         node {
           ...OverviewEntityLinkNodeFragment
+          updatedAt
         }
       }
     }
@@ -142,6 +160,14 @@ query GetSearchedTasks(
           ...OverviewEntityLinkNodeFragment
           label
           subType: taskType
+          updatedAt
+          thumbnailId
+          thumbnail {
+            id
+            relation
+            sourceEntityId
+            sourceEntityType
+          }
         }
       }
     }

--- a/src/containers/Breadcrumbs/Breadcrumbs.styled.ts
+++ b/src/containers/Breadcrumbs/Breadcrumbs.styled.ts
@@ -6,23 +6,38 @@ export const Wrapper = styled.div`
   justify-content: center;
   inset: 0;
   flex: 1;
+  min-width: 0;
+  position: relative;
 `
 
 export const Crumbtainer = styled.div`
   display: flex;
   flex-direction: row;
   align-items: center;
-
-  button {
+  gap: 0;
+  min-width: 0;
+  max-width: 100%;
+  > button {
     border-radius: 0 var(--border-radius-m) var(--border-radius-m) 0;
     z-index: 100;
+    flex-shrink: 0;
   }
 `
 
-export const CrumbsForm = styled.form`
+export const CrumbsForm = styled.form<{ $isSearchEnabled: boolean }>`
+  position: relative;
   background-color: var(--md-sys-color-secondary-container);
   border-radius: 4px 0 0 4px;
   display: inline-flex;
+  min-width: 0;
+  max-width: min(100%, 760px);
+  overflow: visible;
+
+  &.editing {
+    width: ${({ $isSearchEnabled }) => ($isSearchEnabled ? '100%' : 'auto')};
+    min-width: 0;
+  }
+
   *::before,
   *::after {
     box-sizing: border-box;
@@ -48,6 +63,8 @@ export const CrumbsForm = styled.form`
     position: relative;
     padding: 0;
     grid-template-columns: 1fr;
+    min-width: 0;
+    max-width: 100%;
 
     &::after,
     input {
@@ -78,6 +95,19 @@ export const CrumbsForm = styled.form`
       font-size: var(--md-sys-typescale-title-small-font-size);
       letter-spacing: var(--md-sys-typescale-title-small-letter-spacing);
       line-height: var(--md-sys-typescale-title-small-line-height);
+    }
+
+    .editing & {
+      flex: 1 1 auto;
+      width: auto;
+      max-width: 100%;
+    }
+
+    .editing &::after,
+    .editing & input {
+      width: 100%;
+      min-width: 0;
+      max-width: 100%;
     }
 
 

--- a/src/containers/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/containers/Breadcrumbs/Breadcrumbs.tsx
@@ -1,11 +1,18 @@
-import { useEffect, useState, useRef } from 'react'
-import { Button, InputText } from '@ynput/ayon-react-components'
+import { useCallback, useEffect, useId, useRef, useState } from 'react'
+import { Button, Icon, InputText } from '@ynput/ayon-react-components'
 import * as Styled from './Breadcrumbs.styled'
 
 import { upperFirst } from 'lodash'
 import { copyToClipboard } from '@shared/util'
 import { useURIContext } from '@shared/context'
 import clsx from 'clsx'
+import { useLocation, useNavigate } from 'react-router-dom'
+
+import * as SearchStyled from '../header/GlobalSearch/GlobalProjectSearch.styled'
+import {
+  useGlobalProjectSearch,
+} from '../header/GlobalSearch/useGlobalProjectSearch'
+import type { GlobalSearchResult } from '../header/GlobalSearch/useGlobalProjectSearch'
 
 const parseQueryParams = (query: string): Record<string, string> => {
   if (!query) return {}
@@ -65,24 +72,86 @@ const uri2crumbs = (uri: string = '', pathname: string): string[] => {
   return crumbs
 }
 
-const Breadcrumbs = () => {
-  const location = window.location
+type Props = {
+  projectName?: string
+}
+
+type EditMode = 'view' | 'edit'
+
+const getContextLabel = ({ entityType, pathLabel, subType }: GlobalSearchResult) => {
+  const entityLabel = [entityType, subType].filter(Boolean).join(' · ')
+  return [entityLabel, pathLabel].filter(Boolean).join(' • ')
+}
+
+const GlobalSearchResultMedia = ({ result }: { result: GlobalSearchResult }) => {
+  const [hasThumbnailError, setHasThumbnailError] = useState(false)
+
+  if (result.thumbnailUrl && !hasThumbnailError) {
+    return (
+      <SearchStyled.ResultMedia>
+        <SearchStyled.ResultThumbnail
+          src={result.thumbnailUrl}
+          alt=""
+          aria-hidden
+          loading="lazy"
+          onError={() => setHasThumbnailError(true)}
+        />
+      </SearchStyled.ResultMedia>
+    )
+  }
+
+  return (
+    <SearchStyled.ResultMedia>
+      <Icon
+        icon={result.icon}
+        className="result-icon"
+        style={result.iconColor ? { color: result.iconColor } : undefined}
+      />
+    </SearchStyled.ResultMedia>
+  )
+}
+
+const Breadcrumbs = ({ projectName }: Props) => {
+  const location = useLocation()
+  const navigate = useNavigate()
+  const browserLocation = window.location
 
   const [localUri, setLocalUri] = useState<string>('')
-  const [editMode, setEditMode] = useState<boolean>(false)
-  const { uri = '' } = useURIContext()
-  const { setUri } = useURIContext()
+  const [editMode, setEditMode] = useState<EditMode>('view')
+  const [highlightedIndex, setHighlightedIndex] = useState(-1)
+  const { uri = '', setUri } = useURIContext()
 
   const inputRef = useRef<HTMLInputElement>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const optionRefs = useRef<Array<HTMLButtonElement | null>>([])
+  const listId = useId()
+  const canSearchProject = !!projectName?.trim()
+  const isEditing = editMode !== 'view'
+  const trimmedInput = localUri.trim()
+  const hasSearch = isEditing && canSearchProject && !!trimmedInput
+
+  const { results, isLoading, isFetching } = useGlobalProjectSearch({
+    projectName,
+    search: hasSearch ? trimmedInput : '',
+    limit: 8,
+  })
+
+  const showEmptyState = hasSearch && !isLoading && !isFetching && !results.length
+  const showDropdown = hasSearch && (isLoading || isFetching || !!results.length || showEmptyState)
 
   // keep localUri in sync with real uri
   useEffect(() => {
     setLocalUri(uri)
   }, [uri])
 
+  useEffect(() => {
+    setEditMode('view')
+    setHighlightedIndex(-1)
+  }, [location.pathname, projectName])
+
   //   when editing, select all text
   useEffect(() => {
-    if (!editMode) return
+    if (!isEditing) return
     inputRef.current?.select()
 
     // reselect to counter mouse movement
@@ -99,90 +168,239 @@ const Breadcrumbs = () => {
       clearTimeout(timeout)
       clearTimeout(timeout2)
     }
-  }, [editMode])
+  }, [isEditing])
+
+  useEffect(() => {
+    const handlePointerDown = (event: MouseEvent) => {
+      const target = event.target as Node
+      if (containerRef.current?.contains(target)) return
+
+      setEditMode('view')
+      setHighlightedIndex(-1)
+      setLocalUri(uri)
+    }
+
+    document.addEventListener('mousedown', handlePointerDown)
+
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown)
+    }
+  }, [uri])
+
+  useEffect(() => {
+    if (!results.length) {
+      setHighlightedIndex(-1)
+      return
+    }
+
+    setHighlightedIndex((currentIndex) =>
+      currentIndex >= results.length ? results.length - 1 : currentIndex,
+    )
+  }, [results])
+
+  useEffect(() => {
+    if (highlightedIndex < 0) return
+    optionRefs.current[highlightedIndex]?.scrollIntoView({ block: 'nearest' })
+  }, [highlightedIndex])
+
+  const focusInput = useCallback(() => {
+    window.requestAnimationFrame(() => inputRef.current?.focus())
+  }, [])
+
+  const openEditor = useCallback(() => {
+    setLocalUri(uri)
+    setEditMode('edit')
+    setHighlightedIndex(-1)
+    focusInput()
+  }, [focusInput, uri])
+
+  const closeEditor = useCallback(
+    (resetValue = true) => {
+      setEditMode('view')
+      setHighlightedIndex(-1)
+      if (resetValue) setLocalUri(uri)
+      inputRef.current?.blur()
+    },
+    [uri],
+  )
 
   const goThere = async (e?: React.SyntheticEvent) => {
     e?.preventDefault()
-    setEditMode(false)
-    // blur input
+    const nextUri = localUri.trim()
+    if (!nextUri) {
+      closeEditor()
+      return
+    }
+
+    setEditMode('view')
+    setHighlightedIndex(-1)
     inputRef.current?.blur()
 
     try {
       //  set uri
-      setUri(localUri)
+      setUri(nextUri)
       // refresh page ensures that states use this new uri
-      location.reload()
+      browserLocation.reload()
     } catch (error) {
       console.error(error)
       setLocalUri(uri)
     } finally {
-      setEditMode(false)
+      setEditMode('view')
     }
+  }
+
+  const handleSelect = (result: GlobalSearchResult) => {
+    setHighlightedIndex(-1)
+    setEditMode('view')
+    setLocalUri(result.uri)
+    inputRef.current?.blur()
+    setUri(result.uri)
+    navigate(result.targetUrl)
   }
 
   const onCopy = () => {
     copyToClipboard(localUri)
   }
 
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    // if escape, cancel edit mode
-    if (['Escape', 'Enter'].includes(e.key)) {
-      setEditMode(false)
-      setLocalUri(uri)
-      inputRef.current?.blur()
+  const handleFocus = () => {
+    if (editMode === 'view') {
+      openEditor()
     }
-    if (e.key === 'Enter') {
-      goThere(e)
+  }
+
+  const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+    const nextTarget = e.relatedTarget as Node | null
+    if (nextTarget && containerRef.current?.contains(nextTarget)) return
+    closeEditor()
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    switch (e.key) {
+      case 'ArrowDown':
+        if (!hasSearch || !results.length) return
+        e.preventDefault()
+        setHighlightedIndex((currentIndex) =>
+          currentIndex < results.length - 1 ? currentIndex + 1 : 0,
+        )
+        break
+      case 'ArrowUp':
+        if (!hasSearch || !results.length) return
+        e.preventDefault()
+        setHighlightedIndex((currentIndex) =>
+          currentIndex > 0 ? currentIndex - 1 : results.length - 1,
+        )
+        break
+      case 'Escape':
+        e.preventDefault()
+        e.stopPropagation()
+        closeEditor()
+        break
+      case 'Enter':
+        if (hasSearch && results.length) {
+          e.preventDefault()
+          handleSelect(results[highlightedIndex >= 0 ? highlightedIndex : 0])
+          break
+        }
+        goThere(e)
+        break
     }
   }
 
   const uriDisplay = uri2crumbs(uri, location.pathname).join(' / ')
-  const inputValue = editMode ? localUri : uriDisplay || 'Go to URI...'
+  const placeholder = canSearchProject ? 'Search this project or paste URI...' : 'Go to URI...'
+  const inputValue = isEditing ? localUri : uriDisplay || placeholder
 
   return (
-    <Styled.Wrapper>
-      <Styled.Crumbtainer>
-        <Styled.CrumbsForm onSubmit={goThere} className={clsx({ noUri: !uriDisplay || !localUri })}>
-          {uriDisplay && localUri && (
+    <Styled.Wrapper ref={containerRef}>
+      <Styled.Crumbtainer className={clsx({ editing: isEditing })}>
+          <Styled.CrumbsForm
+            $isSearchEnabled={canSearchProject}
+            onSubmit={goThere}
+            className={clsx({
+              noUri: !isEditing && (!uriDisplay || !uri),
+            editing: isEditing,
+          })}
+        >
+          {(canSearchProject || (uriDisplay && localUri)) && (
             <Button
-              icon="edit"
+              icon={canSearchProject ? 'search' : 'edit'}
+              aria-label={canSearchProject ? 'Search this project' : 'Edit URI'}
               style={{
-                padding: editMode ? 0 : '6px',
-                opacity: editMode ? 0 : 1,
-                width: editMode ? 0 : 'auto',
+                padding: isEditing ? 0 : '6px',
+                opacity: isEditing ? 0 : 1,
+                width: isEditing ? 0 : 'auto',
               }}
               onClick={(e) => {
                 e.preventDefault()
-                setEditMode(true)
+                openEditor()
               }}
               variant="tonal"
             />
           )}
-          <label data-value={inputValue}>
+          <label data-value={inputValue || placeholder}>
             <InputText
               value={inputValue}
               onChange={(e) => setLocalUri(e.target.value)}
-              onBlur={() => setEditMode(false)}
-              onFocus={() => setEditMode(true)}
+              onBlur={handleBlur}
+              onFocus={handleFocus}
               onKeyDown={handleKeyDown}
               ref={inputRef}
+              placeholder={placeholder}
+              aria-label={
+                canSearchProject ? `Search within project ${projectName} or go to URI` : 'Go to URI'
+              }
+              aria-autocomplete={canSearchProject ? 'list' : undefined}
+              aria-controls={showDropdown ? listId : undefined}
+              aria-expanded={showDropdown}
+              autoComplete="off"
               style={{ borderRadius: '4px 0 0 4px' }}
             />
           </label>
           <Button
             icon="arrow_forward"
             style={{
-              display: editMode ? 'inline-flex' : 'none',
+              display: isEditing ? 'inline-flex' : 'none',
               borderRadius: '0 4px 4px 0',
             }}
             onMouseDown={goThere}
             variant="tonal"
           />
+          {showDropdown && (
+            <SearchStyled.Dropdown id={listId} role="listbox">
+              {results.map((result, index) => (
+                <SearchStyled.ResultButton
+                  key={result.id}
+                  ref={(element) => {
+                    optionRefs.current[index] = element
+                  }}
+                  type="button"
+                  role="option"
+                  className={clsx({ highlighted: index === highlightedIndex })}
+                  aria-selected={index === highlightedIndex}
+                  onMouseDown={(event) => event.preventDefault()}
+                  onMouseEnter={() => setHighlightedIndex(index)}
+                  onClick={() => handleSelect(result)}
+                >
+                  <GlobalSearchResultMedia result={result} />
+                  <SearchStyled.ResultBody>
+                    <SearchStyled.PrimaryText>{result.label || result.name}</SearchStyled.PrimaryText>
+                    <SearchStyled.SecondaryText>{getContextLabel(result)}</SearchStyled.SecondaryText>
+                  </SearchStyled.ResultBody>
+                </SearchStyled.ResultButton>
+              ))}
+
+              {!results.length && (
+                <SearchStyled.StatusRow>
+                  {isLoading || isFetching ? 'Searching...' : 'No matches found'}
+                </SearchStyled.StatusRow>
+              )}
+            </SearchStyled.Dropdown>
+          )}
         </Styled.CrumbsForm>
         {uriDisplay && localUri && (
           <Button
             icon="content_copy"
-            style={{ display: editMode ? 'none' : 'inline-flex' }}
+            style={{ display: isEditing ? 'none' : 'inline-flex' }}
             onClick={onCopy}
             variant="tonal"
           />

--- a/src/containers/header/AppHeader.tsx
+++ b/src/containers/header/AppHeader.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react'
 import type { MouseEvent } from 'react'
-import { Link, useLocation, useNavigate } from 'react-router-dom'
+import { Link, useLocation, useMatch, useNavigate } from 'react-router-dom'
 import { InputSwitch } from '@ynput/ayon-react-components'
 import { UserImage } from '@shared/components'
 import { useUpdateUserMutation } from '@shared/api'
@@ -92,6 +92,38 @@ const UserButton = styled(HeaderButton)`
   padding: 6px;
 `
 
+const HeaderCenter = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  gap: var(--base-gap-small);
+  min-width: 0;
+`
+
+const HeaderCenterContent = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0;
+  width: min(100%, 760px);
+  min-width: 0;
+  max-width: 100%;
+`
+
+const HeaderCenterSlot = styled.div`
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 1 1 auto;
+
+  & > * {
+    min-width: 0;
+    width: 100%;
+  }
+`
+
 const Header: React.FC = () => {
   const dispatch = useAppDispatch()
   const { menuOpen, toggleMenuOpen, setMenuOpen } = useMenuContext()
@@ -99,6 +131,10 @@ const Header: React.FC = () => {
   const handleSetMenu = (menu: string | false) => setMenuOpen(menu)
   const location = useLocation()
   const navigate = useNavigate()
+  const projectRouteMatch = useMatch('/projects/:projectName')
+  const projectModuleMatch = useMatch('/projects/:projectName/*')
+  const projectMatch = projectModuleMatch ?? projectRouteMatch
+  const projectName = projectMatch?.params.projectName
   // get user from redux store
   const user = useAppSelector((state) => state.user)
   const avatarKey = useAppSelector((state) => state.user.avatarKey)
@@ -195,7 +231,13 @@ const Header: React.FC = () => {
         <ProjectMenu isOpen={menuOpen === 'project'} onHide={() => handleSetMenu(false)} />
       </FlexWrapper>
 
-      <Breadcrumbs />
+      <HeaderCenter>
+        <HeaderCenterContent>
+          <HeaderCenterSlot>
+            <Breadcrumbs projectName={projectName} />
+          </HeaderCenterSlot>
+        </HeaderCenterContent>
+      </HeaderCenter>
       <FlexWrapperEnd id="header-menu-right">
         <InstallerDownloadPrompt />
         <ReleaseInstallerPrompt isAdmin={user.data.isAdmin} />

--- a/src/containers/header/GlobalSearch/GlobalProjectSearch.styled.ts
+++ b/src/containers/header/GlobalSearch/GlobalProjectSearch.styled.ts
@@ -1,0 +1,128 @@
+import { InputText } from '@ynput/ayon-react-components'
+import styled from 'styled-components'
+
+export const Container = styled.div`
+  position: relative;
+  width: 100%;
+  min-width: 0;
+  z-index: 1400;
+`
+
+export const SearchField = styled.div`
+  position: relative;
+  display: flex;
+  align-items: center;
+  width: 100%;
+
+  .search-icon {
+    position: absolute;
+    left: 10px;
+    color: var(--md-sys-color-on-surface-variant);
+    pointer-events: none;
+    z-index: 1;
+  }
+`
+
+export const SearchInput = styled(InputText)`
+  width: 100%;
+  padding-left: 34px;
+  background-color: var(--md-sys-color-surface-container-highest);
+  border-radius: var(--border-radius-m) 0 0 var(--border-radius-m);
+`
+
+export const Dropdown = styled.div`
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  width: max(100%, min(520px, calc(100vw - 32px)));
+  max-width: calc(100vw - 32px);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 6px;
+  background-color: var(--md-sys-color-surface-container-low);
+  border: 1px solid var(--md-sys-color-outline-variant);
+  border-radius: var(--border-radius-m);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.2);
+  max-height: min(420px, calc(100vh - 120px));
+  overflow-y: auto;
+  z-index: 1402;
+`
+
+export const ResultButton = styled.button`
+  width: 100%;
+  border: none;
+  background: transparent;
+  color: inherit;
+  display: grid;
+  grid-template-columns: 28px 1fr;
+  gap: 10px;
+  align-items: center;
+  padding: 8px 10px;
+  border-radius: var(--border-radius-m);
+  text-align: left;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+
+  .result-icon {
+    color: var(--md-sys-color-on-surface-variant);
+  }
+
+  &:hover,
+  &.highlighted {
+    background-color: var(--md-sys-color-surface-container-highest);
+  }
+`
+
+export const ResultMedia = styled.span`
+  width: 28px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+
+  .result-icon {
+    color: var(--md-sys-color-on-surface-variant);
+    font-size: 18px;
+    line-height: 1;
+  }
+`
+
+export const ResultThumbnail = styled.img`
+  width: 100%;
+  height: 100%;
+  display: block;
+  border-radius: var(--border-radius-s);
+  object-fit: cover;
+  background-color: var(--md-sys-color-surface-container-highest);
+`
+
+export const ResultBody = styled.span`
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+`
+
+export const PrimaryText = styled.span`
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--md-sys-color-on-surface);
+`
+
+export const SecondaryText = styled.span`
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--md-sys-color-on-surface-variant);
+  font-size: 0.85rem;
+`
+
+export const StatusRow = styled.div`
+  padding: 10px 12px;
+  color: var(--md-sys-color-on-surface-variant);
+  font-size: 0.9rem;
+`

--- a/src/containers/header/GlobalSearch/GlobalProjectSearch.tsx
+++ b/src/containers/header/GlobalSearch/GlobalProjectSearch.tsx
@@ -1,0 +1,242 @@
+import { Icon } from '@ynput/ayon-react-components'
+import { useURIContext } from '@shared/context'
+import { useCallback, useEffect, useId, useRef, useState } from 'react'
+import type { RefObject } from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
+import clsx from 'clsx'
+
+import * as Styled from './GlobalProjectSearch.styled'
+import {
+  GlobalSearchResult,
+  useGlobalProjectSearch,
+} from './useGlobalProjectSearch'
+
+type Props = {
+  projectName: string
+  onClose?: () => void
+  triggerRef?: RefObject<HTMLElement>
+}
+
+const getContextLabel = ({ entityType, pathLabel, subType }: GlobalSearchResult) => {
+  const entityLabel = [entityType, subType].filter(Boolean).join(' · ')
+  return [entityLabel, pathLabel].filter(Boolean).join(' • ')
+}
+
+const GlobalSearchResultMedia = ({ result }: { result: GlobalSearchResult }) => {
+  const [hasThumbnailError, setHasThumbnailError] = useState(false)
+
+  if (result.thumbnailUrl && !hasThumbnailError) {
+    return (
+      <Styled.ResultMedia>
+        <Styled.ResultThumbnail
+          src={result.thumbnailUrl}
+          alt=""
+          aria-hidden
+          loading="lazy"
+          onError={() => setHasThumbnailError(true)}
+        />
+      </Styled.ResultMedia>
+    )
+  }
+
+  return (
+    <Styled.ResultMedia>
+      <Icon
+        icon={result.icon}
+        className="result-icon"
+        style={result.iconColor ? { color: result.iconColor } : undefined}
+      />
+    </Styled.ResultMedia>
+  )
+}
+
+const GlobalProjectSearch = ({ projectName, onClose, triggerRef }: Props) => {
+  const navigate = useNavigate()
+  const location = useLocation()
+  const { setUri } = useURIContext()
+  const inputRef = useRef<HTMLInputElement>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const optionRefs = useRef<Array<HTMLButtonElement | null>>([])
+  const listId = useId()
+
+  const [search, setSearch] = useState('')
+  const [isOpen, setIsOpen] = useState(false)
+  const [highlightedIndex, setHighlightedIndex] = useState(-1)
+
+  const trimmedSearch = search.trim()
+  const hasSearch = !!trimmedSearch
+
+  const { results, isLoading, isFetching } = useGlobalProjectSearch({
+    projectName,
+    search: trimmedSearch,
+    limit: 8,
+  })
+
+  const showEmptyState = hasSearch && !isLoading && !isFetching && !results.length
+  const showDropdown = isOpen && hasSearch && (isLoading || isFetching || !!results.length || showEmptyState)
+
+  const closeDropdown = () => {
+    setIsOpen(false)
+    setHighlightedIndex(-1)
+  }
+
+  const resetSearch = () => {
+    setSearch('')
+    closeDropdown()
+  }
+
+  const closeSearch = useCallback(() => {
+    setSearch('')
+    setIsOpen(false)
+    setHighlightedIndex(-1)
+    inputRef.current?.blur()
+    onClose?.()
+  }, [onClose])
+
+  const handleSelect = (result: GlobalSearchResult) => {
+    closeSearch()
+    setUri(result.uri)
+    navigate(result.targetUrl)
+  }
+
+  useEffect(() => {
+    inputRef.current?.focus()
+  }, [])
+
+  useEffect(() => {
+    const handlePointerDown = (event: MouseEvent) => {
+      const target = event.target as Node
+      if (containerRef.current?.contains(target)) return
+      if (triggerRef?.current?.contains(target)) return
+
+      closeSearch()
+    }
+
+    document.addEventListener('mousedown', handlePointerDown)
+
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown)
+    }
+  }, [closeSearch, triggerRef])
+
+  useEffect(() => {
+    resetSearch()
+  }, [location.pathname, projectName])
+
+  useEffect(() => {
+    if (!results.length) {
+      setHighlightedIndex(-1)
+      return
+    }
+
+    setHighlightedIndex((currentIndex) =>
+      currentIndex >= results.length ? results.length - 1 : currentIndex,
+    )
+  }, [results])
+
+  useEffect(() => {
+    if (highlightedIndex < 0) return
+    optionRefs.current[highlightedIndex]?.scrollIntoView({ block: 'nearest' })
+  }, [highlightedIndex])
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value
+    const nextSearch = value.trim()
+
+    setSearch(value)
+    setHighlightedIndex(-1)
+    setIsOpen(!!nextSearch)
+  }
+
+  const handleFocus = () => {
+    if (trimmedSearch) {
+      setIsOpen(true)
+    }
+  }
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    switch (event.key) {
+      case 'ArrowDown':
+        if (!results.length) return
+        event.preventDefault()
+        setIsOpen(true)
+        setHighlightedIndex((currentIndex) =>
+          currentIndex < results.length - 1 ? currentIndex + 1 : 0,
+        )
+        break
+      case 'ArrowUp':
+        if (!results.length) return
+        event.preventDefault()
+        setIsOpen(true)
+        setHighlightedIndex((currentIndex) =>
+          currentIndex > 0 ? currentIndex - 1 : results.length - 1,
+        )
+        break
+      case 'Enter': {
+        if (!hasSearch || !results.length) return
+        event.preventDefault()
+        handleSelect(results[highlightedIndex >= 0 ? highlightedIndex : 0])
+        break
+      }
+      case 'Escape':
+        event.preventDefault()
+        event.stopPropagation()
+        closeSearch()
+        break
+    }
+  }
+
+  return (
+    <Styled.Container ref={containerRef}>
+      <Styled.SearchField>
+        <Icon icon="search" className="search-icon" />
+        <Styled.SearchInput
+          ref={inputRef}
+          value={search}
+          placeholder="Search this project..."
+          onChange={handleChange}
+          onFocus={handleFocus}
+          onClick={handleFocus}
+          onKeyDown={handleKeyDown}
+          aria-label={`Search within project ${projectName}`}
+          aria-autocomplete="list"
+          aria-controls={showDropdown ? listId : undefined}
+          aria-expanded={showDropdown}
+          autoComplete="off"
+        />
+      </Styled.SearchField>
+
+      {showDropdown && (
+        <Styled.Dropdown id={listId} role="listbox">
+          {results.map((result, index) => (
+            <Styled.ResultButton
+              key={result.id}
+              ref={(element) => {
+                optionRefs.current[index] = element
+              }}
+              type="button"
+              role="option"
+              className={clsx({ highlighted: index === highlightedIndex })}
+              aria-selected={index === highlightedIndex}
+              onMouseDown={(event) => event.preventDefault()}
+              onMouseEnter={() => setHighlightedIndex(index)}
+              onClick={() => handleSelect(result)}
+            >
+              <GlobalSearchResultMedia result={result} />
+              <Styled.ResultBody>
+                <Styled.PrimaryText>{result.label || result.name}</Styled.PrimaryText>
+                <Styled.SecondaryText>{getContextLabel(result)}</Styled.SecondaryText>
+              </Styled.ResultBody>
+            </Styled.ResultButton>
+          ))}
+
+          {!results.length && (
+            <Styled.StatusRow>{isLoading || isFetching ? 'Searching...' : 'No matches found'}</Styled.StatusRow>
+          )}
+        </Styled.Dropdown>
+      )}
+    </Styled.Container>
+  )
+}
+
+export default GlobalProjectSearch

--- a/src/containers/header/GlobalSearch/index.ts
+++ b/src/containers/header/GlobalSearch/index.ts
@@ -1,0 +1,1 @@
+export { default } from './GlobalProjectSearch'

--- a/src/containers/header/GlobalSearch/searchUtils.ts
+++ b/src/containers/header/GlobalSearch/searchUtils.ts
@@ -1,0 +1,276 @@
+import type { SearchEntityLink } from '@shared/api'
+import { buildEntityUri, extractEntityHierarchyFromParents, getEntityTypeIcon } from '@shared/util'
+import { getEntityColor, getEntityIcon, type IconAnatomy } from '@shared/util/iconUtils'
+import type { GlobalSearchEntityType, GlobalSearchResult } from './types'
+
+const globalSearchEntityTypes: GlobalSearchEntityType[] = ['folder', 'task', 'product', 'version']
+
+const globalSearchTypeBias: Record<GlobalSearchEntityType, number> = {
+  folder: 14,
+  task: 8,
+  product: 3,
+  version: 1,
+}
+
+const globalSearchTypePriority: Record<GlobalSearchEntityType, number> = {
+  folder: 3,
+  task: 2,
+  product: 1,
+  version: 0,
+}
+
+const defaultGlobalProjectSearchLimit = 10
+const whitespaceRegex = /\s+/g
+const separatorRegex = /[_-]+/g
+
+export type GlobalSearchEntity = SearchEntityLink & {
+  entityType: GlobalSearchEntityType
+}
+
+export const normalizeGlobalSearchValue = (value?: string) =>
+  (value || '').trim().toLowerCase().replace(separatorRegex, ' ').replace(whitespaceRegex, ' ')
+
+export const isUsableGlobalSearch = (projectName?: string, search?: string) =>
+  Boolean(projectName?.trim() && normalizeGlobalSearchValue(search))
+
+export const isEntityUriSearch = (value?: string) =>
+  Boolean(value?.trim().toLowerCase().startsWith('ayon+entity://'))
+
+export const isGlobalSearchEntityType = (value: string): value is GlobalSearchEntityType =>
+  globalSearchEntityTypes.includes(value as GlobalSearchEntityType)
+
+export const sanitizeGlobalSearchLimit = (limit?: number) => {
+  if (!limit || limit < 1) return defaultGlobalProjectSearchLimit
+  return Math.floor(limit)
+}
+
+const tokenizeGlobalSearchValue = (value: string) =>
+  normalizeGlobalSearchValue(value)
+    .split(' ')
+    .map((token) => token.trim())
+    .filter(Boolean)
+
+const getOrderedTokenBonus = (tokens: string[], haystack: string) => {
+  let lastIndex = -1
+  let orderedMatches = 0
+
+  for (const token of tokens) {
+    const index = haystack.indexOf(token, lastIndex + 1)
+    if (index === -1) break
+    orderedMatches += 1
+    lastIndex = index
+  }
+
+  return orderedMatches === tokens.length ? 12 : orderedMatches * 3
+}
+
+const getTokenCoverageScore = (tokens: string[], haystack: string) => {
+  if (!tokens.length || !haystack) return 0
+
+  const matchedTokens = tokens.filter((token) => haystack.includes(token))
+  if (!matchedTokens.length) return 0
+
+  const matchedLength = matchedTokens.reduce((total, token) => total + token.length, 0)
+  const coverageRatio = matchedLength / Math.max(haystack.length, 1)
+
+  return matchedTokens.length * 14 + coverageRatio * 24 + getOrderedTokenBonus(tokens, haystack)
+}
+
+const getWordPrefixScore = (query: string, haystack: string) => {
+  if (!query || !haystack) return 0
+
+  const queryTokens = tokenizeGlobalSearchValue(query)
+  const haystackTokens = tokenizeGlobalSearchValue(haystack)
+  if (!queryTokens.length || !haystackTokens.length) return 0
+
+  let matchedPrefixes = 0
+  for (const queryToken of queryTokens) {
+    if (haystackTokens.some((haystackToken) => haystackToken.startsWith(queryToken))) {
+      matchedPrefixes += 1
+    }
+  }
+
+  if (!matchedPrefixes) return 0
+
+  return (matchedPrefixes / queryTokens.length) * 48
+}
+
+export const getGlobalSearchPathLabel = (entity: Pick<GlobalSearchEntity, 'parents' | 'label' | 'name'>) =>
+  [...(entity.parents || []), entity.label || entity.name].filter(Boolean).join(' / ')
+
+const getTextMatchScore = (search: string, value?: string) => {
+  const normalizedSearch = normalizeGlobalSearchValue(search)
+  const normalizedValue = normalizeGlobalSearchValue(value)
+
+  if (!normalizedSearch || !normalizedValue) return 0
+
+  if (normalizedValue === normalizedSearch) return 150
+  if (normalizedValue.startsWith(`${normalizedSearch} `)) return 130
+
+  const phraseIndex = normalizedValue.indexOf(normalizedSearch)
+  if (phraseIndex !== -1) {
+    return Math.max(84, 118 - phraseIndex)
+  }
+
+  const tokenScore = getTokenCoverageScore(tokenizeGlobalSearchValue(normalizedSearch), normalizedValue)
+  const prefixScore = getWordPrefixScore(normalizedSearch, normalizedValue)
+
+  return tokenScore + prefixScore
+}
+
+export const scoreGlobalSearchEntity = (
+  search: string,
+  entity: Pick<GlobalSearchEntity, 'entityType' | 'name' | 'label' | 'parents' | 'subType'>,
+) => {
+  const nameScore = getTextMatchScore(search, entity.name)
+  const labelScore = getTextMatchScore(search, entity.label)
+  const parentsLabel = (entity.parents || []).join(' / ')
+  const pathLabel = getGlobalSearchPathLabel(entity)
+  const parentsScore = getTextMatchScore(search, parentsLabel)
+  const pathScore = getTextMatchScore(search, pathLabel)
+  const subTypeScore = getTextMatchScore(search, entity.subType)
+
+  return Math.round(
+    nameScore * 1.35 +
+      labelScore * 1.2 +
+      pathScore * 0.75 +
+      parentsScore * 0.45 +
+      subTypeScore * 0.2 +
+      globalSearchTypeBias[entity.entityType],
+  )
+}
+
+export const buildGlobalSearchTargetUrl = (
+  projectName: string,
+  entityType: GlobalSearchEntityType,
+  id: string,
+  uri?: string,
+  targetEntityType?: string,
+  targetEntityId?: string,
+) => {
+  const searchParams = new URLSearchParams({
+    project: projectName,
+    type: entityType,
+    id,
+  })
+
+  if (uri) {
+    searchParams.set('uri', uri)
+  }
+
+  if (
+    targetEntityType &&
+    targetEntityId &&
+    (targetEntityType !== entityType || targetEntityId !== id)
+  ) {
+    searchParams.set('targetType', targetEntityType)
+    searchParams.set('targetId', targetEntityId)
+  }
+
+  const module = entityType === 'product' || entityType === 'version' ? 'products' : 'overview'
+  return `/projects/${projectName}/${module}?${searchParams.toString()}`
+}
+
+const buildGlobalSearchThumbnailUrl = (
+  projectName: string,
+  entity: Pick<
+    GlobalSearchEntity,
+    'entityType' | 'id' | 'thumbnailId' | 'targetEntityType' | 'targetEntityId' | 'updatedAt'
+  >,
+) => {
+  if (entity.entityType === 'folder') {
+    if (!entity.thumbnailId) return undefined
+    return `/api/projects/${projectName}/folders/${entity.id}/thumbnail`
+  }
+
+  if (entity.entityType === 'task') {
+    const updatedAt = entity.updatedAt ? `?updatedAt=${entity.updatedAt}` : ''
+    return `/api/projects/${projectName}/tasks/${entity.id}/thumbnail${updatedAt}`
+  }
+
+  if (entity.entityType === 'product' && entity.targetEntityType === 'version' && entity.targetEntityId) {
+    return `/api/projects/${projectName}/versions/${entity.targetEntityId}/thumbnail`
+  }
+
+  if (entity.entityType === 'version') {
+    const updatedAt = entity.updatedAt ? `?updatedAt=${entity.updatedAt}` : ''
+    return `/api/projects/${projectName}/versions/${entity.id}/thumbnail${updatedAt}`
+  }
+
+  if (!entity.thumbnailId) return undefined
+  return `/api/projects/${projectName}/thumbnails/${entity.thumbnailId}`
+}
+
+export const buildGlobalSearchResult = ({
+  entity,
+  projectName,
+  search,
+  anatomy,
+}: {
+  entity: GlobalSearchEntity
+  projectName: string
+  search: string
+  anatomy: IconAnatomy
+}): GlobalSearchResult => {
+  const hierarchy = extractEntityHierarchyFromParents(entity.parents || [], entity.entityType, entity.name)
+  const pathLabel = getGlobalSearchPathLabel(entity)
+  const thumbnailId = entity.thumbnailId || entity.thumbnail?.id || undefined
+  const thumbnailUrl = buildGlobalSearchThumbnailUrl(projectName, { ...entity, thumbnailId })
+
+  return {
+    id: entity.id,
+    projectName,
+    entityType: entity.entityType,
+    targetEntityType: isGlobalSearchEntityType(entity.targetEntityType || '')
+      ? entity.targetEntityType
+      : undefined,
+    targetEntityId: entity.targetEntityId,
+    name: entity.name,
+    label: entity.label || entity.name,
+    parents: entity.parents || [],
+    subType: entity.subType || undefined,
+    icon: getEntityIcon(entity.entityType, entity.subType, anatomy) || getEntityTypeIcon(entity.entityType),
+    iconColor: getEntityColor(entity.entityType, entity.subType, anatomy),
+    thumbnailId,
+    thumbnailUrl,
+    pathLabel,
+    uri: buildEntityUri({ projectName, ...hierarchy }),
+    targetUrl: buildGlobalSearchTargetUrl(
+      projectName,
+      entity.entityType,
+      entity.id,
+      buildEntityUri({ projectName, ...hierarchy }),
+      entity.targetEntityType,
+      entity.targetEntityId,
+    ),
+    score: scoreGlobalSearchEntity(search, entity),
+  }
+}
+
+export const rankGlobalSearchResults = ({
+  entities,
+  projectName,
+  search,
+  limit,
+  anatomy,
+}: {
+  entities: GlobalSearchEntity[]
+  projectName: string
+  search: string
+  limit?: number
+  anatomy: IconAnatomy
+}) => {
+  const usableSearch = normalizeGlobalSearchValue(search)
+  if (!usableSearch) return []
+
+  return entities
+    .map((entity) => buildGlobalSearchResult({ entity, projectName, search: usableSearch, anatomy }))
+    .filter((entity) => entity.score > 0)
+    .sort(
+      (left, right) =>
+        right.score - left.score ||
+        globalSearchTypePriority[right.entityType] - globalSearchTypePriority[left.entityType] ||
+        left.label.localeCompare(right.label),
+    )
+    .slice(0, sanitizeGlobalSearchLimit(limit))
+}

--- a/src/containers/header/GlobalSearch/types.ts
+++ b/src/containers/header/GlobalSearch/types.ts
@@ -1,0 +1,33 @@
+export type GlobalSearchEntityType = 'folder' | 'task' | 'product' | 'version'
+
+export type GlobalSearchResult = {
+  id: string
+  projectName: string
+  entityType: GlobalSearchEntityType
+  targetEntityType?: GlobalSearchEntityType
+  targetEntityId?: string
+  name: string
+  label: string
+  parents: string[]
+  subType?: string
+  icon: string
+  iconColor?: string
+  thumbnailId?: string
+  thumbnailUrl?: string
+  pathLabel: string
+  uri: string
+  targetUrl: string
+  score: number
+}
+
+export type UseGlobalProjectSearchArgs = {
+  projectName?: string
+  search: string
+  limit?: number
+}
+
+export type UseGlobalProjectSearchResult = {
+  results: GlobalSearchResult[]
+  isLoading: boolean
+  isFetching: boolean
+}

--- a/src/containers/header/GlobalSearch/useGlobalProjectSearch.ts
+++ b/src/containers/header/GlobalSearch/useGlobalProjectSearch.ts
@@ -1,0 +1,148 @@
+import { useMemo } from 'react'
+import type { SearchEntityLink } from '@shared/api'
+import {
+  useGetExactEntityLinkDataQuery,
+  useGetProjectAnatomyQuery,
+  useGetSearchedEntitiesLinksInfiniteQuery,
+} from '@shared/api'
+import {
+  buildGlobalSearchResult,
+  isEntityUriSearch,
+  isGlobalSearchEntityType,
+  isUsableGlobalSearch,
+  rankGlobalSearchResults,
+  sanitizeGlobalSearchLimit,
+  type GlobalSearchEntity,
+} from './searchUtils'
+import type {
+  GlobalSearchEntityType,
+  GlobalSearchResult,
+  UseGlobalProjectSearchArgs,
+  UseGlobalProjectSearchResult,
+} from './types'
+
+export type { GlobalSearchResult } from './types'
+
+const getFirstPageEntities = (data?: { pages?: Array<{ entities: SearchEntityLink[] }> }) =>
+  data?.pages?.[0]?.entities || []
+
+const isGlobalSearchEntity = (entity: SearchEntityLink): entity is GlobalSearchEntity =>
+  isGlobalSearchEntityType(entity.entityType)
+
+export const useGlobalProjectSearch = ({
+  projectName,
+  search,
+  limit,
+}: UseGlobalProjectSearchArgs): UseGlobalProjectSearchResult => {
+  const trimmedProjectName = projectName?.trim()
+  const trimmedSearch = search.trim()
+  const canSearch = isUsableGlobalSearch(trimmedProjectName, trimmedSearch)
+  const { data: anatomy = {} } = useGetProjectAnatomyQuery(
+    { projectName: trimmedProjectName || '' },
+    { skip: !trimmedProjectName },
+  )
+
+  const buildQueryArgs = (entityType: GlobalSearchEntityType) => ({
+    projectName: trimmedProjectName || '',
+    entityType,
+    search: trimmedSearch,
+  })
+  const shouldResolveExactUri = canSearch && isEntityUriSearch(trimmedSearch)
+
+  const folderQuery = useGetSearchedEntitiesLinksInfiniteQuery(buildQueryArgs('folder'), {
+    skip: !canSearch,
+  })
+  const taskQuery = useGetSearchedEntitiesLinksInfiniteQuery(buildQueryArgs('task'), {
+    skip: !canSearch,
+  })
+  const productQuery = useGetSearchedEntitiesLinksInfiniteQuery(buildQueryArgs('product'), {
+    skip: !canSearch,
+  })
+  const exactEntityQuery = useGetExactEntityLinkDataQuery(
+    { projectName: trimmedProjectName || '', uri: trimmedSearch },
+    { skip: !shouldResolveExactUri },
+  )
+
+  const results = useMemo(() => {
+    if (!canSearch || !trimmedProjectName) return []
+
+    const entities = [
+      ...getFirstPageEntities(folderQuery.data),
+      ...getFirstPageEntities(taskQuery.data),
+      ...getFirstPageEntities(productQuery.data),
+    ].filter(isGlobalSearchEntity)
+
+    const rankedResults = rankGlobalSearchResults({
+      entities,
+      projectName: trimmedProjectName,
+      search: trimmedSearch,
+      limit,
+      anatomy,
+    })
+
+    const exactEntity = shouldResolveExactUri ? exactEntityQuery.currentData : undefined
+    if (!exactEntity || !isGlobalSearchEntity(exactEntity)) {
+      return rankedResults
+    }
+
+    const duplicateEntity = entities.find(
+      ({ id, entityType }) => id === exactEntity.id && entityType === exactEntity.entityType,
+    )
+
+    const mergedExactEntity: GlobalSearchEntity = {
+      ...duplicateEntity,
+      ...exactEntity,
+      label: exactEntity.label || duplicateEntity?.label || exactEntity.name,
+      parents: exactEntity.parents?.length ? exactEntity.parents : duplicateEntity?.parents || [],
+      subType: exactEntity.subType || duplicateEntity?.subType,
+      updatedAt: exactEntity.updatedAt || duplicateEntity?.updatedAt,
+      thumbnail: exactEntity.thumbnail || duplicateEntity?.thumbnail,
+      thumbnailId: exactEntity.thumbnailId || duplicateEntity?.thumbnailId,
+    }
+
+    const exactResult = {
+      ...buildGlobalSearchResult({
+        entity: mergedExactEntity,
+        projectName: trimmedProjectName,
+        search: trimmedSearch,
+        anatomy,
+      }),
+      score: Number.MAX_SAFE_INTEGER,
+    }
+
+    const dedupedRankedResults = rankedResults.filter(
+      ({ id, entityType }) => id !== exactResult.id || entityType !== exactResult.entityType,
+    )
+
+    return [exactResult, ...dedupedRankedResults].slice(0, sanitizeGlobalSearchLimit(limit))
+  }, [
+      anatomy,
+      canSearch,
+      exactEntityQuery.currentData,
+      folderQuery.data,
+      limit,
+      productQuery.data,
+      shouldResolveExactUri,
+      taskQuery.data,
+      trimmedProjectName,
+      trimmedSearch,
+  ])
+
+  return {
+    results,
+    isLoading:
+      canSearch &&
+      (folderQuery.isLoading ||
+        taskQuery.isLoading ||
+        productQuery.isLoading ||
+        exactEntityQuery.isLoading),
+    isFetching:
+      canSearch &&
+      (folderQuery.isFetching ||
+        taskQuery.isFetching ||
+        productQuery.isFetching ||
+        exactEntityQuery.isFetching),
+  }
+}
+
+export default useGlobalProjectSearch

--- a/src/pages/ProjectOverviewPage/ProjectOverviewPage.tsx
+++ b/src/pages/ProjectOverviewPage/ProjectOverviewPage.tsx
@@ -1,6 +1,6 @@
 // libraries
 import { Splitter, SplitterPanel } from 'primereact/splitter'
-import { FC, useMemo } from 'react'
+import { FC, useEffect, useMemo, useRef } from 'react'
 import styled from 'styled-components'
 
 // state
@@ -22,7 +22,7 @@ import {
 } from '@shared/containers/ProjectTreeTable'
 import { useProjectOverviewContext } from './context/ProjectOverviewContext'
 import ProjectOverviewSettings from './containers/ProjectOverviewSettings'
-import { useGlobalContext, useSettingsPanel } from '@shared/context'
+import { useGlobalContext, useSettingsPanel, useURIContext } from '@shared/context'
 import ReloadButton from './components/ReloadButton'
 import OverviewActions from './components/OverviewActions'
 import { useNavigate, useSearchParams } from 'react-router-dom'
@@ -75,6 +75,7 @@ const ProjectOverviewPage: FC = () => {
 
   const [searchParams, setSearchParams] = useSearchParams()
   const navigate = useNavigate()
+  const { uriType, entity: uriEntity, getUriEntities } = useURIContext()
 
   const {
     projectName,
@@ -159,6 +160,7 @@ const ProjectOverviewPage: FC = () => {
   }
 
   const { getGoToEntityData } = useGoToEntity()
+  const lastUriSelectionRef = useRef<string | null>(null)
 
   // select the entity in the table and expand its parent folders
   const handleUriOpen = (entity: DetailsPanelEntityData) => {
@@ -186,6 +188,67 @@ const ProjectOverviewPage: FC = () => {
       ]),
     )
   }
+
+  useEffect(() => {
+    const project = searchParams.get('project')
+    const type = searchParams.get('type') as 'folder' | 'task' | null
+    const id = searchParams.get('id')
+
+    if (project !== projectName || !type || !id) {
+      lastUriSelectionRef.current = null
+      return
+    }
+
+    const selectionKey = `${type}:${id}:${uriType === 'entity' ? uriEntity?.projectName || '' : ''}`
+    if (lastUriSelectionRef.current === selectionKey) return
+
+    let cancelled = false
+
+    const resolveAndSelect = async () => {
+      let folderId: string | undefined
+
+      if (uriType === 'entity' && uriEntity?.projectName === projectName) {
+        const resolvedUris = await getUriEntities()
+        const resolvedEntity = resolvedUris[0]?.entities?.[0]
+        folderId = resolvedEntity?.folderId
+      }
+
+      if (cancelled) return
+
+      const data = getGoToEntityData(id, type, {
+        folder: type === 'folder' ? folderId || id : folderId,
+      })
+
+      setQueryFilters({})
+      updateViewGroupBy(null)
+      updateExpanded(data.expandedFolders)
+      slicer.setExpanded(data.expandedFolders)
+      slicer.setRowSelection(data.selectedFolders)
+      setSelectedCells(
+        new Set([getCellId(data.entityId, 'name'), getCellId(data.entityId, ROW_SELECTION_COLUMN_ID)]),
+      )
+
+      lastUriSelectionRef.current = selectionKey
+    }
+
+    void resolveAndSelect()
+
+    return () => {
+      cancelled = true
+    }
+  }, [
+    getGoToEntityData,
+    getUriEntities,
+    projectName,
+    searchParams,
+    setQueryFilters,
+    setSelectedCells,
+    slicer,
+    updateExpanded,
+    updateViewGroupBy,
+    uriEntity?.projectName,
+    uriType,
+  ])
 
   return (
     <main style={{ gap: 4 }}>

--- a/src/pages/VersionsProductsPage/VersionsProductsPage.tsx
+++ b/src/pages/VersionsProductsPage/VersionsProductsPage.tsx
@@ -1,9 +1,16 @@
-import { FC, useState } from 'react'
+import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import VersionsProductsPageProviders from './providers'
 import { Section } from '@ynput/ayon-react-components'
 import { Splitter, SplitterPanel } from 'primereact/splitter'
 import { useSlicerContext, Slicer } from '@shared/containers/Slicer'
-import { useProjectContext, useSettingsPanel } from '@shared/context'
+import { useProjectContext, useProjectFoldersContext, useSettingsPanel, useURIContext } from '@shared/context'
+import {
+  getCellId,
+  parseCellId,
+  ROW_SELECTION_COLUMN_ID,
+  useSelectionCellsContext,
+} from '@shared/containers'
+import { useSearchParams } from 'react-router-dom'
 import VPToolbar from './components/VPToolbar/VPToolbar'
 // TABLES
 import VPTable from './components/VPTable/VPTable'
@@ -13,15 +20,197 @@ import VersionsListTable from './components/VersionsListTable/VersionsListTable'
 import { useVPViewsContext } from './context/VPViewsContext'
 import VPDetailsPanel from './components/VPDetailsPanel/VPDetailsPanel'
 import { useVersionsSelectionContext } from './context/VPSelectionContext'
+import { useVersionsDataContext } from './context/VPDataContext'
 import { VPTableSettings } from './components/VPTableSettings/VPTableSettings'
 import { DetailsDialog } from '@shared/components'
 import { useVPContextMenu } from './hooks/useVPContextMenu'
 import DetailsPanelSplitter from '@components/DetailsPanelSplitter'
 import NewListFromContext from '@pages/ProjectListsPage/components/NewListDialog/NewListFromContext.tsx'
+import useGoToEntity from '@hooks/useGoToEntity'
 
 interface VersionsProductsPageProps {
   projectName: string
   children?: React.ReactNode
+}
+
+const URLSelectionSync = () => {
+  const [searchParams] = useSearchParams()
+  const { projectName } = useProjectContext()
+  const { entitiesMap, setExpanded: setProductsExpanded } = useVersionsDataContext()
+  const { onUpdateFilters, onUpdateViewGroupBy, onUpdateSlicerType } = useVPViewsContext()
+  const slicer = useSlicerContext()
+  const { getFolderById } = useProjectFoldersContext()
+  const { setSelectedCells, setFocusedCellId, setAnchorCell } = useSelectionCellsContext()
+  const { uriType, entity: uriEntity, getUriEntities } = useURIContext()
+  const { getGoToEntityData } = useGoToEntity()
+  const [selectionRequest, setSelectionRequest] = useState<{
+    key: string
+    entityId: string
+    entityType: 'product' | 'version'
+    viewGroupBy: 'hierarchy' | undefined
+    folderId?: string
+    productId?: string
+  } | null>(null)
+  const preparedSelectionRef = useRef<string | null>(null)
+  const lastAppliedSelectionRef = useRef<string | null>(null)
+
+  const buildFolderSelectionData = useCallback(
+    (selectedFolders: Record<string, boolean>) =>
+      Object.keys(selectedFolders).reduce<Record<string, { id: string; name?: string; label?: string; path?: string; parents?: string[] }>>((acc, folderId) => {
+        if (!selectedFolders[folderId]) return acc
+
+        const folder = getFolderById(folderId)
+        acc[folderId] = {
+          id: folderId,
+          name: folder?.name,
+          label: folder?.label || folder?.name,
+          path: folder?.path,
+          parents: folder?.parents,
+        }
+        return acc
+      }, {}),
+    [getFolderById],
+  )
+
+  const selectionTarget = useMemo(() => {
+    if (searchParams.get('project') !== projectName) return null
+
+    const entityType = searchParams.get('type') as 'product' | 'version' | null
+    const entityId = searchParams.get('id')
+    const targetEntityType = searchParams.get('targetType')
+    const targetEntityId = searchParams.get('targetId')
+
+    if (!entityType || !entityId) return null
+
+    if (entityType === 'product') {
+      return { entityType: 'product' as const, entityId, viewGroupBy: 'hierarchy' as const }
+    }
+
+    if (targetEntityType === 'version' && targetEntityId) {
+      return { entityType: 'version' as const, entityId: targetEntityId, viewGroupBy: undefined }
+    }
+
+    return { entityType, entityId, viewGroupBy: undefined }
+  }, [projectName, searchParams])
+
+  useEffect(() => {
+    if (!selectionTarget) {
+      preparedSelectionRef.current = null
+      lastAppliedSelectionRef.current = null
+      setSelectionRequest(null)
+      return
+    }
+
+    const selectionKey = `${selectionTarget.entityType}:${selectionTarget.entityId}:${uriType === 'entity' ? uriEntity?.projectName || '' : ''}`
+    if (preparedSelectionRef.current === selectionKey) return
+
+    preparedSelectionRef.current = selectionKey
+    lastAppliedSelectionRef.current = null
+    void onUpdateFilters({})
+    void onUpdateViewGroupBy(selectionTarget.viewGroupBy)
+    void onUpdateSlicerType('hierarchy')
+    slicer.setSliceType('hierarchy')
+    slicer.setPersistentRowSelectionData({})
+
+    let cancelled = false
+
+    const resolveSelection = async () => {
+      let folderId: string | undefined
+      let productId: string | undefined
+
+      if (uriType === 'entity' && uriEntity?.projectName === projectName) {
+        const resolvedUris = await getUriEntities()
+        const resolvedEntity = resolvedUris.find(({ uri }) => uri === searchParams.get('uri'))?.entities?.[0] ||
+          resolvedUris[0]?.entities?.[0]
+
+        folderId = resolvedEntity?.folderId
+        productId = resolvedEntity?.productId
+      }
+
+      if (cancelled) return
+
+      const data = getGoToEntityData(selectionTarget.entityId, selectionTarget.entityType, {
+        folder: folderId,
+        product: productId,
+      })
+      const selectionData = buildFolderSelectionData(data.selectedFolders)
+
+      slicer.setSliceType('hierarchy')
+      slicer.setExpanded(data.expandedFolders)
+      slicer.setRowSelection(data.selectedFolders)
+      slicer.setRowSelectionData(selectionData)
+      slicer.setPersistentRowSelectionData(selectionData)
+
+      setSelectionRequest({
+        key: selectionKey,
+        entityId: selectionTarget.entityId,
+        entityType: selectionTarget.entityType as 'product' | 'version',
+        viewGroupBy: selectionTarget.viewGroupBy,
+        folderId,
+        productId,
+      })
+    }
+
+    void resolveSelection()
+
+    return () => {
+      cancelled = true
+    }
+  }, [
+    getUriEntities,
+    getGoToEntityData,
+    buildFolderSelectionData,
+    onUpdateFilters,
+    onUpdateSlicerType,
+    onUpdateViewGroupBy,
+    projectName,
+    searchParams,
+    selectionTarget,
+    uriEntity?.projectName,
+    uriType,
+  ])
+
+  useEffect(() => {
+    if (!selectionRequest) return
+    if (lastAppliedSelectionRef.current === selectionRequest.key) return
+    if (!entitiesMap.has(selectionRequest.entityId)) return
+
+    const data = getGoToEntityData(selectionRequest.entityId, selectionRequest.entityType, {
+      folder: selectionRequest.folderId,
+      product: selectionRequest.productId,
+    })
+    const selectionData = buildFolderSelectionData(data.selectedFolders)
+
+    slicer.setSliceType('hierarchy')
+    slicer.setExpanded(data.expandedFolders)
+    slicer.setRowSelection(data.selectedFolders)
+    slicer.setRowSelectionData(selectionData)
+    slicer.setPersistentRowSelectionData(selectionData)
+
+    if (selectionRequest.entityType === 'product') {
+      setProductsExpanded({ [selectionRequest.entityId]: true })
+    } else if (selectionRequest.entityType === 'version' && selectionRequest.productId) {
+      setProductsExpanded({ [selectionRequest.productId]: true })
+    }
+
+    const rowSelectionCellId = getCellId(selectionRequest.entityId, ROW_SELECTION_COLUMN_ID)
+    setSelectedCells(new Set([getCellId(selectionRequest.entityId, 'name'), rowSelectionCellId]))
+    setFocusedCellId(rowSelectionCellId)
+    setAnchorCell(parseCellId(rowSelectionCellId))
+    lastAppliedSelectionRef.current = selectionRequest.key
+  }, [
+    entitiesMap,
+    buildFolderSelectionData,
+    getGoToEntityData,
+    selectionRequest,
+    setAnchorCell,
+    setFocusedCellId,
+    setProductsExpanded,
+    setSelectedCells,
+    slicer,
+  ])
+
+  return null
 }
 
 const VersionsProductsPage: FC<VersionsProductsPageProps> = ({}) => {
@@ -53,6 +242,7 @@ const VersionsProductsPage: FC<VersionsProductsPageProps> = ({}) => {
 
   return (
     <main style={{ gap: 4 }}>
+      <URLSelectionSync />
       <Splitter
         layout="horizontal"
         style={{ width: '100%', height: '100%' }}


### PR DESCRIPTION
## Description of changes 

When in a project add a Project wide search that is a quick search for a folder, task or product.

## Technical details

⚠️ This is currently just a UX draft to discuss the UI - the implementation will surely need heavy cleanup.

- [ ] It seems quite finnicky to get the right Product selected on the Products page automatically when choosing it from the search.  We seem to be lacking an easy way to ensure a page will display the entity if we redirect the user to it. So that we can enforce e.g. "highlight this item"

## Additional context

https://github.com/user-attachments/assets/525b9276-a135-4fa9-b54a-09b2e5d2c476


<img width="593" height="137" alt="image" src="https://github.com/user-attachments/assets/22e22ac3-b03f-4f68-9e99-251f3b9dae8d" />

<img width="522" height="470" alt="image" src="https://github.com/user-attachments/assets/39b598c4-b40f-41a1-9c5e-90e34c79cfbe" />

<img width="539" height="303" alt="image" src="https://github.com/user-attachments/assets/867401f7-7e76-4d42-901a-874778c60a72" />
