### PR TITLE
Settings: Fix textarea widget enter misbehaving

### DIFF
--- a/src/containers/SettingsEditor/Widgets/TextWidget.tsx
+++ b/src/containers/SettingsEditor/Widgets/TextWidget.tsx
@@ -213,10 +213,14 @@ export const TextWidget = (props: $Any) => {
     }
   }
 
+  const isMultilineWidget = props.schema.widget === 'textarea'
+
   // Disable propagation of enter key
   // to prevent form submission. Just commit the change instead.
   opts.onKeyDown = (e: $Any) => {
-    if (Input === InputTextarea) return
+    // Multiline settings fields need Enter to insert a newline. This also covers
+    // syntax-highlighted textarea widgets, which do not render InputTextarea.
+    if (isMultilineWidget) return
     if (e.keyCode === 13) {
       e.preventDefault()
       e.stopPropagation()


### PR DESCRIPTION
## Description of changes 

Fix settings textarea widget enter misbehaving if textarea widget also has syntax set (e.g. `syntax="json"`)

Fix #1917 

## Technical details

Root cause: the bug was in `src\containers\SettingsEditor\Widgets\TextWidget.tsx:216-225`, not in the code editor library itself. 
That handler blocks Enter for every widget except InputTextarea:

```js
   opts.onKeyDown = (e) => {
     if (Input === InputTextarea) return
     if (e.keyCode === 13) {
       e.preventDefault()
       e.stopPropagation()
       onChangeCommit()
     }
   }
```

That was safe until the settings UI gained a second multiline implementation: `widget === 'textarea' && props.schema.syntax` now renders `SettingsCodeEditor` instead of `InputTextarea` (`TextWidget.tsx:174-183`). So pressing Enter in those fields hits `preventDefault()` and commits instead of inserting a newline.
The same `@uiw/react-textarea-code-editor` works normally in `src\containers\RawSettingsDialog\RawSettingsDialog.jsx`, which confirms the regression is from the settings wrapper logic, not the editor package.

## Additional context
<!-- Add any other context or screenshots here. -->

