### PR TITLE
Settings: Fix checking "enabled" expanding collapsed sections

### DIFF
--- a/src/containers/SettingsEditor/SettingsPanel.jsx
+++ b/src/containers/SettingsEditor/SettingsPanel.jsx
@@ -136,7 +136,12 @@ const SettingsPanel = ({
 
   useEffect(() => {
     if (!currentId) return
-    if (currentId.startsWith(objId + '_') && !expandedObjects.includes(objId)) {
+    const isHeaderEnabledField = currentId === `${objId}_enabled`
+    if (
+      currentId.startsWith(objId + '_') &&
+      !isHeaderEnabledField &&
+      !expandedObjects.includes(objId)
+    ) {
       console.log('expanding', objId)
       setExpandedObjects([...expandedObjects, objId])
     }


### PR DESCRIPTION
## Description of changes 

Settings: Fix "enabled" checkbox influencing the expanded state of collapsed section due to breadcrumbs setting the expanded object state.

## Technical details

The "enabled" checkbox is technically part of the parent group - and when the 'breadcrumb' is set on value change it's really keen on expanding the parent group. This skips that by making it so that these `enabled` header objects do not influence the expanded state.

## Additional context

Fix https://github.com/ynput/ayon-frontend/issues/1335
Fix https://github.com/ynput/ayon-frontend/issues/1895
