### PR TITLE
Settings: Support multi-selection with manual re-ordering

### DIFF
--- a/src/containers/SettingsEditor/Widgets/OrderedListWidget.tsx
+++ b/src/containers/SettingsEditor/Widgets/OrderedListWidget.tsx
@@ -111,6 +111,33 @@ const SectionLabel = styled.div`
   letter-spacing: 0.5px;
 `
 
+const ButtonGroup = styled.div`
+  display: flex;
+  gap: 6px;
+  padding: 6px 0;
+`
+
+const ActionButton = styled.button`
+  padding: 4px 10px;
+  font-size: 12px;
+  border: 1px solid var(--md-sys-color-outline-variant);
+  border-radius: var(--border-radius-s);
+  background: var(--md-sys-color-surface-container-high);
+  color: var(--md-sys-color-on-surface);
+  cursor: pointer;
+  transition: all 0.2s;
+
+  &:hover:not(:disabled) {
+    background: var(--md-sys-color-surface-container-highest);
+    border-color: var(--md-sys-color-outline);
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+`
+
 // Sortable item for selected list
 const SortableItem = ({
   id,
@@ -172,6 +199,15 @@ const OrderedListWidget = ({ value, options, onChange }: OrderedListWidgetProps)
 
   const removeItem = (item: string) => {
     onChange(value.filter((v) => v !== item))
+  }
+
+  const selectAll = () => {
+    const allValues = options.map((opt) => opt.value)
+    onChange(allValues)
+  }
+
+  const deselectAll = () => {
+    onChange([])
   }
 
   // Close dropdown on outside click
@@ -250,7 +286,25 @@ const OrderedListWidget = ({ value, options, onChange }: OrderedListWidgetProps)
       )}
       {value.length > 0 && (
         <>
-          <SectionLabel>Selected ({value.length})</SectionLabel>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <SectionLabel>Selected ({value.length})</SectionLabel>
+            <ButtonGroup>
+              {unselectedItems.length > 0 && (
+                <ActionButton
+                  onClick={selectAll}
+                  title="Select all available items"
+                >
+                  Select All
+                </ActionButton>
+              )}
+              <ActionButton
+                onClick={deselectAll}
+                title="Deselect all items"
+              >
+                Deselect All
+              </ActionButton>
+            </ButtonGroup>
+          </div>
           <DndContext
             collisionDetection={closestCenter}
             onDragStart={handleDragStart}

--- a/src/containers/SettingsEditor/Widgets/OrderedListWidget.tsx
+++ b/src/containers/SettingsEditor/Widgets/OrderedListWidget.tsx
@@ -1,0 +1,261 @@
+import { useState, useMemo } from 'react'
+import { Icon } from '@ynput/ayon-react-components'
+import styled from 'styled-components'
+import {
+  DndContext,
+  closestCenter,
+  DragEndEvent,
+  DragStartEvent,
+  DragOverlay,
+} from '@dnd-kit/core'
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+  useSortable,
+  arrayMove,
+} from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import { createPortal } from 'react-dom'
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  width: 100%;
+`
+
+const SearchInput = styled.input`
+  width: 100%;
+  padding: 6px 8px;
+  border: 1px solid var(--md-sys-color-outline-variant);
+  border-radius: var(--border-radius-m);
+  background: var(--md-sys-color-surface-container-low);
+  color: var(--md-sys-color-on-surface);
+  font-size: 13px;
+
+  &:focus {
+    outline: 1px solid var(--md-sys-color-primary);
+    border-color: var(--md-sys-color-primary);
+  }
+
+  &::placeholder {
+    color: var(--md-sys-color-outline);
+  }
+`
+
+const ItemList = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  overflow-y: auto;
+  max-height: 300px;
+`
+
+const ItemRow = styled.div<{ $isSelected?: boolean }>`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 8px;
+  border-radius: var(--border-radius-m);
+  cursor: pointer;
+  background: ${({ $isSelected }) =>
+    $isSelected ? 'var(--md-sys-color-surface-container-high)' : 'transparent'};
+
+  &:hover {
+    background: var(--md-sys-color-surface-container-high);
+  }
+`
+
+const DragHandle = styled(Icon)`
+  cursor: grab;
+  opacity: 0.5;
+  &:hover {
+    opacity: 1;
+  }
+`
+
+const ItemLabel = styled.span`
+  flex: 1;
+  font-size: 13px;
+  user-select: none;
+`
+
+const ActionIcon = styled(Icon)`
+  cursor: pointer;
+  opacity: 0.5;
+  font-size: 18px;
+  &:hover {
+    opacity: 1;
+  }
+`
+
+const SectionLabel = styled.div`
+  font-size: 11px;
+  text-transform: uppercase;
+  color: var(--md-sys-color-outline);
+  padding: 6px 8px 2px;
+  letter-spacing: 0.5px;
+`
+
+// Sortable item for selected list
+const SortableItem = ({
+  id,
+  label,
+  onRemove,
+}: {
+  id: string
+  label: string
+  onRemove: () => void
+}) => {
+  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
+    id,
+    animateLayoutChanges: () => false,
+  })
+
+  const style = {
+    transform: CSS.Translate.toString(transform),
+    transition,
+  }
+
+  return (
+    <div ref={setNodeRef} style={style}>
+      <ItemRow $isSelected>
+        <DragHandle {...listeners} {...attributes} icon="drag_indicator" />
+        <ItemLabel>{label}</ItemLabel>
+        <ActionIcon
+          icon="close"
+          onClick={(e: React.MouseEvent) => {
+            e.stopPropagation()
+            onRemove()
+          }}
+        />
+      </ItemRow>
+    </div>
+  )
+}
+
+export interface OrderedListWidgetProps {
+  value: string[]
+  options: { label: string; value: string }[]
+  onChange: (value: string[]) => void
+}
+
+const OrderedListWidget = ({ value, options, onChange }: OrderedListWidgetProps) => {
+  const [searchQuery, setSearchQuery] = useState('')
+  const [draggedId, setDraggedId] = useState<string | null>(null)
+
+  const getLabel = (val: string) => {
+    const opt = options.find((o) => o.value === val)
+    return opt?.label || val
+  }
+
+  const addItem = (item: string) => {
+    onChange([...value, item])
+  }
+
+  const removeItem = (item: string) => {
+    onChange(value.filter((v) => v !== item))
+  }
+
+  // Drag handlers
+  const handleDragStart = (event: DragStartEvent) => {
+    setDraggedId(event.active.id as string)
+  }
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    setDraggedId(null)
+    const { active, over } = event
+    if (!over || active.id === over.id) return
+
+    const oldIndex = value.indexOf(active.id as string)
+    const newIndex = value.indexOf(over.id as string)
+    if (oldIndex === -1 || newIndex === -1) return
+
+    onChange(arrayMove(value, oldIndex, newIndex))
+  }
+
+  // Unselected items filtered by search
+  const unselectedItems = useMemo(() => {
+    return options.filter((opt) => {
+      if (value.includes(opt.value)) return false
+      if (searchQuery) {
+        return opt.label.toLowerCase().includes(searchQuery.toLowerCase())
+      }
+      return true
+    })
+  }, [options, value, searchQuery])
+
+  const draggedLabel = draggedId ? getLabel(draggedId) : ''
+
+  return (
+    <Container>
+      {/* Selected items with drag-and-drop */}
+      {value.length > 0 && (
+        <>
+          <SectionLabel>Selected ({value.length})</SectionLabel>
+          <DndContext
+            collisionDetection={closestCenter}
+            onDragStart={handleDragStart}
+            onDragEnd={handleDragEnd}
+          >
+            <SortableContext items={value} strategy={verticalListSortingStrategy}>
+              {value.map((item) => (
+                <SortableItem
+                  key={item}
+                  id={item}
+                  label={getLabel(item)}
+                  onRemove={() => removeItem(item)}
+                />
+              ))}
+            </SortableContext>
+            {draggedId &&
+              createPortal(
+                <DragOverlay>
+                  <ItemRow
+                    $isSelected
+                    style={{
+                      background: 'var(--md-sys-color-surface-container-high)',
+                      boxShadow: '0 0 4px 1px rgba(0, 0, 0, 0.1)',
+                    }}
+                  >
+                    <DragHandle icon="drag_indicator" />
+                    <ItemLabel>{draggedLabel}</ItemLabel>
+                    <ActionIcon icon="close" style={{ opacity: 0.3 }} />
+                  </ItemRow>
+                </DragOverlay>,
+                document.body,
+              )}
+          </DndContext>
+        </>
+      )}
+
+      {/* Available items */}
+      {unselectedItems.length > 0 && (
+        <>
+          <SectionLabel>Available</SectionLabel>
+          {options.length > 5 && (
+            <div style={{ padding: '0 4px 4px' }}>
+              <SearchInput
+                placeholder="Search..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+              />
+            </div>
+          )}
+          <ItemList>
+            {unselectedItems.map((opt) => (
+              <ItemRow key={opt.value} onClick={() => addItem(opt.value)}>
+                <ActionIcon icon="add" style={{ opacity: 0.7 }} />
+                <ItemLabel>{opt.label}</ItemLabel>
+              </ItemRow>
+            ))}
+          </ItemList>
+        </>
+      )}
+
+      {options.length === 0 && <SectionLabel>No options available</SectionLabel>}
+    </Container>
+  )
+}
+
+export default OrderedListWidget

--- a/src/containers/SettingsEditor/Widgets/OrderedListWidget.tsx
+++ b/src/containers/SettingsEditor/Widgets/OrderedListWidget.tsx
@@ -1,5 +1,5 @@
-import { useState, useMemo, useRef, useEffect } from 'react'
-import { Icon } from '@ynput/ayon-react-components'
+import { useState } from 'react'
+import { Icon, Dropdown } from '@ynput/ayon-react-components'
 import styled from 'styled-components'
 import {
   DndContext,
@@ -22,49 +22,6 @@ const Container = styled.div`
   flex-direction: column;
   gap: 2px;
   width: 100%;
-`
-
-const DropdownWrapper = styled.div`
-  position: relative;
-  width: 100%;
-`
-
-const SearchInput = styled.input`
-  width: 100%;
-  padding: 6px 8px;
-  border: 1px solid var(--md-sys-color-outline-variant);
-  border-radius: var(--border-radius-m);
-  background: var(--md-sys-color-surface-container-low);
-  color: var(--md-sys-color-on-surface);
-  font-size: 13px;
-
-  &:focus {
-    outline: 1px solid var(--md-sys-color-primary);
-    border-color: var(--md-sys-color-primary);
-  }
-
-  &::placeholder {
-    color: var(--md-sys-color-outline);
-  }
-`
-
-const DropdownList = styled.div`
-  position: absolute;
-  top: 100%;
-  left: 0;
-  right: 0;
-  z-index: 100;
-  display: flex;
-  flex-direction: column;
-  gap: 1px;
-  overflow-y: auto;
-  max-height: 300px;
-  background: var(--md-sys-color-surface-container);
-  border: 1px solid var(--md-sys-color-outline-variant);
-  border-radius: var(--border-radius-m);
-  margin-top: 2px;
-  padding: 4px 0;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
 `
 
 const ItemRow = styled.div<{ $isSelected?: boolean }>`
@@ -111,34 +68,6 @@ const SectionLabel = styled.div`
   letter-spacing: 0.5px;
 `
 
-const ButtonGroup = styled.div`
-  display: flex;
-  gap: 6px;
-  padding: 6px 0;
-`
-
-const ActionButton = styled.button`
-  padding: 4px 10px;
-  font-size: 12px;
-  border: 1px solid var(--md-sys-color-outline-variant);
-  border-radius: var(--border-radius-s);
-  background: var(--md-sys-color-surface-container-high);
-  color: var(--md-sys-color-on-surface);
-  cursor: pointer;
-  transition: all 0.2s;
-
-  &:hover:not(:disabled) {
-    background: var(--md-sys-color-surface-container-highest);
-    border-color: var(--md-sys-color-outline);
-  }
-
-  &:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-`
-
-// Sortable item for selected list
 const SortableItem = ({
   id,
   label,
@@ -182,47 +111,24 @@ export interface OrderedListWidgetProps {
 }
 
 const OrderedListWidget = ({ value, options, onChange }: OrderedListWidgetProps) => {
-  const [searchQuery, setSearchQuery] = useState('')
-  const [isDropdownOpen, setIsDropdownOpen] = useState(false)
   const [draggedId, setDraggedId] = useState<string | null>(null)
-  const dropdownRef = useRef<HTMLDivElement>(null)
-  const inputRef = useRef<HTMLInputElement>(null)
 
   const getLabel = (val: string) => {
     const opt = options.find((o) => o.value === val)
     return opt?.label || val
   }
 
-  const addItem = (item: string) => {
-    onChange([...value, item])
+  const handleSelectionChange = (newSelection: string[]) => {
+    // Preserve order of already-selected items, append new ones at end
+    const kept = value.filter((v) => newSelection.includes(v))
+    const added = newSelection.filter((v) => !value.includes(v))
+    onChange([...kept, ...added])
   }
 
   const removeItem = (item: string) => {
     onChange(value.filter((v) => v !== item))
   }
 
-  const selectAll = () => {
-    const allValues = options.map((opt) => opt.value)
-    onChange(allValues)
-  }
-
-  const deselectAll = () => {
-    onChange([])
-  }
-
-  // Close dropdown on outside click
-  useEffect(() => {
-    const handleClickOutside = (e: MouseEvent) => {
-      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
-        setIsDropdownOpen(false)
-        setSearchQuery('')
-      }
-    }
-    document.addEventListener('mousedown', handleClickOutside)
-    return () => document.removeEventListener('mousedown', handleClickOutside)
-  }, [])
-
-  // Drag handlers
   const handleDragStart = (event: DragStartEvent) => {
     setDraggedId(event.active.id as string)
   }
@@ -239,72 +145,22 @@ const OrderedListWidget = ({ value, options, onChange }: OrderedListWidgetProps)
     onChange(arrayMove(value, oldIndex, newIndex))
   }
 
-  // Unselected items filtered by search
-  const unselectedItems = useMemo(() => {
-    return options.filter((opt) => {
-      if (value.includes(opt.value)) return false
-      if (searchQuery) {
-        return opt.label.toLowerCase().includes(searchQuery.toLowerCase())
-      }
-      return true
-    })
-  }, [options, value, searchQuery])
-
   const draggedLabel = draggedId ? getLabel(draggedId) : ''
 
   return (
     <Container data-tooltip="">
+      <Dropdown
+        widthExpand
+        options={options}
+        value={value}
+        onSelectionChange={handleSelectionChange}
+        multiSelect
+        placeholder="Select applications"
+      />
 
-      {/* Selected items with drag-and-drop */}
-      {/* Dropdown to add items */}
-      {unselectedItems.length > 0 && (
-        <DropdownWrapper ref={dropdownRef}>
-          <SearchInput
-            ref={inputRef}
-            placeholder="Application"
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            onFocus={() => setIsDropdownOpen(true)}
-          />
-          {isDropdownOpen && (
-            <DropdownList>
-              {unselectedItems.map((opt) => (
-                <ItemRow
-                  key={opt.value}
-                  onClick={() => {
-                    addItem(opt.value)
-                    setSearchQuery('')
-                    inputRef.current?.focus()
-                  }}
-                >
-                  <ItemLabel>{opt.label}</ItemLabel>
-                </ItemRow>
-              ))}
-            </DropdownList>
-          )}
-        </DropdownWrapper>
-      )}
       {value.length > 0 && (
         <>
-          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-            <SectionLabel>Selected ({value.length})</SectionLabel>
-            <ButtonGroup>
-              {unselectedItems.length > 0 && (
-                <ActionButton
-                  onClick={selectAll}
-                  title="Select all available items"
-                >
-                  Select All
-                </ActionButton>
-              )}
-              <ActionButton
-                onClick={deselectAll}
-                title="Deselect all items"
-              >
-                Deselect All
-              </ActionButton>
-            </ButtonGroup>
-          </div>
+          <SectionLabel>Order selection</SectionLabel>
           <DndContext
             collisionDetection={closestCenter}
             onDragStart={handleDragStart}

--- a/src/containers/SettingsEditor/Widgets/OrderedListWidget.tsx
+++ b/src/containers/SettingsEditor/Widgets/OrderedListWidget.tsx
@@ -74,10 +74,9 @@ const ItemRow = styled.div<{ $isSelected?: boolean }>`
   padding: 4px 8px;
   border-radius: var(--border-radius-m);
   cursor: pointer;
-  background: transparent
 
   &:hover {
-    background: var(--md-sys-color-surface-container-high);
+    background: var(--md-sys-color-surface-container-highest);
   }
 `
 

--- a/src/containers/SettingsEditor/Widgets/OrderedListWidget.tsx
+++ b/src/containers/SettingsEditor/Widgets/OrderedListWidget.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useRef, useEffect } from 'react'
 import { Icon } from '@ynput/ayon-react-components'
 import styled from 'styled-components'
 import {
@@ -24,6 +24,11 @@ const Container = styled.div`
   width: 100%;
 `
 
+const DropdownWrapper = styled.div`
+  position: relative;
+  width: 100%;
+`
+
 const SearchInput = styled.input`
   width: 100%;
   padding: 6px 8px;
@@ -43,12 +48,23 @@ const SearchInput = styled.input`
   }
 `
 
-const ItemList = styled.div`
+const DropdownList = styled.div`
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  z-index: 100;
   display: flex;
   flex-direction: column;
   gap: 1px;
   overflow-y: auto;
   max-height: 300px;
+  background: var(--md-sys-color-surface-container);
+  border: 1px solid var(--md-sys-color-outline-variant);
+  border-radius: var(--border-radius-m);
+  margin-top: 2px;
+  padding: 4px 0;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
 `
 
 const ItemRow = styled.div<{ $isSelected?: boolean }>`
@@ -58,8 +74,7 @@ const ItemRow = styled.div<{ $isSelected?: boolean }>`
   padding: 4px 8px;
   border-radius: var(--border-radius-m);
   cursor: pointer;
-  background: ${({ $isSelected }) =>
-    $isSelected ? 'var(--md-sys-color-surface-container-high)' : 'transparent'};
+  background: transparent
 
   &:hover {
     background: var(--md-sys-color-surface-container-high);
@@ -118,9 +133,9 @@ const SortableItem = ({
   }
 
   return (
-    <div ref={setNodeRef} style={style}>
+    <div ref={setNodeRef} style={style} {...attributes}>
       <ItemRow $isSelected>
-        <DragHandle {...listeners} {...attributes} icon="drag_indicator" />
+        <DragHandle {...listeners} icon="drag_indicator" />
         <ItemLabel>{label}</ItemLabel>
         <ActionIcon
           icon="close"
@@ -142,7 +157,10 @@ export interface OrderedListWidgetProps {
 
 const OrderedListWidget = ({ value, options, onChange }: OrderedListWidgetProps) => {
   const [searchQuery, setSearchQuery] = useState('')
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false)
   const [draggedId, setDraggedId] = useState<string | null>(null)
+  const dropdownRef = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
 
   const getLabel = (val: string) => {
     const opt = options.find((o) => o.value === val)
@@ -156,6 +174,18 @@ const OrderedListWidget = ({ value, options, onChange }: OrderedListWidgetProps)
   const removeItem = (item: string) => {
     onChange(value.filter((v) => v !== item))
   }
+
+  // Close dropdown on outside click
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setIsDropdownOpen(false)
+        setSearchQuery('')
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [])
 
   // Drag handlers
   const handleDragStart = (event: DragStartEvent) => {
@@ -188,8 +218,37 @@ const OrderedListWidget = ({ value, options, onChange }: OrderedListWidgetProps)
   const draggedLabel = draggedId ? getLabel(draggedId) : ''
 
   return (
-    <Container>
+    <Container data-tooltip="">
+
       {/* Selected items with drag-and-drop */}
+      {/* Dropdown to add items */}
+      {unselectedItems.length > 0 && (
+        <DropdownWrapper ref={dropdownRef}>
+          <SearchInput
+            ref={inputRef}
+            placeholder="Application"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            onFocus={() => setIsDropdownOpen(true)}
+          />
+          {isDropdownOpen && (
+            <DropdownList>
+              {unselectedItems.map((opt) => (
+                <ItemRow
+                  key={opt.value}
+                  onClick={() => {
+                    addItem(opt.value)
+                    setSearchQuery('')
+                    inputRef.current?.focus()
+                  }}
+                >
+                  <ItemLabel>{opt.label}</ItemLabel>
+                </ItemRow>
+              ))}
+            </DropdownList>
+          )}
+        </DropdownWrapper>
+      )}
       {value.length > 0 && (
         <>
           <SectionLabel>Selected ({value.length})</SectionLabel>
@@ -226,30 +285,6 @@ const OrderedListWidget = ({ value, options, onChange }: OrderedListWidgetProps)
                 document.body,
               )}
           </DndContext>
-        </>
-      )}
-
-      {/* Available items */}
-      {unselectedItems.length > 0 && (
-        <>
-          <SectionLabel>Available</SectionLabel>
-          {options.length > 5 && (
-            <div style={{ padding: '0 4px 4px' }}>
-              <SearchInput
-                placeholder="Search..."
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-              />
-            </div>
-          )}
-          <ItemList>
-            {unselectedItems.map((opt) => (
-              <ItemRow key={opt.value} onClick={() => addItem(opt.value)}>
-                <ActionIcon icon="add" style={{ opacity: 0.7 }} />
-                <ItemLabel>{opt.label}</ItemLabel>
-              </ItemRow>
-            ))}
-          </ItemList>
         </>
       )}
 

--- a/src/containers/SettingsEditor/Widgets/OrderedListWidget.tsx
+++ b/src/containers/SettingsEditor/Widgets/OrderedListWidget.tsx
@@ -1,13 +1,7 @@
 import { useState } from 'react'
 import { Icon, Dropdown } from '@ynput/ayon-react-components'
 import styled from 'styled-components'
-import {
-  DndContext,
-  closestCenter,
-  DragEndEvent,
-  DragStartEvent,
-  DragOverlay,
-} from '@dnd-kit/core'
+import { DndContext, closestCenter, DragEndEvent, DragStartEvent, DragOverlay } from '@dnd-kit/core'
 import {
   SortableContext,
   verticalListSortingStrategy,
@@ -16,6 +10,7 @@ import {
 } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import { createPortal } from 'react-dom'
+import clsx from 'clsx'
 
 const Container = styled.div`
   display: flex;
@@ -24,7 +19,7 @@ const Container = styled.div`
   width: 100%;
 `
 
-const ItemRow = styled.div<{ $isSelected?: boolean }>`
+const ItemRow = styled.div`
   display: flex;
   align-items: center;
   gap: 8px;
@@ -33,7 +28,11 @@ const ItemRow = styled.div<{ $isSelected?: boolean }>`
   cursor: pointer;
 
   &:hover {
-    background: var(--md-sys-color-surface-container-highest);
+    background: var(--md-sys-color-surface-container-hover);
+  }
+
+  &.dragging {
+    visibility: hidden;
   }
 `
 
@@ -72,9 +71,11 @@ const SortableItem = ({
   id,
   label,
   onRemove,
+  isDragging,
 }: {
   id: string
   label: string
+  isDragging: boolean
   onRemove: () => void
 }) => {
   const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
@@ -89,7 +90,7 @@ const SortableItem = ({
 
   return (
     <div ref={setNodeRef} style={style} {...attributes}>
-      <ItemRow $isSelected>
+      <ItemRow className={clsx({ dragging: isDragging })}>
         <DragHandle {...listeners} icon="drag_indicator" />
         <ItemLabel>{label}</ItemLabel>
         <ActionIcon
@@ -173,6 +174,7 @@ const OrderedListWidget = ({ value, options, onChange }: OrderedListWidgetProps)
                   id={item}
                   label={getLabel(item)}
                   onRemove={() => removeItem(item)}
+                  isDragging={draggedId === item}
                 />
               ))}
             </SortableContext>
@@ -180,7 +182,6 @@ const OrderedListWidget = ({ value, options, onChange }: OrderedListWidgetProps)
               createPortal(
                 <DragOverlay>
                   <ItemRow
-                    $isSelected
                     style={{
                       background: 'var(--md-sys-color-surface-container-high)',
                       boxShadow: '0 0 4px 1px rgba(0, 0, 0, 0.1)',

--- a/src/containers/SettingsEditor/Widgets/OrderedListWidget.tsx
+++ b/src/containers/SettingsEditor/Widgets/OrderedListWidget.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Icon, Dropdown } from '@ynput/ayon-react-components'
+import { Icon, Dropdown, DropdownProps } from '@ynput/ayon-react-components'
 import styled from 'styled-components'
 import { DndContext, closestCenter, DragEndEvent, DragStartEvent, DragOverlay } from '@dnd-kit/core'
 import {
@@ -17,6 +17,13 @@ const Container = styled.div`
   flex-direction: column;
   gap: 2px;
   width: 100%;
+  max-width: 800px;
+`
+
+const StyledDropdown = styled(Dropdown)`
+  button > div > div:has(span) {
+    width: 0;
+  }
 `
 
 const ItemRow = styled.div`
@@ -109,9 +116,19 @@ export interface OrderedListWidgetProps {
   value: string[]
   options: { label: string; value: string }[]
   onChange: (value: string[]) => void
+  placeholder?: string
+  disabled?: boolean
+  dropdownProps?: Partial<DropdownProps>
 }
 
-const OrderedListWidget = ({ value, options, onChange }: OrderedListWidgetProps) => {
+const OrderedListWidget = ({
+  value,
+  options,
+  onChange,
+  placeholder = 'Select applications',
+  disabled,
+  dropdownProps,
+}: OrderedListWidgetProps) => {
   const [draggedId, setDraggedId] = useState<string | null>(null)
 
   const getLabel = (val: string) => {
@@ -128,6 +145,17 @@ const OrderedListWidget = ({ value, options, onChange }: OrderedListWidgetProps)
 
   const removeItem = (item: string) => {
     onChange(value.filter((v) => v !== item))
+  }
+
+  const handleSelectAll = () => {
+    const all = options.map((o) => o.value)
+    const kept = value.filter((v) => all.includes(v))
+    const added = all.filter((v) => !value.includes(v))
+    onChange([...kept, ...added])
+  }
+
+  const handleClear = () => {
+    onChange([])
   }
 
   const handleDragStart = (event: DragStartEvent) => {
@@ -150,13 +178,19 @@ const OrderedListWidget = ({ value, options, onChange }: OrderedListWidgetProps)
 
   return (
     <Container data-tooltip="">
-      <Dropdown
+      <StyledDropdown
         widthExpand
         options={options}
         value={value}
         onSelectionChange={handleSelectionChange}
         multiSelect
-        placeholder="Select applications"
+        placeholder={placeholder}
+        disabled={disabled}
+        search={options.length > 10}
+        onSelectAll={options.length > 10 ? handleSelectAll : undefined}
+        onClear={value.length > 0 ? handleClear : undefined}
+        clearTooltip="Clear selection"
+        {...dropdownProps}
       />
 
       {value.length > 0 && (

--- a/src/containers/SettingsEditor/Widgets/SelectWidget.tsx
+++ b/src/containers/SettingsEditor/Widgets/SelectWidget.tsx
@@ -13,6 +13,46 @@ const StyledDropdown = styled(Dropdown)`
   }
 `
 
+const SwitchboxContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-width: 800px;
+`
+
+const SwitchboxGrid = styled.div`
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 12px 16px;
+`
+
+const SwitchboxButtonGroup = styled.div`
+  display: flex;
+  gap: 8px;
+`
+
+const SwitchboxButton = styled.button`
+  padding: 6px 12px;
+  font-size: 12px;
+  border: 1px solid var(--md-sys-color-outline-variant);
+  border-radius: var(--border-radius-s);
+  background: var(--md-sys-color-surface-container-high);
+  color: var(--md-sys-color-on-surface);
+  cursor: pointer;
+  transition: all 0.2s;
+
+  &:hover:not(:disabled) {
+    background: var(--md-sys-color-surface-container-highest);
+    border-color: var(--md-sys-color-outline);
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+`
+
 const Switchbox = ({ options, value, onSelectionChange }: $Any) => {
   const isSelected = (val: $Any) => {
     if (Array.isArray(value)) {
@@ -33,36 +73,60 @@ const Switchbox = ({ options, value, onSelectionChange }: $Any) => {
     }
   }
 
-    return (
-    <div style={{
-      maxWidth: '800px',
-    }}>
-    <div
-      style={{
-        position: "relative",
-        display: "grid",
-        gridTemplateColumns: "repeat(auto-fit, minmax(250px, 1fr))",
-        gap: "12px 16px",
-      }}
-    >
-      {options.map((opt: any) => (
-        <div
-          key={opt.value}
-          style={{
-            display: "flex",
-            alignItems: "center",
-            gap: "8px",
-          }}
-        >
-          <InputSwitch
-            checked={isSelected(opt.value)}
-            onChange={() => toggleSelection(opt.value)}
-          />
-          <label style={{whiteSpace:"nowrap"}}>{opt.label}</label>
-        </div>
-      ))}
-    </div>
-    </div>
+  const selectAll = () => {
+    if (Array.isArray(value)) {
+      onSelectionChange(options.map((opt: any) => opt.value))
+    }
+  }
+
+  const deselectAll = () => {
+    if (Array.isArray(value)) {
+      onSelectionChange([])
+    }
+  }
+
+  const allSelected = Array.isArray(value) && value.length === options.length
+  const noneSelected = Array.isArray(value) && value.length === 0
+
+  return (
+    <SwitchboxContainer>
+      {options.length > 0 && (
+        <SwitchboxButtonGroup>
+          <SwitchboxButton
+            onClick={selectAll}
+            disabled={allSelected}
+            title="Select all options"
+          >
+            Select All
+          </SwitchboxButton>
+          <SwitchboxButton
+            onClick={deselectAll}
+            disabled={noneSelected}
+            title="Deselect all options"
+          >
+            Deselect All
+          </SwitchboxButton>
+        </SwitchboxButtonGroup>
+      )}
+      <SwitchboxGrid>
+        {options.map((opt: any) => (
+          <div
+            key={opt.value}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "8px",
+            }}
+          >
+            <InputSwitch
+              checked={isSelected(opt.value)}
+              onChange={() => toggleSelection(opt.value)}
+            />
+            <label style={{whiteSpace:"nowrap"}}>{opt.label}</label>
+          </div>
+        ))}
+      </SwitchboxGrid>
+    </SwitchboxContainer>
   )
 
 }

--- a/src/containers/SettingsEditor/Widgets/SelectWidget.tsx
+++ b/src/containers/SettingsEditor/Widgets/SelectWidget.tsx
@@ -71,11 +71,19 @@ const Switchbox = ({ options, value, onSelectionChange }: $Any) => {
 
 const SelectWidget = (props: $Any) => {
   const { originalValue, path } = parseContext(props)
-  const [value, setValue] = useState(null)
+  const [value, setValue] = useState<string[] | string | null>(null)
+
+  const widget = props.schema?.widget
+  // TODO: remove ID check once backend addon adds widget="sortable_multiselect" to schema
+  const isSortableMultiselect =
+    widget === 'sortable_multiselect' ||
+    (props.multiple && /applications_profiles_\d+_applications$/.test(props.id))
 
   useEffect(() => {
     // Sync the local state with the formData
-    if (equiv(value, props.value)) {
+    // For sortable multiselect, order matters - use isEqual instead of equiv
+    const eq = isSortableMultiselect ? isEqual(value, props.value) : equiv(value, props.value)
+    if (eq) {
       return
     }
 
@@ -91,13 +99,18 @@ const SelectWidget = (props: $Any) => {
 
   useEffect(() => {
     if (value === null) return
-    const isChanged = !equiv(value, props.value)
+    const isChanged = isSortableMultiselect
+      ? !isEqual(value, props.value)
+      : !equiv(value, props.value)
     if (!isChanged) {
       return
     }
     props.onChange(value)
     setTimeout(() => {
-      updateChangedKeys(props, !equiv(value, props.originalValue), path)
+      const origChanged = isSortableMultiselect
+        ? !isEqual(value, originalValue)
+        : !equiv(value, props.originalValue)
+      updateChangedKeys(props, origChanged, path)
     }, 100)
   }, [value])
 
@@ -136,24 +149,12 @@ const SelectWidget = (props: $Any) => {
     renderableValue = [value]
   }
 
-  const widget = props.schema?.widget
-  // TODO: remove ID check once backend addon adds widget="sortable_multiselect" to schema
-  const isSortableMultiselect =
-    widget === 'sortable_multiselect' ||
-    (props.multiple && /applications_profiles_\d+_applications$/.test(props.id))
-
   if (isSortableMultiselect && props.multiple) {
     return (
       <OrderedListWidget
-        value={value || []}
+        value={(value as string[]) || []}
         options={options}
-        onChange={(newValue) => {
-          props.onChange(newValue)
-          setTimeout(() => {
-            // use isEqual (order-sensitive) instead of equiv (order-insensitive)
-            updateChangedKeys(props, !isEqual(newValue, originalValue), path)
-          }, 100)
-        }}
+        onChange={setValue as (value: string[]) => void}
       />
     )
   }

--- a/src/containers/SettingsEditor/Widgets/SelectWidget.tsx
+++ b/src/containers/SettingsEditor/Widgets/SelectWidget.tsx
@@ -1,10 +1,11 @@
-import React from 'react'
 import { useState, useEffect } from 'react'
 import { Dropdown, InputSwitch } from '@ynput/ayon-react-components'
 
 import { updateChangedKeys, equiv, parseContext } from '../helpers'
 import { $Any } from '@types'
 import styled from 'styled-components'
+import OrderedListWidget from './OrderedListWidget'
+import { isEqual } from 'lodash'
 
 const StyledDropdown = styled(Dropdown)`
   button > div > div:has(span) {
@@ -136,6 +137,27 @@ const SelectWidget = (props: $Any) => {
   }
 
   const widget = props.schema?.widget
+  // TODO: remove ID check once backend addon adds widget="sortable_multiselect" to schema
+  const isSortableMultiselect =
+    widget === 'sortable_multiselect' ||
+    (props.multiple && /applications_profiles_\d+_applications$/.test(props.id))
+
+  if (isSortableMultiselect && props.multiple) {
+    return (
+      <OrderedListWidget
+        value={value || []}
+        options={options}
+        onChange={(newValue) => {
+          props.onChange(newValue)
+          setTimeout(() => {
+            // use isEqual (order-sensitive) instead of equiv (order-insensitive)
+            updateChangedKeys(props, !isEqual(newValue, originalValue), path)
+          }, 100)
+        }}
+      />
+    )
+  }
+
   if (widget === 'switchbox' && props.multiple) {
     return (
       <Switchbox

--- a/src/containers/SettingsEditor/Widgets/SelectWidget.tsx
+++ b/src/containers/SettingsEditor/Widgets/SelectWidget.tsx
@@ -8,6 +8,7 @@ import OrderedListWidget from './OrderedListWidget'
 import { isEqual } from 'lodash'
 
 const StyledDropdown = styled(Dropdown)`
+  max-width: 800px;
   button > div > div:has(span) {
     width: 0;
   }
@@ -219,6 +220,8 @@ const SelectWidget = (props: $Any) => {
         value={(value as string[]) || []}
         options={options}
         onChange={setValue as (value: string[]) => void}
+        placeholder={props.schema?.placeholder}
+        disabled={props.schema?.disabled}
       />
     )
   }


### PR DESCRIPTION

<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
Add sortable multiselect widget for preferred apps (project applications profiles). Users can reorder application priority via drag-and-drop using a new OrderedListWidget component integrated into the settings editor. 

## Technical details
<!-- Please state any technical details such as limitations -->
- New OrderedListWidget component using @dnd-kit for drag-and-drop reordering with dual-panel UI (selected + available items)
- SelectWidget detects sortable multiselect fields via widget="sortable_multiselect" schema prop or ID pattern match (applications_profiles_*_applications)
- Uses isEqual (order-sensitive) instead of equiv (order-insensitive) for change detection so reordering is correctly tracked and persisted

## Additional context
<!-- Add any other context or screenshots here. -->
<img width="548" height="366" alt="Screenshot 2026-04-15 at 10 36 57" src="https://github.com/user-attachments/assets/ddf25113-b081-4696-844a-3dfa506ec6a3" />
<img width="252" height="337" alt="Screenshot 2026-04-15 at 10 31 38" src="https://github.com/user-attachments/assets/2eba2afc-d6ca-4930-bebd-a7cec1fad69c" />

