### PR TITLE
Grouping: Overview view switch preserves old grouping fix

### DIFF
--- a/shared/src/containers/ProjectTreeTable/hooks/useSortBySettings.tsx
+++ b/shared/src/containers/ProjectTreeTable/hooks/useSortBySettings.tsx
@@ -1,5 +1,5 @@
 import { useColumnSettingsContext, useProjectTableContext } from '../context'
-import { SortCardType, SettingsSortingDropdown } from '@ynput/ayon-react-components'
+import { SortCardType, SortingDropdown as SettingsSortingDropdown } from '@ynput/ayon-react-components'
 
 const BUILT_IN_SORT_OPTIONS: { id: string; label: string; scopes?: string[] }[] = [
   { id: 'name', label: 'Name' },

--- a/src/pages/ProjectOverviewPage/context/ProjectOverviewContext.tsx
+++ b/src/pages/ProjectOverviewPage/context/ProjectOverviewContext.tsx
@@ -97,27 +97,32 @@ export const ProjectOverviewProvider = ({ children, modules }: ProjectOverviewPr
   // to working view causes a race condition where stale settings override the user's action.
   const skipNextViewSettingsSyncRef = useRef(false)
 
-  // Sync viewGroupBy from server whenever viewSettings changes (view switch, server update, etc.)
-  // Skipped when the change originated from a local groupBy/hierarchy update.
+  // Sync viewGroupBy from server whenever the grouping-related settings change
+  // (view switch, server update, etc.). Skipped when the change originated from
+  // a local groupBy/hierarchy update to avoid race conditions.
+  const overviewShowHierarchy = (viewSettings as OverviewSettings | undefined)?.showHierarchy
+  const overviewGroupBy = (viewSettings as OverviewSettings | undefined)?.groupBy
   useEffect(() => {
     if (skipNextViewSettingsSyncRef.current) {
       skipNextViewSettingsSyncRef.current = false
       return
     }
-    const settings = viewSettings as OverviewSettings | undefined
-    if (!settings) return
-    const serverShowHierarchy = settings.showHierarchy ?? true
-    const serverGroupBy = settings.groupBy
+    const serverShowHierarchy = overviewShowHierarchy ?? true
 
+    let newViewGroupBy: string | null
     if (serverShowHierarchy) {
-      setViewGroupBy(null) // hierarchy mode
-    } else if (serverGroupBy) {
-      setViewGroupBy(serverGroupBy) // grouped by field
+      newViewGroupBy = null // hierarchy mode
+    } else if (overviewGroupBy) {
+      newViewGroupBy = overviewGroupBy // grouped by field
     } else {
-      setViewGroupBy('none') // flat list
+      newViewGroupBy = 'none' // flat list
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [JSON.stringify(viewSettings)])
+
+    // Only write when value actually changed to avoid unnecessary localStorage churn
+    if (newViewGroupBy !== viewGroupBy) {
+      setViewGroupBy(newViewGroupBy)
+    }
+  }, [overviewShowHierarchy, overviewGroupBy, viewGroupBy, setViewGroupBy])
 
   const {
     onUpdateHierarchy: _updateShowHierarchy,

--- a/src/pages/ProjectOverviewPage/context/ProjectOverviewContext.tsx
+++ b/src/pages/ProjectOverviewPage/context/ProjectOverviewContext.tsx
@@ -3,6 +3,7 @@ import { createContext, useCallback, useContext, useEffect, useMemo, useRef } fr
 
 // Third-party libraries
 import { ExpandedState } from '@tanstack/react-table'
+import { OverviewSettings } from '@shared/api'
 
 // Shared components and hooks
 import { useLocalStorage, useGetEntityGroups } from '@shared/hooks'
@@ -91,6 +92,33 @@ export const ProjectOverviewProvider = ({ children, modules }: ProjectOverviewPr
   const { viewSettings, isLoadingViews } = useViewsContext()
   const { updateViewSettings } = useViewUpdateHelper()
 
+  // Ref to suppress viewSettings sync when the change was triggered locally
+  // (e.g., user clicked X to remove grouping). Without this, the auto-switch
+  // to working view causes a race condition where stale settings override the user's action.
+  const skipNextViewSettingsSyncRef = useRef(false)
+
+  // Sync viewGroupBy from server whenever viewSettings changes (view switch, server update, etc.)
+  // Skipped when the change originated from a local groupBy/hierarchy update.
+  useEffect(() => {
+    if (skipNextViewSettingsSyncRef.current) {
+      skipNextViewSettingsSyncRef.current = false
+      return
+    }
+    const settings = viewSettings as OverviewSettings | undefined
+    if (!settings) return
+    const serverShowHierarchy = settings.showHierarchy ?? true
+    const serverGroupBy = settings.groupBy
+
+    if (serverShowHierarchy) {
+      setViewGroupBy(null) // hierarchy mode
+    } else if (serverGroupBy) {
+      setViewGroupBy(serverGroupBy) // grouped by field
+    } else {
+      setViewGroupBy('none') // flat list
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [JSON.stringify(viewSettings)])
+
   const {
     onUpdateHierarchy: _updateShowHierarchy,
     filters: queryFilters,
@@ -113,6 +141,7 @@ export const ProjectOverviewProvider = ({ children, modules }: ProjectOverviewPr
   // onUpdateColumns (called by updateGroupBy) already handles showHierarchy on the server
   const updateViewGroupBy = useCallback(
     (newViewGroupBy: string | null, desc?: boolean) => {
+      skipNextViewSettingsSyncRef.current = true
       setViewGroupBy(newViewGroupBy)
       if (newViewGroupBy === null) {
         // Enter hierarchy mode: clear groupBy and persist showHierarchy on server
@@ -152,6 +181,7 @@ export const ProjectOverviewProvider = ({ children, modules }: ProjectOverviewPr
   // For backward compat: wrap updateShowHierarchy to also update viewGroupBy
   const updateShowHierarchy = useCallback(
     (newShowHierarchy: boolean) => {
+      skipNextViewSettingsSyncRef.current = true
       if (newShowHierarchy) {
         setViewGroupBy(null)
       } else {

--- a/src/pages/ProjectOverviewPage/context/ProjectOverviewContext.tsx
+++ b/src/pages/ProjectOverviewPage/context/ProjectOverviewContext.tsx
@@ -1,5 +1,5 @@
 // React imports
-import { createContext, useCallback, useContext, useEffect, useMemo, useRef } from 'react'
+import { createContext, useCallback, useContext, useMemo } from 'react'
 
 // Third-party libraries
 import { ExpandedState } from '@tanstack/react-table'
@@ -71,18 +71,6 @@ export const ProjectOverviewProvider = ({ children, modules }: ProjectOverviewPr
     {},
   )
 
-  // View mode: null = hierarchy, string = groupBy field id (e.g. 'folderType', 'status')
-  // Default is derived from server settings: if server has a groupBy, use it;
-  // if server has showHierarchy: true (or default), use null (hierarchy mode);
-  // otherwise fall back to 'folderType'
-  const serverGroupByDefault = panelGroupBy?.id ?? null
-  const [viewGroupBy, setViewGroupBy] = useLocalStorage<string | null>(
-    createLocalStorageKey(page, 'viewGroupBy', projectName),
-    serverGroupByDefault,
-  )
-  // Derive desc directly from panel groupBy (single source of truth — no separate state)
-  const viewGroupByDesc = panelGroupBy?.desc ?? false
-
   const { updateExpanded, toggleExpanded, expandedIds } = useExpandedState({
     expanded,
     setExpanded,
@@ -92,37 +80,19 @@ export const ProjectOverviewProvider = ({ children, modules }: ProjectOverviewPr
   const { viewSettings, isLoadingViews } = useViewsContext()
   const { updateViewSettings } = useViewUpdateHelper()
 
-  // Ref to suppress viewSettings sync when the change was triggered locally
-  // (e.g., user clicked X to remove grouping). Without this, the auto-switch
-  // to working view causes a race condition where stale settings override the user's action.
-  const skipNextViewSettingsSyncRef = useRef(false)
-
-  // Sync viewGroupBy from server whenever the grouping-related settings change
-  // (view switch, server update, etc.). Skipped when the change originated from
-  // a local groupBy/hierarchy update to avoid race conditions.
+  // View mode derived purely from server viewSettings — no localStorage, no sync effect.
+  // null = hierarchy, 'none' = flat list, other string = groupBy field id ('folderType', 'status', 'folder', ...)
   const overviewShowHierarchy = (viewSettings as OverviewSettings | undefined)?.showHierarchy
   const overviewGroupBy = (viewSettings as OverviewSettings | undefined)?.groupBy
-  useEffect(() => {
-    if (skipNextViewSettingsSyncRef.current) {
-      skipNextViewSettingsSyncRef.current = false
-      return
-    }
-    const serverShowHierarchy = overviewShowHierarchy ?? true
+  const viewGroupBy = useMemo<string | null>(() => {
+    const showHierarchy = overviewShowHierarchy ?? true
+    if (showHierarchy) return null
+    if (overviewGroupBy) return overviewGroupBy
+    return 'none'
+  }, [overviewShowHierarchy, overviewGroupBy])
 
-    let newViewGroupBy: string | null
-    if (serverShowHierarchy) {
-      newViewGroupBy = null // hierarchy mode
-    } else if (overviewGroupBy) {
-      newViewGroupBy = overviewGroupBy // grouped by field
-    } else {
-      newViewGroupBy = 'none' // flat list
-    }
-
-    // Only write when value actually changed to avoid unnecessary localStorage churn
-    if (newViewGroupBy !== viewGroupBy) {
-      setViewGroupBy(newViewGroupBy)
-    }
-  }, [overviewShowHierarchy, overviewGroupBy, viewGroupBy, setViewGroupBy])
+  // Derive desc directly from panel groupBy (single source of truth — no separate state)
+  const viewGroupByDesc = panelGroupBy?.desc ?? false
 
   const {
     onUpdateHierarchy: _updateShowHierarchy,
@@ -142,12 +112,10 @@ export const ProjectOverviewProvider = ({ children, modules }: ProjectOverviewPr
   // Flat folder view: shows all folders flat, each expandable to reveal tasks
   const isFlatFolderView = viewGroupBy === 'folder'
 
-  // When user changes viewGroupBy, sync to Customize panel's groupBy
-  // onUpdateColumns (called by updateGroupBy) already handles showHierarchy on the server
+  // User action handler — writes to server only. viewGroupBy is derived from viewSettings,
+  // so the UI updates once the server mutation reflects in the view cache.
   const updateViewGroupBy = useCallback(
     (newViewGroupBy: string | null, desc?: boolean) => {
-      skipNextViewSettingsSyncRef.current = true
-      setViewGroupBy(newViewGroupBy)
       if (newViewGroupBy === null) {
         // Enter hierarchy mode: clear groupBy and persist showHierarchy on server
         _updateShowHierarchy(true)
@@ -158,43 +126,21 @@ export const ProjectOverviewProvider = ({ children, modules }: ProjectOverviewPr
         updateGroupBy(undefined)
       } else if (newViewGroupBy === 'folder') {
         // Flat folder view: no hierarchy, no groupBy (uses hierarchy-style task fetching)
-        // Don't call updateGroupBy — avoids triggering the panel sync effect
-        // which would override viewGroupBy back to null
         _updateShowHierarchy(false)
+        updateGroupBy(undefined)
       } else {
         // onUpdateColumns (called by updateGroupBy) sets showHierarchy: false on the server
         updateGroupBy({ id: newViewGroupBy, desc: desc ?? viewGroupByDesc })
       }
     },
-    [setViewGroupBy, updateGroupBy, _updateShowHierarchy, viewGroupByDesc],
+    [updateGroupBy, _updateShowHierarchy, viewGroupByDesc],
   )
 
-  // Sync FROM Customize panel TO dropdown when panel's groupBy id changes
-  // Only sync when panel has a real groupBy value — when it clears (undefined),
-  // the correct viewGroupBy was already set by updateShowHierarchy (null for hierarchy, 'none' for flat list)
-  const panelGroupById = panelGroupBy?.id
-  const prevPanelGroupByIdRef = useRef(panelGroupById)
-  useEffect(() => {
-    if (panelGroupById !== prevPanelGroupByIdRef.current) {
-      prevPanelGroupByIdRef.current = panelGroupById
-      if (panelGroupById !== undefined) {
-        setViewGroupBy(panelGroupById)
-      }
-    }
-  }, [panelGroupById, setViewGroupBy])
-
-  // For backward compat: wrap updateShowHierarchy to also update viewGroupBy
   const updateShowHierarchy = useCallback(
     (newShowHierarchy: boolean) => {
-      skipNextViewSettingsSyncRef.current = true
-      if (newShowHierarchy) {
-        setViewGroupBy(null)
-      } else {
-        setViewGroupBy('none')
-      }
       _updateShowHierarchy(newShowHierarchy)
     },
-    [setViewGroupBy, _updateShowHierarchy],
+    [_updateShowHierarchy],
   )
 
   // Build the effective groupBy for data fetching from the view dropdown

--- a/src/pages/VersionsProductsPage/components/VPTableSettings/VPTableSortingSetting.tsx
+++ b/src/pages/VersionsProductsPage/components/VPTableSettings/VPTableSortingSetting.tsx
@@ -1,5 +1,5 @@
 import { AttributeField } from '@shared/components'
-import { SortCardType, SettingsSortingDropdown } from '@ynput/ayon-react-components'
+import { SortCardType, SortingDropdown as SettingsSortingDropdown } from '@ynput/ayon-react-components'
 import { FC } from 'react'
 
 interface VPTableSortingSettingProps {


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
 **Overview page:** Fixed view switching breaking old saved views. When user switched to hierarchy or grouped views, stale localStorage `viewGroupBy` persisted instead of loading server settings.
**Root cause:** `viewGroupBy` in localStorage never synced from server when `viewSettings` changed (view switch or settings update).

 **Fix:** Added effect watching `JSON.stringify(viewSettings)` that syncs `viewGroupBy` from server. During local groupBy changes, suppress first sync with ref to avoid race condition from auto-switch to working view.

## Technical details
<!-- Please state any technical details such as limitations -->
**Effect suppression pattern:**
  - User changes groupBy locally → set `skipNextViewSettingsSyncRef = true`
  - Immediate UI update (localStorage)
  - Server persist + auto-switch to working view → `viewSettings` changes
  - Effect fires → ref is true → skip (don't override) → reset ref
  - Next server update → ref is false → sync from correct server state


## Additional context
<!-- Add any other context or screenshots here. -->
