### PR TITLE
Attributes: Redesign with user friendly types

### DIFF
--- a/shared/src/components/AttributeEditor/AttributeEditor.tsx
+++ b/shared/src/components/AttributeEditor/AttributeEditor.tsx
@@ -15,6 +15,14 @@ import { camelCase, upperFirst } from 'lodash'
 import { MinMaxField } from './components'
 import { EnumEditor } from '@shared/components/EnumEditor'
 import { AttributeData, AttributeModel, AttributeEnumItem } from '@shared/api'
+import {
+  UIAttributeType,
+  UI_TYPE_OPTIONS,
+  UI_TYPE_FIELDS,
+  UI_TYPE_EXCLUDE,
+  backendToUiType,
+  uiTypeToBackend,
+} from './attributeTypeMap'
 
 const SCOPE_OPTIONS = [
   { value: 'project', label: 'Project' },
@@ -43,51 +51,6 @@ const GLOBAL_FIELDS: GlobalFieldEntry[] = [
     scope: ['project', 'folder', 'task', 'product', 'version', 'representation', 'user'],
   },
 ]
-
-interface TypeOptionDef {
-  value: AttributeData['type']
-  label: string
-  fields: (keyof AttributeData)[]
-  exclude?: (keyof AttributeData)[]
-}
-
-interface TypeOptionsMap {
-  [key: string]: TypeOptionDef
-}
-
-const TYPE_OPTIONS: TypeOptionsMap = {
-  string: {
-    value: 'string',
-    label: 'String',
-    fields: ['minLength', 'maxLength', 'enum', 'regex'],
-  },
-  integer: {
-    value: 'integer',
-    label: 'Integer',
-    fields: ['ge', 'gt', 'le', 'lt'],
-  },
-  float: {
-    value: 'float',
-    label: 'Decimal number',
-    fields: ['ge', 'gt', 'le', 'lt'],
-  },
-  list_of_strings: {
-    value: 'list_of_strings',
-    label: 'List Of Strings',
-    fields: ['minItems', 'maxItems', 'enum'],
-  },
-  boolean: {
-    value: 'boolean',
-    label: 'Boolean',
-    fields: [],
-    exclude: ['example'],
-  },
-  datetime: {
-    value: 'datetime',
-    label: 'Datetime',
-    fields: [],
-  },
-}
 
 type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
 type PartialBy<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>
@@ -196,16 +159,25 @@ export const AttributeEditor: FC<AttributeEditorProps> = ({
       }
     : undefined
 
-  const [formData, setFormData] = useState<AttributeForm | null>(
+  const initData =
     attribute ||
-      buildInitFormData(excludes, {
-        position: existingNames.length,
-        ...resolvedDefaultData,
-      }),
+    buildInitFormData(excludes, {
+      position: existingNames.length,
+      ...resolvedDefaultData,
+    })
+
+  const [formData, setFormData] = useState<AttributeForm | null>(initData)
+  const [uiType, setUiType] = useState<UIAttributeType>(() =>
+    backendToUiType(initData?.data?.type, initData?.data?.enum),
   )
+  const [isDecimal, setIsDecimal] = useState<boolean>(() => initData?.data?.type === 'float')
 
   useEffect(() => {
-    if (!!attribute) setFormData(attribute)
+    if (!!attribute) {
+      setFormData(attribute)
+      setUiType(backendToUiType(attribute.data?.type, attribute.data?.enum))
+      setIsDecimal(attribute.data?.type === 'float')
+    }
   }, [attribute])
 
   const isNew = !attribute
@@ -282,10 +254,9 @@ export const AttributeEditor: FC<AttributeEditorProps> = ({
     }
   })
 
-  if (formData?.data.type && TYPE_OPTIONS[formData.data.type]) {
-    const typeOpt = TYPE_OPTIONS[formData.data.type]
-    dataFields = [...dataFields, ...typeOpt.fields].filter((f) => !typeOpt.exclude?.includes(f))
-  }
+  const typeFields = UI_TYPE_FIELDS[uiType] ?? []
+  const typeExclude = UI_TYPE_EXCLUDE[uiType] ?? []
+  dataFields = [...dataFields, ...typeFields].filter((f) => !typeExclude.includes(f))
 
   type CustomFieldRenderer = (value: any, onChange: (newValue: any) => void) => JSX.Element | null
   const customFields: {
@@ -321,6 +292,21 @@ export const AttributeEditor: FC<AttributeEditorProps> = ({
 
     if (isNew) {
       setTopLevelData('name', camelCase(v))
+    }
+  }
+
+  const handleUiTypeChange = (v: string[]) => {
+    const newUiType = v[0] as UIAttributeType
+    setUiType(newUiType)
+    setData('type', uiTypeToBackend(newUiType, isDecimal))
+
+    // Clear enum when switching away from select/multi_select
+    if (newUiType !== 'select' && newUiType !== 'multi_select') {
+      setData('enum', undefined)
+    }
+    // Clear regex if not supported by the new type
+    if (newUiType !== 'text' && formData?.data?.regex) {
+      setData('regex', '')
     }
   }
 
@@ -372,23 +358,25 @@ export const AttributeEditor: FC<AttributeEditorProps> = ({
           {!excludes.includes('type') && (
             <FormRow label="Type">
               <Dropdown
-                value={[formData?.data?.type]}
+                value={[uiType]}
                 disabled={formData.builtin || !isNew}
-                options={Object.values(TYPE_OPTIONS)}
-                onChange={(v) => {
-                  const newType = v[0] as AttributeData['type']
-                  // Check if regex is supported for the new type
-                  const typeOpt = TYPE_OPTIONS[newType]
-                  const supportsRegex = typeOpt?.fields?.includes('regex')
-
-                  setData('type', newType)
-                  // Clear regex if not supported by the new type
-                  if (!supportsRegex && formData?.data?.regex) {
-                    setData('regex', '')
-                  }
-                }}
+                options={UI_TYPE_OPTIONS}
+                onChange={handleUiTypeChange}
                 minSelected={1}
                 widthExpand
+              />
+            </FormRow>
+          )}
+          {!excludes.includes('type') && uiType === 'number' && (
+            <FormRow label="Decimal">
+              <InputSwitch
+                checked={isDecimal}
+                disabled={formData.builtin || !isNew}
+                onChange={(e) => {
+                  const checked = (e.target as HTMLInputElement).checked
+                  setIsDecimal(checked)
+                  setData('type', checked ? 'float' : 'integer')
+                }}
               />
             </FormRow>
           )}

--- a/shared/src/components/AttributeEditor/AttributeEditor.tsx
+++ b/shared/src/components/AttributeEditor/AttributeEditor.tsx
@@ -360,6 +360,7 @@ export const AttributeEditor: FC<AttributeEditorProps> = ({
               <Dropdown
                 value={[uiType]}
                 disabled={formData.builtin || !isNew}
+                valueIcon={UI_TYPE_OPTIONS.find((o) => o.value === uiType)?.icon}
                 options={UI_TYPE_OPTIONS}
                 onChange={handleUiTypeChange}
                 minSelected={1}

--- a/shared/src/components/AttributeEditor/attributeTypeMap.ts
+++ b/shared/src/components/AttributeEditor/attributeTypeMap.ts
@@ -1,19 +1,31 @@
 import { AttributeData } from '@shared/api'
+import { getAttributeIcon } from '@shared/util'
 
-export type UIAttributeType = 'text' | 'select' | 'multi_select' | 'number' | 'checkbox' | 'datetime'
+export type UIAttributeType =
+  | 'text'
+  | 'select'
+  | 'multi_select'
+  | 'number'
+  | 'checkbox'
+  | 'datetime'
 
 export interface UITypeOption {
   value: UIAttributeType
   label: string
+  icon: string
 }
 
 export const UI_TYPE_OPTIONS: UITypeOption[] = [
-  { value: 'text', label: 'Text' },
-  { value: 'select', label: 'Select' },
-  { value: 'multi_select', label: 'Multi-select' },
-  { value: 'number', label: 'Number' },
-  { value: 'checkbox', label: 'Checkbox' },
-  { value: 'datetime', label: 'Date and time' },
+  { value: 'text', label: 'Text', icon: getAttributeIcon('text', 'string') },
+  { value: 'select', label: 'Select', icon: getAttributeIcon('select', 'string', true) },
+  {
+    value: 'multi_select',
+    label: 'Multi-select',
+    icon: getAttributeIcon('multi_select', 'list_of_strings', true),
+  },
+  { value: 'number', label: 'Number', icon: getAttributeIcon('number', 'integer') },
+  { value: 'checkbox', label: 'Checkbox', icon: getAttributeIcon('checkbox', 'boolean') },
+  { value: 'datetime', label: 'Date and time', icon: getAttributeIcon('datetime', 'datetime') },
 ]
 
 export const UI_TYPE_FIELDS: Record<UIAttributeType, (keyof AttributeData)[]> = {

--- a/shared/src/components/AttributeEditor/attributeTypeMap.ts
+++ b/shared/src/components/AttributeEditor/attributeTypeMap.ts
@@ -1,0 +1,79 @@
+import { AttributeData } from '@shared/api'
+
+export type UIAttributeType = 'text' | 'select' | 'multi_select' | 'number' | 'checkbox' | 'datetime'
+
+export interface UITypeOption {
+  value: UIAttributeType
+  label: string
+}
+
+export const UI_TYPE_OPTIONS: UITypeOption[] = [
+  { value: 'text', label: 'Text' },
+  { value: 'select', label: 'Select' },
+  { value: 'multi_select', label: 'Multi-select' },
+  { value: 'number', label: 'Number' },
+  { value: 'checkbox', label: 'Checkbox' },
+  { value: 'datetime', label: 'Date and time' },
+]
+
+export const UI_TYPE_FIELDS: Record<UIAttributeType, (keyof AttributeData)[]> = {
+  text: ['minLength', 'maxLength', 'regex'],
+  select: ['enum'],
+  multi_select: ['enum', 'minItems', 'maxItems'],
+  number: ['ge', 'gt', 'le', 'lt'],
+  checkbox: [],
+  datetime: [],
+}
+
+export const UI_TYPE_EXCLUDE: Partial<Record<UIAttributeType, (keyof AttributeData)[]>> = {
+  checkbox: ['example'],
+}
+
+export const backendToUiType = (
+  type: AttributeData['type'] | undefined,
+  enumValues?: AttributeData['enum'],
+): UIAttributeType => {
+  switch (type) {
+    case 'string':
+      return enumValues?.length ? 'select' : 'text'
+    case 'list_of_strings':
+      return 'multi_select'
+    case 'integer':
+    case 'float':
+      return 'number'
+    case 'boolean':
+      return 'checkbox'
+    case 'datetime':
+      return 'datetime'
+    default:
+      return 'text'
+  }
+}
+
+export const uiTypeToBackend = (
+  uiType: UIAttributeType,
+  isDecimal: boolean,
+): AttributeData['type'] => {
+  switch (uiType) {
+    case 'text':
+      return 'string'
+    case 'select':
+      return 'string'
+    case 'multi_select':
+      return 'list_of_strings'
+    case 'number':
+      return isDecimal ? 'float' : 'integer'
+    case 'checkbox':
+      return 'boolean'
+    case 'datetime':
+      return 'datetime'
+  }
+}
+
+export const getUiTypeLabel = (
+  type: AttributeData['type'] | undefined,
+  enumValues?: AttributeData['enum'],
+): string => {
+  const uiType = backendToUiType(type, enumValues)
+  return UI_TYPE_OPTIONS.find((o) => o.value === uiType)?.label ?? type ?? ''
+}

--- a/shared/src/components/AttributeEditor/attributeTypeMap.ts
+++ b/shared/src/components/AttributeEditor/attributeTypeMap.ts
@@ -70,10 +70,22 @@ export const uiTypeToBackend = (
   }
 }
 
+const UI_MAPPED_BACKEND_TYPES: ReadonlyArray<AttributeData['type']> = [
+  'string',
+  'integer',
+  'float',
+  'boolean',
+  'datetime',
+  'list_of_strings',
+]
+
 export const getUiTypeLabel = (
   type: AttributeData['type'] | undefined,
   enumValues?: AttributeData['enum'],
 ): string => {
+  // Unknown / unsupported backend types fall back to the raw type string
+  // so the table doesn't mislabel them (e.g. list_of_integers, dict).
+  if (!type || !UI_MAPPED_BACKEND_TYPES.includes(type)) return type ?? ''
   const uiType = backendToUiType(type, enumValues)
-  return UI_TYPE_OPTIONS.find((o) => o.value === uiType)?.label ?? type ?? ''
+  return UI_TYPE_OPTIONS.find((o) => o.value === uiType)?.label ?? type
 }

--- a/shared/src/components/AttributeEditor/index.ts
+++ b/shared/src/components/AttributeEditor/index.ts
@@ -1,1 +1,2 @@
 export * from './AttributeEditor'
+export { getUiTypeLabel } from './attributeTypeMap'

--- a/shared/src/containers/Slicer/hooks/useTableDataBySlice.ts
+++ b/shared/src/containers/Slicer/hooks/useTableDataBySlice.ts
@@ -110,7 +110,7 @@ const useTableDataBySlice = ({
       sliceOptions.push({
         label: attr.data.title || attr.name,
         value: 'attrib.' + attr.name,
-        icon: getAttributeIcon(attr.name, attr.data.type, Boolean(attr.data.enum)),
+        icon: getAttributeIcon(attr.name, attr.data.type, !!attr.data.enum?.length),
       }),
     )
   }

--- a/shared/src/util/getAttributeIcon.ts
+++ b/shared/src/util/getAttributeIcon.ts
@@ -38,8 +38,8 @@ export const getAttributeIcon: GetAttributesIcon = (name, type, hasEnum) => {
     [key in AttributeData['type']]?: string
   } = {
     integer: 'pin',
-    float: 'speed_1_2',
-    boolean: 'radio_button_checked',
+    float: 'pin',
+    boolean: 'check_box',
     datetime: 'calendar_month',
     list_of_strings: 'format_list_bulleted',
     list_of_integers: 'format_list_numbered',
@@ -53,6 +53,8 @@ export const getAttributeIcon: GetAttributesIcon = (name, type, hasEnum) => {
     icon = customIcons[name]
   } else if (entityTypesWithIcons.includes(name)) {
     icon = getEntityTypeIcon(name)
+  } else if (hasEnum && type === 'string') {
+    icon = 'checklist'
   } else if (hasEnum) {
     icon = 'format_list_bulleted'
   } else if (type && typeIcons[type]) {

--- a/shared/src/util/getAttributeIcon.ts
+++ b/shared/src/util/getAttributeIcon.ts
@@ -38,7 +38,7 @@ export const getAttributeIcon: GetAttributesIcon = (name, type, hasEnum) => {
     [key in AttributeData['type']]?: string
   } = {
     integer: 'pin',
-    float: 'pin',
+    float: 'speed_1_2',
     boolean: 'check_box',
     datetime: 'calendar_month',
     list_of_strings: 'format_list_bulleted',
@@ -54,9 +54,9 @@ export const getAttributeIcon: GetAttributesIcon = (name, type, hasEnum) => {
   } else if (entityTypesWithIcons.includes(name)) {
     icon = getEntityTypeIcon(name)
   } else if (hasEnum && type === 'string') {
-    icon = 'checklist'
-  } else if (hasEnum) {
     icon = 'format_list_bulleted'
+  } else if (hasEnum) {
+    icon = 'checklist'
   } else if (type && typeIcons[type]) {
     icon = typeIcons[type]
   }

--- a/src/pages/SettingsPage/Attributes.jsx
+++ b/src/pages/SettingsPage/Attributes.jsx
@@ -221,6 +221,14 @@ const Attributes = () => {
                 sortable
                 sortField="data.type"
                 body={(rowData) => getUiTypeLabel(rowData.data?.type, rowData.data?.enum)}
+                sortFunction={(e) => {
+                  const dir = e.order ?? 1
+                  return [...e.data].sort((a, b) => {
+                    const la = getUiTypeLabel(a.data?.type, a.data?.enum)
+                    const lb = getUiTypeLabel(b.data?.type, b.data?.enum)
+                    return la.localeCompare(lb) * dir
+                  })
+                }}
               />
               <Column field="data.example" header="Example" style={{ maxWidth: 200 }} sortable />
               <Column field="data.description" header="Description" sortable />

--- a/src/pages/SettingsPage/Attributes.jsx
+++ b/src/pages/SettingsPage/Attributes.jsx
@@ -11,7 +11,7 @@ import {
   Spacer,
   SaveButton,
 } from '@ynput/ayon-react-components'
-import { AttributeEditor } from '@shared/components'
+import { AttributeEditor, getUiTypeLabel } from '@shared/components'
 import { useGetAttributeListQuery, useSetAttributeListMutation } from '@shared/api'
 import { useCreateContextMenu } from '@shared/containers/ContextMenu'
 import useSearchFilter from '@hooks/useSearchFilter'
@@ -215,7 +215,13 @@ const Attributes = () => {
                 style={{ maxWidth: 330 }}
                 sortable
               />
-              <Column field="data.type" header="Type" style={{ maxWidth: 150 }} sortable />
+              <Column
+                header="Type"
+                style={{ maxWidth: 150 }}
+                sortable
+                sortField="data.type"
+                body={(rowData) => getUiTypeLabel(rowData.data?.type, rowData.data?.enum)}
+              />
               <Column field="data.example" header="Example" style={{ maxWidth: 200 }} sortable />
               <Column field="data.description" header="Description" sortable />
               <Column field="data.inherit" header="Inherit" sortable style={{ maxWidth: 80 }} />


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
Refactored attribute type labels across the editor UI and settings table to user-friendly terminology per #826.

- String → Text 
- String + enum → Select (split into its own UI type)
- List Of Strings → Multi-select
- Integer / Decimal number → Number (merged, with a Decimal toggle)
- Boolean → Checkbox
- Datetime → Date and time

  Changes visible in:
- /settings/attributes — table type column now shows friendly labels; creation/edit dialog dropdown shows the 6 UI types
- Any consumer of getAttributeIcon (filter bars, tree table columns, slicer, lists filter dialog) — Select type now has its own checklist icon; Number icon unified; Checkbox uses check_box


## Technical details
<!-- Please state any technical details such as limitations -->
UI-only mapping — no backend type contract change. Backend still receives the original type values (string, integer, float, list_of_strings, boolean, datetime).

- New centralized map in shared/src/components/AttributeEditor/attributeTypeMap.ts with backendToUiType() / uiTypeToBackend() / getUiTypeLabel() + UI_TYPE_OPTIONS / UI_TYPE_FIELDS
- AttributeEditor now tracks uiType + isDecimal as separate state; the dropdown shows 6 options and a conditional Decimal toggle for Number type. Backend data.type is derived on save
- Type picker and Decimal toggle are disabled when editing an existing attribute (prevents data corruption from switching types)
- Existing string + enum attributes auto-detect as Select on load
- Attributes.jsx table type column switched from plain field="data.type" to a body template so the row's data.enum is available for the Text-vs-Select distinction
- getAttributeIcon gains a type-aware hasEnum branch (string + enum → checklist, others unchanged)

## Additional context
<!-- Add any other context or screenshots here. -->

