### PR TITLE
Descriptions not working on production instances

### DIFF
--- a/shared/src/components/DetailsPanelDetails/DescriptionSection.styles.ts
+++ b/shared/src/components/DetailsPanelDetails/DescriptionSection.styles.ts
@@ -473,11 +473,3 @@ export const StyledQuillContainer = styled.div`
   }
 `
 
-export const StyledHiddenMarkdown = styled.div`
-  position: fixed;
-  visibility: hidden;
-  pointer-events: none;
-  opacity: 0;
-  top: -9999px;
-  left: -9999px;
-`

--- a/shared/src/components/DetailsPanelDetails/DescriptionSection.tsx
+++ b/shared/src/components/DetailsPanelDetails/DescriptionSection.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useMemo } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
 import { Button } from '@ynput/ayon-react-components'
 import ReactQuill from 'react-quill-ayon'
 import clsx from 'clsx'
@@ -11,7 +12,6 @@ import {
   StyledLoadingSkeleton,
   StyledButtonContainer,
   StyledQuillContainer,
-  StyledHiddenMarkdown,
 } from './DescriptionSection.styles'
 import InputMarkdownConvert from '@shared/containers/Feed/components/CommentInput/InputMarkdownConvert'
 import { mentionTypeOptions, useDescriptionEditor, useQuillFormats } from './hooks'
@@ -55,19 +55,11 @@ export const DescriptionSection: React.FC<DescriptionSectionProps> = ({
   onChange,
   isLoading,
 }) => {
-  const markdownRef = useRef<HTMLDivElement>(null)
-  const [descriptionHtml, setDescriptionHtml] = useState('')
-
-  useEffect(() => {
-    if (!description?.trim()) {
-      setDescriptionHtml('')
-      return
-    }
-
-    if (!markdownRef.current) return
-
-    const html = markdownRef.current.innerHTML
-    setDescriptionHtml(html)
+  const descriptionHtml = useMemo(() => {
+    if (!description?.trim()) return ''
+    return renderToStaticMarkup(
+      <InputMarkdownConvert typeOptions={mentionTypeOptions} initValue={description} />,
+    )
   }, [description])
 
   // Use custom hooks to manage state and logic
@@ -164,12 +156,6 @@ export const DescriptionSection: React.FC<DescriptionSectionProps> = ({
           </StyledFooter>
         )}
       </StyledContent>
-      <StyledHiddenMarkdown ref={markdownRef}>
-        <InputMarkdownConvert
-          typeOptions={mentionTypeOptions}
-          initValue={description || ''}
-        />
-      </StyledHiddenMarkdown>
     </BorderedSection>
   )
 }

--- a/shared/src/components/DetailsPanelDetails/DescriptionSection.tsx
+++ b/shared/src/components/DetailsPanelDetails/DescriptionSection.tsx
@@ -60,7 +60,7 @@ export const DescriptionSection: React.FC<DescriptionSectionProps> = ({
     return renderToStaticMarkup(
       <InputMarkdownConvert typeOptions={mentionTypeOptions} initValue={description} />,
     )
-  }, [description])
+  }, [description, mentionTypeOptions])
 
   // Use custom hooks to manage state and logic
   const {

--- a/shared/src/containers/ProjectTreeTable/widgets/TextContentWidget.tsx
+++ b/shared/src/containers/ProjectTreeTable/widgets/TextContentWidget.tsx
@@ -111,7 +111,7 @@ export const TextContentWidget: FC<TextContentWidgetProps> = ({
     return renderToStaticMarkup(
       <InputMarkdownConvert typeOptions={mentionTypeOptions} initValue={normalizedValue} />,
     )
-  }, [normalizedValue, isRichText])
+  }, [normalizedValue, isRichText, mentionTypeOptions])
 
   const [editingValue, setEditingValue] = useState(
     () => draftValue ?? (isRichText ? descriptionHtml : normalizedValue),

--- a/shared/src/containers/ProjectTreeTable/widgets/TextContentWidget.tsx
+++ b/shared/src/containers/ProjectTreeTable/widgets/TextContentWidget.tsx
@@ -1,4 +1,5 @@
-import { FC, useRef, useEffect, useCallback, useState, Suspense, type ChangeEvent } from 'react'
+import { FC, useRef, useEffect, useCallback, useMemo, useState } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
 import styled from 'styled-components'
 
 import { CellEditingDialog } from '@shared/components/LinksManager/CellEditingDialog'
@@ -56,10 +57,6 @@ const PlainPreview = styled.div`
   overflow: auto;
 `
 
-const StyledHiddenMarkdown = styled.div`
-  display: none;
-`
-
 export interface TextContentWidgetProps extends WidgetBaseProps {
   value?: string | number | null
   cellId: string
@@ -95,10 +92,7 @@ export const TextContentWidget: FC<TextContentWidgetProps> = ({
   onPreviewMouseLeave,
 }) => {
   const hasDraftRef = useRef(draftValue != null)
-  const [editingValue, setEditingValue] = useState(draftValue ?? '')
-  const [descriptionHtml, setDescriptionHtml] = useState(draftValue ?? '')
   const quillRef = useRef<any>(null)
-  const markdownRef = useRef<HTMLDivElement>(null)
   const isPreview = variant === 'preview'
   const isRichText = allowMarkdown
   const plainTextAreaRef = useRef<HTMLTextAreaElement>(null)
@@ -110,6 +104,19 @@ export const TextContentWidget: FC<TextContentWidgetProps> = ({
     originalValueRef.current = normalizedValue
   }, [normalizedValue])
 
+  // Sync markdown → HTML conversion. Avoids DOM-timing race with hidden div + innerHTML.
+  const descriptionHtml = useMemo(() => {
+    if (!isRichText) return ''
+    if (!normalizedValue.trim()) return ''
+    return renderToStaticMarkup(
+      <InputMarkdownConvert typeOptions={mentionTypeOptions} initValue={normalizedValue} />,
+    )
+  }, [normalizedValue, isRichText])
+
+  const [editingValue, setEditingValue] = useState(
+    () => draftValue ?? (isRichText ? descriptionHtml : normalizedValue),
+  )
+
   const updateEditingValue = useCallback(
     (newValue: string) => {
       setEditingValue(newValue)
@@ -118,27 +125,15 @@ export const TextContentWidget: FC<TextContentWidgetProps> = ({
     [onEditingDraftChange],
   )
 
-  // Parse markdown to HTML to initialize the editor content for edit and preview
+  // Re-seed editor when content changes (skip if a draft has been restored)
   useEffect(() => {
     if (hasDraftRef.current) {
       hasDraftRef.current = false
       return
     }
     if (!isEditing && !isPreview) return
-    if (!isRichText) {
-      setEditingValue(normalizedValue)
-      return
-    }
-    if (!normalizedValue.trim()) {
-      setDescriptionHtml('')
-      setEditingValue('')
-      return
-    }
-    if (!markdownRef.current) return
-    const html = markdownRef.current.innerHTML
-    setDescriptionHtml(html)
-    setEditingValue(html)
-  }, [isEditing, isPreview, normalizedValue, isRichText])
+    setEditingValue(isRichText ? descriptionHtml : normalizedValue)
+  }, [isEditing, isPreview, normalizedValue, isRichText, descriptionHtml])
 
   // Autofocus editor when dialog opens
   useEffect(() => {
@@ -389,32 +384,16 @@ export const TextContentWidget: FC<TextContentWidgetProps> = ({
     </StyledDialog>
   )
 
-  return (
-    <>
-      {/* Always render the hidden markdown component so markdownRef is available */}
-      {isRichText && (
-        <StyledHiddenMarkdown
-          className="markdown-content"
-          data-cell-id={cellId}
-          ref={markdownRef}
-          style={{ display: 'none' }}
-        >
-          <Suspense fallback={null}>
-            <InputMarkdownConvert typeOptions={mentionTypeOptions} initValue={normalizedValue} />
-          </Suspense>
-        </StyledHiddenMarkdown>
-      )}
+  if (!isEditing && !isPreview) return null
 
-      {(isEditing || isPreview) && (
-        <CellEditingDialog
-          isEditing={Boolean(isEditing || isPreview)}
-          anchorId={cellId}
-          onClose={onCancelEdit}
-          matchAnchorWidth
-        >
-          {dialogContent}
-        </CellEditingDialog>
-      )}
-    </>
+  return (
+    <CellEditingDialog
+      isEditing={Boolean(isEditing || isPreview)}
+      anchorId={cellId}
+      onClose={onCancelEdit}
+      matchAnchorWidth
+    >
+      {dialogContent}
+    </CellEditingDialog>
   )
 }


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Fixes prod-only bug: description empty in Details panel and cell edit/preview popup (inline cell was fine)
Root cause: both components rendered markdown into a hidden <div> then scraped markdownRef.current.innerHTML inside a useEffect to feed Quill. DOM round-trip race.

## Technical details
<!-- Please state any technical details such as limitations -->
- DescriptionSection.tsx, TextContentWidget.tsx: dropped hidden div + ref + effect; swapped to renderToStaticMarkup + useMemo.                                      
- DescriptionSection.styles.ts: removed unused StyledHiddenMarkdown.
- Draft persistence, autofocus, save/cancel shortcuts unchanged.                                                                                                    
- Quill's own root.innerHTML on save kept, Quill is source of truth for user input.        

## Additional context
<!-- Add any other context or screenshots here. -->

