### PR TITLE
Add ability to show tags and context menus in ReviewablesSelector

### DIFF
--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ynput/ayon-frontend-shared",
-  "version": "0.3.23",
+  "version": "0.3.24",
   "description": "Shared React components for AYON frontend",
   "main": "dist/index.cjs.js",
   "module": "dist/index.es.js",

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ynput/ayon-frontend-shared",
-  "version": "0.3.22",
+  "version": "0.3.23",
   "description": "Shared React components for AYON frontend",
   "main": "dist/index.cjs.js",
   "module": "dist/index.es.js",

--- a/shared/src/components/ReviewablesSelector/Card.tsx
+++ b/shared/src/components/ReviewablesSelector/Card.tsx
@@ -14,7 +14,7 @@ export type ReviewableCard = Pick<ReviewableModel, 'fileId' | 'label'> & {
 export type ReviewableCardProps = ReviewableCard & {
   projectName: string | null,
   selected: boolean,
-  onChange?: (fileId: string) => void,
+  onChange?: (fileId: string, modifier?: boolean) => void,
   onKeyDown: (event: KeyboardEvent<HTMLDivElement>) => void,
   onMouseOver: (event: MouseEvent<HTMLDivElement>, { label }: { label?: string }) => void,
 }
@@ -37,7 +37,7 @@ export default function Card({
     <Styled.ReviewableCard
       key={fileId}
       id={'preview-' + fileId}
-      onClick={() => onChange && onChange(fileId)}
+      onClick={(event) => onChange?.(fileId, event.metaKey || event.ctrlKey)}
       className={clsx('reviewable-card', { selected }, selectionVariant)}
       onMouseOver={(e) => onMouseOver(e, { label })}
       onKeyDown={onKeyDown}

--- a/shared/src/components/ReviewablesSelector/Card.tsx
+++ b/shared/src/components/ReviewablesSelector/Card.tsx
@@ -1,0 +1,58 @@
+import clsx from 'clsx'
+import { FileThumbnail } from '@shared/components'
+import { ReviewableModel } from '@shared/api'
+import { ContextMenuItemType, useCreateContextMenu } from '@shared/containers'
+import * as Styled from './ReviewablesSelector.styled'
+import { KeyboardEvent, MouseEvent } from 'react'
+
+export type ReviewableCard = Pick<ReviewableModel, 'fileId' | 'label'> & {
+  tag?: JSX.Element,
+  contextMenuItems?: ContextMenuItemType[],
+  selectionVariant?: 'primary' | 'tertiary',
+}
+
+export type ReviewableCardProps = ReviewableCard & {
+  projectName: string | null,
+  selected: boolean,
+  onChange?: (fileId: string) => void,
+  onKeyDown: (event: KeyboardEvent<HTMLDivElement>) => void,
+  onMouseOver: (event: MouseEvent<HTMLDivElement>, { label }: { label?: string }) => void,
+}
+
+export default function Card({
+  fileId,
+  label,
+  selected,
+  projectName,
+  onKeyDown,
+  onMouseOver,
+  onChange,
+  tag,
+  contextMenuItems,
+  selectionVariant = 'primary',
+}: ReviewableCardProps) {
+  const [contextMenuShow] = useCreateContextMenu()
+
+  return (
+    <Styled.ReviewableCard
+      key={fileId}
+      id={'preview-' + fileId}
+      onClick={() => onChange && onChange(fileId)}
+      className={clsx('reviewable-card', { selected }, selectionVariant)}
+      onMouseOver={(e) => onMouseOver(e, { label })}
+      onKeyDown={onKeyDown}
+      onContextMenu={(event) => {
+        if (!contextMenuItems) return
+
+        event.preventDefault()
+        contextMenuShow(event, contextMenuItems)
+      }}
+      tabIndex={0}
+    >
+      <FileThumbnail src={`/api/projects/${projectName}/files/${fileId}/thumbnail`} />
+      {
+        tag && <Styled.Tag>{tag}</Styled.Tag>
+      }
+    </Styled.ReviewableCard>
+  )
+}

--- a/shared/src/components/ReviewablesSelector/ReviewablesSelector.styled.ts
+++ b/shared/src/components/ReviewablesSelector/ReviewablesSelector.styled.ts
@@ -54,10 +54,20 @@ export const ReviewableCard = styled.div`
     text-align: center;
   }
 
+  --selection-background: var(--md-sys-color-primary-container);
+  --selection-border-color: var(--md-sys-color-primary);
+  --selection-color: var(--md-sys-color-on-primary-container);
+
+  &.tertiary {
+    --selection-background: var(--md-sys-color-tertiary-container);
+    --selection-border-color: var(--md-sys-color-tertiary);
+    --selection-color: var(--md-sys-color-on-tertiary-container);
+  }
+
   &.selected {
-    background-color: var(--md-sys-color-primary-container);
-    border-color: var(--md-sys-color-primary);
-    color: var(--md-sys-color-on-primary-container);
+    background-color: var(--selection-background);
+    border-color: var(--selection-border-color);
+    color: var(--selection-color);
   }
 `
 
@@ -82,4 +92,13 @@ export const AddButton = styled(Button)`
   &:hover {
     background-color: var(--md-sys-color-surface-container-high-hover);
   }
+`
+
+export const Tag = styled.div`
+  border-radius: var(--border-radius-m);
+  background-color: var(--md-sys-color-surface-container-high);
+  position: absolute;
+  top: var(--padding-s);
+  right: var(--padding-s);
+  padding: var(--padding-s);
 `

--- a/shared/src/components/ReviewablesSelector/ReviewablesSelector.tsx
+++ b/shared/src/components/ReviewablesSelector/ReviewablesSelector.tsx
@@ -1,12 +1,8 @@
 import { FC, useEffect, useRef, useState } from 'react'
 import * as Styled from './ReviewablesSelector.styled'
-import clsx from 'clsx'
-import { FileThumbnail } from '@shared/components'
-import { ReviewableModel } from '@shared/api'
 import { isHTMLElement } from '@shared/util'
 import ScrollBar from 'react-perfect-scrollbar'
-
-type ReviewableCard = Pick<ReviewableModel, 'fileId' | 'label' | 'fileId'>
+import Card, { ReviewableCard, ReviewableCardProps } from './Card'
 
 interface ReviewablesSelectorProps {
   reviewables: ReviewableCard[]
@@ -111,7 +107,7 @@ const ReviewablesSelector: FC<ReviewablesSelectorProps> = ({
 
   const handleMouseOver = (
     event: React.MouseEvent<HTMLDivElement>,
-    { label }: Pick<ReviewableCard, 'label'>,
+    { label }: Pick<ReviewableCardProps, 'label'>,
   ) => {
     // check event is coming from a reviewable card
     const closest = (event.target as HTMLElement).closest('.reviewable-card') as HTMLElement
@@ -144,18 +140,19 @@ const ReviewablesSelector: FC<ReviewablesSelectorProps> = ({
           scrollContainerRef.current = ref
         }}
       >
-        {reviewables.map(({ fileId, label }) => (
-          <Styled.ReviewableCard
-            key={fileId}
-            id={'preview-' + fileId}
-            onClick={() => onChange && onChange(fileId)}
-            className={clsx('reviewable-card', { selected: selected.includes(fileId) })}
-            onMouseOver={(e) => handleMouseOver(e, { label })}
+        {reviewables.map(({ fileId, label, tag, selectionVariant, contextMenuItems }) => (
+          <Card
+            projectName={projectName}
+            fileId={fileId}
+            label={label}
+            selected={selected.includes(fileId)}
+            selectionVariant={selectionVariant}
+            tag={tag}
+            contextMenuItems={contextMenuItems}
+            onChange={onChange}
             onKeyDown={handleKeyDown}
-            tabIndex={0}
-          >
-            <FileThumbnail src={`/api/projects/${projectName}/files/${fileId}/thumbnail`} />
-          </Styled.ReviewableCard>
+            onMouseOver={handleMouseOver}
+          />
         ))}
         {!!onUpload && (
           <Styled.AddButton

--- a/shared/src/components/ReviewablesSelector/ReviewablesSelector.tsx
+++ b/shared/src/components/ReviewablesSelector/ReviewablesSelector.tsx
@@ -8,7 +8,7 @@ interface ReviewablesSelectorProps {
   reviewables: ReviewableCard[]
   selected: string[]
   projectName: string | null
-  onChange?: (fileId: string) => void
+  onChange?: (fileId: string, modifier?: boolean) => void
   onUpload?: () => void
 }
 

--- a/src/containers/Viewer/Viewer.tsx
+++ b/src/containers/Viewer/Viewer.tsx
@@ -18,6 +18,7 @@ import { getGroupedReviewables, ReviewablesSelector } from '@shared/components'
 import { useScopedDetailsPanel } from '@shared/context'
 import { ProjectContextProvider, useProjectContext } from '@shared/context/ProjectContext'
 import { useLocalStorage } from '@shared/hooks'
+import { ReviewableCard, ReviewableCardProps } from '@shared/components/ReviewablesSelector/Card'
 
 interface ViewerProps {
   onClose?: () => void

--- a/src/containers/Viewer/Viewer.tsx
+++ b/src/containers/Viewer/Viewer.tsx
@@ -18,7 +18,6 @@ import { getGroupedReviewables, ReviewablesSelector } from '@shared/components'
 import { useScopedDetailsPanel } from '@shared/context'
 import { ProjectContextProvider, useProjectContext } from '@shared/context/ProjectContext'
 import { useLocalStorage } from '@shared/hooks'
-import { ReviewableCard, ReviewableCardProps } from '@shared/components/ReviewablesSelector/Card'
 
 interface ViewerProps {
   onClose?: () => void


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

The `ReviewablesSelector` now has several configuration options allowing it  to show small tags in the top right corner, as well as customised context menus when right-clicking on a reviewable.

## Technical details
<!-- Please state any technical details such as limitations -->

I had to move the `Card` component out of `ReviewablesSelector` so I could use an individual `useCreateContextMenu` hook per each card.

## Additional context
<!-- Add any other context or screenshots here. -->

