### PR TITLE
Overview: Group by folder and hierarchy broken

### DIFF
--- a/shared/src/containers/ProjectTreeTable/context/ProjectTableProvider.tsx
+++ b/shared/src/containers/ProjectTreeTable/context/ProjectTableProvider.tsx
@@ -212,8 +212,10 @@ export const ProjectTableProvider = ({
     isLoadingMore,
   })
 
-  // overrideGroupBy (from view dropdown) takes priority over Customize panel's groupBy
-  const effectiveGroupBy = overrideGroupBy || columnSettingsGroupBy
+  // overrideGroupBy (from view dropdown) takes priority over Customize panel's groupBy.
+  // In flat folder view, ignore both — the 'folder' sentinel persisted on the server
+  // must not leak into grouping logic (it's only used to distinguish the mode from 'none').
+  const effectiveGroupBy = isFlatFolderView ? undefined : (overrideGroupBy || columnSettingsGroupBy)
 
   const buildGroupByTableData = useBuildGroupByTableData({
     entities: entitiesMap,

--- a/shared/src/containers/ProjectTreeTable/types/overviewContext.ts
+++ b/shared/src/containers/ProjectTreeTable/types/overviewContext.ts
@@ -64,7 +64,10 @@ export interface ProjectOverviewContextType {
   updateShowHierarchy: (showHierarchy: boolean) => void
 
   // View mode grouping (top-level dropdown, independent from Customize panel groupBy)
-  viewGroupBy: string | null // null = hierarchy mode, string = groupBy field id (e.g. 'folderType', 'status')
+  // undefined = view settings not loaded yet (dropdown shows empty)
+  // null = hierarchy mode
+  // string = groupBy field id (e.g. 'folderType', 'status', 'folder', 'none')
+  viewGroupBy: string | null | undefined
   viewGroupByDesc: boolean // sort direction for grouping (true = descending)
   updateViewGroupBy: (viewGroupBy: string | null, desc?: boolean) => void
 

--- a/shared/src/containers/Views/hooks/pages/useOverviewViewSettings.ts
+++ b/shared/src/containers/Views/hooks/pages/useOverviewViewSettings.ts
@@ -34,6 +34,8 @@ type Return = {
   // Column management
   columns: ColumnsConfig
   onUpdateColumns: (columns: ColumnsConfig, allColumnIds?: string[]) => void
+  // Atomic groupBy + showHierarchy update (avoids 2-PATCH race)
+  onUpdateGroupBy: (groupBy: string | undefined, showHierarchy: boolean, desc?: boolean) => void
   // Slicer type management
   sliceType: string | undefined
   onUpdateSliceType: (sliceType: string) => void
@@ -156,6 +158,48 @@ export const useOverviewViewSettings = ({ viewSettings, updateViewSettings }: Pr
     [updateViewSettings],
   )
 
+  // Atomic groupBy + showHierarchy update.
+  // Merges both fields into a single PATCH to avoid a race where two sequential
+  // updateViewSettings calls both capture the same pre-update viewSettings snapshot
+  // and the second overwrites the first.
+  const onUpdateGroupBy = useCallback(
+    async (groupBy: string | undefined, newShowHierarchy: boolean, desc?: boolean) => {
+      const updates: Partial<OverviewSettings> = {
+        showHierarchy: newShowHierarchy,
+        groupBy: groupBy,
+        groupSortByDesc: groupBy ? desc ?? false : undefined,
+      }
+
+      const baseColumns = columns as ColumnsConfig
+      const newLocalColumns: ColumnsConfig = {
+        ...baseColumns,
+        groupBy: groupBy ? { id: groupBy, desc: desc ?? false } : undefined,
+      }
+
+      // Combined setter lets updateViewSettings manage optimism/reset for both
+      // local states atomically (so error paths don't leave one stale).
+      const combinedSetter = (
+        value: { showHierarchy: boolean; columns: ColumnsConfig } | null,
+      ) => {
+        if (value === null) {
+          setLocalHierarchy(null)
+          setLocalColumns(null)
+        } else {
+          setLocalHierarchy(value.showHierarchy)
+          setLocalColumns(value.columns)
+        }
+      }
+
+      await updateViewSettings(
+        updates,
+        combinedSetter,
+        { showHierarchy: newShowHierarchy, columns: newLocalColumns },
+        { errorMessage: 'Failed to update grouping' },
+      )
+    },
+    [updateViewSettings, columns],
+  )
+
   return {
     filters,
     onUpdateFilters,
@@ -163,6 +207,7 @@ export const useOverviewViewSettings = ({ viewSettings, updateViewSettings }: Pr
     onUpdateHierarchy,
     columns,
     onUpdateColumns,
+    onUpdateGroupBy,
     sliceType: serverSliceType,
     onUpdateSliceType,
   }

--- a/shared/src/containers/Views/utils/viewUpdateHelper.ts
+++ b/shared/src/containers/Views/utils/viewUpdateHelper.ts
@@ -1,11 +1,13 @@
 /**
  * Shared helper for updating view settings with optimistic local state management.
  *
- * This helper provides common functionality used by view settings hooks:
- * - Optimistic local state updates for immediate UI response
- * - Background API calls to persist changes
- * - Error handling with state reversion
- * - Working view management
+ * Sequential updateViewSettings calls in the same event tick MUST chain correctly:
+ * the second call has to see the first call's changes. Closure-captured
+ * `viewSettings` does not refresh between sync calls (no re-render yet), so we
+ * read the latest settings from the RTK Query cache at call time instead.
+ * RTK's updateView mutation performs an optimistic cache write in
+ * `onQueryStarted`, so the cache is already up-to-date by the time the next
+ * call reads it.
  */
 
 import {
@@ -13,15 +15,32 @@ import {
   EntityIdResponse,
   useCreateViewMutation,
   useUpdateViewMutation,
+  viewsQueries,
 } from '@shared/api'
 import { generateWorkingView } from './generateWorkingView'
 import { toast } from 'react-toastify'
 import { useCallback } from 'react'
-import { useViewsContext, ViewsContextValue } from '../context/ViewsContext'
+import { useStore } from 'react-redux'
+import { useViewsContext, ViewsContextValue, ViewSettings } from '../context/ViewsContext'
 
 interface UpdateOptions {
   successMessage?: string
   errorMessage?: string
+}
+
+// Module-level flag shared across every useViewUpdateHelper instance. Set true
+// when a mutation has been dispatched in the current tick (RTK cache is now
+// optimistically fresh); reset on the next microtask. Must be module-level so
+// that two different hook instances (e.g. ProjectOverviewDataProvider +
+// ProjectOverviewContext) coordinate correctly when writes flow through one
+// and subsequent reads come from the other in the same event tick.
+let cacheDirtyThisTick = false
+const markCacheDirty = () => {
+  if (cacheDirtyThisTick) return
+  cacheDirtyThisTick = true
+  queueMicrotask(() => {
+    cacheDirtyThisTick = false
+  })
 }
 
 export type UpdateViewSettingsFn = (
@@ -38,6 +57,13 @@ export const updateViewSettings = async (
   options: UpdateOptions = {},
   viewContext: ViewsContextValue,
   onApplyViewChanges: (arg: any, viewId?: string) => Promise<EntityIdResponse | void>,
+  // Reads latest effective settings from RTK Query cache at call time. Required to
+  // prevent stale-closure races when two updates fire in the same tick.
+  getLatestSettings: () => ViewSettings | undefined,
+  // Invoked synchronously right after the mutation is dispatched. The caller
+  // uses this to flip a "cache is fresh this tick" flag so subsequent sync
+  // calls in the same tick read the just-updated cache instead of stale state.
+  markCacheDirty: () => void,
 ): Promise<void> => {
   const {
     viewSettings,
@@ -58,8 +84,12 @@ export const updateViewSettings = async (
     // Immediately update local state for fast UI response
     localStateSetter(newLocalValue)
 
+    // Read latest settings from RTK cache (includes prior same-tick optimistic writes).
+    // Fallback to closure-captured value if cache has nothing (first render, etc.).
+    const latestSettings = getLatestSettings() ?? viewSettings
+
     // Create settings with updates
-    const newSettings = { ...viewSettings, ...updatedSettings }
+    const newSettings = { ...latestSettings, ...updatedSettings }
 
     // always update the working view no matter what
     const newWorkingView = generateWorkingView(newSettings)
@@ -83,6 +113,11 @@ export const updateViewSettings = async (
       },
       viewId,
     )
+
+    // Mutation dispatch above ran onQueryStarted synchronously → RTK cache now
+    // reflects `newSettings`. Signal this so any subsequent sync call in the
+    // same tick reads the fresh cache instead of the stale closure baseline.
+    markCacheDirty()
 
     // if not already on the working view: set that the settings have been changed to show the little blue save button and switch to the working view
     if (!wasWorking) {
@@ -123,6 +158,7 @@ export const useViewUpdateHelper = () => {
   const [updateView] = useUpdateViewMutation()
 
   const viewContext = useViewsContext()
+  const store = useStore()
 
   const onApplyViewChanges = useCallback(
     async (arg: any, viewId?: string) => {
@@ -151,9 +187,33 @@ export const useViewUpdateHelper = () => {
     [createView, updateView],
   )
 
+  // Returns cached settings when a same-tick prior write has refreshed the
+  // cache. Otherwise returns undefined and the caller falls back to the
+  // closure-captured viewSettings (correct baseline for the first write in a
+  // tick, including the named-view → working-view fork).
+  const getLatestSettings = useCallback((): ViewSettings | undefined => {
+    if (!cacheDirtyThisTick) return undefined
+    const { viewType, projectName } = viewContext
+    if (!viewType) return undefined
+    // RTK selector state is typed against the full RootState; we don't have that
+    // type in @shared and the store is project-specific. Cast is safe: the
+    // selector only touches the api slice, which exists in every consumer app.
+    const entry = viewsQueries.endpoints.getWorkingView.select({ viewType, projectName })(
+      store.getState() as any,
+    )
+    return entry?.data?.settings
+  }, [store, viewContext])
+
   const updateViewSettingsHandler = useCallback<UpdateViewSettingsFn>(
-    async (...args) => await updateViewSettings(...args, viewContext, onApplyViewChanges),
-    [viewContext, onApplyViewChanges],
+    async (...args) =>
+      await updateViewSettings(
+        ...args,
+        viewContext,
+        onApplyViewChanges,
+        getLatestSettings,
+        markCacheDirty,
+      ),
+    [viewContext, onApplyViewChanges, getLatestSettings],
   )
 
   return { updateViewSettings: updateViewSettingsHandler, onCreateView: onApplyViewChanges }

--- a/src/pages/ProjectOverviewPage/ProjectOverviewPage.tsx
+++ b/src/pages/ProjectOverviewPage/ProjectOverviewPage.tsx
@@ -104,13 +104,14 @@ const ProjectOverviewPage: FC = () => {
     ]
   }, [groupedFields])
 
-  const viewGroupByValue = useMemo(
-    () =>
-      viewGroupByOptions
-        .filter((o) => o.id === (viewGroupBy === 'none' ? undefined : viewGroupBy ?? 'hierarchy'))
-        .map((o) => ({ ...o, sortOrder: !viewGroupByDesc })),
-    [viewGroupBy, viewGroupByOptions, viewGroupByDesc],
-  )
+  const viewGroupByValue = useMemo(() => {
+    // undefined = view settings not loaded yet — keep dropdown empty so the
+    // user doesn't see a "Hierarchy" default flicker before the saved value arrives.
+    if (viewGroupBy === undefined) return []
+    return viewGroupByOptions
+      .filter((o) => o.id === (viewGroupBy === 'none' ? undefined : viewGroupBy ?? 'hierarchy'))
+      .map((o) => ({ ...o, sortOrder: !viewGroupByDesc }))
+  }, [viewGroupBy, viewGroupByOptions, viewGroupByDesc])
 
   const handleViewGroupByChange = (values: { id: string; sortOrder?: boolean }[]) => {
     const value = values[0]

--- a/src/pages/ProjectOverviewPage/context/ProjectOverviewContext.tsx
+++ b/src/pages/ProjectOverviewPage/context/ProjectOverviewContext.tsx
@@ -48,7 +48,7 @@ export const ProjectOverviewProvider = ({ children, modules }: ProjectOverviewPr
   const { rowSelection, rowSelectionData, sliceType, persistentRowSelectionData } =
     useSlicerContext()
 
-  const { sorting, groupBy: panelGroupBy, updateGroupBy } = useColumnSettingsContext()
+  const { sorting, groupBy: panelGroupBy } = useColumnSettingsContext()
 
   const sliceFilter = createFilterFromSlicer({
     type: sliceType,
@@ -81,21 +81,27 @@ export const ProjectOverviewProvider = ({ children, modules }: ProjectOverviewPr
   const { updateViewSettings } = useViewUpdateHelper()
 
   // View mode derived purely from server viewSettings — no localStorage, no sync effect.
+  // undefined = view settings not loaded yet (dropdown stays empty)
   // null = hierarchy, 'none' = flat list, other string = groupBy field id ('folderType', 'status', 'folder', ...)
   const overviewShowHierarchy = (viewSettings as OverviewSettings | undefined)?.showHierarchy
   const overviewGroupBy = (viewSettings as OverviewSettings | undefined)?.groupBy
-  const viewGroupBy = useMemo<string | null>(() => {
+  const viewGroupBy = useMemo<string | null | undefined>(() => {
+    // Before first load, do not assume any grouping — the dropdown must stay
+    // empty so the user doesn't see a "Hierarchy" flicker while the saved
+    // view is still being fetched.
+    if (isLoadingViews || !viewSettings) return undefined
     const showHierarchy = overviewShowHierarchy ?? true
     if (showHierarchy) return null
     if (overviewGroupBy) return overviewGroupBy
     return 'none'
-  }, [overviewShowHierarchy, overviewGroupBy])
+  }, [isLoadingViews, viewSettings, overviewShowHierarchy, overviewGroupBy])
 
   // Derive desc directly from panel groupBy (single source of truth — no separate state)
   const viewGroupByDesc = panelGroupBy?.desc ?? false
 
   const {
     onUpdateHierarchy: _updateShowHierarchy,
+    onUpdateGroupBy: _updateGroupByAtomic,
     filters: queryFilters,
     onUpdateFilters: setQueryFilters,
     sliceType: viewSliceType,
@@ -105,35 +111,32 @@ export const ProjectOverviewProvider = ({ children, modules }: ProjectOverviewPr
   // Sync slicer slice type with view settings, selection with localStorage
   useSlicerViewSync(viewSliceType, onUpdateSliceType, isLoadingViews, `slicer-selection-overview-${projectName}`)
 
-  // Derive effective showHierarchy from viewGroupBy
-  // viewGroupBy === null means hierarchy mode, otherwise it's a groupBy field
-  const showHierarchy = viewGroupBy === null
+  // Derive effective showHierarchy from viewGroupBy.
+  // null = explicit hierarchy, undefined = not loaded yet — both default to
+  // hierarchy-style fetching to avoid firing a flat-list query against an
+  // empty config during the initial load window.
+  const showHierarchy = viewGroupBy === null || viewGroupBy === undefined
 
   // Flat folder view: shows all folders flat, each expandable to reveal tasks
   const isFlatFolderView = viewGroupBy === 'folder'
 
-  // User action handler — writes to server only. viewGroupBy is derived from viewSettings,
-  // so the UI updates once the server mutation reflects in the view cache.
+  // User action handler — writes to server via ONE atomic PATCH. Previously split
+  // into `_updateShowHierarchy` + `updateGroupBy`, which fired two requests that
+  // both captured the same pre-update viewSettings snapshot; the second silently
+  // reverted the first's showHierarchy change (race).
   const updateViewGroupBy = useCallback(
     (newViewGroupBy: string | null, desc?: boolean) => {
       if (newViewGroupBy === null) {
-        // Enter hierarchy mode: clear groupBy and persist showHierarchy on server
-        _updateShowHierarchy(true)
-        updateGroupBy(undefined)
+        _updateGroupByAtomic(undefined, true, undefined)
       } else if (newViewGroupBy === 'none') {
-        // Flat list: no hierarchy, no grouping
-        _updateShowHierarchy(false)
-        updateGroupBy(undefined)
-      } else if (newViewGroupBy === 'folder') {
-        // Flat folder view: no hierarchy, no groupBy (uses hierarchy-style task fetching)
-        _updateShowHierarchy(false)
-        updateGroupBy(undefined)
+        _updateGroupByAtomic(undefined, false, undefined)
       } else {
-        // onUpdateColumns (called by updateGroupBy) sets showHierarchy: false on the server
-        updateGroupBy({ id: newViewGroupBy, desc: desc ?? viewGroupByDesc })
+        // 'folder' persists as groupBy sentinel so reload distinguishes it
+        // from 'none'. ProjectTableProvider skips grouping when isFlatFolderView.
+        _updateGroupByAtomic(newViewGroupBy, false, desc ?? viewGroupByDesc)
       }
     },
-    [updateGroupBy, _updateShowHierarchy, viewGroupByDesc],
+    [_updateGroupByAtomic, viewGroupByDesc],
   )
 
   const updateShowHierarchy = useCallback(


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
Fixes the Overview page grouping bug where selecting a Group By option (Status, Folder, etc.) either failed to apply or flickered back to the previous mode. Also removes the "Hierarchy" flicker during initial view-settings load.


## Technical details
<!-- Please state any technical details such as limitations -->

- viewUpdateHelper.ts is shared by all view types (Overview, Lists, TaskProgress, VersionsProducts). Safe fallback: if cache-read returns undefined, we use the old closure path — same behavior as before.
- The fix assumes RTK's onQueryStarted runs synchronously before updateView(...) returns. Standard RTK behavior.                                                    
- The "cache is fresh this tick" flag is module-level so two different useViewUpdateHelper instances (data provider + context) can see each other's writes in the same tick. A per-instance ref wouldn't work.                                                                                                                        
- store.getState() is cast to any — RootState lives in the app, not @shared. Selector only reads the api slice, which every app has.                                
- Type: viewGroupBy: string | null → string | null | undefined. 

## Additional context
<!-- Add any other context or screenshots here. -->

