### PR TITLE
Add playlist view to Review page

### DIFF
--- a/src/pages/ProjectListsPage/ProjectListsPage.tsx
+++ b/src/pages/ProjectListsPage/ProjectListsPage.tsx
@@ -13,7 +13,7 @@ import {
 } from './context/ListsAttributesContext'
 import ListItemsTable from './components/ListItemsTable/ListItemsTable'
 import ListItemsFilter from './components/ListItemsFilter/ListItemsFilter'
-import { CustomizeButton, TableGridSwitch } from '@shared/components'
+import { CustomizeButton } from '@shared/components'
 import {
   MoveEntityProvider,
   SettingsPanelProvider,
@@ -57,6 +57,7 @@ import { getCellIdForColumn } from './util/cellIds.ts'
 import ImportDialogButton from '@containers/ImportDialog/ImportDialogButton.tsx'
 import useStoryboardsCardsModules from './hooks/useStoryboardsCardsModules.tsx'
 import OpenStoryboardButton from '@pages/ReviewPage/OpenStoryboardButton.tsx'
+import { TableGridPlaylistSwitch, TableGridPlaylistView } from './components/TableGridPlaylistSwitch/TableGridPlaylistSwitch.tsx'
 
 type ProjectListsPageProps = {
   projectName: string
@@ -64,8 +65,6 @@ type ProjectListsPageProps = {
   isReview?: boolean
   isStoryboards?: boolean
 }
-
-export type ReviewPageView = "table" | "cards"
 
 const ProjectListsWithOuterProviders: FC<ProjectListsPageProps> = ({
   projectName,
@@ -264,12 +263,14 @@ const ProjectLists: FC<ProjectListsProps> = ({
   } = useModules({ skip: !isReview })
 
   const handleOpenPlayer = useTableOpenViewer({ projectName: projectName })
-  const [view, setView] = useState<ReviewPageView>(isReview ? "cards" : "table")
+  const [view, setView] = useState<TableGridPlaylistView>(
+    isReview ? TableGridPlaylistView.GRID : TableGridPlaylistView.TABLE,
+  )
 
   // if the addon is outdated, make sure we land in table view
   useEffect(() => {
     if (!reviewSessionCardsOutdated) return
-    setView("table")
+    setView(TableGridPlaylistView.TABLE)
   }, [reviewSessionCardsOutdated])
 
   return (
@@ -298,6 +299,7 @@ const ProjectLists: FC<ProjectListsProps> = ({
               api={api}
               toast={toast}
               gridSize={gridHeight}
+              playlistView={view === TableGridPlaylistView.PLAYLIST}
               onSelectionChange={(versionIds) => {
                 if (versionIds.length === 0) return clearSelection()
 
@@ -346,12 +348,12 @@ const ProjectLists: FC<ProjectListsProps> = ({
                       />
                   }
                   {
-                    reviewModulesLoaded && view === "cards" && (
+                    reviewModulesLoaded && view !== TableGridPlaylistView.TABLE && (
                       <ReviewSessionCardsControlsLeft />
                     )
                   }
                   {
-                    view === "table" && (
+                    view === TableGridPlaylistView.TABLE && (
                       <>
                         <OverviewActions items={['undo', 'redo', deleteListItemAction]} />
                         {/*@ts-expect-error - we do not support product right now*/}
@@ -363,7 +365,7 @@ const ProjectLists: FC<ProjectListsProps> = ({
                     isReview && reviewModulesLoaded && (
                       <>
                         <Spacer />
-                        <ReviewSessionCardsControlsRight groupingDisabled={view === "table"} />
+                        <ReviewSessionCardsControlsRight groupingDisabled={view === TableGridPlaylistView.TABLE} />
                       </>
                     )
                   }
@@ -392,9 +394,9 @@ const ProjectLists: FC<ProjectListsProps> = ({
                   />
                   {
                     !reviewSessionCardsOutdated && isReview && !isStoryboards && (
-                      <TableGridSwitch
-                        showGrid={view === "cards"}
-                        onChange={(showGrid) => setView(showGrid ? "cards" : "table")}
+                      <TableGridPlaylistSwitch
+                        value={view}
+                        onChange={(v) => setView(v)}
                       />
                     )
                   }
@@ -417,7 +419,7 @@ const ProjectLists: FC<ProjectListsProps> = ({
                   >
                     <SplitterPanel size={70}>
                       {
-                        selectedList && isReview && view === "cards"
+                        selectedList && isReview && view !== TableGridPlaylistView.TABLE
                         ? (reviewModulesLoaded && <ReviewSessionCards />)
                         : (
                           <ListItemsTable
@@ -453,7 +455,7 @@ const ProjectLists: FC<ProjectListsProps> = ({
                     }}
                   >
                     {
-                      view === "table" ? (
+                      view === TableGridPlaylistView.TABLE ? (
                         <ListsTableSettings
                           extraColumns={extraColumnsSettings}
                           highlightedSetting={highlightedSetting}

--- a/src/pages/ProjectListsPage/components/ProjectListsDetailsPanels/ProjectListsDetailsPanels.tsx
+++ b/src/pages/ProjectListsPage/components/ProjectListsDetailsPanels/ProjectListsDetailsPanels.tsx
@@ -14,13 +14,13 @@ import { useProjectContext } from "@shared/context"
 import { useEffect, useMemo, useState } from "react"
 import ListDetailsPanel from "../ListDetailsPanel/ListDetailsPanel"
 import useReviewSessionCardsModules from "@pages/ProjectListsPage/hooks/useReviewSessionCardsModules"
-import { ReviewPageView } from "@pages/ProjectListsPage/ProjectListsPage"
 import useStoryboardsCardsModules from "@pages/ProjectListsPage/hooks/useStoryboardsCardsModules"
+import { TableGridPlaylistView } from "../TableGridPlaylistSwitch"
 
 type Props = {
   isReview: boolean
   isStoryboards: boolean
-  view: ReviewPageView
+  view: TableGridPlaylistView
 }
 
 export default function ProjectListsDetailsPanels({ isReview, isStoryboards, view }: Props) {
@@ -104,7 +104,7 @@ export default function ProjectListsDetailsPanels({ isReview, isStoryboards, vie
   // For review session lists, closing the details panel
   // should also clear the state in the addon component.
   const onClose = useMemo(() => {
-    if (!clearHighlighted || view !== "cards") return
+    if (!clearHighlighted || view !== TableGridPlaylistView.GRID) return
 
     return () => {
       clearHighlighted()

--- a/src/pages/ProjectListsPage/components/TableGridPlaylistSwitch/TableGridPlaylistSwitch.styled.ts
+++ b/src/pages/ProjectListsPage/components/TableGridPlaylistSwitch/TableGridPlaylistSwitch.styled.ts
@@ -1,0 +1,19 @@
+import { Button } from '@ynput/ayon-react-components'
+import styled from 'styled-components'
+
+export const ButtonsContainer = styled.div`
+  display: flex;
+  gap: var(--base-gap-small);
+  background-color: var(--md-sys-color-surface-container-high);
+  padding: 2px;
+  border-radius: var(--border-radius-m);
+`
+
+export const InnerButton = styled(Button)`
+  &.hasIcon {
+    padding: 4px;
+    &:hover:not(.selected) {
+      background-color: var(--md-sys-color-surface-container-highest-hover);
+    }
+  }
+`

--- a/src/pages/ProjectListsPage/components/TableGridPlaylistSwitch/TableGridPlaylistSwitch.tsx
+++ b/src/pages/ProjectListsPage/components/TableGridPlaylistSwitch/TableGridPlaylistSwitch.tsx
@@ -1,0 +1,72 @@
+import { forwardRef, useEffect } from 'react'
+import * as Styled from './TableGridPlaylistSwitch.styled'
+
+export enum TableGridPlaylistView {
+  TABLE = "table",
+  GRID = "cards",
+  PLAYLIST = "playlist",
+}
+
+interface TableGridPlaylistSwitchProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange'> {
+  value: TableGridPlaylistView
+  onChange: (view: TableGridPlaylistView) => void
+}
+
+export const TableGridPlaylistSwitch = forwardRef<HTMLDivElement, TableGridPlaylistSwitchProps>(
+  ({ value, onChange, ...props }, ref) => {
+    useEffect(() => {
+      const handleKeyPress = (event: KeyboardEvent) => {
+        // check we are not in an input or textarea
+        const target = event.target as HTMLElement
+        if (
+          target.tagName === 'INPUT' ||
+          target.tagName === 'TEXTAREA' ||
+          target.isContentEditable ||
+          target.getAttribute('role') === 'textbox' ||
+          target.tagName === 'LI'
+        ) {
+          return
+        }
+        if (event.key.toLowerCase() === 't') {
+          onChange(TableGridPlaylistView.TABLE)
+        } else if (event.key.toLowerCase() === 'g') {
+          onChange(TableGridPlaylistView.GRID)
+        } else if (event.key.toLowerCase() === 'p') {
+          onChange(TableGridPlaylistView.PLAYLIST)
+        }
+      }
+
+      window.addEventListener('keydown', handleKeyPress)
+      return () => window.removeEventListener('keydown', handleKeyPress)
+    }, [onChange])
+
+    return (
+      <Styled.ButtonsContainer {...props} ref={ref}>
+        <Styled.InnerButton
+          icon="table_rows"
+          selected={value === TableGridPlaylistView.TABLE}
+          onClick={() => onChange(TableGridPlaylistView.TABLE)}
+          variant="text"
+          data-tooltip="Table"
+          data-shortcut="T"
+        />
+        <Styled.InnerButton
+          icon="grid_view"
+          selected={value === TableGridPlaylistView.GRID}
+          onClick={() => onChange(TableGridPlaylistView.GRID)}
+          variant="text"
+          data-tooltip="Cards"
+          data-shortcut="G"
+        />
+        <Styled.InnerButton
+          icon="format_list_bulleted"
+          selected={value === TableGridPlaylistView.PLAYLIST}
+          onClick={() => onChange(TableGridPlaylistView.PLAYLIST)}
+          variant="text"
+          data-tooltip="Playlist"
+          data-shortcut="P"
+        />
+      </Styled.ButtonsContainer>
+    )
+  },
+)

--- a/src/pages/ProjectListsPage/components/TableGridPlaylistSwitch/index.ts
+++ b/src/pages/ProjectListsPage/components/TableGridPlaylistSwitch/index.ts
@@ -1,0 +1,1 @@
+export * from './TableGridPlaylistSwitch'

--- a/src/pages/ProjectListsPage/hooks/useReviewSessionCardsModules.tsx
+++ b/src/pages/ProjectListsPage/hooks/useReviewSessionCardsModules.tsx
@@ -16,6 +16,7 @@ function FallbackReviewCardsProvider({ children }: RemoteAddonProjectProps & Pro
   headerContentEnd?: JSX.Element
   api?: any
   gridSize?: number
+  playlistView?: boolean
 }) { return <>{children}</> }
 
 function FallbackReviewCardsControlsRight({ }: {


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Added a three-way switch to the Review page between Table, Grid and Playlist views and wired it up to the addon component.

## Technical details
<!-- Please state any technical details such as limitations -->


## Additional context
<!-- Add any other context or screenshots here. -->


fixes: https://github.com/ynput/ayon-frontend/issues/1914