### PR TITLE
Reviews: store display style (grid/table/playlist) in Views

### DIFF
--- a/shared/src/api/generated/views.ts
+++ b/shared/src/api/generated/views.ts
@@ -300,6 +300,8 @@ export type ReviewsSettings = {
   sortDesc?: boolean
   filter?: QueryFilter
   columns?: ColumnItemModel[]
+  gridHeight?: number
+  displayStyle?: 'cards' | 'table' | 'playlist'
 }
 export type ReviewsViewPostModel = {
   /** Unique identifier for the view within the given scope. */

--- a/src/pages/ProjectListsPage/ProjectListsPage.tsx
+++ b/src/pages/ProjectListsPage/ProjectListsPage.tsx
@@ -57,7 +57,7 @@ import { getCellIdForColumn } from './util/cellIds.ts'
 import ImportDialogButton from '@containers/ImportDialog/ImportDialogButton.tsx'
 import useStoryboardsCardsModules from './hooks/useStoryboardsCardsModules.tsx'
 import OpenStoryboardButton from '@pages/ReviewPage/OpenStoryboardButton.tsx'
-import { TableGridPlaylistSwitch, TableGridPlaylistView } from './components/TableGridPlaylistSwitch/TableGridPlaylistSwitch.tsx'
+import { TableGridPlaylistSwitch } from './components/TableGridPlaylistSwitch/TableGridPlaylistSwitch.tsx'
 
 type ProjectListsPageProps = {
   projectName: string
@@ -247,7 +247,12 @@ const ProjectLists: FC<ProjectListsProps> = ({
     selectSetting('columns', attrib)
   }
 
-  const { gridHeight } = useReviewCardsSettingsContext()
+  const {
+    gridHeight,
+    displayStyle,
+    onUpdateDisplayStyle,
+    onUpdateDisplayStyleWithPersistence,
+  } = useReviewCardsSettingsContext()
 
   const useModules = isStoryboards
     ? useStoryboardsCardsModules
@@ -263,14 +268,12 @@ const ProjectLists: FC<ProjectListsProps> = ({
   } = useModules({ skip: !isReview })
 
   const handleOpenPlayer = useTableOpenViewer({ projectName: projectName })
-  const [view, setView] = useState<TableGridPlaylistView>(
-    isReview ? TableGridPlaylistView.GRID : TableGridPlaylistView.TABLE,
-  )
 
   // if the addon is outdated, make sure we land in table view
   useEffect(() => {
     if (!reviewSessionCardsOutdated) return
-    setView(TableGridPlaylistView.TABLE)
+    onUpdateDisplayStyle("table")
+    onUpdateDisplayStyleWithPersistence("table")
   }, [reviewSessionCardsOutdated])
 
   return (
@@ -299,7 +302,7 @@ const ProjectLists: FC<ProjectListsProps> = ({
               api={api}
               toast={toast}
               gridSize={gridHeight}
-              playlistView={view === TableGridPlaylistView.PLAYLIST}
+              playlistView={displayStyle === "playlist"}
               onSelectionChange={(versionIds) => {
                 if (versionIds.length === 0) return clearSelection()
 
@@ -348,12 +351,12 @@ const ProjectLists: FC<ProjectListsProps> = ({
                       />
                   }
                   {
-                    reviewModulesLoaded && view !== TableGridPlaylistView.TABLE && (
+                    reviewModulesLoaded && displayStyle !== "table" && (
                       <ReviewSessionCardsControlsLeft />
                     )
                   }
                   {
-                    view === TableGridPlaylistView.TABLE && (
+                    displayStyle === "table" && (
                       <>
                         <OverviewActions items={['undo', 'redo', deleteListItemAction]} />
                         {/*@ts-expect-error - we do not support product right now*/}
@@ -365,7 +368,7 @@ const ProjectLists: FC<ProjectListsProps> = ({
                     isReview && reviewModulesLoaded && (
                       <>
                         <Spacer />
-                        <ReviewSessionCardsControlsRight groupingDisabled={view === TableGridPlaylistView.TABLE} />
+                        <ReviewSessionCardsControlsRight groupingDisabled={displayStyle === "table"} />
                       </>
                     )
                   }
@@ -395,8 +398,11 @@ const ProjectLists: FC<ProjectListsProps> = ({
                   {
                     !reviewSessionCardsOutdated && isReview && !isStoryboards && (
                       <TableGridPlaylistSwitch
-                        value={view}
-                        onChange={(v) => setView(v)}
+                        value={displayStyle}
+                        onChange={(style) => {
+                          onUpdateDisplayStyle(style)
+                          onUpdateDisplayStyleWithPersistence(style)
+                        }}
                       />
                     )
                   }
@@ -419,7 +425,7 @@ const ProjectLists: FC<ProjectListsProps> = ({
                   >
                     <SplitterPanel size={70}>
                       {
-                        selectedList && isReview && view !== TableGridPlaylistView.TABLE
+                        selectedList && isReview && displayStyle !== "table"
                         ? (reviewModulesLoaded && <ReviewSessionCards />)
                         : (
                           <ListItemsTable
@@ -442,7 +448,7 @@ const ProjectLists: FC<ProjectListsProps> = ({
                       <ProjectListsDetailsPanels
                         isReview={!!isReview}
                         isStoryboards={!!isStoryboards}
-                        view={view}
+                        displayStyle={displayStyle}
                       />
                     </SplitterPanel>
                   </DetailsPanelSplitter>
@@ -455,7 +461,7 @@ const ProjectLists: FC<ProjectListsProps> = ({
                     }}
                   >
                     {
-                      view === TableGridPlaylistView.TABLE ? (
+                      displayStyle === "table" ? (
                         <ListsTableSettings
                           extraColumns={extraColumnsSettings}
                           highlightedSetting={highlightedSetting}

--- a/src/pages/ProjectListsPage/components/ProjectListsDetailsPanels/ProjectListsDetailsPanels.tsx
+++ b/src/pages/ProjectListsPage/components/ProjectListsDetailsPanels/ProjectListsDetailsPanels.tsx
@@ -15,15 +15,15 @@ import { useEffect, useMemo, useState } from "react"
 import ListDetailsPanel from "../ListDetailsPanel/ListDetailsPanel"
 import useReviewSessionCardsModules from "@pages/ProjectListsPage/hooks/useReviewSessionCardsModules"
 import useStoryboardsCardsModules from "@pages/ProjectListsPage/hooks/useStoryboardsCardsModules"
-import { TableGridPlaylistView } from "../TableGridPlaylistSwitch"
+import { ReviewsSettings } from "@shared/api"
 
 type Props = {
   isReview: boolean
   isStoryboards: boolean
-  view: TableGridPlaylistView
+  displayStyle: ReviewsSettings['displayStyle']
 }
 
-export default function ProjectListsDetailsPanels({ isReview, isStoryboards, view }: Props) {
+export default function ProjectListsDetailsPanels({ isReview, isStoryboards, displayStyle }: Props) {
   const { projectName, ...projectInfo } = useProjectContext()
   const { getEntityById } = useProjectTableContext()
   const { selectedList, listDetailsOpen } = useListsContext()
@@ -104,12 +104,12 @@ export default function ProjectListsDetailsPanels({ isReview, isStoryboards, vie
   // For review session lists, closing the details panel
   // should also clear the state in the addon component.
   const onClose = useMemo(() => {
-    if (!clearHighlighted || view !== TableGridPlaylistView.GRID) return
+    if (!clearHighlighted || displayStyle !== "cards") return
 
     return () => {
       clearHighlighted()
     }
-  }, [clearHighlighted, view])
+  }, [clearHighlighted, displayStyle])
 
   return (
     <>

--- a/src/pages/ProjectListsPage/components/TableGridPlaylistSwitch/TableGridPlaylistSwitch.tsx
+++ b/src/pages/ProjectListsPage/components/TableGridPlaylistSwitch/TableGridPlaylistSwitch.tsx
@@ -1,15 +1,10 @@
 import { forwardRef, useEffect } from 'react'
 import * as Styled from './TableGridPlaylistSwitch.styled'
-
-export enum TableGridPlaylistView {
-  TABLE = "table",
-  GRID = "cards",
-  PLAYLIST = "playlist",
-}
+import { ReviewsSettings } from '@shared/api'
 
 interface TableGridPlaylistSwitchProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange'> {
-  value: TableGridPlaylistView
-  onChange: (view: TableGridPlaylistView) => void
+  value: ReviewsSettings['displayStyle']
+  onChange: (view: ReviewsSettings['displayStyle']) => void
 }
 
 export const TableGridPlaylistSwitch = forwardRef<HTMLDivElement, TableGridPlaylistSwitchProps>(
@@ -28,11 +23,11 @@ export const TableGridPlaylistSwitch = forwardRef<HTMLDivElement, TableGridPlayl
           return
         }
         if (event.key.toLowerCase() === 't') {
-          onChange(TableGridPlaylistView.TABLE)
+          onChange("table")
         } else if (event.key.toLowerCase() === 'g') {
-          onChange(TableGridPlaylistView.GRID)
+          onChange("cards")
         } else if (event.key.toLowerCase() === 'p') {
-          onChange(TableGridPlaylistView.PLAYLIST)
+          onChange("playlist")
         }
       }
 
@@ -44,24 +39,24 @@ export const TableGridPlaylistSwitch = forwardRef<HTMLDivElement, TableGridPlayl
       <Styled.ButtonsContainer {...props} ref={ref}>
         <Styled.InnerButton
           icon="table_rows"
-          selected={value === TableGridPlaylistView.TABLE}
-          onClick={() => onChange(TableGridPlaylistView.TABLE)}
+          selected={value === "table"}
+          onClick={() => onChange("table")}
           variant="text"
           data-tooltip="Table"
           data-shortcut="T"
         />
         <Styled.InnerButton
           icon="grid_view"
-          selected={value === TableGridPlaylistView.GRID}
-          onClick={() => onChange(TableGridPlaylistView.GRID)}
+          selected={value === "cards"}
+          onClick={() => onChange("cards")}
           variant="text"
           data-tooltip="Cards"
           data-shortcut="G"
         />
         <Styled.InnerButton
           icon="format_list_bulleted"
-          selected={value === TableGridPlaylistView.PLAYLIST}
-          onClick={() => onChange(TableGridPlaylistView.PLAYLIST)}
+          selected={value === "playlist"}
+          onClick={() => onChange("playlist")}
           variant="text"
           data-tooltip="Playlist"
           data-shortcut="P"

--- a/src/pages/ProjectListsPage/context/ReviewCardsSettingsContext.tsx
+++ b/src/pages/ProjectListsPage/context/ReviewCardsSettingsContext.tsx
@@ -1,4 +1,4 @@
-import { VersionsSettings } from '@shared/api'
+import { ReviewsSettings } from '@shared/api'
 import { useViewsContext } from '@shared/containers'
 import { useViewUpdateHelper } from '@shared/containers/Views/utils/viewUpdateHelper'
 import {
@@ -16,6 +16,9 @@ export type ReviewCardsSettingsContextValue = {
   gridHeight: number
   onUpdateGridHeight: (gridHeight: number) => void
   onUpdateGridHeightWithPersistence: (gridHeight: number) => void
+  displayStyle: ReviewsSettings['displayStyle']
+  onUpdateDisplayStyle: (displayStyle: ReviewsSettings['displayStyle']) => void
+  onUpdateDisplayStyleWithPersistence: (displayStyle: ReviewsSettings['displayStyle']) => void
 }
 
 const ReviewCardsContext = createContext<ReviewCardsSettingsContextValue | null>(null)
@@ -38,10 +41,12 @@ export const ReviewCardsSettingsProvider: FC<ReviewCardsSettingsProviderProps> =
 
   // Memoize versionsSettings to prevent unnecessary re-renders when viewSettings
   // reference changes but values are the same
-  const settings = useMemo(() => viewSettings as VersionsSettings, [viewSettings])
+  const settings = useMemo(() => viewSettings as ReviewsSettings, [viewSettings])
 
   const [localGridHeight, setLocalGridHeight] = useState<number | null>(null)
   const [localGridHeightImmediate, setLocalGridHeightImmediate] = useState<number | null>(null)
+  const [localDisplayStyle, setLocalDisplayStyle] = useState<ReviewsSettings['displayStyle']>()
+  const [localDisplayStyleImmediate, setLocalDisplayStyleImmediate] = useState<ReviewsSettings['displayStyle']>()
 
   // Get view update helper
   const { updateViewSettings } = useViewUpdateHelper()
@@ -51,10 +56,17 @@ export const ReviewCardsSettingsProvider: FC<ReviewCardsSettingsProviderProps> =
     [settings?.gridHeight],
   )
 
+  const serverDisplayStyle = useMemo(
+    () => settings?.displayStyle ?? "cards",
+    [settings?.displayStyle],
+  )
+
   // Sync local state with server when viewSettings change
   useEffect(() => {
     setLocalGridHeight(null)
     setLocalGridHeightImmediate(null)
+    setLocalDisplayStyle(undefined)
+    setLocalDisplayStyleImmediate(undefined)
   }, [JSON.stringify(viewSettings)])
 
   const gridHeight = useMemo(
@@ -66,10 +78,19 @@ export const ReviewCardsSettingsProvider: FC<ReviewCardsSettingsProviderProps> =
         : serverGridHeight,
     [localGridHeightImmediate, localGridHeight, serverGridHeight],
   )
+  const displayStyle = useMemo(
+    () => localDisplayStyleImmediate ?? localDisplayStyle ?? serverDisplayStyle,
+    [localDisplayStyleImmediate, localDisplayStyle, serverDisplayStyle],
+  )
 
   // Grid height update handler (immediate, no API call)
   const onUpdateGridHeight = useCallback((newGridHeight: number) => {
     setLocalGridHeightImmediate(newGridHeight)
+  }, [])
+
+  // Display style update handler (immediate, no API call)
+  const onUpdateDisplayStyle = useCallback((newDisplayStyle: ReviewsSettings['displayStyle']) => {
+    setLocalDisplayStyleImmediate(newDisplayStyle)
   }, [])
 
   // Grid height update handler with persistence (API call)
@@ -84,12 +105,27 @@ export const ReviewCardsSettingsProvider: FC<ReviewCardsSettingsProviderProps> =
     [updateViewSettings],
   )
 
+  // Display style update handler with persistence (API call)
+  const onUpdateDisplayStyleWithPersistence = useCallback(
+    async (newDisplayStyle: ReviewsSettings['displayStyle']) => {
+      await updateViewSettings({ displayStyle: newDisplayStyle }, setLocalDisplayStyle, newDisplayStyle, {
+        errorMessage: 'Failed to update display style',
+      })
+      // Clear immediate state after persistence
+      setLocalDisplayStyleImmediate(undefined)
+    },
+    [updateViewSettings],
+  )
+
   return (
     <ReviewCardsContext.Provider
       value={{
         gridHeight,
         onUpdateGridHeight,
         onUpdateGridHeightWithPersistence,
+        displayStyle,
+        onUpdateDisplayStyle,
+        onUpdateDisplayStyleWithPersistence,
       }}
     >
       {children}


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

The display style (grid/table/playlist) on the Reviews page is now stored in Views.

## Technical details

Needs latest `develop` of ayon-backend to work because the Reviews view is a typed view.

## Additional context
<!-- Add any other context or screenshots here. -->

closes https://github.com/ynput/ayon-frontend/issues/1914