### PR TITLE
Subtasks: Ensure users have proper access to assignees dropdown options

### DIFF
--- a/shared/src/components/SubtasksManager/SubtasksManagerWrapper.tsx
+++ b/shared/src/components/SubtasksManager/SubtasksManagerWrapper.tsx
@@ -2,7 +2,7 @@
 import {
   QueryFilter,
   SubTaskNode,
-  useGetUsersQuery,
+  useGetUsersAssigneeQuery,
   UserModel,
   useUpdateSubtasksMutation,
 } from '@shared/api'
@@ -35,7 +35,7 @@ export const SubtasksManagerWrapper = ({
   ...props
 }: SubtasksManagerWrapperProps) => {
   const [updateSubtasks] = useUpdateSubtasksMutation()
-  const { data: users = [] } = useGetUsersQuery({})
+  const { data: users = [] } = useGetUsersAssigneeQuery({ projectName: props.projectName })
 
   return (
     <SubtasksManager


### PR DESCRIPTION
The incorrect users query was being used on the studio scope that regular users did not have access to. This caused the assignees dropdown to show to no users, prevent users from assigning users to a subtask.

The correct query on the project scope is now being used.