### PR TITLE
Views: Changing view permissions does not move view to correct section

### DIFF
--- a/shared/src/api/queries/views/getViews.ts
+++ b/shared/src/api/queries/views/getViews.ts
@@ -1,10 +1,5 @@
 import { ListViewsApiResponse, viewsApi } from '@shared/api/generated'
-import {
-  DefinitionsFromApi,
-  OverrideResultType,
-  TagDescription,
-  TagTypesFromApi,
-} from '@reduxjs/toolkit/query'
+import { DefinitionsFromApi, OverrideResultType, TagTypesFromApi } from '@reduxjs/toolkit/query'
 
 export const getScopeTag = (viewType: string, projectName?: string) => {
   return {
@@ -28,7 +23,7 @@ export const getViewsApi = viewsApi.enhanceEndpoints<TagTypes, UpdatedDefinition
   endpoints: {
     listViews: {
       transformResponse: (response: ListViewsApiResponse) => response?.views || [],
-      providesTags: (result, _e, { viewType, projectName }): TagDescription<TagTypes>[] =>
+      providesTags: (result, _e, { viewType, projectName }) =>
         result
           ? [
               VIEW_LIST_TAG,

--- a/shared/src/api/queries/views/getViews.ts
+++ b/shared/src/api/queries/views/getViews.ts
@@ -33,7 +33,9 @@ export const getViewsApi = viewsApi.enhanceEndpoints<TagTypes, UpdatedDefinition
           ? [
               VIEW_LIST_TAG,
               getScopeTag(viewType, projectName),
-              ...result.map((v) => ({ type: 'view' as const, id: v.id })),
+              ...result
+                .filter((v) => v.id != null)
+                .map((v) => ({ type: 'view' as const, id: v.id })),
             ]
           : [VIEW_LIST_TAG],
       transformErrorResponse: (error: any) => error.data?.detail,

--- a/shared/src/api/queries/views/getViews.ts
+++ b/shared/src/api/queries/views/getViews.ts
@@ -1,5 +1,10 @@
 import { ListViewsApiResponse, viewsApi } from '@shared/api/generated'
-import { DefinitionsFromApi, OverrideResultType, TagTypesFromApi } from '@reduxjs/toolkit/query'
+import {
+  DefinitionsFromApi,
+  OverrideResultType,
+  TagDescription,
+  TagTypesFromApi,
+} from '@reduxjs/toolkit/query'
 
 export const getScopeTag = (viewType: string, projectName?: string) => {
   return {
@@ -23,8 +28,14 @@ export const getViewsApi = viewsApi.enhanceEndpoints<TagTypes, UpdatedDefinition
   endpoints: {
     listViews: {
       transformResponse: (response: ListViewsApiResponse) => response?.views || [],
-      providesTags: (result, _e, { viewType, projectName }) =>
-        result ? [VIEW_LIST_TAG, getScopeTag(viewType, projectName)] : [VIEW_LIST_TAG],
+      providesTags: (result, _e, { viewType, projectName }): TagDescription<TagTypes>[] =>
+        result
+          ? [
+              VIEW_LIST_TAG,
+              getScopeTag(viewType, projectName),
+              ...result.map((v) => ({ type: 'view' as const, id: v.id })),
+            ]
+          : [VIEW_LIST_TAG],
       transformErrorResponse: (error: any) => error.data?.detail,
     },
     getWorkingView: {


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
Fixes [YN-1938] — when a view's permissions change (e.g. from private → studio, or studio → project), the view did not move to the correct section in the views dropdown until a hard refresh.      


## Technical details
<!-- Please state any technical details such as limitations -->
Fix: extend `providesTags` in `getViews.ts` so each list also provides a per-view tag `{ type: 'view', id: v.id }` for every view in the result. Now any mutation that invalidates `view:<id>` will cause the affected `listViews` queries to refetch and the view will surface in the correct section automatically.

## Additional context
<!-- Add any other context or screenshots here. -->

