### PR TITLE
Review page sorting and settings adjustments

### DIFF
--- a/shared/src/components/ProjectTableSettings/ProjectTableSettings.tsx
+++ b/shared/src/components/ProjectTableSettings/ProjectTableSettings.tsx
@@ -46,6 +46,7 @@ export type ProjectTableSettingsProps = {
   hiddenSettings?: ('columns' | 'row-height' | 'group-by' | 'sort-by')[]
   highlighted?: SettingHighlightedId
   includeLinks?: boolean
+  hideSortBy?: boolean
   order?: string[]
   scope?: string
 }
@@ -57,6 +58,7 @@ export const ProjectTableSettings: FC<ProjectTableSettingsProps> = ({
   hiddenSettings = [],
   highlighted,
   includeLinks = true,
+  hideSortBy = false,
   order,
   scope,
 }) => {
@@ -168,7 +170,7 @@ export const ProjectTableSettings: FC<ProjectTableSettingsProps> = ({
       preview: `${visibleCount}/${visibleColumns.length}`,
       component: <ColumnsSettings columns={visibleColumns} highlighted={highlighted} />,
     },
-    sortBySettings,
+    hideSortBy ? null : sortBySettings,
     groupBySettings,
     {
       id: 'row-height',

--- a/shared/src/containers/ProjectTreeTable/ProjectTreeTable.tsx
+++ b/shared/src/containers/ProjectTreeTable/ProjectTreeTable.tsx
@@ -143,6 +143,7 @@ export interface ProjectTreeTableProps extends React.HTMLAttributes<HTMLDivEleme
   includeLinks?: boolean
   isLoading?: boolean
   isExpandable?: boolean // if true, show the expand/collapse icons
+  enableSorting?: boolean
   clientSorting?: boolean
   sortableRows?: boolean
   onRowReorder?: (active: UniqueIdentifier, over: UniqueIdentifier | null) => void // Adjusted type for active/over if needed, or keep as Active, Over
@@ -169,6 +170,7 @@ export const ProjectTreeTable = ({
   includeLinks,
   isLoading: isLoadingProp,
   isExpandable,
+  enableSorting = true,
   clientSorting = false,
   sortableRows = false,
   onRowReorder,
@@ -406,7 +408,7 @@ export const ProjectTreeTable = ({
     // EXPANDABLE
     onExpandedChange: updateExpanded,
     // SORTING
-    enableSorting: true,
+    enableSorting,
     getSortedRowModel: getSortedRowModel(),
     sortDescFirst: false,
     manualSorting: !clientSorting,

--- a/src/pages/ProjectListsPage/ProjectListsPage.tsx
+++ b/src/pages/ProjectListsPage/ProjectListsPage.tsx
@@ -455,7 +455,7 @@ const ProjectLists: FC<ProjectListsProps> = ({
                         onGoTo={handleGoToCustomAttrib}
                       />
                     ) : (
-                      <ReviewCardsSettings />
+                      <ReviewCardsSettings pageDisplayStyle={pageDisplayStyle} />
                     )}
                   </SplitterPanel>
                 ) : (

--- a/src/pages/ProjectListsPage/components/ListItemsTable/ListItemsTable.tsx
+++ b/src/pages/ProjectListsPage/components/ListItemsTable/ListItemsTable.tsx
@@ -68,7 +68,8 @@ const ListItemsTable: FC<ListItemsTableProps> = ({
         excludedColumns={hiddenColumns}
         extraColumns={extraColumns}
         isLoading={isLoading}
-        sortableRows={!viewOnly && !isReview}
+        sortableRows={!viewOnly}
+        enableSorting={!isReview}
         dndActiveId={dndActiveId} // Pass prop
       />
       <ListItemsShortcuts />

--- a/src/pages/ProjectListsPage/components/ListsTableSettings/ListsTableSettings.tsx
+++ b/src/pages/ProjectListsPage/components/ListsTableSettings/ListsTableSettings.tsx
@@ -18,7 +18,7 @@ export const ListsTableSettings: FC<ListsTableSettingsProps> = ({
   extraColumns,
   highlightedSetting,
 }) => {
-  const { selectedList } = useListsContext()
+  const { selectedList, isReview } = useListsContext()
   const { listAttributes, entityAttribFields, updateAttributes, isUpdating, isLoadingNewList } =
     useListsAttributesContext()
   const { ListsAttributesSettings, requiredVersion } = useListsModuleContext()
@@ -36,6 +36,7 @@ export const ListsTableSettings: FC<ListsTableSettingsProps> = ({
       hiddenColumns={['folder']}
       highlighted={highlightedSetting}
       hiddenSettings={['group-by']}
+      hideSortBy={isReview}
       settings={[
         {
           id: 'list_attributes',

--- a/src/pages/ProjectListsPage/components/ReviewCardsSettings/ReviewCardsSettings.tsx
+++ b/src/pages/ProjectListsPage/components/ReviewCardsSettings/ReviewCardsSettings.tsx
@@ -3,26 +3,31 @@ import { SizeSlider } from '@shared/components'
 import { SettingsPanel } from '@shared/components/SettingsPanel'
 
 export default function ReviewCardsSettings() {
-  const { gridHeight, onUpdateGridHeight, onUpdateGridHeightWithPersistence } = useReviewCardsSettingsContext()
+  const {
+    gridHeight,
+    displayStyle,
+    onUpdateGridHeight,
+    onUpdateGridHeightWithPersistence,
+  } = useReviewCardsSettingsContext()
+
+  const settings = displayStyle === "cards"
+    ? [{
+      id: 'grid-size',
+      component: (
+        <SizeSlider
+          value={gridHeight}
+          onChange={onUpdateGridHeight}
+          onChangeComplete={onUpdateGridHeightWithPersistence}
+          title="Grid size"
+          id="grid-size-slider"
+          min={90}
+          max={300}
+          step={10}
+        />
+      ),
+    }] : []
+
   return (
-    <SettingsPanel
-      settings={[
-        {
-          id: 'grid-size',
-          component: (
-            <SizeSlider
-              value={gridHeight}
-              onChange={onUpdateGridHeight}
-              onChangeComplete={onUpdateGridHeightWithPersistence}
-              title="Grid size"
-              id="grid-size-slider"
-              min={90}
-              max={300}
-              step={10}
-            />
-          ),
-        }
-      ]}
-    />
+    <SettingsPanel settings={settings} />
   )
 }

--- a/src/pages/ProjectListsPage/components/TableGridPlaylistSwitch/TableGridPlaylistSwitch.tsx
+++ b/src/pages/ProjectListsPage/components/TableGridPlaylistSwitch/TableGridPlaylistSwitch.tsx
@@ -46,20 +46,20 @@ export const TableGridPlaylistSwitch = forwardRef<HTMLDivElement, TableGridPlayl
           data-shortcut="T"
         />
         <Styled.InnerButton
-          icon="grid_view"
-          selected={value === "cards"}
-          onClick={() => onChange("cards")}
-          variant="text"
-          data-tooltip="Cards"
-          data-shortcut="G"
-        />
-        <Styled.InnerButton
           icon="format_list_bulleted"
           selected={value === "playlist"}
           onClick={() => onChange("playlist")}
           variant="text"
           data-tooltip="Playlist"
           data-shortcut="P"
+        />
+        <Styled.InnerButton
+          icon="grid_view"
+          selected={value === "cards"}
+          onClick={() => onChange("cards")}
+          variant="text"
+          data-tooltip="Cards"
+          data-shortcut="G"
         />
       </Styled.ButtonsContainer>
     )

--- a/src/pages/ProjectListsPage/context/ListItemsDataContext.tsx
+++ b/src/pages/ProjectListsPage/context/ListItemsDataContext.tsx
@@ -59,6 +59,13 @@ interface ListItemsDataProviderProps {
   children: ReactNode
 }
 
+const reviewSortKeys = new Map([
+  ["task", "task_id"],
+  ["product", "product_id"],
+  ["path", "name"],
+  ["versionAuthor", "author"],
+])
+
 // fetch all items and provide methods to update the items
 export const ListItemsDataProvider = ({ children }: ListItemsDataProviderProps) => {
   // Get project data from the new context
@@ -105,7 +112,7 @@ export const ListItemsDataProvider = ({ children }: ListItemsDataProviderProps) 
     if (!sorting) return null
 
     return [{
-      id: sorting.property,
+      id: reviewSortKeys.get(sorting.property) ?? sorting.property,
       desc: sorting.order,
     }]
   }, [isReview, selectedList?.data.sorting])

--- a/src/pages/ProjectListsPage/context/ListItemsDataContext.tsx
+++ b/src/pages/ProjectListsPage/context/ListItemsDataContext.tsx
@@ -65,7 +65,7 @@ export const ListItemsDataProvider = ({ children }: ListItemsDataProviderProps) 
   const { projectName } = useProjectContext()
   const { attribFields, users, isInitialized, isLoading: isLoadingData } = useProjectDataContext()
 
-  const { selectedList } = useListsContext()
+  const { selectedList, isReview } = useListsContext()
   const selectedListId = selectedList?.id
 
   // TODO: finish setting up settings for lists
@@ -96,6 +96,20 @@ export const ListItemsDataProvider = ({ children }: ListItemsDataProviderProps) 
     setListItemsFilters({ conditions: [], operator: 'and' })
   }, [setListItemsFilters])
 
+  // For review sessions, we use the sorting setting stored in the entity list's `data`.
+  // This allows us to use the sorting in the review session itself, too.
+  const reviewSorting: SortingState | null = useMemo(() => {
+    if (!isReview) return null
+
+    const sorting = selectedList?.data.sorting
+    if (!sorting) return null
+
+    return [{
+      id: sorting.property,
+      desc: sorting.order,
+    }]
+  }, [isReview, selectedList?.data.sorting])
+
   const {
     data: listItemsData,
     isLoading,
@@ -107,7 +121,7 @@ export const ListItemsDataProvider = ({ children }: ListItemsDataProviderProps) 
     projectName,
     entityType: selectedList?.entityType,
     listId: selectedListId,
-    sorting: columns.sorting || [],
+    sorting: reviewSorting ?? columns.sorting ?? [],
     filters: listItemsFilters,
   })
 

--- a/src/pages/ProjectListsPage/context/ListsProvider.tsx
+++ b/src/pages/ProjectListsPage/context/ListsProvider.tsx
@@ -83,8 +83,6 @@ export const ListsProvider = ({ children, isReview, isStoryboards }: ListsProvid
     [unstableListSelection, unstableReviewSelection, unstableStoryboardSelection, isReview, isStoryboards],
   )
 
-  console.log('unstableStoryboardSelection', unstableStoryboardSelection)
-
   const setRowSelection = useCallback(
     (ids: RowSelectionState) => {
       if (isStoryboards) {


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

If there is a `sorting` stored in the Review Session entity list, the Table view will now be automatically sorted according to that sorting key. The manual sorting in Table view has been re-enabled for Reviews.

The Sort by setting has been removed from review page settings, since we're now going to rely on the Sort by chip from the addon. Also, the Grid size setting is only going to be visible in the Grid view.

## Technical details
<!-- Please state any technical details such as limitations -->


## Additional context
<!-- Add any other context or screenshots here. -->

