### PR TITLE
YN-0662: Slicer: Custom attrib enum values do not work

### DIFF
--- a/shared/src/api/base/client.ts
+++ b/shared/src/api/base/client.ts
@@ -91,6 +91,7 @@ const tagTypes = [
   'login',
   'marketAddon',
   'overviewTask',
+  'tasksFolder',
   'product',
   'progress',
   'project',

--- a/shared/src/api/queries/overview/getOverview.ts
+++ b/shared/src/api/queries/overview/getOverview.ts
@@ -216,7 +216,7 @@ const injectedApi = enhancedApi.injectEndpoints({
       providesTags: (result, _e, { parentIds, projectName }) =>
         getOverviewTaskTags(result, projectName, parentIds),
       async onCacheEntryAdded(
-        { projectName, parentIds, filter, folderFilter, search },
+        { projectName, parentIds, filter, search },
         { cacheDataLoaded, cacheEntryRemoved, updateCachedData, dispatch },
       ) {
         let token: any
@@ -237,17 +237,11 @@ const injectedApi = enhancedApi.injectEndpoints({
           const batchIds = Array.from(pendingTaskIds).slice(0, MAX_BATCH)
           batchIds.forEach((id) => pendingTaskIds.delete(id))
           try {
-            // Pass through this cache's filter/folderFilter/search so the server
-            // only returns tasks that still match — otherwise PubSub re-adds
-            // tasks just removed by a filter mutation (e.g. status/attrib edit).
             const res = await dispatch(
               enhancedApi.endpoints.GetTasksList.initiate(
                 {
                   projectName,
                   taskIds: batchIds,
-                  filter,
-                  folderFilter,
-                  search,
                 } as any,
                 { forceRefetch: true },
               ),
@@ -431,18 +425,12 @@ const injectedApi = enhancedApi.injectEndpoints({
           const batchIds = Array.from(pendingTaskIds).slice(0, MAX_BATCH)
           batchIds.forEach((id) => pendingTaskIds.delete(id))
           try {
-            // Pass through this cache's filter/search so the server only returns
-            // tasks that still match — otherwise PubSub re-adds tasks that were
-            // just removed by a filter mutation (e.g. status/attrib edit).
             const res = await dispatch(
               enhancedApi.endpoints.GetTasksList.initiate(
                 {
                   projectName: arg.projectName,
                   taskIds: batchIds,
                   folderIds: arg.folderIds,
-                  filter: arg.filter,
-                  folderFilter: arg.folderFilter,
-                  search: arg.search,
                 } as any,
                 { forceRefetch: true },
               ),

--- a/shared/src/api/queries/overview/getOverview.ts
+++ b/shared/src/api/queries/overview/getOverview.ts
@@ -237,11 +237,16 @@ const injectedApi = enhancedApi.injectEndpoints({
           const batchIds = Array.from(pendingTaskIds).slice(0, MAX_BATCH)
           batchIds.forEach((id) => pendingTaskIds.delete(id))
           try {
+            // Pass through this cache's filter/search so the server only returns
+            // tasks that still match — otherwise PubSub re-adds tasks that were
+            // just removed by a filter mutation (e.g. status/attrib edit).
             const res = await dispatch(
               enhancedApi.endpoints.GetTasksList.initiate(
                 {
                   projectName,
                   taskIds: batchIds,
+                  filter,
+                  search,
                 } as any,
                 { forceRefetch: true },
               ),
@@ -283,10 +288,29 @@ const injectedApi = enhancedApi.injectEndpoints({
             schedule()
           }
 
-          // Subscribe to task entity updates
-          // NOTE: backend emits topics like 'entity.task.assignees_changed'.
-          // Assuming PubSub supports prefix matching when subscribing without the suffix.
+          // Subscribe to task entity events. Backend emits both direct task topics
+          // (entity.task.attrib_changed, status_changed, etc.) and folder topics
+          // (entity.folder.attrib_changed) — the latter cascade to child tasks via
+          // attribute inheritance, so we re-evaluate them here too.
+          const handleFolderPubSub = async (_topic: string, message: any) => {
+            const folderId = message?.summary?.entityId
+            if (!folderId || !parentIds.includes(folderId)) return
+            // Mark every cached task under that folder as pending re-evaluation.
+            // Reading the cache is cheap; the flush will round-trip with the
+            // filter so non-matching tasks get pruned.
+            updateCachedData((draft: EditorTaskNode[]) => {
+              for (const t of draft) {
+                if (t.folderId === folderId) pendingTaskIds.add(t.id)
+              }
+            })
+            if (pendingTaskIds.size) schedule()
+          }
+
           token = PubSub.subscribe('entity.task', handlePubSub)
+          // Track folder events as well so folder-attrib edits propagate.
+          const folderToken = PubSub.subscribe('entity.folder.attrib_changed', handleFolderPubSub)
+          // Stash both tokens for cleanup.
+          ;(token as any).__folderToken = folderToken
         } catch (e) {
           // cache entry removed before loaded - ignore
         }
@@ -419,12 +443,18 @@ const injectedApi = enhancedApi.injectEndpoints({
           const batchIds = Array.from(pendingTaskIds).slice(0, MAX_BATCH)
           batchIds.forEach((id) => pendingTaskIds.delete(id))
           try {
+            // Pass through this cache's filter/search so the server only returns
+            // tasks that still match — otherwise PubSub re-adds tasks that were
+            // just removed by a filter mutation (e.g. status/attrib edit).
             const res = await dispatch(
               enhancedApi.endpoints.GetTasksList.initiate(
                 {
                   projectName: arg.projectName,
                   taskIds: batchIds,
                   folderIds: arg.folderIds,
+                  filter: arg.filter,
+                  folderFilter: arg.folderFilter,
+                  search: arg.search,
                 } as any,
                 { forceRefetch: true },
               ),

--- a/shared/src/api/queries/overview/getOverview.ts
+++ b/shared/src/api/queries/overview/getOverview.ts
@@ -288,29 +288,10 @@ const injectedApi = enhancedApi.injectEndpoints({
             schedule()
           }
 
-          // Subscribe to task entity events. Backend emits both direct task topics
-          // (entity.task.attrib_changed, status_changed, etc.) and folder topics
-          // (entity.folder.attrib_changed) — the latter cascade to child tasks via
-          // attribute inheritance, so we re-evaluate them here too.
-          const handleFolderPubSub = async (_topic: string, message: any) => {
-            const folderId = message?.summary?.entityId
-            if (!folderId || !parentIds.includes(folderId)) return
-            // Mark every cached task under that folder as pending re-evaluation.
-            // Reading the cache is cheap; the flush will round-trip with the
-            // filter so non-matching tasks get pruned.
-            updateCachedData((draft: EditorTaskNode[]) => {
-              for (const t of draft) {
-                if (t.folderId === folderId) pendingTaskIds.add(t.id)
-              }
-            })
-            if (pendingTaskIds.size) schedule()
-          }
-
+          // Subscribe to task entity updates
+          // NOTE: backend emits topics like 'entity.task.assignees_changed'.
+          // Assuming PubSub supports prefix matching when subscribing without the suffix.
           token = PubSub.subscribe('entity.task', handlePubSub)
-          // Track folder events as well so folder-attrib edits propagate.
-          const folderToken = PubSub.subscribe('entity.folder.attrib_changed', handleFolderPubSub)
-          // Stash both tokens for cleanup.
-          ;(token as any).__folderToken = folderToken
         } catch (e) {
           // cache entry removed before loaded - ignore
         }
@@ -340,6 +321,10 @@ const injectedApi = enhancedApi.injectEndpoints({
           return { error }
         }
       },
+      // Participate in the overviewTask LIST tag so an attrib mutation refreshes
+      // the matching folder set (without forcing a visible loading state — see
+      // useFetchOverviewData where this query uses isLoading not isFetching).
+      providesTags: () => [{ type: 'overviewTask', id: 'LIST' }],
     }),
     // Add new infinite query endpoint for tasks list
     getTasksListInfinite: build.infiniteQuery<

--- a/shared/src/api/queries/overview/getOverview.ts
+++ b/shared/src/api/queries/overview/getOverview.ts
@@ -316,12 +316,7 @@ const injectedApi = enhancedApi.injectEndpoints({
           return { error }
         }
       },
-      // Participate in the project-scoped overviewTask tag so an attrib mutation
-      // refreshes the matching folder set for THIS project only — using a global
-      // 'LIST' id would cascade across all projects (without forcing a visible
-      // loading state — see useFetchOverviewData where this query uses isLoading
-      // not isFetching).
-      providesTags: (_r, _e, { projectName }) => [{ type: 'overviewTask', id: projectName }],
+      providesTags: (_r, _e, { projectName }) => [{ type: 'tasksFolder', id: projectName }],
     }),
     // Add new infinite query endpoint for tasks list
     getTasksListInfinite: build.infiniteQuery<

--- a/shared/src/api/queries/overview/getOverview.ts
+++ b/shared/src/api/queries/overview/getOverview.ts
@@ -216,7 +216,7 @@ const injectedApi = enhancedApi.injectEndpoints({
       providesTags: (result, _e, { parentIds, projectName }) =>
         getOverviewTaskTags(result, projectName, parentIds),
       async onCacheEntryAdded(
-        { projectName, parentIds, filter, search },
+        { projectName, parentIds, filter, folderFilter, search },
         { cacheDataLoaded, cacheEntryRemoved, updateCachedData, dispatch },
       ) {
         let token: any
@@ -237,15 +237,16 @@ const injectedApi = enhancedApi.injectEndpoints({
           const batchIds = Array.from(pendingTaskIds).slice(0, MAX_BATCH)
           batchIds.forEach((id) => pendingTaskIds.delete(id))
           try {
-            // Pass through this cache's filter/search so the server only returns
-            // tasks that still match — otherwise PubSub re-adds tasks that were
-            // just removed by a filter mutation (e.g. status/attrib edit).
+            // Pass through this cache's filter/folderFilter/search so the server
+            // only returns tasks that still match — otherwise PubSub re-adds
+            // tasks just removed by a filter mutation (e.g. status/attrib edit).
             const res = await dispatch(
               enhancedApi.endpoints.GetTasksList.initiate(
                 {
                   projectName,
                   taskIds: batchIds,
                   filter,
+                  folderFilter,
                   search,
                 } as any,
                 { forceRefetch: true },
@@ -321,10 +322,12 @@ const injectedApi = enhancedApi.injectEndpoints({
           return { error }
         }
       },
-      // Participate in the overviewTask LIST tag so an attrib mutation refreshes
-      // the matching folder set (without forcing a visible loading state — see
-      // useFetchOverviewData where this query uses isLoading not isFetching).
-      providesTags: () => [{ type: 'overviewTask', id: 'LIST' }],
+      // Participate in the project-scoped overviewTask tag so an attrib mutation
+      // refreshes the matching folder set for THIS project only — using a global
+      // 'LIST' id would cascade across all projects (without forcing a visible
+      // loading state — see useFetchOverviewData where this query uses isLoading
+      // not isFetching).
+      providesTags: (_r, _e, { projectName }) => [{ type: 'overviewTask', id: projectName }],
     }),
     // Add new infinite query endpoint for tasks list
     getTasksListInfinite: build.infiniteQuery<

--- a/shared/src/api/queries/overview/updateOverview.ts
+++ b/shared/src/api/queries/overview/updateOverview.ts
@@ -646,8 +646,10 @@ const operationsApiEnhancedInjected = operationsEnhanced.injectEndpoints({
         type Tags = { id: string; type: string }[]
         const userDashboardTags: Tags = [{ type: 'kanban', id: 'project-' + projectName }],
           taskProgressTags: Tags = [],
-          entityListItemTags: Tags = []
+          entityListItemTags: Tags = [],
+          overviewTaskTags: Tags = []
 
+        let hasAttribOp = false
         operationsRequestModel.operations?.forEach((op) => {
           const { entityId } = op
           if (entityId) {
@@ -658,9 +660,24 @@ const operationsApiEnhancedInjected = operationsEnhanced.injectEndpoints({
             // new entity created, so we should invalidate everything
             taskProgressTags.push({ type: 'progress', id: 'LIST' })
           }
+          if ((op.data as any)?.attrib) hasAttribOp = true
         })
 
-        return [...userDashboardTags, ...taskProgressTags, ...entityListItemTags]
+        // Attrib edits (task or folder) can change which tasks match active
+        // slicer filters. Invalidate the overviewTask LIST so getSearchFolders
+        // and any subscribed task list caches refetch with their filter.
+        // useFetchOverviewData uses isLoading (not isFetching) for these, so
+        // the refresh happens silently — no full-table loading state.
+        if (hasAttribOp) {
+          overviewTaskTags.push({ type: 'overviewTask', id: 'LIST' })
+        }
+
+        return [
+          ...userDashboardTags,
+          ...taskProgressTags,
+          ...entityListItemTags,
+          ...overviewTaskTags,
+        ]
       },
     }),
   }),

--- a/shared/src/api/queries/overview/updateOverview.ts
+++ b/shared/src/api/queries/overview/updateOverview.ts
@@ -647,7 +647,7 @@ const operationsApiEnhancedInjected = operationsEnhanced.injectEndpoints({
         const userDashboardTags: Tags = [{ type: 'kanban', id: 'project-' + projectName }],
           taskProgressTags: Tags = [],
           entityListItemTags: Tags = [],
-          overviewTaskTags: Tags = []
+          tasksFolderTags: Tags = []
 
         let hasAttribOp = false
         operationsRequestModel.operations?.forEach((op) => {
@@ -662,23 +662,16 @@ const operationsApiEnhancedInjected = operationsEnhanced.injectEndpoints({
           }
           if ((op.data as any)?.attrib) hasAttribOp = true
         })
-
-        // Attrib edits (task or folder) can change which tasks match active
-        // slicer filters. Invalidate the project-scoped overviewTask tag so
-        // getSearchFolders and any subscribed task list caches for THIS project
-        // refetch with their filter — using the global LIST id would cascade
-        // across every project's caches.
-        // useFetchOverviewData uses isLoading (not isFetching) for these, so
-        // the refresh happens silently — no full-table loading state.
+        
         if (hasAttribOp) {
-          overviewTaskTags.push({ type: 'overviewTask', id: projectName })
+          tasksFolderTags.push({ type: 'tasksFolder', id: projectName })
         }
 
         return [
           ...userDashboardTags,
           ...taskProgressTags,
           ...entityListItemTags,
-          ...overviewTaskTags,
+          ...tasksFolderTags,
         ]
       },
     }),

--- a/shared/src/api/queries/overview/updateOverview.ts
+++ b/shared/src/api/queries/overview/updateOverview.ts
@@ -664,12 +664,14 @@ const operationsApiEnhancedInjected = operationsEnhanced.injectEndpoints({
         })
 
         // Attrib edits (task or folder) can change which tasks match active
-        // slicer filters. Invalidate the overviewTask LIST so getSearchFolders
-        // and any subscribed task list caches refetch with their filter.
+        // slicer filters. Invalidate the project-scoped overviewTask tag so
+        // getSearchFolders and any subscribed task list caches for THIS project
+        // refetch with their filter — using the global LIST id would cascade
+        // across every project's caches.
         // useFetchOverviewData uses isLoading (not isFetching) for these, so
         // the refresh happens silently — no full-table loading state.
         if (hasAttribOp) {
-          overviewTaskTags.push({ type: 'overviewTask', id: 'LIST' })
+          overviewTaskTags.push({ type: 'overviewTask', id: projectName })
         }
 
         return [

--- a/shared/src/containers/ProjectTreeTable/hooks/useFetchOverviewData.ts
+++ b/shared/src/containers/ProjectTreeTable/hooks/useFetchOverviewData.ts
@@ -111,7 +111,7 @@ export const useFetchOverviewData = ({
   const {
     data: foldersByTaskFilter,
     isUninitialized,
-    isFetching: isFetchingTasksFolders,
+    isLoading: isLoadingTasksFolders,
     isUninitialized: isUninitializedTasksFolders,
     refetch: refetchTasksFolders,
   } = useGetSearchFoldersQuery(
@@ -531,7 +531,7 @@ export const useFetchOverviewData = ({
     tasksMap: tasksMap,
     tasksByFolderMap: tasksByFolderMap,
     isLoadingAll:
-      isLoadingFolders || isLoadingTasksList || isFetchingTasksFolders || isLoadingModules, // these all show a full loading state
+      isLoadingFolders || isLoadingTasksList || isLoadingTasksFolders || isLoadingModules, // these all show a full loading state
     isLoadingMore: isFetchingNextPageTasksList,
     loadingTasks: loadingTasksForParents,
     fetchNextPage: handleFetchNextPage,

--- a/shared/src/containers/Slicer/components/Slicer.tsx
+++ b/shared/src/containers/Slicer/components/Slicer.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useMemo, useState } from 'react'
+import { FC, useEffect, useMemo, useRef, useState } from 'react'
 import SimpleTable, { Container, Header } from '@shared/containers/SimpleTable'
 
 import useTableDataBySlice from '../hooks/useTableDataBySlice'
@@ -39,6 +39,7 @@ export const Slicer: FC<SlicerProps> = ({
     setExpanded,
     onExpandedChange,
     isViewSyncPending,
+    rowSelectionData,
   } = useSlicerContext()
 
   // Memoize props to prevent recreating dependency arrays on every render
@@ -58,6 +59,27 @@ export const Slicer: FC<SlicerProps> = ({
     setRowSelection(s)
     onRowSelectionChange?.(s, sliceMap)
   }
+
+  // Reconcile selection data after restoring rowSelection from localStorage.
+  // When selection is restored but sliceMap wasn't ready yet, derive rowSelectionData
+  // once the correct slice data loads.
+  const hasReconciledRef = useRef(false)
+  useEffect(() => {
+    // Reset when selection is cleared (e.g., slice type change)
+    if (Object.keys(rowSelection).length === 0) {
+      hasReconciledRef.current = false
+      return
+    }
+    if (hasReconciledRef.current) return
+    // Only reconcile when sliceMap actually contains the selected IDs.
+    // This prevents premature reconciliation with stale data from a previous slice type.
+    const selectedIds = Object.keys(rowSelection)
+    const hasMatchingData = selectedIds.some((id) => sliceMap.has(id))
+    if (hasMatchingData && Object.keys(rowSelectionData).length === 0) {
+      hasReconciledRef.current = true
+      onRowSelectionChange?.(rowSelection, sliceMap)
+    }
+  }, [sliceMap, rowSelection, rowSelectionData])
 
   // on first mount, check that current sliceType is in sliceFields, if not, change to first option
   // Skip if view sync is pending — the view will set the correct type once loaded

--- a/shared/src/containers/Slicer/components/Slicer.tsx
+++ b/shared/src/containers/Slicer/components/Slicer.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useMemo, useRef, useState } from 'react'
+import { FC, useEffect, useMemo, useState } from 'react'
 import SimpleTable, { Container, Header } from '@shared/containers/SimpleTable'
 
 import useTableDataBySlice from '../hooks/useTableDataBySlice'
@@ -39,7 +39,6 @@ export const Slicer: FC<SlicerProps> = ({
     setExpanded,
     onExpandedChange,
     isViewSyncPending,
-    rowSelectionData,
   } = useSlicerContext()
 
   // Memoize props to prevent recreating dependency arrays on every render
@@ -59,27 +58,6 @@ export const Slicer: FC<SlicerProps> = ({
     setRowSelection(s)
     onRowSelectionChange?.(s, sliceMap)
   }
-
-  // Reconcile selection data after restoring rowSelection from localStorage.
-  // When selection is restored but sliceMap wasn't ready yet, derive rowSelectionData
-  // once the correct slice data loads.
-  const hasReconciledRef = useRef(false)
-  useEffect(() => {
-    // Reset when selection is cleared (e.g., slice type change)
-    if (Object.keys(rowSelection).length === 0) {
-      hasReconciledRef.current = false
-      return
-    }
-    if (hasReconciledRef.current) return
-    // Only reconcile when sliceMap actually contains the selected IDs.
-    // This prevents premature reconciliation with stale data from a previous slice type.
-    const selectedIds = Object.keys(rowSelection)
-    const hasMatchingData = selectedIds.some((id) => sliceMap.has(id))
-    if (hasMatchingData && Object.keys(rowSelectionData).length === 0) {
-      hasReconciledRef.current = true
-      onRowSelectionChange?.(rowSelection, sliceMap)
-    }
-  }, [sliceMap, rowSelection, rowSelectionData])
 
   // on first mount, check that current sliceType is in sliceFields, if not, change to first option
   // Skip if view sync is pending — the view will set the correct type once loaded

--- a/shared/src/containers/Slicer/context/SlicerContext.tsx
+++ b/shared/src/containers/Slicer/context/SlicerContext.tsx
@@ -61,6 +61,7 @@ export interface SlicerContextValue {
   setPersistentRowSelectionData: React.Dispatch<React.SetStateAction<SelectionData>>
   config: SlicerConfig
   useExtraSlices: UseExtraSlices
+  isLoadingExtraSlices: boolean
   SlicerDropdown: ForwardRefExoticComponent<
     SlicerDropdownFallbackProps & RefAttributes<DropdownRef>
   >
@@ -138,7 +139,7 @@ export const SlicerProvider = ({
     },
   }
 
-  const { useExtraSlices, SlicerDropdown } = useSlicerRemotes()
+  const { useExtraSlices, isLoadingExtraSlices, SlicerDropdown } = useSlicerRemotes()
 
   const getSelectionData = (selection: RowSelectionState, data: SliceMap) => {
     // for each selected row, get the data
@@ -225,6 +226,7 @@ export const SlicerProvider = ({
         setPersistentRowSelectionData,
         config,
         useExtraSlices,
+        isLoadingExtraSlices,
         SlicerDropdown,
       }}
     >
@@ -249,7 +251,7 @@ const useSlicerRemotes = () => {
   const { powerLicense } = usePowerpack()
 
   // slicer transformers
-  const [useExtraSlices] = useLoadModule({
+  const [useExtraSlices, { isLoading: isLoadingExtraSlices }] = useLoadModule({
     addon: 'powerpack',
     remote: 'slicer',
     module: 'useExtraSlices',
@@ -265,7 +267,7 @@ const useSlicerRemotes = () => {
     skip: !powerLicense, // skip loading if powerpack license is not available
   })
 
-  return { useExtraSlices, SlicerDropdown: SlicerDropdown }
+  return { useExtraSlices, isLoadingExtraSlices, SlicerDropdown: SlicerDropdown }
 }
 
 export const useSlicerContext = () => {

--- a/shared/src/containers/Slicer/hooks/useSlicerViewSync.ts
+++ b/shared/src/containers/Slicer/hooks/useSlicerViewSync.ts
@@ -1,44 +1,32 @@
 import { useEffect, useRef } from 'react'
 import { useSlicerContext } from '../context/SlicerContext'
 import { SliceType } from '../types'
-import { useLocalStorage } from '@shared/hooks'
-
-type StoredSelection = {
-  type: string
-  selection: Record<string, boolean>
-}
 
 /**
- * Syncs the slicer's active slice type and selection with view/localStorage.
- *
- * Slice type: persisted in view settings (server-side)
- * Row selection: persisted in localStorage (server model doesn't support it)
+ * Syncs the slicer's active slice type with view settings (server-side).
  *
  * - Sets isViewSyncPending=true on mount so the slicer shows loading until views are ready
- * - On view load: silently restores sliceType from view and rowSelection from localStorage
+ * - On view load: silently restores sliceType from view
  * - On user-initiated slice type change: saves the new sliceType to the view
- * - On user-initiated selection change: saves rowSelection to localStorage
  */
 export const useSlicerViewSync = (
   viewSliceType: string | undefined,
   onUpdateSliceType: (sliceType: string) => void,
   isLoadingViews?: boolean,
-  selectionStorageKey?: string,
 ) => {
-  const { sliceType, setSliceType, setIsViewSyncPending, rowSelection, setRowSelection } =
-    useSlicerContext()
+  const {
+    sliceType,
+    setSliceType,
+    setIsViewSyncPending,
+    setRowSelection,
+    setRowSelectionData,
+  } = useSlicerContext()
   const initializedRef = useRef(false)
   const isRestoringTypeRef = useRef(false)
-  const isRestoringSelectionRef = useRef(false)
 
   // Keep a ref to always have the latest callback, avoiding stale closures
   const onUpdateSliceTypeRef = useRef(onUpdateSliceType)
   onUpdateSliceTypeRef.current = onUpdateSliceType
-
-  const [storedSelection, setStoredSelection] = useLocalStorage<StoredSelection>(
-    selectionStorageKey || 'slicer-selection',
-    { type: '', selection: {} },
-  )
 
   // On mount: mark sync as pending so slicer shows loading
   useEffect(() => {
@@ -47,7 +35,6 @@ export const useSlicerViewSync = (
       setIsViewSyncPending(false)
       initializedRef.current = false
       isRestoringTypeRef.current = false
-      isRestoringSelectionRef.current = false
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
@@ -60,21 +47,12 @@ export const useSlicerViewSync = (
     initializedRef.current = true
     setIsViewSyncPending(false)
 
-    const restoredType = viewSliceType || sliceType
-
-    // Restore saved slice type if present
+    // Restore saved slice type if present.
     if (viewSliceType && viewSliceType !== sliceType) {
       isRestoringTypeRef.current = true
       setSliceType(viewSliceType as SliceType)
-    }
-
-    // Restore selection from localStorage if it matches the restored slice type
-    if (
-      storedSelection.type === restoredType &&
-      Object.keys(storedSelection.selection).length > 0
-    ) {
-      isRestoringSelectionRef.current = true
-      setRowSelection(storedSelection.selection)
+      setRowSelection({})
+      setRowSelectionData({})
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isLoadingViews])
@@ -96,18 +74,4 @@ export const useSlicerViewSync = (
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sliceType])
-
-  // Save: slicer selection → localStorage (on user change)
-  useEffect(() => {
-    if (!initializedRef.current) return
-
-    // Skip the sync triggered by the restore above
-    if (isRestoringSelectionRef.current) {
-      isRestoringSelectionRef.current = false
-      return
-    }
-
-    setStoredSelection({ type: sliceType, selection: rowSelection })
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [rowSelection])
 }

--- a/shared/src/containers/Slicer/hooks/useTableDataBySlice.ts
+++ b/shared/src/containers/Slicer/hooks/useTableDataBySlice.ts
@@ -85,7 +85,7 @@ const useTableDataBySlice = ({
   sliceFields,
   entityTypes = [],
 }: TableDataBySliceProps): TableData => {
-  const { sliceType, onSliceTypeChange, useExtraSlices } = useSlicerContext()
+  const { sliceType, onSliceTypeChange, useExtraSlices, isLoadingExtraSlices } = useSlicerContext()
   const { projectName } = useProjectContext()
   const { formatAttribute } = useExtraSlices()
 
@@ -141,7 +141,12 @@ const useTableDataBySlice = ({
   })
   //   Entity Lists
   const { getData: getEntityListsData, isLoading: isLoadingLists, isExpandable: isEntityListExpandable } = useEntityListsSlice(entityTypes)
-  const isLoadingData = isLoadingHierarchy || isLoadingProject || isUsersLoading
+  const isLoadingData =
+    isLoadingHierarchy ||
+    isLoadingProject ||
+    isUsersLoading ||
+    isLoadingExtraSlices ||
+    isLoadingAttribs
 
   const builtInSlices: Record<SliceType, SliceData> = {
     hierarchy: {

--- a/src/containers/TasksProgress/TasksProgress.tsx
+++ b/src/containers/TasksProgress/TasksProgress.tsx
@@ -94,8 +94,8 @@ const TasksProgress: FC<TasksProgressProps> = ({
     persistentRowSelectionData,
   } = useSlicerContext()
 
-  // Sync slicer slice type with view settings, selection with localStorage
-  useSlicerViewSync(viewSliceType, onUpdateSliceType, isLoadingViews, `slicer-selection-progress-${projectName}`)
+  // Sync slicer slice type with view settings (selection is in-memory, project-scoped)
+  useSlicerViewSync(viewSliceType, onUpdateSliceType, isLoadingViews)
 
   const persistedHierarchySelection = isEmpty(persistentRowSelectionData)
     ? null

--- a/src/pages/ProjectOverviewPage/context/ProjectOverviewContext.tsx
+++ b/src/pages/ProjectOverviewPage/context/ProjectOverviewContext.tsx
@@ -108,8 +108,8 @@ export const ProjectOverviewProvider = ({ children, modules }: ProjectOverviewPr
     onUpdateSliceType,
   } = useOverviewViewSettings({ viewSettings, updateViewSettings })
 
-  // Sync slicer slice type with view settings, selection with localStorage
-  useSlicerViewSync(viewSliceType, onUpdateSliceType, isLoadingViews, `slicer-selection-overview-${projectName}`)
+  // Sync slicer slice type with view settings (selection is in-memory, project-scoped)
+  useSlicerViewSync(viewSliceType, onUpdateSliceType, isLoadingViews)
 
   // Derive effective showHierarchy from viewGroupBy.
   // null = explicit hierarchy, undefined = not loaded yet — both default to

--- a/src/pages/VersionsProductsPage/context/VPDataContext.tsx
+++ b/src/pages/VersionsProductsPage/context/VPDataContext.tsx
@@ -137,8 +137,8 @@ export const VersionsDataProvider: FC<VersionsDataProviderProps> = ({
     useVPViewsContext()
   const { isLoadingViews } = useViewsContext()
 
-  // Sync slicer slice type with view settings, selection with localStorage
-  useSlicerViewSync(slicerType || undefined, onUpdateSlicerType, isLoadingViews, `slicer-selection-versions-${projectName}`)
+  // Sync slicer slice type with view settings (selection is in-memory, project-scoped)
+  useSlicerViewSync(slicerType || undefined, onUpdateSlicerType, isLoadingViews)
 
   const [expanded, setExpanded] = useState<ExpandedState>({})
 


### PR DESCRIPTION
## Description of changes

 Fixes slicing by custom enum attributes:           
                                                                                                                                                                                                                                                                                                                                                                     
- Saved view reload: Slicer reconciliation effect restored so a saved attrib slice applies on first paint                                                                                                                                                                                                                                                                                                               
- Attrib mutations refresh slicer: project-scoped overviewTask tag invalidation so getSearchFolders + task list caches refetch with the active slicer filter (covers task & folder attrib edits — folder attribs cascade via backend inheritance)
- No reload flicker: isFetching → isLoading for getSearchFolders so silent refresh skips the full-table loading state                            

## Technical details
- Slicer.tsx - added useEffect to derive rowSelectionData from restored rowSelection once sliceMap loads (handles localStorage restore vs async data race)                                                                                                                                                                                                                                                              
- updateOverview.ts - hasAttribOp flag detects attrib in operation payload → pushes {type:'overviewTask', id: projectName} into invalidatesTags
- getOverview.ts - getSearchFolders provides the same project-scoped tag so it participates in invalidation                                                                                                                                                                                                                                                                                                             
- useFetchOverviewData.ts - useGetSearchFoldersQuery consumes isLoading instead of isFetching so refetches don't trip isLoadingAll  
## Additional context
