### PR TITLE
Overview: Folder grouping should not pin name column

### DIFF
--- a/shared/src/containers/ProjectTreeTable/buildTreeTableColumns.tsx
+++ b/shared/src/containers/ProjectTreeTable/buildTreeTableColumns.tsx
@@ -218,10 +218,10 @@ const buildTreeTableColumns = ({
       header: nameLabel,
       minSize: COLUMN_MIN_SIZE,
       sortingFn: withLoadingStateSort(pathSort),
-      enableSorting: groupBy ? false : canSort('name'),
+      enableSorting: groupBy && groupBy.id !== 'folder' ? false : canSort('name'),
       enableResizing: true,
       enablePinning: true,
-      enableHiding: groupBy ? false : true,
+      enableHiding: !(groupBy && groupBy.id !== 'folder'),
       cell: ({ row, column, table }) => {
         const { value, id, type } = getValueIdType(row, column.id)
         const meta = table.options.meta

--- a/shared/src/containers/ProjectTreeTable/context/ColumnSettingsProvider.tsx
+++ b/shared/src/containers/ProjectTreeTable/context/ColumnSettingsProvider.tsx
@@ -98,9 +98,9 @@ export const ColumnSettingsProvider: React.FC<ColumnSettingsProviderProps> = ({
     }
   })
 
-  // if we are in grouping mode, always pin the name column
+  // if we are in grouping mode (except folder grouping), always pin the name column
   // and ensure it is first in column order
-  if (groupBy) {
+  if (groupBy && groupBy.id !== 'folder') {
     // ensure name column is pinned and first in pinning order
     if (!columnPinning.left?.includes('name')) {
       columnPinning.left = ['name', ...(columnPinning?.left || [])]

--- a/shared/src/containers/ProjectTreeTable/hooks/useGroupBySettings.tsx
+++ b/shared/src/containers/ProjectTreeTable/hooks/useGroupBySettings.tsx
@@ -4,13 +4,16 @@ import { useGetGroupedFields } from '..'
 import { TableGroupBy } from '@shared/containers'
 
 const HIERARCHY_ID = 'hierarchy'
+const FOLDER_ID = 'folder'
+const NAME_SORT_COLUMN = 'name'
 
 interface UseGroupBySettingsProps {
   scope?: string
 }
 
 export const useGroupBySettings = ({ scope }: UseGroupBySettingsProps) => {
-  const { groupBy, groupByConfig, updateGroupBy, updateGroupByConfig } = useColumnSettingsContext()
+  const { groupBy, groupByConfig, updateGroupBy, updateGroupByConfig, sorting, updateSorting } =
+    useColumnSettingsContext()
   const { modules, showHierarchy, updateShowHierarchy, hierarchyOptions: customHierarchyOptions, hierarchyActive, } = useProjectTableContext()
   const groupByFields = useGetGroupedFields({ scope })
   if (!modules) return null
@@ -30,17 +33,32 @@ export const useGroupBySettings = ({ scope }: UseGroupBySettingsProps) => {
   // so the GroupSettings component highlights the hierarchy option as selected
   // hierarchyActive overrides showHierarchy for panel display when table behavior differs
   const isHierarchyActive = hierarchyActive ?? showHierarchy
-  const virtualGroupBy =
+  const baseVirtualGroupBy =
     groupBy ?? (hasHierarchy && isHierarchyActive ? { id: HIERARCHY_ID, desc: false } : undefined)
+  const nameSortDesc =
+    sorting?.[0]?.id === NAME_SORT_COLUMN ? !!sorting[0].desc : false
+  const virtualGroupBy =
+    baseVirtualGroupBy?.id === FOLDER_ID || baseVirtualGroupBy?.id === HIERARCHY_ID
+      ? { ...baseVirtualGroupBy, desc: nameSortDesc }
+      : baseVirtualGroupBy
 
-  // Wrap updateGroupBy to intercept "hierarchy" and "none" selection
+  // Wrap updateGroupBy to intercept "hierarchy", "folder" and "none" selection
   const handleUpdateGroupBy = useCallback(
     (newGroupBy: TableGroupBy | undefined) => {
-      if (newGroupBy?.id === HIERARCHY_ID) {
-        // Hierarchy selected: delegate entirely to updateShowHierarchy
-        // which routes through onUpdateViewGroupBy('hierarchy') and also
-        // sets localColumns.groupBy = undefined — no need to call updateGroupBy separately
-        updateShowHierarchy?.(true)
+      if (newGroupBy?.id === HIERARCHY_ID || newGroupBy?.id === FOLDER_ID) {
+        const isAlreadyActive =
+          newGroupBy.id === HIERARCHY_ID ? isHierarchyActive : groupBy?.id === FOLDER_ID
+        if (isAlreadyActive) {
+          if (newGroupBy.desc !== nameSortDesc) {
+            updateSorting([{ id: NAME_SORT_COLUMN, desc: !!newGroupBy.desc }])
+          }
+          return
+        }
+        if (newGroupBy.id === HIERARCHY_ID) {
+          updateShowHierarchy?.(true)
+        } else {
+          updateGroupBy(newGroupBy)
+        }
         return
       }
       if (!newGroupBy) {
@@ -57,7 +75,7 @@ export const useGroupBySettings = ({ scope }: UseGroupBySettingsProps) => {
       }
       updateGroupBy(newGroupBy)
     },
-    [updateGroupBy, updateShowHierarchy],
+    [updateGroupBy, updateShowHierarchy, updateSorting, groupBy, nameSortDesc, isHierarchyActive],
   )
 
   const preview = virtualGroupBy
@@ -77,7 +95,6 @@ export const useGroupBySettings = ({ scope }: UseGroupBySettingsProps) => {
         updateGroupBy={handleUpdateGroupBy}
         config={groupByConfig}
         onConfigChange={updateGroupByConfig}
-        sortDisabled={virtualGroupBy?.id === 'hierarchy' || virtualGroupBy?.id === 'folder'}
       />
     ),
   }

--- a/src/pages/ProjectOverviewPage/ProjectOverviewPage.tsx
+++ b/src/pages/ProjectOverviewPage/ProjectOverviewPage.tsx
@@ -17,6 +17,7 @@ import { Actions } from '@shared/containers/Actions/Actions'
 import {
   getCellId,
   ROW_SELECTION_COLUMN_ID,
+  useColumnSettingsContext,
   useGetGroupedFields,
   useSelectionCellsContext,
 } from '@shared/containers/ProjectTreeTable'
@@ -90,6 +91,9 @@ const ProjectOverviewPage: FC = () => {
     updateExpanded,
   } = useProjectOverviewContext()
 
+  const { sorting, updateSorting } = useColumnSettingsContext()
+  const nameSortDesc = sorting?.[0]?.id === 'name' ? sorting[0].desc : false
+
   // Build group-by dropdown options
   const groupedFields = useGetGroupedFields({ scope: 'task' })
   const viewGroupByOptions = useMemo(() => {
@@ -111,21 +115,34 @@ const ProjectOverviewPage: FC = () => {
     if (viewGroupBy === undefined) return []
     return viewGroupByOptions
       .filter((o) => o.id === (viewGroupBy === 'none' ? undefined : viewGroupBy ?? 'hierarchy'))
-      .map((o) => ({ ...o, sortOrder: !viewGroupByDesc }))
-  }, [viewGroupBy, viewGroupByOptions, viewGroupByDesc])
+      .map((o) => ({
+        ...o,
+        sortOrder:
+          o.id === 'folder' || o.id === 'hierarchy' ? !nameSortDesc : !viewGroupByDesc,
+      }))
+  }, [viewGroupBy, viewGroupByOptions, viewGroupByDesc, nameSortDesc])
 
   const handleViewGroupByChange = (values: { id: string; sortOrder?: boolean }[]) => {
     const value = values[0]
     if (!value) {
       // X clicked — flat list (no grouping)
       updateViewGroupBy('none')
-    } else if (value.id === 'hierarchy') {
-      updateViewGroupBy(null)
-    } else {
-      // sortOrder: true = ascending, desc: false = ascending
-      const desc = value.sortOrder === false
-      updateViewGroupBy(value.id, desc)
+      return
     }
+    const desc = value.sortOrder === false
+    if (value.id === 'hierarchy' || value.id === 'folder') {
+      const targetView = value.id === 'hierarchy' ? null : 'folder'
+      if (viewGroupBy === targetView) {
+        if (desc !== nameSortDesc) {
+          updateSorting([{ id: 'name', desc }])
+        }
+        return
+      }
+      updateViewGroupBy(targetView)
+      return
+    }
+    // sortOrder: true = ascending, desc: false = ascending
+    updateViewGroupBy(value.id, desc)
   }
 
   const { isPanelOpen } = useSettingsPanel()
@@ -223,7 +240,6 @@ const ProjectOverviewPage: FC = () => {
               />
               <ReloadButton />
               <GroupByDropdown
-                $disableSortOrder={viewGroupBy === null || viewGroupBy === 'folder'}
                 title="Group by"
                 options={viewGroupByOptions}
                 value={viewGroupByValue}


### PR DESCRIPTION


<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
Removes the forced name-column pinning + first-position when grouping by Folder, so column order and pinning are free. Other groupings (status, taskType, etc.) keep the existing behavior.


## Technical details
<!-- Please state any technical details such as limitations -->
- ColumnSettingsProvider.tsx — gated the name-pin / name-first block on groupBy.id !== 'folder'.      

## Additional context
<!-- Add any other context or screenshots here. -->

