### PR TITLE
YN-0581: Project folders: Hide empty folders with restricted projects

### DIFF
--- a/shared/src/api/generated/projectFolders.ts
+++ b/shared/src/api/generated/projectFolders.ts
@@ -80,6 +80,7 @@ export type ProjectFolderModel = {
   label: string
   parentId?: string
   position?: number
+  isEmpty?: boolean
   data?: ProjectFolderData
 }
 export type ProjectFoldersResponseModel = {

--- a/shared/src/util/buildHierarchicalTableRows.ts
+++ b/shared/src/util/buildHierarchicalTableRows.ts
@@ -37,6 +37,8 @@ export interface BuildHierarchicalRowsConfig<TFolder, TItem> {
   getFolderColor: (folder: TFolder) => string | undefined
   /** Function to get item count for display */
   getItemCount: (node: HierarchicalFolderNode<TFolder, TItem>) => number
+  /** Optional: returns true if the folder is genuinely empty, false if it has items the user can't see (e.g. restricted projects). Hides folders with restricted content regardless of showEmptyFolders. */
+  getFolderIsEmpty?: (folder: TFolder) => boolean | undefined
 }
 
 /**
@@ -58,13 +60,20 @@ export const buildHierarchicalTableRows = <TFolder, TItem>(
     getFolderIcon,
     getFolderColor,
     getItemCount,
+    getFolderIsEmpty,
   } = config
+
+  const isFolderVisible = (node: HierarchicalFolderNode<TFolder, TItem>): boolean => {
+    if (node.hasAnyItems) return true
+    if (getFolderIsEmpty?.(node.folder) === false) return false
+    return showEmptyFolders
+  }
 
   const result: SimpleTableRow[] = []
 
   // Get root folders and sort them
   const rootNodes = Array.from(folderNodes.values()).filter(
-    (node) => rootFolderIds.has(node.id) && (showEmptyFolders || node.hasAnyItems),
+    (node) => rootFolderIds.has(node.id) && isFolderVisible(node),
   )
   const sortedRootNodes = sortFolderNodes(rootNodes)
 
@@ -134,9 +143,7 @@ export const buildHierarchicalTableRows = <TFolder, TItem>(
     }
 
     // Get child folders and sort them
-    const childNodes = Array.from(node.children.values()).filter(
-      (child) => showEmptyFolders || child.hasAnyItems,
-    )
+    const childNodes = Array.from(node.children.values()).filter(isFolderVisible)
     const sortedChildNodes = sortFolderNodes(childNodes)
 
     // Add child folders to stack in reverse order (for correct processing order)

--- a/src/containers/ProjectsList/buildProjectsTableData.ts
+++ b/src/containers/ProjectsList/buildProjectsTableData.ts
@@ -130,6 +130,7 @@ const buildProjectsTableData = (
     getItemCount: (node) =>
       node.items.length +
       Array.from(node.children.values()).reduce((acc, child) => acc + child.items.length, 0),
+    getFolderIsEmpty: (folder) => folder.isEmpty,
   })
 
   // Create rows for root projects (projects not in folders)


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
 Hide project folders that appear empty to the user because they don't have permission to the projects inside.


## Technical details
<!-- Please state any technical details such as limitations -->

Extended `buildHierarchicalTableRows` with optional `getFolderIsEmpty` predicate. New visibility rule:
1. Folder has visible items then show.                                                                                                                                                                                                               
2. `isEmpty === false` and no visible items,  hide (restricted content inside).                                                           
3. Else, respect `showEmptyFolders`.       

## Additional context
<!-- Add any other context or screenshots here. -->

