### PR TITLE
Project: Add label alongside project name

### DIFF
--- a/shared/src/api/queries/project/updateProject.ts
+++ b/shared/src/api/queries/project/updateProject.ts
@@ -29,6 +29,33 @@ const enhancedProjectApi = projectApi.enhanceEndpoints({
               { type: 'projects', id: 'LIST' },
             ],
       transformErrorResponse: (error: any) => error.data.detail,
+      // Optimistically patch listProjects cache for fields exposed in the list view
+      // so the UI updates instantly without waiting for refetch.
+      async onQueryStarted({ projectName, projectPatchModel }, { dispatch, queryFulfilled }) {
+        if (!('label' in projectPatchModel)) return
+
+        const newLabel = projectPatchModel.label ?? undefined
+        const patches = [
+          dispatch(
+            projectApi.util.updateQueryData('listProjects', { active: true }, (draft) => {
+              const project = draft.find((p) => p.name === projectName)
+              if (project) project.label = newLabel
+            }),
+          ),
+          dispatch(
+            projectApi.util.updateQueryData('listProjects', { active: undefined }, (draft) => {
+              const project = draft.find((p) => p.name === projectName)
+              if (project) project.label = newLabel
+            }),
+          ),
+        ]
+
+        try {
+          await queryFulfilled
+        } catch {
+          patches.forEach((patch) => patch.undo())
+        }
+      },
     },
     setProjectBundle: {
       invalidatesTags: (_r, _e, { projectName }) => [

--- a/shared/src/util/getProjectDisplayName.ts
+++ b/shared/src/util/getProjectDisplayName.ts
@@ -1,0 +1,10 @@
+type ProjectLike = {
+  name: string
+  label?: string | null
+}
+
+export const getProjectDisplayName = (project: ProjectLike | null | undefined): string => {
+  if (!project) return ''
+  const label = project.label?.trim()
+  return label || project.name
+}

--- a/shared/src/util/index.ts
+++ b/shared/src/util/index.ts
@@ -22,6 +22,7 @@ export * from './keyboardShortcuts'
 export * from './buildHierarchicalTableRows'
 export * from './folderHierarchy'
 export * from './folderOperations'
+export * from './getProjectDisplayName'
 
 import isHTMLElement from './isHTMLElement'
 export { isHTMLElement }

--- a/src/components/AttribForm/AttribForm.tsx
+++ b/src/components/AttribForm/AttribForm.tsx
@@ -10,6 +10,7 @@ interface Field {
   title?: string
   format?: string
   enumLabels?: Record<string, string>
+  disabled?: boolean
 }
 
 type Fields = Record<string, Field>
@@ -24,6 +25,7 @@ interface AttribFormProps {
   form?: Record<string, any>
   onChange: (key: string, value: any) => void
   fields: Fields
+  topLevelFields?: Fields
   isLoading: boolean
 }
 
@@ -43,7 +45,13 @@ export const getDefaultFromType = (type: FieldType): any => {
   }
 }
 
-const AttribForm: React.FC<AttribFormProps> = ({ form = {}, onChange, fields, isLoading }) => {
+const AttribForm: React.FC<AttribFormProps> = ({
+  form = {},
+  onChange,
+  fields,
+  topLevelFields,
+  isLoading,
+}) => {
   //   we build the attrib form data based on the schema, trying to match the data types
   // we do this in case form.attrib is missing any fields
   // and so that formData is always in the same format (we don't get uncontrolled inputs)
@@ -99,7 +107,9 @@ const AttribForm: React.FC<AttribFormProps> = ({ form = {}, onChange, fields, is
   return (
     <Styled.FormContainer>
       {formFields.map(({ key, id, value }) => {
-        const { title = key, type = typeof value, format, enumLabels } = fields[key] || {}
+        const isNested = id.includes('.')
+        const fieldDef = (!isNested && topLevelFields?.[key]) || fields[key] || {}
+        const { title = key, type = typeof value, format, enumLabels, disabled } = fieldDef
         return (
           <Styled.Row key={id}>
             <label>{title}</label>
@@ -111,6 +121,7 @@ const AttribForm: React.FC<AttribFormProps> = ({ form = {}, onChange, fields, is
                 value={value}
                 onChange={onChange}
                 enumLabels={enumLabels}
+                disabled={disabled}
               />
             </Styled.Field>
           </Styled.Row>

--- a/src/components/AttribForm/AttribFormType.jsx
+++ b/src/components/AttribForm/AttribFormType.jsx
@@ -8,7 +8,16 @@ import {
 import { isEmpty, isEqual } from 'lodash'
 import React from 'react'
 
-const AttribFormType = ({ type, value, onChange, id, enumLabels = {}, format, ...props }) => {
+const AttribFormType = ({
+  type,
+  value,
+  onChange,
+  id,
+  enumLabels = {},
+  format,
+  disabled,
+  ...props
+}) => {
   let options = []
   for (const key in enumLabels) {
     options.push({ label: enumLabels[key], value: key })
@@ -30,7 +39,14 @@ const AttribFormType = ({ type, value, onChange, id, enumLabels = {}, format, ..
     onChange(id, newValue)
   }
 
-  const sharedProps = { value, onChange: handleChange, id, ...props, autoComplete: 'off' }
+  const sharedProps = {
+    value,
+    onChange: handleChange,
+    id,
+    ...props,
+    disabled,
+    autoComplete: 'off',
+  }
 
   if (format === 'date-time') type = 'date'
   if (!isEmpty(enumLabels) && type !== 'array') type = 'array-single'
@@ -43,7 +59,13 @@ const AttribFormType = ({ type, value, onChange, id, enumLabels = {}, format, ..
     case 'integer':
       return <InputNumber {...sharedProps} step={1} min={0} />
     case 'boolean':
-      return <InputSwitch checked={value} onChange={() => handleChange(null, !value)} />
+      return (
+        <InputSwitch
+          checked={value}
+          onChange={() => !disabled && handleChange(null, !value)}
+          disabled={disabled}
+        />
+      )
     case 'date':
       return (
         <InputDate
@@ -63,6 +85,7 @@ const AttribFormType = ({ type, value, onChange, id, enumLabels = {}, format, ..
           search={options.length > 5}
           onClear={value?.length ? () => handleChange(null, []) : false}
           multiSelect
+          disabled={disabled}
           style={{ width: '100%' }}
         />
       )
@@ -75,6 +98,7 @@ const AttribFormType = ({ type, value, onChange, id, enumLabels = {}, format, ..
           search={options.length > 5}
           multiple={false}
           onClear={() => handleChange(null, null)}
+          disabled={disabled}
           style={{ width: '100%' }}
         />
       )

--- a/src/containers/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/containers/Breadcrumbs/Breadcrumbs.tsx
@@ -33,6 +33,7 @@ const getPathnameLabel = (pathname: string): string => {
   return ''
 }
 
+// TODO(YN-0581 / issue #1940): swap project-name crumb to project label (label || name).
 const uri2crumbs = (uri: string = '', pathname: string): string[] => {
   const [scope, pathAndQuery = ''] = (uri || '').split('://')
   const [path, query] = pathAndQuery.split('?')

--- a/src/containers/ProjectMenu/projectMenu.jsx
+++ b/src/containers/ProjectMenu/projectMenu.jsx
@@ -120,6 +120,7 @@ const ProjectMenu = ({ isOpen, onHide }) => {
 
     const foldersToExpand = new Set()
 
+    const searchLower = search.toLowerCase()
     const filterNodes = (nodes) => {
       return nodes.reduce((acc, node) => {
         if (node.data?.isFolder) {
@@ -129,7 +130,10 @@ const ProjectMenu = ({ isOpen, onHide }) => {
             foldersToExpand.add(node.id)
             acc.push({ ...node, subRows: filteredChildren })
           }
-        } else if (node.name?.toLowerCase().includes(search.toLowerCase())) {
+        } else if (
+          node.name?.toLowerCase().includes(searchLower) ||
+          node.label?.toLowerCase().includes(searchLower)
+        ) {
           acc.push(node)
         }
         return acc

--- a/src/containers/ProjectsList/ProjectsList.tsx
+++ b/src/containers/ProjectsList/ProjectsList.tsx
@@ -269,13 +269,15 @@ const ProjectsList: FC<ProjectsListProps> = ({
     handleOpenFolderDialog,
   })
 
+  const canEditProjectLabel = !!(user?.data?.isAdmin || user?.data?.isManager)
+
   // Generate menu items used in both header and context menu
   const buildMenuItems = useProjectsListMenuItems({
     hidden: {
       'add-project': !canCreateProject,
-      'delete-project': !user?.data?.isAdmin && !user?.data?.isManager,
-      'archive-project': !user?.data?.isAdmin && !user?.data?.isManager,
-      'edit-label': !user?.data?.isAdmin && !user?.data?.isManager,
+      'delete-project': !canEditProjectLabel,
+      'archive-project': !canEditProjectLabel,
+      'edit-label': !canEditProjectLabel,
     },
     projects: projects,
     folders: folders || [],
@@ -301,7 +303,7 @@ const ProjectsList: FC<ProjectsListProps> = ({
     powerLicense,
     onEditFolder,
     onRenameFolder,
-    onRenameProject,
+    onRenameProject: canEditProjectLabel ? onRenameProject : undefined,
   })
 
   return (
@@ -355,7 +357,7 @@ const ProjectsList: FC<ProjectsListProps> = ({
         folders={folders || []}
         onOpenFolderDialog={handleOpenFolderDialog}
         onRenameFolder={onRenameFolder}
-        onRenameProject={onRenameProject}
+        onRenameProject={canEditProjectLabel ? onRenameProject : undefined}
         disabled={!powerLicense}
       />
     </>

--- a/src/containers/ProjectsList/ProjectsList.tsx
+++ b/src/containers/ProjectsList/ProjectsList.tsx
@@ -1,4 +1,5 @@
 import { useGetProjectFoldersQuery, useListProjectsQuery } from '@shared/api'
+import { getProjectDisplayName } from '@shared/util'
 import { ExpandedState, RowSelectionState } from '@tanstack/react-table'
 import { FC, useCallback, useEffect, useMemo, useState } from 'react'
 import useUserProjectPermissions from '@hooks/useUserProjectPermissions'
@@ -67,12 +68,12 @@ const ProjectsList: FC<ProjectsListProps> = ({
   const { data: folders } = useGetProjectFoldersQuery()
 
   // transformations
-  // sort projects by active pinned, active, inactive (active=false) and then alphabetically
+  // sort projects by active pinned, active, inactive (active=false) and then alphabetically by display name (label || name)
   const projects = useMemo(() => {
     return [...data].sort((a, b) => {
       if (a.active && !b.active) return -1
       if (!a.active && b.active) return 1
-      return a.name.localeCompare(b.name)
+      return getProjectDisplayName(a).localeCompare(getProjectDisplayName(b))
     })
   }, [data, rowPinning])
 
@@ -258,6 +259,10 @@ const ProjectsList: FC<ProjectsListProps> = ({
     renamingFolder,
     onSubmitRenameFolder,
     closeRenameFolder,
+    onRenameProject,
+    renamingProject,
+    onSubmitRenameProject,
+    closeRenameProject,
   } = useProjectFolderActions({
     folders,
     onSelect,
@@ -270,6 +275,7 @@ const ProjectsList: FC<ProjectsListProps> = ({
       'add-project': !canCreateProject,
       'delete-project': !user?.data?.isAdmin && !user?.data?.isManager,
       'archive-project': !user?.data?.isAdmin && !user?.data?.isManager,
+      'edit-label': !user?.data?.isAdmin && !user?.data?.isManager,
     },
     projects: projects,
     folders: folders || [],
@@ -295,6 +301,7 @@ const ProjectsList: FC<ProjectsListProps> = ({
     powerLicense,
     onEditFolder,
     onRenameFolder,
+    onRenameProject,
   })
 
   return (
@@ -326,6 +333,9 @@ const ProjectsList: FC<ProjectsListProps> = ({
         renamingFolder={renamingFolder}
         onSubmitRenameFolder={onSubmitRenameFolder}
         closeRenameFolder={closeRenameFolder}
+        renamingProject={renamingProject}
+        onSubmitRenameProject={onSubmitRenameProject}
+        closeRenameProject={closeRenameProject}
         pt={pt}
       />
       <ProjectFolderFormDialog
@@ -345,6 +355,7 @@ const ProjectsList: FC<ProjectsListProps> = ({
         folders={folders || []}
         onOpenFolderDialog={handleOpenFolderDialog}
         onRenameFolder={onRenameFolder}
+        onRenameProject={onRenameProject}
         disabled={!powerLicense}
       />
     </>

--- a/src/containers/ProjectsList/ProjectsListRow.tsx
+++ b/src/containers/ProjectsList/ProjectsListRow.tsx
@@ -105,7 +105,7 @@ const ProjectsListRow = forwardRef<HTMLDivElement, ProjectsListRowProps>(
             style={{ flex: 1 }}
             onChange={(e) => setRenameValue(e.target.value)}
             value={renameValue}
-            placeholder={!isFolder ? 'Project label (empty for none)' : undefined}
+            placeholder={!isFolder ? 'Project label' : undefined}
             onKeyDown={(e) => {
               if (e.key === 'Enter') {
                 onSubmitRename?.(renameValue)

--- a/src/containers/ProjectsList/ProjectsListRow.tsx
+++ b/src/containers/ProjectsList/ProjectsListRow.tsx
@@ -21,6 +21,7 @@ export interface ProjectsListRowProps extends React.HTMLAttributes<HTMLDivElemen
   isRowExpanded?: boolean
   isPinned?: boolean
   hidePinned?: boolean
+  renameInitialValue?: string
   onSubmitRename?: (value: string) => void
   onCancelRename?: () => void
   onExpandClick?: () => void
@@ -49,6 +50,7 @@ const ProjectsListRow = forwardRef<HTMLDivElement, ProjectsListRowProps>(
       isRowExpanded,
       isPinned,
       hidePinned,
+      renameInitialValue,
       onSubmitRename,
       onCancelRename,
       onExpandClick,
@@ -61,13 +63,13 @@ const ProjectsListRow = forwardRef<HTMLDivElement, ProjectsListRowProps>(
     },
     ref,
   ) => {
-    const [renameValue, setRenameValue] = useState(value)
+    const [renameValue, setRenameValue] = useState(renameInitialValue ?? value)
 
     useEffect(() => {
       if (isRenaming) {
-        setRenameValue(value)
+        setRenameValue(renameInitialValue ?? value)
       }
-    }, [value, isRenaming])
+    }, [value, isRenaming, renameInitialValue])
 
     // Check if this is a folder row using the canonical folder ID parser
     const isFolder = !!parseProjectFolderRowId(id || '')
@@ -97,12 +99,13 @@ const ProjectsListRow = forwardRef<HTMLDivElement, ProjectsListRowProps>(
             style={iconColor ? { color: iconColor } : undefined}
           />
         )}
-        {isRenaming && isFolder ? (
+        {isRenaming ? (
           <InputText
             autoFocus
             style={{ flex: 1 }}
             onChange={(e) => setRenameValue(e.target.value)}
             value={renameValue}
+            placeholder={!isFolder ? 'Project label (empty for none)' : undefined}
             onKeyDown={(e) => {
               if (e.key === 'Enter') {
                 onSubmitRename?.(renameValue)

--- a/src/containers/ProjectsList/ProjectsShortcuts.tsx
+++ b/src/containers/ProjectsList/ProjectsShortcuts.tsx
@@ -10,6 +10,7 @@ interface ProjectsShortcutsProps {
   folders: ProjectFolderModel[]
   onOpenFolderDialog: () => void
   onRenameFolder: (folderId: string) => void
+  onRenameProject?: (projectName: string) => void
   disabled?: boolean
 }
 
@@ -18,11 +19,11 @@ const ProjectsShortcuts: FC<ProjectsShortcutsProps> = ({
   folders,
   onOpenFolderDialog,
   onRenameFolder,
+  onRenameProject,
   disabled,
 }) => {
   const handleKeyPress = useCallback(
     (e: KeyboardEvent) => {
-      if (disabled) return
       if (shouldBlockShortcuts(e)) return
 
       const key = e.key.toLowerCase()
@@ -42,22 +43,27 @@ const ProjectsShortcuts: FC<ProjectsShortcutsProps> = ({
 
       // Handle different key combinations
       if (key === 'f' && !isMeta && !isShift && !isAlt) {
-        // 'f' - Create folder
+        // 'f' - Create folder (powerpack-gated)
+        if (disabled) return
         e.preventDefault()
         onOpenFolderDialog()
         actionExecuted = true
       } else if (key === 'r' && !isMeta && !isShift && !isAlt) {
-        // 'r' - Rename folder (single folder selection only)
+        // 'r' - Rename folder (powerpack) OR edit project label (always)
         if (selectedRowIds.length === 0 || hasMultipleSelected) return
 
-        // Only allow renaming folders, not projects
         if (allSelectedRowsAreFolders) {
+          if (disabled) return
           e.preventDefault()
           const folderId = parseProjectFolderRowId(firstSelectedRow)
           if (folderId) {
             onRenameFolder(folderId)
             actionExecuted = true
           }
+        } else if (onRenameProject && !parseProjectFolderRowId(firstSelectedRow)) {
+          e.preventDefault()
+          onRenameProject(firstSelectedRow)
+          actionExecuted = true
         }
       }
 
@@ -65,7 +71,7 @@ const ProjectsShortcuts: FC<ProjectsShortcutsProps> = ({
         e.stopPropagation()
       }
     },
-    [disabled, rowSelection, folders, onOpenFolderDialog, onRenameFolder],
+    [disabled, rowSelection, folders, onOpenFolderDialog, onRenameFolder, onRenameProject],
   )
 
   useEffect(() => {

--- a/src/containers/ProjectsList/ProjectsSimpleTable.tsx
+++ b/src/containers/ProjectsList/ProjectsSimpleTable.tsx
@@ -14,6 +14,9 @@ interface ProjectsSimpleTableProps extends React.HTMLAttributes<HTMLDivElement> 
   renamingFolder?: string | null
   onSubmitRenameFolder?: (value: string) => void
   closeRenameFolder?: () => void
+  renamingProject?: string | null
+  onSubmitRenameProject?: (value: string) => void
+  closeRenameProject?: () => void
   onOpenProject?: (projectName: string) => void
   fitContent?: boolean
   hidePinned?: boolean
@@ -31,6 +34,9 @@ export const ProjectsSimpleTable: FC<ProjectsSimpleTableProps> = ({
   renamingFolder,
   onSubmitRenameFolder,
   closeRenameFolder,
+  renamingProject,
+  onSubmitRenameProject,
+  closeRenameProject,
   onOpenProject,
   fitContent,
   hidePinned,
@@ -61,6 +67,9 @@ export const ProjectsSimpleTable: FC<ProjectsSimpleTableProps> = ({
         renamingFolder,
         onSubmitRenameFolder,
         closeRenameFolder,
+        renamingProject,
+        onSubmitRenameProject,
+        closeRenameProject,
       }}
       {...props}
     >
@@ -87,9 +96,25 @@ export const ProjectsSimpleTable: FC<ProjectsSimpleTableProps> = ({
           isRowExpandable={row.getCanExpand()}
           isRowExpanded={row.getIsExpanded()}
           onExpandClick={row.getToggleExpandedHandler()}
-          isRenaming={row.id === table.options.meta?.renamingFolder}
-          onSubmitRename={(v) => table.options.meta?.onSubmitRenameFolder?.(v)}
-          onCancelRename={table.options.meta?.closeRenameFolder}
+          isRenaming={
+            row.id === table.options.meta?.renamingFolder ||
+            row.id === table.options.meta?.renamingProject
+          }
+          renameInitialValue={
+            row.id === table.options.meta?.renamingProject
+              ? row.original.data.projectLabel || ''
+              : undefined
+          }
+          onSubmitRename={(v) =>
+            row.id === table.options.meta?.renamingProject
+              ? table.options.meta?.onSubmitRenameProject?.(v)
+              : table.options.meta?.onSubmitRenameFolder?.(v)
+          }
+          onCancelRename={
+            row.id === table.options.meta?.renamingProject
+              ? table.options.meta?.closeRenameProject
+              : table.options.meta?.closeRenameFolder
+          }
           count={row.original.data.count}
           onSettingsClick={() => onSettings(row.id)}
         />

--- a/src/containers/ProjectsList/ProjectsTable.tsx
+++ b/src/containers/ProjectsList/ProjectsTable.tsx
@@ -38,6 +38,9 @@ interface ProjectsTableProps {
   renamingFolder?: string | null
   onSubmitRenameFolder?: (value: string) => void
   closeRenameFolder?: () => void
+  renamingProject?: string | null
+  onSubmitRenameProject?: (value: string) => void
+  closeRenameProject?: () => void
   containerClassName?: string
   pt?: {
     container?: React.HTMLAttributes<HTMLDivElement>
@@ -71,6 +74,9 @@ const ProjectsTable: FC<ProjectsTableProps> = ({
   renamingFolder,
   onSubmitRenameFolder,
   closeRenameFolder,
+  renamingProject,
+  onSubmitRenameProject,
+  closeRenameProject,
   containerClassName,
   pt,
 }) => {
@@ -212,6 +218,9 @@ const ProjectsTable: FC<ProjectsTableProps> = ({
             renamingFolder={renamingFolder}
             onSubmitRenameFolder={onSubmitRenameFolder}
             closeRenameFolder={closeRenameFolder}
+            renamingProject={renamingProject}
+            onSubmitRenameProject={onSubmitRenameProject}
+            closeRenameProject={closeRenameProject}
             onOpenProject={onOpenProject}
             onSettingsClick={onSettingsClick}
             fitContent
@@ -241,6 +250,9 @@ const ProjectsTable: FC<ProjectsTableProps> = ({
           renamingFolder={renamingFolder}
           onSubmitRenameFolder={onSubmitRenameFolder}
           closeRenameFolder={closeRenameFolder}
+          renamingProject={renamingProject}
+          onSubmitRenameProject={onSubmitRenameProject}
+          closeRenameProject={closeRenameProject}
           onOpenProject={onOpenProject}
           onSettingsClick={onSettingsClick}
           hidePinned={!search}

--- a/src/containers/ProjectsList/buildProjectsTableData.ts
+++ b/src/containers/ProjectsList/buildProjectsTableData.ts
@@ -2,6 +2,7 @@ import { ListProjectsItemModel, ProjectFolderModel } from '@shared/api'
 import { SimpleTableRow } from '@shared/containers/SimpleTable'
 import {
   buildHierarchicalTableRows,
+  getProjectDisplayName,
   HierarchicalFolderNode,
 } from '@shared/util'
 
@@ -94,13 +95,14 @@ const buildProjectsTableData = (
   ): SimpleTableRow => ({
     id: project.name,
     name: project.name,
-    label: project.name,
+    label: getProjectDisplayName(project),
     inactive: !project.active,
     subRows: [],
     data: {
       id: project.name,
       active: project.active,
       code: project.code || project.name,
+      projectLabel: project.label || undefined,
     },
   })
 

--- a/src/containers/ProjectsList/hooks/useProjectFolderActions.ts
+++ b/src/containers/ProjectsList/hooks/useProjectFolderActions.ts
@@ -3,10 +3,12 @@ import {
   useAssignProjectsToFolderMutation,
   useDeleteProjectFolderMutation,
   useUpdateProjectFolderMutation,
+  useUpdateProjectMutation,
   ProjectFolderModel,
 } from '@shared/api'
 import { getErrorMessage, handleDeleteFolders } from '@shared/util'
 import { ProjectFolderFormData } from '@pages/ProjectManagerPage/components/ProjectFolderFormDialog'
+import { toast } from 'react-toastify'
 
 interface UseProjectFolderActionsProps {
   folders?: ProjectFolderModel[]
@@ -23,9 +25,12 @@ export const useProjectFolderActions = ({
   const [assignFolderToFolder] = useUpdateProjectFolderMutation()
   const [deleteProjectFolder] = useDeleteProjectFolderMutation()
   const [updateProjectFolder] = useUpdateProjectFolderMutation()
+  const [updateProject] = useUpdateProjectMutation()
 
   // Folder renaming state
   const [renamingFolder, setRenamingFolder] = useState<string | null>(null)
+  // Project label inline-editing state (row id = project.name)
+  const [renamingProject, setRenamingProject] = useState<string | null>(null)
 
   const onPutProjectsInFolder = useCallback(
     async (projectNames: string[], projectFolderId?: string) => {
@@ -133,6 +138,38 @@ export const useProjectFolderActions = ({
     [openRenameFolder],
   )
 
+  // Project label rename
+  const onRenameProject = useCallback(
+    (projectName: string) => {
+      setRenamingProject(projectName)
+      onSelect([projectName])
+    },
+    [onSelect],
+  )
+
+  const closeRenameProject = useCallback(() => {
+    setRenamingProject(null)
+  }, [])
+
+  const onSubmitRenameProject = useCallback(
+    (newLabel: string) => {
+      if (!renamingProject) return
+      const projectName = renamingProject
+      const trimmed = newLabel.trim()
+
+      closeRenameProject()
+      updateProject({
+        projectName,
+        projectPatchModel: { label: trimmed },
+      })
+        .unwrap()
+        .catch((error: any) => {
+          toast.error(getErrorMessage(error, 'Failed to update project label'))
+        })
+    },
+    [renamingProject, updateProject, closeRenameProject],
+  )
+
   return {
     onPutProjectsInFolder,
     onPutFolderInFolder,
@@ -143,5 +180,9 @@ export const useProjectFolderActions = ({
     renamingFolder,
     onSubmitRenameFolder,
     closeRenameFolder,
+    onRenameProject,
+    renamingProject,
+    onSubmitRenameProject,
+    closeRenameProject,
   }
 }

--- a/src/containers/ProjectsList/hooks/useProjectsListMenuItems.ts
+++ b/src/containers/ProjectsList/hooks/useProjectsListMenuItems.ts
@@ -17,6 +17,7 @@ type Hidden = {
   'select-all'?: boolean
   'archive-project'?: boolean
   'delete-project'?: boolean
+  'edit-label'?: boolean
   'show-archived'?: boolean
   'create-folder'?: boolean
   'move-project'?: boolean
@@ -53,6 +54,7 @@ interface MenuItemProps {
   onDeleteFolder?: (folderId: string[]) => void
   onRenameFolder?: (folderId: string) => void
   onEditFolder?: (folderId: string) => void
+  onRenameProject?: (projectName: string) => void
 }
 
 type MenuItem = {
@@ -103,6 +105,7 @@ const useProjectsListMenuItems = ({
   onDeleteFolder,
   onEditFolder,
   onRenameFolder,
+  onRenameProject,
 }: MenuItemProps): BuildMenuItems => {
   // Remove allPinned, singleProject from hook scope, move to buildMenuItems
   const handlePin = (allPinned: boolean, selection: string[]) => {
@@ -369,6 +372,16 @@ const useProjectsListMenuItems = ({
           hidden: !isSelectedRowFolder,
         },
         {
+          id: 'edit-label',
+          label: 'Edit label',
+          icon: 'edit',
+          shortcut: 'R',
+          [command ? 'command' : 'onClick']: () =>
+            singleProject && onRenameProject?.(singleProject.name),
+          disabled: selection.length !== 1,
+          hidden: !isSelectedProject,
+        },
+        {
           id: 'edit-folder',
           label: 'Edit folder',
           icon: 'folder_managed',
@@ -465,6 +478,7 @@ const useProjectsListMenuItems = ({
       wouldCreateCircularDependency,
       onRenameFolder,
       onEditFolder,
+      onRenameProject,
     ],
   )
 

--- a/src/pages/ProjectDashboard/panels/ProjectDetails/ProjectDetails.jsx
+++ b/src/pages/ProjectDashboard/panels/ProjectDetails/ProjectDetails.jsx
@@ -237,23 +237,6 @@ const ProjectDetails = ({ projectName }) => {
       stylePanel={{ height: 'calc(100% - 8px)', flex: 1, overflow: 'hidden', minHeight: 'unset' }}
       style={{ height: '100%', overflow: 'hidden' }}
     >
-      {editing ? (
-        <AttribForm
-          form={projectForm}
-          onChange={(field, value) => handleProjectChange(field, value)}
-          fields={fields}
-          topLevelFields={topLevelFields}
-          isLoading={isFetching}
-        />
-      ) : (
-        <AttributeTable
-          projectAttrib={attribArray}
-          style={{
-            overflow: 'auto',
-          }}
-          isLoading={isFetching}
-        />
-      )}
       <ProjectThumbnailUploader
         projectName={projectName}
         projectUpdatedAt={data?.updatedAt}
@@ -265,6 +248,7 @@ const ProjectDetails = ({ projectName }) => {
             form={projectForm}
             onChange={(field, value) => handleProjectChange(field, value)}
             fields={fields}
+            topLevelFields={topLevelFields}
             isLoading={isFetching}
           />
         ) : (

--- a/src/pages/ProjectDashboard/panels/ProjectDetails/ProjectDetails.jsx
+++ b/src/pages/ProjectDashboard/panels/ProjectDetails/ProjectDetails.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import { useUpdateProjectMutation } from '@shared/api'
 import { useGetProjectQuery } from '@queries/project/enhancedProject'
+import { getProjectDisplayName } from '@shared/util'
 import DashboardPanelWrapper from '../DashboardPanelWrapper'
 import AttributeTable from '@containers/attributeTable'
 import { format } from 'date-fns'
@@ -73,7 +74,7 @@ const ProjectDetails = ({ projectName }) => {
     }
   }, [data, isFetching, fields])
 
-  const { attrib = {}, active, code, library } = data
+  const { attrib = {}, active, code, library, label } = data
 
   // Every thing below creates the attribute table
   // this is where we add new fields to the attribute table
@@ -177,7 +178,7 @@ const ProjectDetails = ({ projectName }) => {
       title={
         !isFetching && (
           <Toolbar style={{ gap: 8 }}>
-            <h1>{projectName}</h1>
+            <h1>{getProjectDisplayName({ name: projectName, label })}</h1>
             <Styled.Code>{code}</Styled.Code>
           </Toolbar>
         )

--- a/src/pages/ProjectDashboard/panels/ProjectDetails/ProjectDetails.jsx
+++ b/src/pages/ProjectDashboard/panels/ProjectDetails/ProjectDetails.jsx
@@ -29,10 +29,20 @@ const ProjectDetails = ({ projectName }) => {
 
   // this where we add new fields to the editing form
   const projectFormInit = {
-    active: false,
+    name: '',
+    label: '',
     code: '',
+    active: false,
     library: false,
     attrib: {},
+  }
+
+  const topLevelFields = {
+    name: { type: 'string', title: 'Name', disabled: true },
+    label: { type: 'string', title: 'Label' },
+    code: { type: 'string', title: 'Code' },
+    active: { type: 'boolean', title: 'Active' },
+    library: { type: 'boolean', title: 'Library' },
   }
 
   // This is the start, used to compare changes
@@ -46,9 +56,11 @@ const ProjectDetails = ({ projectName }) => {
       if (key === 'attrib') {
         updatedProjectForm[key] = { ...projectData[key] }
       } else {
-        updatedProjectForm[key] = projectData[key]
+        updatedProjectForm[key] = projectData[key] ?? projectFormInit[key]
       }
     }
+    // name is immutable — always source from projectName prop
+    updatedProjectForm.name = projectName
 
     // add any fields that have not been added to the form
     for (const key in fields) {
@@ -105,6 +117,18 @@ const ProjectDetails = ({ projectName }) => {
     value: code,
   })
 
+  // editable label
+  attribArray.unshift({
+    name: 'Label',
+    value: label || '',
+  })
+
+  // immutable name
+  attribArray.unshift({
+    name: 'Name',
+    value: projectName,
+  })
+
   // Active status
   attribArray.unshift({
     value: (
@@ -136,7 +160,9 @@ const ProjectDetails = ({ projectName }) => {
 
   const handleAttribSubmit = async () => {
     try {
-      const data = { ...projectForm }
+      // strip name — immutable, not part of patch model
+      const { name: _name, ...patchData } = projectForm
+      const data = { ...patchData }
       // validate dates inside attrib
       const attrib = { ...projectForm['attrib'] }
       for (const key in attrib) {
@@ -215,6 +241,7 @@ const ProjectDetails = ({ projectName }) => {
           form={projectForm}
           onChange={(field, value) => handleProjectChange(field, value)}
           fields={fields}
+          topLevelFields={topLevelFields}
           isLoading={isFetching}
         />
       ) : (

--- a/src/pages/ProjectManagerPage/ProjectManagerPage.jsx
+++ b/src/pages/ProjectManagerPage/ProjectManagerPage.jsx
@@ -12,7 +12,8 @@ import ProjectRoots from './ProjectRoots'
 import NewProjectDialog from './NewProjectDialog'
 
 import { selectProject } from '@state/context'
-import { useDeleteProjectMutation, useUpdateProjectMutation } from '@shared/api'
+import { useDeleteProjectMutation, useListProjectsQuery, useUpdateProjectMutation } from '@shared/api'
+import { getProjectDisplayName } from '@shared/util'
 import TeamsPage from '../TeamsPage'
 import ProjectManagerPageContainer from './ProjectManagerPageContainer'
 import ProjectManagerPageLayout from './ProjectManagerPageLayout'
@@ -78,10 +79,17 @@ const ProjectManagerPage = () => {
   }, [])
 
   const [deleteProject] = useDeleteProjectMutation()
+  const { data: allProjects = [] } = useListProjectsQuery({ active: undefined })
 
   const handleDeleteProject = (sel) => {
+    const project = allProjects.find((p) => p.name === sel)
+    const displayName = project ? getProjectDisplayName(project) : sel
+    const confirmLabel =
+      displayName && displayName !== sel
+        ? `Project: ${displayName} (${sel})`
+        : `Project: ${sel}`
     confirmDelete({
-      label: `Project: ${sel}`,
+      label: confirmLabel,
       accept: async () => {
         await deleteProject({ projectName: sel }).unwrap()
         setSelectedProject(null)

--- a/src/pages/ProjectManagerPage/Users/ProjectUserAccessProjectList.tsx
+++ b/src/pages/ProjectManagerPage/Users/ProjectUserAccessProjectList.tsx
@@ -6,6 +6,7 @@ import useTableLoadingData from '@hooks/useTableLoadingData'
 import { $Any } from '@types'
 import { TablePanel } from '@ynput/ayon-react-components'
 import { ProjectNode } from '@shared/api'
+import { getProjectDisplayName } from '@shared/util'
 import { UserPermissions, UserPermissionsEntity } from '@hooks/useUserProjectPermissions'
 
 const StyledProjectName = styled.div`
@@ -42,7 +43,7 @@ const formatName = (rowData: ProjectNode, userPermissions: UserPermissions) => {
   const readOnly =
     !userPermissions.canEdit(UserPermissionsEntity.access, rowData.name) &&
     userPermissions.canView(UserPermissionsEntity.access, rowData.name)
-  return rowData.name + (readOnly ? ' (read only)' : '')
+  return getProjectDisplayName(rowData) + (readOnly ? ' (read only)' : '')
 }
 
 type Props = {
@@ -76,7 +77,7 @@ const ProjectUserAccessProjectList = ({
             return mainComparison
           }
 
-          return a.name.localeCompare(b.name)
+          return getProjectDisplayName(a).localeCompare(getProjectDisplayName(b))
         })}
         selection={selected}
         multiple={true}

--- a/src/pages/ProjectManagerPage/Users/ProjectUserAccessSearchFilterWrapper.tsx
+++ b/src/pages/ProjectManagerPage/Users/ProjectUserAccessSearchFilterWrapper.tsx
@@ -5,6 +5,7 @@ import { useGetAccessGroupsQuery } from '@queries/accessGroups/getAccessGroups'
 import { $Any } from '@types'
 import { getProjectAccessSearchFilterBuiler } from './mappers'
 import { SearchFilter } from '@ynput/ayon-react-components'
+import { getProjectDisplayName } from '@shared/util'
 
 type Props = {
   filters: $Any
@@ -24,7 +25,10 @@ const ProjectUserAccessSearchFilterWrapper = ({
   })
 
   const options = getProjectAccessSearchFilterBuiler({
-    projects: projects.map((project: $Any) => ({ id: project.name, label: project.name })),
+    projects: projects.map((project: $Any) => ({
+      id: project.name,
+      label: getProjectDisplayName(project),
+    })),
     users: users.map((user: $Any) => ({
       id: user.name,
       label: user.name,

--- a/src/pages/ProjectPage/ProjectPage.tsx
+++ b/src/pages/ProjectPage/ProjectPage.tsx
@@ -14,6 +14,7 @@ import ProjectListsPage from '../ProjectListsPage'
 
 import { selectProject } from '@state/project'
 import { useGetProjectAddonsQuery } from '@shared/api'
+import { getProjectDisplayName } from '@shared/util'
 import { TabPanel, TabView } from 'primereact/tabview'
 import AppNavLinks, { NavLinkItem } from '@containers/header/AppNavLinks'
 import { SlicerProvider } from '@shared/containers/Slicer'
@@ -70,7 +71,7 @@ const ProjectPageInner = () => {
    */
   const { siteInfo } = useGlobalContext()
   const { uiExposureLevel = 0, frontendFlags = [] } = siteInfo || {}
-  const { projectName, isLoading, error } = useProjectContext()
+  const { projectName, label: projectLabel, isLoading, error } = useProjectContext()
   const isManager = useAppSelector((state) => state.user.data.isManager)
   const isAdmin = useAppSelector((state) => state.user.data.isAdmin)
   const navigate = useNavigate()
@@ -235,7 +236,11 @@ const ProjectPageInner = () => {
     return links.find((link) => link.module === module) || null
   }, [links, module])
 
-  const title = useTitle(module, links, projectName || 'AYON')
+  const title = useTitle(
+    module,
+    links,
+    getProjectDisplayName({ name: projectName, label: projectLabel }) || 'AYON',
+  )
 
   const tab = !!addonName ? addonsData?.find((item) => item.name === addonName)?.name : module
   const isAddon = !!addonName // Check if we're on an addon page


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Show optional project.label as a friendly display name (falls back to name) in sidebar, Project Manager list, page title, delete confirm, and user-access filter. Inline-edit label via right-click → "Edit label" (or R) on project rows.

## Technical details
<!-- Please state any technical details such as limitations -->
- New getProjectDisplayName(project) helper in shared/src/util/.
- buildProjectsTableData swaps row display label only; routing, selection, pinned memory still keyed on project.name.
- Sort + sidebar search use display name; SimpleTable fuzzy filter already covered both fields.
- Label PATCH via useUpdateProjectMutation with optimistic update on listProjects cache (rollback on failure).
- Manager+ permission gate, mirroring archive/delete.
- Breadcrumbs left untouched — TODO added (needs per-scope crumb detection).

## Additional context
<!-- Add any other context or screenshots here. -->

