### PR TITLE
YN-0717: Date: Setting date can set it to day before

### DIFF
--- a/shared/src/components/DateRangePicker/DateRangePicker.tsx
+++ b/shared/src/components/DateRangePicker/DateRangePicker.tsx
@@ -12,6 +12,7 @@ import {
 } from 'react'
 import { createPortal } from 'react-dom'
 import { format, isValid, parseISO } from 'date-fns'
+import { formatUTCDate } from '../../util/formatUTCDate'
 import * as Styled from './DateRangePicker.styled'
 import clsx from 'clsx'
 import { BLOCK_DIALOG_CLOSE_CLASS } from '../LinksManager/CellEditingDialog'
@@ -72,7 +73,7 @@ const formatDateForInput = (dateStr: string | null): string => {
   try {
     const date = parseISO(dateStr)
     if (isValid(date)) {
-      return format(date, 'yyyy-MM-dd')
+      return formatUTCDate(date, 'yyyy-MM-dd')
     }
   } catch {
     return ''
@@ -85,7 +86,7 @@ const formatDateForDisplay = (dateStr: string | null, formatStr: string): string
   try {
     const date = parseISO(dateStr)
     if (isValid(date)) {
-      return format(date, formatStr)
+      return formatUTCDate(date, formatStr)
     }
   } catch {
     return null
@@ -96,10 +97,9 @@ const formatDateForDisplay = (dateStr: string | null, formatStr: string): string
 const parseDateInput = (value: string): string | null => {
   if (!value) return null
   try {
-    const date = new Date(value)
-    if (isValid(date)) {
-      date.setUTCHours(0, 0, 0, 0)
-      return date.toISOString()
+    const [y, m, d] = value.split('-').map(Number)
+    if (y && m && d) {
+      return new Date(Date.UTC(y, m - 1, d)).toISOString()
     }
   } catch {
     return null

--- a/shared/src/containers/ProjectTreeTable/widgets/DateWidget.tsx
+++ b/shared/src/containers/ProjectTreeTable/widgets/DateWidget.tsx
@@ -2,6 +2,7 @@ import { format } from 'date-fns'
 import { forwardRef } from 'react'
 import { DateWidgetInput } from './DateWidgetInput'
 import { WidgetBaseProps } from './CellWidget'
+import { formatUTCDate } from '../../../util/formatUTCDate'
 
 export interface DateWidgetProps
   extends Omit<React.HTMLAttributes<HTMLSpanElement>, 'onChange'>,
@@ -30,7 +31,8 @@ export const DateWidget = forwardRef<HTMLSpanElement, DateWidgetProps>(
     if (value) {
       try {
         const formatString = showTime ? 'dd-MM-yyyy HH:mm:ss' : 'dd-MM-yyyy'
-        dateString = format(new Date(value), formatString)
+        const date = new Date(value)
+        dateString = showTime ? format(date, formatString) : formatUTCDate(date, formatString)
       } catch (error) {
         console.error('Invalid date value:', value)
         dateString = 'Invalid Date'

--- a/shared/src/containers/ProjectTreeTable/widgets/DateWidgetInput.tsx
+++ b/shared/src/containers/ProjectTreeTable/widgets/DateWidgetInput.tsx
@@ -1,7 +1,8 @@
 import { forwardRef, useState, useEffect, useRef } from 'react'
 import styled from 'styled-components'
-import { format, isValid, parseISO } from 'date-fns'
+import { isValid, parseISO } from 'date-fns'
 import { WidgetBaseProps } from './CellWidget'
+import { formatUTCDate } from '@shared/util/formatUTCDate'
 
 interface DateWidgetInputProps
   extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange'>,
@@ -33,7 +34,7 @@ export const DateWidgetInput = forwardRef<HTMLInputElement, DateWidgetInputProps
       if (initialValue) {
         const parsedDate = parseISO(initialValue)
         if (isValid(parsedDate)) {
-          return format(parsedDate, 'yyyy-MM-dd')
+          return formatUTCDate(parsedDate, 'yyyy-MM-dd')
         }
       }
       return ''
@@ -43,7 +44,7 @@ export const DateWidgetInput = forwardRef<HTMLInputElement, DateWidgetInputProps
       if (initialValue) {
         const parsedDate = parseISO(initialValue)
         if (isValid(parsedDate)) {
-          setValue(format(parsedDate, 'yyyy-MM-dd'))
+          setValue(formatUTCDate(parsedDate, 'yyyy-MM-dd'))
         } else {
           setValue('')
         }
@@ -78,11 +79,10 @@ export const DateWidgetInput = forwardRef<HTMLInputElement, DateWidgetInputProps
 
     const handleDateSubmit = (event?: 'Click' | 'Enter') => {
       if (value) {
-        const parsed = Date.parse(value)
-        if (isValid(parsed)) {
-          const dateWithZeroTime = new Date(parsed)
-          dateWithZeroTime.setUTCHours(0, 0, 0, 0)
-          const newISOValue = dateWithZeroTime.toISOString()
+        const [y, m, d] = value.split('-').map(Number)
+        if (y && m && d) {
+          const utcDate = new Date(Date.UTC(y, m - 1, d))
+          const newISOValue = utcDate.toISOString()
 
           // For Click/Blur: only save if value changed
           // For Enter: always save

--- a/shared/src/util/formatUTCDate.ts
+++ b/shared/src/util/formatUTCDate.ts
@@ -1,0 +1,6 @@
+import { format } from 'date-fns'
+
+export const formatUTCDate = (date: Date, formatStr: string): string => {
+  const shifted = new Date(date.getTime() + date.getTimezoneOffset() * 60000)
+  return format(shifted, formatStr)
+}


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Fixes off-by-one day when setting Start/End dates on entities in timezones west of UTC (e.g. US Pacific). Reported on macOS but the underlying cause is timezone, not OS.

## Technical details
<!-- Please state any technical details such as limitations -->
Root cause: date-only fields are stored as UTC midnight (YYYY-MM-DDT00:00:00.000Z) but displayed via date-fns format(), which renders in the host's local timezone. In any TZ with a negative UTC offset, UTC midnight resolves to the previous day local — so picking May 10 displayed as May 9, every reopen-and-save drifted another day.
## Additional context
<!-- Add any other context or screenshots here. -->

