### PR TITLE
YN-0683: Entity picker disable versions without reviewables

### DIFF
--- a/shared/src/api/generated/graphqlLinks.ts
+++ b/shared/src/api/generated/graphqlLinks.ts
@@ -1610,7 +1610,7 @@ export type GetVersionLinkDataQueryVariables = Exact<{
 }>;
 
 
-export type GetVersionLinkDataQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', version?: { __typename: 'VersionNode', id: string, name: string, parents: Array<string> } | null } };
+export type GetVersionLinkDataQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', version?: { __typename: 'VersionNode', hasReviewables: boolean, id: string, name: string, parents: Array<string> } | null } };
 
 export type GetWorkfileLinkDataQueryVariables = Exact<{
   projectName: Scalars['String']['input'];
@@ -1631,7 +1631,7 @@ export type GetFoldersLinksQuery = { __typename?: 'Query', project: { __typename
                 | { __typename: 'ProductNode', id: string, name: string, parents: Array<string> }
                 | { __typename: 'RepresentationNode', id: string, name: string, parents: Array<string> }
                 | { __typename: 'TaskNode', label?: string | null, id: string, name: string, parents: Array<string>, subType: string }
-                | { __typename: 'VersionNode', id: string, name: string, parents: Array<string> }
+                | { __typename: 'VersionNode', hasReviewables: boolean, id: string, name: string, parents: Array<string> }
                 | { __typename: 'WorkfileNode', id: string, name: string, parents: Array<string> }
                | null }> } } }> } } };
 
@@ -1646,7 +1646,7 @@ export type GetProductsLinksQuery = { __typename?: 'Query', project: { __typenam
                 | { __typename: 'ProductNode', id: string, name: string, parents: Array<string> }
                 | { __typename: 'RepresentationNode', id: string, name: string, parents: Array<string> }
                 | { __typename: 'TaskNode', label?: string | null, id: string, name: string, parents: Array<string>, subType: string }
-                | { __typename: 'VersionNode', id: string, name: string, parents: Array<string> }
+                | { __typename: 'VersionNode', hasReviewables: boolean, id: string, name: string, parents: Array<string> }
                 | { __typename: 'WorkfileNode', id: string, name: string, parents: Array<string> }
                | null }> } } }> } } };
 
@@ -1661,7 +1661,7 @@ export type GetTasksLinksQuery = { __typename?: 'Query', project: { __typename?:
                 | { __typename: 'ProductNode', id: string, name: string, parents: Array<string> }
                 | { __typename: 'RepresentationNode', id: string, name: string, parents: Array<string> }
                 | { __typename: 'TaskNode', label?: string | null, id: string, name: string, parents: Array<string>, subType: string }
-                | { __typename: 'VersionNode', id: string, name: string, parents: Array<string> }
+                | { __typename: 'VersionNode', hasReviewables: boolean, id: string, name: string, parents: Array<string> }
                 | { __typename: 'WorkfileNode', id: string, name: string, parents: Array<string> }
                | null }> } } }> } } };
 
@@ -1676,7 +1676,7 @@ export type GetVersionsLinksQuery = { __typename?: 'Query', project: { __typenam
                 | { __typename: 'ProductNode', id: string, name: string, parents: Array<string> }
                 | { __typename: 'RepresentationNode', id: string, name: string, parents: Array<string> }
                 | { __typename: 'TaskNode', label?: string | null, id: string, name: string, parents: Array<string>, subType: string }
-                | { __typename: 'VersionNode', id: string, name: string, parents: Array<string> }
+                | { __typename: 'VersionNode', hasReviewables: boolean, id: string, name: string, parents: Array<string> }
                 | { __typename: 'WorkfileNode', id: string, name: string, parents: Array<string> }
                | null }> } } }> } } };
 
@@ -1691,7 +1691,7 @@ export type GetWorkfilesLinksQuery = { __typename?: 'Query', project: { __typena
                 | { __typename: 'ProductNode', id: string, name: string, parents: Array<string> }
                 | { __typename: 'RepresentationNode', id: string, name: string, parents: Array<string> }
                 | { __typename: 'TaskNode', label?: string | null, id: string, name: string, parents: Array<string>, subType: string }
-                | { __typename: 'VersionNode', id: string, name: string, parents: Array<string> }
+                | { __typename: 'VersionNode', hasReviewables: boolean, id: string, name: string, parents: Array<string> }
                 | { __typename: 'WorkfileNode', id: string, name: string, parents: Array<string> }
                | null }> } } }> } } };
 
@@ -1706,7 +1706,7 @@ export type GetRepresentationsLinksQuery = { __typename?: 'Query', project: { __
                 | { __typename: 'ProductNode', id: string, name: string, parents: Array<string> }
                 | { __typename: 'RepresentationNode', id: string, name: string, parents: Array<string> }
                 | { __typename: 'TaskNode', label?: string | null, id: string, name: string, parents: Array<string>, subType: string }
-                | { __typename: 'VersionNode', id: string, name: string, parents: Array<string> }
+                | { __typename: 'VersionNode', hasReviewables: boolean, id: string, name: string, parents: Array<string> }
                 | { __typename: 'WorkfileNode', id: string, name: string, parents: Array<string> }
                | null }> } } }> } } };
 
@@ -1772,7 +1772,7 @@ export type GetSearchedVersionsQueryVariables = Exact<{
 }>;
 
 
-export type GetSearchedVersionsQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', name: string, versions: { __typename?: 'VersionsConnection', pageInfo: { __typename?: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean }, edges: Array<{ __typename?: 'VersionEdge', cursor?: string | null, node: { __typename: 'VersionNode', id: string, name: string, parents: Array<string> } }> } } };
+export type GetSearchedVersionsQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', name: string, versions: { __typename?: 'VersionsConnection', pageInfo: { __typename?: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean }, edges: Array<{ __typename?: 'VersionEdge', cursor?: string | null, node: { __typename: 'VersionNode', hasReviewables: boolean, id: string, name: string, parents: Array<string> } }> } } };
 
 export type GetSearchedWorkfilesQueryVariables = Exact<{
   projectName: Scalars['String']['input'];
@@ -1792,7 +1792,7 @@ export type OverviewEntityLinkFragmentFragment = { __typename?: 'LinkEdge', id: 
     | { __typename: 'ProductNode', id: string, name: string, parents: Array<string> }
     | { __typename: 'RepresentationNode', id: string, name: string, parents: Array<string> }
     | { __typename: 'TaskNode', label?: string | null, id: string, name: string, parents: Array<string>, subType: string }
-    | { __typename: 'VersionNode', id: string, name: string, parents: Array<string> }
+    | { __typename: 'VersionNode', hasReviewables: boolean, id: string, name: string, parents: Array<string> }
     | { __typename: 'WorkfileNode', id: string, name: string, parents: Array<string> }
    | null };
 
@@ -1804,7 +1804,7 @@ type OverviewEntityLinkNodeFragment_RepresentationNode_Fragment = { __typename: 
 
 type OverviewEntityLinkNodeFragment_TaskNode_Fragment = { __typename: 'TaskNode', label?: string | null, id: string, name: string, parents: Array<string>, subType: string };
 
-type OverviewEntityLinkNodeFragment_VersionNode_Fragment = { __typename: 'VersionNode', id: string, name: string, parents: Array<string> };
+type OverviewEntityLinkNodeFragment_VersionNode_Fragment = { __typename: 'VersionNode', hasReviewables: boolean, id: string, name: string, parents: Array<string> };
 
 type OverviewEntityLinkNodeFragment_WorkfileNode_Fragment = { __typename: 'WorkfileNode', id: string, name: string, parents: Array<string> };
 
@@ -1831,6 +1831,9 @@ export const OverviewEntityLinkNodeFragmentFragmentDoc = new TypedDocumentString
     label
     subType: folderType
   }
+  ... on VersionNode {
+    hasReviewables
+  }
 }
     `, {"fragmentName":"OverviewEntityLinkNodeFragment"});
 export const OverviewEntityLinkFragmentFragmentDoc = new TypedDocumentString(`
@@ -1856,6 +1859,9 @@ export const OverviewEntityLinkFragmentFragmentDoc = new TypedDocumentString(`
     label
     subType: folderType
   }
+  ... on VersionNode {
+    hasReviewables
+  }
 }`, {"fragmentName":"OverviewEntityLinkFragment"});
 export const GetFolderLinkDataDocument = new TypedDocumentString(`
     query GetFolderLinkData($projectName: String!, $folderId: String!) {
@@ -1877,6 +1883,9 @@ export const GetFolderLinkDataDocument = new TypedDocumentString(`
   ... on FolderNode {
     label
     subType: folderType
+  }
+  ... on VersionNode {
+    hasReviewables
   }
 }`);
 export const GetProductLinkDataDocument = new TypedDocumentString(`
@@ -1900,6 +1909,9 @@ export const GetProductLinkDataDocument = new TypedDocumentString(`
     label
     subType: folderType
   }
+  ... on VersionNode {
+    hasReviewables
+  }
 }`);
 export const GetRepresentationLinkDataDocument = new TypedDocumentString(`
     query GetRepresentationLinkData($projectName: String!, $representationId: String!) {
@@ -1921,6 +1933,9 @@ export const GetRepresentationLinkDataDocument = new TypedDocumentString(`
   ... on FolderNode {
     label
     subType: folderType
+  }
+  ... on VersionNode {
+    hasReviewables
   }
 }`);
 export const GetTaskLinkDataDocument = new TypedDocumentString(`
@@ -1944,6 +1959,9 @@ export const GetTaskLinkDataDocument = new TypedDocumentString(`
     label
     subType: folderType
   }
+  ... on VersionNode {
+    hasReviewables
+  }
 }`);
 export const GetVersionLinkDataDocument = new TypedDocumentString(`
     query GetVersionLinkData($projectName: String!, $versionId: String!) {
@@ -1966,6 +1984,9 @@ export const GetVersionLinkDataDocument = new TypedDocumentString(`
     label
     subType: folderType
   }
+  ... on VersionNode {
+    hasReviewables
+  }
 }`);
 export const GetWorkfileLinkDataDocument = new TypedDocumentString(`
     query GetWorkfileLinkData($projectName: String!, $workfileId: String!) {
@@ -1987,6 +2008,9 @@ export const GetWorkfileLinkDataDocument = new TypedDocumentString(`
   ... on FolderNode {
     label
     subType: folderType
+  }
+  ... on VersionNode {
+    hasReviewables
   }
 }`);
 export const GetFoldersLinksDocument = new TypedDocumentString(`
@@ -2028,6 +2052,9 @@ fragment OverviewEntityLinkNodeFragment on BaseNode {
     label
     subType: folderType
   }
+  ... on VersionNode {
+    hasReviewables
+  }
 }`);
 export const GetProductsLinksDocument = new TypedDocumentString(`
     query GetProductsLinks($projectName: String!, $entityIds: [String!]) {
@@ -2067,6 +2094,9 @@ fragment OverviewEntityLinkNodeFragment on BaseNode {
   ... on FolderNode {
     label
     subType: folderType
+  }
+  ... on VersionNode {
+    hasReviewables
   }
 }`);
 export const GetTasksLinksDocument = new TypedDocumentString(`
@@ -2108,6 +2138,9 @@ fragment OverviewEntityLinkNodeFragment on BaseNode {
     label
     subType: folderType
   }
+  ... on VersionNode {
+    hasReviewables
+  }
 }`);
 export const GetVersionsLinksDocument = new TypedDocumentString(`
     query GetVersionsLinks($projectName: String!, $entityIds: [String!]) {
@@ -2147,6 +2180,9 @@ fragment OverviewEntityLinkNodeFragment on BaseNode {
   ... on FolderNode {
     label
     subType: folderType
+  }
+  ... on VersionNode {
+    hasReviewables
   }
 }`);
 export const GetWorkfilesLinksDocument = new TypedDocumentString(`
@@ -2188,6 +2224,9 @@ fragment OverviewEntityLinkNodeFragment on BaseNode {
     label
     subType: folderType
   }
+  ... on VersionNode {
+    hasReviewables
+  }
 }`);
 export const GetRepresentationsLinksDocument = new TypedDocumentString(`
     query GetRepresentationsLinks($projectName: String!, $entityIds: [String!]) {
@@ -2227,6 +2266,9 @@ fragment OverviewEntityLinkNodeFragment on BaseNode {
   ... on FolderNode {
     label
     subType: folderType
+  }
+  ... on VersionNode {
+    hasReviewables
   }
 }`);
 export const GetSearchedFoldersDocument = new TypedDocumentString(`
@@ -2271,6 +2313,9 @@ export const GetSearchedFoldersDocument = new TypedDocumentString(`
     label
     subType: folderType
   }
+  ... on VersionNode {
+    hasReviewables
+  }
 }`);
 export const GetSearchedProductsDocument = new TypedDocumentString(`
     query GetSearchedProducts($projectName: String!, $search: String, $parentIds: [String!], $after: String, $first: Int, $before: String, $last: Int) {
@@ -2314,6 +2359,9 @@ export const GetSearchedProductsDocument = new TypedDocumentString(`
     label
     subType: folderType
   }
+  ... on VersionNode {
+    hasReviewables
+  }
 }`);
 export const GetSearchedRepresentationsDocument = new TypedDocumentString(`
     query GetSearchedRepresentations($projectName: String!, $search: String, $parentIds: [String!], $after: String, $first: Int, $before: String, $last: Int) {
@@ -2354,6 +2402,9 @@ export const GetSearchedRepresentationsDocument = new TypedDocumentString(`
   ... on FolderNode {
     label
     subType: folderType
+  }
+  ... on VersionNode {
+    hasReviewables
   }
 }`);
 export const GetSearchedTasksDocument = new TypedDocumentString(`
@@ -2399,6 +2450,9 @@ export const GetSearchedTasksDocument = new TypedDocumentString(`
     label
     subType: folderType
   }
+  ... on VersionNode {
+    hasReviewables
+  }
 }`);
 export const GetSearchedVersionsDocument = new TypedDocumentString(`
     query GetSearchedVersions($projectName: String!, $search: String, $parentIds: [String!], $after: String, $first: Int, $before: String, $last: Int) {
@@ -2440,6 +2494,9 @@ export const GetSearchedVersionsDocument = new TypedDocumentString(`
     label
     subType: folderType
   }
+  ... on VersionNode {
+    hasReviewables
+  }
 }`);
 export const GetSearchedWorkfilesDocument = new TypedDocumentString(`
     query GetSearchedWorkfiles($projectName: String!, $search: String, $parentIds: [String!], $after: String, $first: Int, $before: String, $last: Int) {
@@ -2480,6 +2537,9 @@ export const GetSearchedWorkfilesDocument = new TypedDocumentString(`
   ... on FolderNode {
     label
     subType: folderType
+  }
+  ... on VersionNode {
+    hasReviewables
   }
 }`);
 

--- a/shared/src/api/queries/links/getLinks.ts
+++ b/shared/src/api/queries/links/getLinks.ts
@@ -25,6 +25,7 @@ export type SearchEntityLink = {
   label: string
   icon: string | undefined
   subType: string | undefined
+  hasReviewables?: boolean
 }
 
 export type GetSearchedEntitiesLinksResult = {
@@ -201,6 +202,7 @@ const injectedQueries = gqlLinksApi.injectEndpoints({
                     name: versionNode.name,
                     label: versionNode.name,
                     parents: versionNode.parents || [],
+                    hasReviewables: versionNode.hasReviewables,
                   }
                 case 'representation':
                   const representationNode = node as SearchedRepresentationNode

--- a/shared/src/api/queries/links/gql/fragments/OverviewEntityLinkNodeFragment.graphql
+++ b/shared/src/api/queries/links/gql/fragments/OverviewEntityLinkNodeFragment.graphql
@@ -11,4 +11,7 @@ fragment OverviewEntityLinkNodeFragment on BaseNode {
     label
     subType: folderType
   }
+  ... on VersionNode {
+    hasReviewables
+  }
 }

--- a/shared/src/containers/EntityPickerDialog/EntityPickerDialog.tsx
+++ b/shared/src/containers/EntityPickerDialog/EntityPickerDialog.tsx
@@ -55,6 +55,7 @@ interface EntityPickerDialogProps extends Pick<DialogProps, 'onClose'> {
   disabledIds?: string[] // IDs to display as disabled/unselectable
   disabledMessage?: string // Default tooltip message for disabled items
   getDisabledMessage?: (id: string) => string | undefined // Custom message per disabled item
+  reviewableRequired?: boolean // When entityType is 'version', disable versions without reviewables
 }
 
 export const EntityPickerDialog: FC<EntityPickerDialogProps> = ({
@@ -68,6 +69,7 @@ export const EntityPickerDialog: FC<EntityPickerDialogProps> = ({
   disabledIds = [],
   disabledMessage = 'Cannot select this item',
   getDisabledMessage,
+  reviewableRequired,
   ...props
 }) => {
   const initSelectionState: PickerSelection = {
@@ -121,6 +123,27 @@ export const EntityPickerDialog: FC<EntityPickerDialogProps> = ({
     selection: entitySelection,
   })
 
+  // When reviewableRequired is set and we're picking versions, disable any
+  // version returned by the query that does not have reviewables.
+  const nonReviewableVersionIds =
+    reviewableRequired && entityType === 'version'
+      ? entityData.version.data
+          .filter((v) => 'hasReviewables' in v && v.hasReviewables === false)
+          .map((v) => v.id)
+      : []
+
+  const effectiveDisabledIds =
+    nonReviewableVersionIds.length > 0
+      ? Array.from(new Set([...disabledIds, ...nonReviewableVersionIds]))
+      : disabledIds
+
+  const effectiveGetDisabledMessage = (id: string): string | undefined => {
+    if (nonReviewableVersionIds.includes(id)) {
+      return 'Version has no reviewables'
+    }
+    return getDisabledMessage?.(id)
+  }
+
   const handleFetchNextPage = (entityType: PickerEntityType) => {
     const entityDataForType = entityData[entityType]
     if (entityDataForType?.hasNextPage && !entityDataForType.isFetchingNextPage) {
@@ -154,7 +177,7 @@ export const EntityPickerDialog: FC<EntityPickerDialogProps> = ({
     // A row is disabled if its parent is disabled OR its own ID is in the disabledIds list.
     const isDisabled = parentIsDisabled || disabledIds.includes(row.id)
     const disabledRowMessage = isDisabled
-      ? getDisabledMessage?.(row.id) || disabledMessage
+      ? effectiveGetDisabledMessage(row.id) || disabledMessage
       : undefined
 
     // Create a new row object with the updated disabled state.
@@ -175,12 +198,12 @@ export const EntityPickerDialog: FC<EntityPickerDialogProps> = ({
   }
 
   const processTableDataWithDisabled = (tableData: any) => {
-    if (!disabledIds || disabledIds.length === 0) {
+    if (!effectiveDisabledIds || effectiveDisabledIds.length === 0) {
       return tableData
     }
 
     // Iterate over the top-level rows and start the recursive processing.
-    return tableData.map((row: any) => recursivelyProcessRows(row, disabledIds, false))
+    return tableData.map((row: any) => recursivelyProcessRows(row, effectiveDisabledIds, false))
   }
 
   const handleSubmit = () => {

--- a/src/pages/BrowserPage/Products/Products.jsx
+++ b/src/pages/BrowserPage/Products/Products.jsx
@@ -627,7 +627,16 @@ const Products = () => {
   } = useEntityListsContext()
 
   const ctxMenuItems = (id, selectedProducts, selectedVersions) => {
-    const selectedEntities = selectedVersions.map((id) => ({ entityId: id, entityType: 'version' }))
+    // Look up hasReviewables per selected version (productsData rows expose the field for the active version)
+    const versionReviewablesById = new Map(
+      productsData.map((p) => [p.versionId, p.hasReviewables]),
+    )
+    const selectedEntities = selectedVersions.map((vId) => ({
+      entityId: vId,
+      entityType: 'version',
+      hasReviewables: versionReviewablesById.get(vId),
+    }))
+    const hasAnyNonReviewable = selectedEntities.some((v) => v.hasReviewables === false)
     const selectedProductsData = productsData.filter((p) => selectedProducts.includes(p.id))
     const firstProductData = selectedProductsData[0] || {}
 
@@ -650,6 +659,7 @@ const Products = () => {
             [...versionsLists, ...reviewsLists],
             selectedEntities,
             (l) => (l.entityListType === 'review-session' ? true : !!reviewsLists.length),
+            (l) => l.entityListType === 'review-session' && hasAnyNonReviewable,
           ),
           newListMenuItem('version', selectedEntities),
         ],

--- a/src/pages/ProjectListsPage/context/EntityListsContext.tsx
+++ b/src/pages/ProjectListsPage/context/EntityListsContext.tsx
@@ -23,7 +23,7 @@ interface EntityListsContextProps {
 // Define a new interface for the newListData state
 interface NewListData {
   entityType: ListEntityType
-  selectedEntities: { entityId: string; entityType: string | undefined }[]
+  selectedEntities: ListEntityInput[]
 }
 
 type ListSubMenuItem = {
@@ -36,6 +36,12 @@ type ListSubMenuItem = {
   hidden?: boolean
 }
 
+export type ListEntityInput = {
+  entityId: string
+  entityType: string | undefined
+  hasReviewables?: boolean
+}
+
 export interface EntityListsContextType {
   allLists: UseGetListsDataReturn
   folders: EntityList[]
@@ -43,16 +49,13 @@ export interface EntityListsContextType {
   products: EntityList[]
   versions: EntityList[]
   reviews: EntityList[]
-  addToList: (
-    listId: string,
-    entityType: string,
-    entities: { entityId: string; entityType: string | undefined }[],
-  ) => Promise<void>
+  addToList: (listId: string, entityType: string, entities: ListEntityInput[]) => Promise<void>
   menuItems: (filter?: (item: ListSubMenuItem) => boolean) => ContextMenuItemConstructor
   buildListMenuItem: (
     list: EntityList,
-    selected: { entityId: string; entityType: string | undefined }[],
+    selected: ListEntityInput[],
     showIcon?: boolean,
+    disabled?: boolean,
   ) => ListSubMenuItem
   buildAddToListMenu: (
     items: ListSubMenuItem[],
@@ -65,15 +68,12 @@ export interface EntityListsContextType {
   }
   newListMenuItem: (
     entityType: ListEntityType,
-    selected: { entityId: string; entityType: string | undefined }[],
+    selected: ListEntityInput[],
   ) => ListSubMenuItem
   // Update the type of newListData
   newListData: NewListData | null
   // Update the signature of openCreateNewList
-  openCreateNewList: (
-    entityType: ListEntityType,
-    selectedEntities: { entityId: string; entityType: string | undefined }[],
-  ) => void
+  openCreateNewList: (entityType: ListEntityType, selectedEntities: ListEntityInput[]) => void
   closeCreateNewList: () => void
   // Remove entities parameter as it will be stored in newListData
   createNewList: (label: string) => Promise<void>
@@ -81,8 +81,9 @@ export interface EntityListsContextType {
   // Build hierarchical menu items for arbitrary list collections (folders grouping)
   buildHierarchicalMenuItems: (
     lists: EntityList[],
-    selected: { entityId: string; entityType: string | undefined }[],
+    selected: ListEntityInput[],
     getShowIcon?: (list: EntityList) => boolean,
+    getDisabled?: (list: EntityList) => boolean,
   ) => ListSubMenuItem[]
 }
 
@@ -156,7 +157,30 @@ export const EntityListsProvider = ({ children, projectName }: EntityListsProvid
       }
 
       // filter out entities that do not match entityType
-      const filteredEntities = entities.filter((entity) => entity.entityType === entityType)
+      let filteredEntities = entities.filter((entity) => entity.entityType === entityType)
+
+      // Review sessions only accept versions with reviewables
+      const targetList = allLists.data.find((l) => l.id === listId)
+      if (targetList?.entityListType === 'review-session') {
+        const eligible = filteredEntities.filter((e) => e.hasReviewables !== false)
+        const skippedCount = filteredEntities.length - eligible.length
+        if (skippedCount > 0 && eligible.length === 0) {
+          toast.error(
+            skippedCount === 1
+              ? 'Cannot add version without reviewables to review session'
+              : `Cannot add ${skippedCount} versions without reviewables to review session`,
+          )
+          return Promise.reject(new Error('No reviewable versions to add'))
+        }
+        if (skippedCount > 0) {
+          toast.warn(
+            skippedCount === 1
+              ? '1 version skipped (no reviewables)'
+              : `${skippedCount} versions skipped (no reviewables)`,
+          )
+        }
+        filteredEntities = eligible
+      }
 
       if (filteredEntities.length === 0) {
         toast.error('No entities to add')
@@ -184,7 +208,7 @@ export const EntityListsProvider = ({ children, projectName }: EntityListsProvid
         return Promise.reject(error)
       }
     },
-    [projectName],
+    [projectName, allLists.data],
   )
 
   // Update the state type and initialize as null
@@ -192,10 +216,8 @@ export const EntityListsProvider = ({ children, projectName }: EntityListsProvid
 
   // Update openCreateNewList to store selected entities
   const openCreateNewList = useCallback(
-    (
-      entityType: ListEntityType,
-      selectedEntities: { entityId: string; entityType: string | undefined }[],
-    ) => setNewListData({ entityType, selectedEntities }),
+    (entityType: ListEntityType, selectedEntities: ListEntityInput[]) =>
+      setNewListData({ entityType, selectedEntities }),
     [setNewListData],
   )
   const closeCreateNewList = useCallback(() => setNewListData(null), [setNewListData])
@@ -273,16 +295,23 @@ export const EntityListsProvider = ({ children, projectName }: EntityListsProvid
   }
 
   const buildListMenuItem: EntityListsContextType['buildListMenuItem'] = useCallback(
-    (list, selected, showIcon?) => ({
+    (list, selected, showIcon?, disabled?) => ({
       id: list.id,
       label: list.label,
       icon: showIcon ? getListIcon(list.entityType, list.entityListType) : undefined,
-      command: () =>
-        addToList(
-          list.id,
-          list.entityType,
-          selected.map((i) => ({ entityId: i.entityId, entityType: i.entityType })),
-        ),
+      disabled,
+      command: disabled
+        ? undefined
+        : () =>
+            addToList(
+              list.id,
+              list.entityType,
+              selected.map((i) => ({
+                entityId: i.entityId,
+                entityType: i.entityType,
+                hasReviewables: i.hasReviewables,
+              })),
+            ),
     }),
     [addToList],
   )
@@ -303,15 +332,16 @@ export const EntityListsProvider = ({ children, projectName }: EntityListsProvid
   const buildHierarchicalMenuItems = useCallback(
     (
       lists: EntityList[],
-      selected: { entityId: string; entityType: string | undefined }[],
+      selected: ListEntityInput[],
       getShowIcon?: (list: EntityList) => boolean,
+      getDisabled?: (list: EntityList) => boolean,
     ): ListSubMenuItem[] => {
       // Simple cache keyed by folder+list ids + selection length + powerLicense flag
       // This prevents rebuilding identical structures across repeated context menu openings.
       // (Selection identities beyond length don't affect structure of destination list tree).
       type CacheValue = {
         items: ListSubMenuItem[]
-        selectedRef: { entityId: string; entityType: string | undefined }[]
+        selectedRef: ListEntityInput[]
       }
       const staticCache = (buildHierarchicalMenuItems as any)._cache as
         | Map<string, CacheValue>
@@ -321,13 +351,15 @@ export const EntityListsProvider = ({ children, projectName }: EntityListsProvid
         ;(buildHierarchicalMenuItems as any)._cache = cache
       }
 
+      // When getDisabled is supplied, results depend on per-call selection state — skip cache
+      const useCache = !getDisabled
       const folderSig = powerLicense
         ? listFolders.map((f) => `${f.id}:${f.parentId || ''}:${f.label}`).join('|')
         : 'nofolders'
       const listSig = lists.map((l) => `${l.id}:${l.entityListFolderId || ''}`).join('|')
       const key = `${folderSig}::${listSig}::${selected.length}::${powerLicense}`
 
-      const cached = cache.get(key)
+      const cached = useCache ? cache.get(key) : undefined
       if (cached) {
         // Recreate command closures with current selection (list items carry command depending on selected)
         const rebindCommands = (items: ListSubMenuItem[]): ListSubMenuItem[] => {
@@ -359,12 +391,15 @@ export const EntityListsProvider = ({ children, projectName }: EntityListsProvid
       }
 
       const resolveShowIcon = getShowIcon || (() => false)
+      const resolveDisabled = getDisabled || (() => false)
 
       // Filter lists to only include those with editor access (accessLevel >= 20)
       const editableLists = lists.filter((list) => (list.accessLevel ?? 0) >= 20)
 
       if (!powerLicense || !listFolders.length) {
-        return editableLists.map((l) => buildListMenuItem(l, selected, resolveShowIcon(l)))
+        return editableLists.map((l) =>
+          buildListMenuItem(l, selected, resolveShowIcon(l), resolveDisabled(l)),
+        )
       }
 
       // folder node structure
@@ -411,7 +446,9 @@ export const EntityListsProvider = ({ children, projectName }: EntityListsProvid
           .filter((n) => hasAnyLists(n.folder.id))
           .map((n) => {
             const childFolders = buildFolderItems(n.children)
-            const listItems = n.lists.map((l) => buildListMenuItem(l, selected, resolveShowIcon(l)))
+            const listItems = n.lists.map((l) =>
+              buildListMenuItem(l, selected, resolveShowIcon(l), resolveDisabled(l)),
+            )
             return {
               id: `folder-${n.folder.id}`,
               label: n.folder.label,
@@ -432,10 +469,12 @@ export const EntityListsProvider = ({ children, projectName }: EntityListsProvid
 
       // lists without a folder (root lists)
       const rootLists = editableLists.filter((l) => !l.entityListFolderId)
-      const rootListItems = rootLists.map((l) => buildListMenuItem(l, selected, resolveShowIcon(l)))
+      const rootListItems = rootLists.map((l) =>
+        buildListMenuItem(l, selected, resolveShowIcon(l), resolveDisabled(l)),
+      )
 
       const result = [...folderItems, ...rootListItems]
-      cache.set(key, { items: result, selectedRef: selected })
+      if (useCache) cache.set(key, { items: result, selectedRef: selected })
       return result
     },
     [buildListMenuItem, listFolders, powerLicense],
@@ -477,7 +516,19 @@ export const EntityListsProvider = ({ children, projectName }: EntityListsProvid
         }
       } else if (cell.entityType === 'version') {
         const combined = [...versions, ...reviews]
-        subMenuItems = buildHierarchicalMenuItems(combined, selected, (l) => getShowIconVersion(l))
+        // Cells expose hasReviewables on .data — propagate so addToList + UI gating can consume it
+        const selectedWithReviewable: ListEntityInput[] = selected.map((s) => ({
+          entityId: s.entityId,
+          entityType: s.entityType,
+          hasReviewables: (s.data as any)?.hasReviewables,
+        }))
+        const hasAnyNonReviewable = selectedWithReviewable.some((s) => s.hasReviewables === false)
+        subMenuItems = buildHierarchicalMenuItems(
+          combined,
+          selectedWithReviewable,
+          (l) => getShowIconVersion(l),
+          (l) => l.entityListType === 'review-session' && hasAnyNonReviewable,
+        )
       }
 
       // Apply filter if provided

--- a/src/pages/ProjectListsPage/context/EntityListsContext.tsx
+++ b/src/pages/ProjectListsPage/context/EntityListsContext.tsx
@@ -302,8 +302,9 @@ export const EntityListsProvider = ({ children, projectName }: EntityListsProvid
       disabled,
       command: disabled
         ? undefined
-        : () =>
-            addToList(
+        : () => {
+            // Fire-and-forget from context menu — swallow rejections (errors are already toasted)
+            void addToList(
               list.id,
               list.entityType,
               selected.map((i) => ({
@@ -311,7 +312,8 @@ export const EntityListsProvider = ({ children, projectName }: EntityListsProvid
                 entityType: i.entityType,
                 hasReviewables: i.hasReviewables,
               })),
-            ),
+            ).catch(() => {})
+          },
     }),
     [addToList],
   )

--- a/src/pages/ProjectListsPage/context/EntityListsContext.tsx
+++ b/src/pages/ProjectListsPage/context/EntityListsContext.tsx
@@ -302,9 +302,8 @@ export const EntityListsProvider = ({ children, projectName }: EntityListsProvid
       disabled,
       command: disabled
         ? undefined
-        : () => {
-            // Fire-and-forget from context menu — swallow rejections (errors are already toasted)
-            void addToList(
+        : () =>
+            addToList(
               list.id,
               list.entityType,
               selected.map((i) => ({
@@ -312,8 +311,7 @@ export const EntityListsProvider = ({ children, projectName }: EntityListsProvid
                 entityType: i.entityType,
                 hasReviewables: i.hasReviewables,
               })),
-            ).catch(() => {})
-          },
+            ),
     }),
     [addToList],
   )

--- a/src/pages/VersionsProductsPage/hooks/useVPContextMenu.tsx
+++ b/src/pages/VersionsProductsPage/hooks/useVPContextMenu.tsx
@@ -282,7 +282,11 @@ export const useVPContextMenu = (callbacks?: {
       const selectedEntityIds = meta.selectedRows.length > 0 ? meta.selectedRows : [cell.entityId]
 
       // Filter to only version entities, converting products to their featuredVersion
-      const versionEntities: { entityId: string; entityType: string | undefined }[] = []
+      const versionEntities: {
+        entityId: string
+        entityType: string | undefined
+        hasReviewables?: boolean
+      }[] = []
       let singleVersionName: string | undefined
 
       for (const entityId of selectedEntityIds) {
@@ -290,7 +294,11 @@ export const useVPContextMenu = (callbacks?: {
         if (!entity) continue
 
         if (entity.entityType === 'version') {
-          versionEntities.push({ entityId: entity.id, entityType: 'version' })
+          versionEntities.push({
+            entityId: entity.id,
+            entityType: 'version',
+            hasReviewables: (entity as any).hasReviewables,
+          })
           if (versionEntities.length === 1) {
             singleVersionName = entity.name
           }
@@ -300,6 +308,7 @@ export const useVPContextMenu = (callbacks?: {
             versionEntities.push({
               entityId: product.featuredVersion.id,
               entityType: 'version',
+              hasReviewables: product.featuredVersion.hasReviewables,
             })
             if (versionEntities.length === 1) {
               singleVersionName = product.featuredVersion.name
@@ -319,11 +328,17 @@ export const useVPContextMenu = (callbacks?: {
         }
       }
 
+      // Review sessions only accept versions with reviewables — disable when any selected lacks them
+      const hasAnyNonReviewable = versionEntities.some((v) => v.hasReviewables === false)
+
       // Build the menu items for add to list using versions and reviews data
       const combined = [...versions, ...reviews]
-      const menuItems = buildHierarchicalMenuItems(combined, versionEntities, (list) => {
-        return list.entityListType === 'review-session' ? true : !!reviews.length
-      })
+      const menuItems = buildHierarchicalMenuItems(
+        combined,
+        versionEntities,
+        (list) => (list.entityListType === 'review-session' ? true : !!reviews.length),
+        (list) => list.entityListType === 'review-session' && hasAnyNonReviewable,
+      )
       menuItems.push(newListMenuItem('version', versionEntities))
 
       // Include version name in label if only one version


### PR DESCRIPTION

<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Versions without reviewables can no longer be added to review-session lists. Review-session targets appear greyed out in the "Add to list" context menu when any selected version lacks reviewables. The API helper also blocks the request as a safety net.

## Technical details
<!-- Please state any technical details such as limitations -->
- `EntityListsContext.addToList` filters non-reviewable versions when target list is `review-session`, toasts a warning on partial skip, errors when all skipped.
  - `buildHierarchicalMenuItems` / `buildListMenuItem` gain an optional `getDisabled` predicate; menu cache bypassed when supplied.
  - Wired in VersionsProductsPage, BrowserPage Products, and ProjectListsPage right-click menus. 

## Additional context
<!-- Add any other context or screenshots here. -->

