### PR TITLE
Fix ternary statement determining list folder scope between storyboards and review sessions

### DIFF
--- a/src/pages/ProjectListsPage/components/ListFolderFormDialog/ListFolderFormDialog.tsx
+++ b/src/pages/ProjectListsPage/components/ListFolderFormDialog/ListFolderFormDialog.tsx
@@ -29,11 +29,11 @@ export const ListFolderFormDialog: FC<ListFolderFormDialogProps> = ({}) => {
 
   const editingFolder = listFolders?.find((f) => f.id === folderId)
 
+  const reviewScope = isStoryboards ? 'storyboard' : 'review-session'
+
   const initFolderForm: ListFolderFormData = {
     label: '',
-    scope: [isReview
-      ? isStoryboards ? 'review-session' : 'storyboard'
-      : 'generic'],
+    scope: [isReview ? reviewScope : 'generic'],
   }
   const [folderForm, setFolderForm] = useState<ListFolderFormData>(initFolderForm)
   const [isSaving, setIsSaving] = useState(false)


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Reverses the ternary statement which determines the scope of newly created list folders so it correctly assigns storyboard and review session scopes.

## Technical details
<!-- Please state any technical details such as limitations -->


## Additional context
<!-- Add any other context or screenshots here. -->

