### PR TITLE
Group by: lost when having additional view opened when refreshing the page

### DIFF
--- a/shared/src/containers/DetailsPanel/DetailsPanel.tsx
+++ b/shared/src/containers/DetailsPanel/DetailsPanel.tsx
@@ -52,7 +52,7 @@ export type DetailsPanelProps = {
   onOpenViewer?: (entity: any) => void
   onEntityFocus?: (id: string, entityType: DetailsPanelEntityType) => void
   onOpen?: () => void
-  onUriOpen?: (entity: DetailsPanelEntityData) => void
+  onUriOpen?: (entity: DetailsPanelEntityData, source: 'uri' | 'url') => void
   // annotations
   annotations?: any
   removeAnnotation?: (id: string) => void
@@ -210,8 +210,7 @@ DetailsPanelProps) => {
     if (isFetchingEntitiesDetails) return
 
     if (
-      contextEntities?.source &&
-      ['uri', 'url'].includes(contextEntities.source) &&
+      (contextEntities?.source === 'uri' || contextEntities?.source === 'url') &&
       contextEntities?.entities?.length &&
       !!onUriOpen
     ) {
@@ -220,7 +219,7 @@ DetailsPanelProps) => {
       )
       if (!uriEntity) return
 
-      onUriOpen(uriEntity)
+      onUriOpen(uriEntity, contextEntities.source)
     }
   }, [entityDetailsData, isFetchingEntitiesDetails])
 

--- a/src/pages/ProjectOverviewPage/ProjectOverviewPage.tsx
+++ b/src/pages/ProjectOverviewPage/ProjectOverviewPage.tsx
@@ -180,7 +180,7 @@ const ProjectOverviewPage: FC = () => {
   const { getGoToEntityData } = useGoToEntity()
 
   // select the entity in the table and expand its parent folders
-  const handleUriOpen = (entity: DetailsPanelEntityData) => {
+  const handleUriOpen = (entity: DetailsPanelEntityData, source: 'uri' | 'url') => {
     console.debug('URI found, selecting and expanding folders to entity:', entity.name)
 
     // Get the data needed to navigate to this entity
@@ -188,9 +188,11 @@ const ProjectOverviewPage: FC = () => {
       folder: entity.folder?.id,
     })
 
-    // Reset view state
-    setQueryFilters({})
-    updateViewGroupBy(null) // switches to hierarchy and syncs groupBy in one server call
+    // Only reset view state
+    if (source === 'uri') {
+      setQueryFilters({})
+      updateViewGroupBy(null) // switches to hierarchy and syncs groupBy in one server call
+    }
 
     // Expand folders in both table and slicer
     updateExpanded(data.expandedFolders)

--- a/src/pages/ProjectOverviewPage/containers/ProjectOverviewDetailsPanel.tsx
+++ b/src/pages/ProjectOverviewPage/containers/ProjectOverviewDetailsPanel.tsx
@@ -17,7 +17,7 @@ type ProjectOverviewDetailsPanelProps = {
   projectInfo?: ProjectModel
   projectName: string
   isOpen?: boolean
-  onUriOpen?: (entity: DetailsPanelEntityData) => void
+  onUriOpen?: (entity: DetailsPanelEntityData, source: 'uri' | 'url') => void
   onClose?: () => void
 }
 

--- a/src/pages/TasksProgressPage/TaskProgressDetailsPanel.tsx
+++ b/src/pages/TasksProgressPage/TaskProgressDetailsPanel.tsx
@@ -34,14 +34,16 @@ const TaskProgressDetailsPanel = ({ projectInfo, projectName }: TaskProgressDeta
 
   const { getGoToEntityData } = useGoToEntity()
 
-  const handleUriOpen = (entity: any) => {
+  const handleUriOpen = (entity: any, source: 'uri' | 'url') => {
     // Get the data needed to navigate to this entity
     const data = getGoToEntityData(entity.id, entity.entityType, {
       folder: entity.folder?.id,
     })
 
-    // Reset filters
-    setQueryFilters({})
+    // Only reset filters
+    if (source === 'uri') {
+      setQueryFilters({})
+    }
 
     // Expand folders in slicer
     slicer.setExpanded(data.expandedFolders)

--- a/src/pages/VersionsProductsPage/components/VPDetailsPanel/VPDetailsPanel.tsx
+++ b/src/pages/VersionsProductsPage/components/VPDetailsPanel/VPDetailsPanel.tsx
@@ -84,7 +84,7 @@ const VPDetailsPanel = ({}: VPDetailsPanelProps) => {
   const { getGoToEntityData } = useGoToEntity()
 
   // select the entity in the table and expand its parent folders
-  const handleUriOpen = (entity: DetailsPanelEntityData) => {
+  const handleUriOpen = (entity: DetailsPanelEntityData, source: 'uri' | 'url') => {
     console.debug('URI found, selecting and expanding folders to entity:', entity.name)
 
     // Get the data needed to navigate to this entity
@@ -93,9 +93,11 @@ const VPDetailsPanel = ({}: VPDetailsPanelProps) => {
       product: entity.product?.id,
     })
 
-    // Reset view state
-    onUpdateFilters({})
-    onUpdateViewGroupBy(undefined)
+    // Only reset view state
+    if (source === 'uri') {
+      onUpdateFilters({})
+      onUpdateViewGroupBy(undefined)
+    }
 
     // Expand folders in slicer
     slicer.setExpanded(data.expandedFolders)

--- a/src/pages/VersionsProductsPage/components/VPToolbar/VPToolbar.tsx
+++ b/src/pages/VersionsProductsPage/components/VPToolbar/VPToolbar.tsx
@@ -74,14 +74,15 @@ const VPToolbar: FC = () => {
   }, [viewGroupBy, viewGroupByOptions, columns.groupBy, sorting])
 
   const handleViewGroupByChange = useCallback(
-    (values: { id: string; sortOrder?: boolean }[]) => {
+    async (values: { id: string; sortOrder?: boolean }[]) => {
       const value = values[0]
 
       // Get the grouping selection from the dropdown (what the user selected)
       const selectedGrouping = !value ? undefined : value.id === 'product' ? 'hierarchy' : value.id
+      const isGroupingChange = selectedGrouping !== viewGroupBy
 
       // Handle sort order changes by updating the columns config
-      if (value && value.sortOrder !== undefined) {
+      if (value && value.sortOrder !== undefined && !isGroupingChange) {
         const newDesc = !value.sortOrder // invert sortOrder to desc
 
         // When grouping (not hierarchy), toggle group sorting (groupBy.desc)
@@ -105,14 +106,14 @@ const VPToolbar: FC = () => {
       }
 
       // Handle grouping selection change (only if selection actually changed)
-      if (selectedGrouping !== viewGroupBy) {
+      if (isGroupingChange) {
         if (!value) {
           // X clicked — flat list (no grouping, no products)
-          onUpdateViewGroupBy(undefined)
+          await onUpdateViewGroupBy(undefined)
         } else if (value.id === 'product') {
-          onUpdateViewGroupBy('hierarchy')
+          await onUpdateViewGroupBy('hierarchy')
         } else {
-          onUpdateViewGroupBy(value.id)
+          await onUpdateViewGroupBy(value.id)
         }
       }
     },

--- a/src/pages/VersionsProductsPage/context/VPViewsContext.tsx
+++ b/src/pages/VersionsProductsPage/context/VPViewsContext.tsx
@@ -31,7 +31,7 @@ export type VPViewsContextValue = {
 
   // View mode management
   viewGroupBy: string | undefined
-  onUpdateViewGroupBy: (viewGroupBy: string | undefined) => void
+  onUpdateViewGroupBy: (viewGroupBy: string | undefined) => Promise<void>
 
   showProducts: boolean
   onUpdateShowProducts: (showProducts: boolean) => void


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Fixes Group by  being wiped when refreshing a page that has the Details panel open. Affects Products, Overview, and Tasks Progress.


## Technical details
<!-- Please state any technical details such as limitations -->

- `onUriOpen` now receives `source: 'uri' | 'url'`. Page-level handlers only reset filters / groupBy / hierarchy when `source === 'uri'` (true URI navigation); plain URL refresh (`?project&type&id`) leaves view state alone.
- Fixed a race in `VPToolbar.handleViewGroupByChange`: picking a new option fired both a sort-only `onUpdateColumns` PATCH and the grouping PATCH in parallel, and the stale columns payload could land last and overwrite `showProducts: true`. Sort-only PATCH is now skipped when the grouping selection itself is changing, and the grouping update is awaited.
- Same gate applied in `ProjectOverviewPage` and `TaskProgressDetailsPanel`.
## Additional context
<!-- Add any other context or screenshots here. -->

 Closes #1980