### PR TITLE
Reviewables: Using keyboard causes double selection

### DIFF
--- a/shared/src/components/ReviewablesSelector/ReviewablesSelector.tsx
+++ b/shared/src/components/ReviewablesSelector/ReviewablesSelector.tsx
@@ -63,6 +63,7 @@ const ReviewablesSelector = forwardRef<ReviewablesSelectorHandle, ReviewablesSel
         if (el) {
           const top = el.offsetTop + el.offsetHeight / 2 - getScrollTop()
           setLabelTooltipYPos(top)
+          el.focus({ preventScroll: true })
         }
       },
     }),


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
Fixes keyboard navigation in the reviewables panel leaving the previously clicked thumbnail with a stray focus outline alongside the new selection.


## Technical details
<!-- Please state any technical details such as limitations -->
- `notifyNavigation` in `ReviewablesSelector` now calls `el.focus({ preventScroll: true })` on the newly selected card so DOM focus follows the selection.
- `preventScroll: true` leaves the existing `scrollReviewableIntoView` flow in charge of scroll positioning.

## Additional context
<!-- Add any other context or screenshots here. --> 
Closes #1915