### PR TITLE
Action form: Text input with 'multiline' is shown as single line

### DIFF
--- a/shared/src/components/SimpleFormDialog/SimpleFormDialog.tsx
+++ b/shared/src/components/SimpleFormDialog/SimpleFormDialog.tsx
@@ -9,6 +9,7 @@ import {
   FormRow,
   InputNumber,
   InputText,
+  InputTextarea,
   InputSwitch,
   Dropdown,
   DefaultItemTemplate,
@@ -112,6 +113,15 @@ const DropdownItemTemplate = (option: FormSelectOption) => {
 const FormField = ({ field, value, onChange }: FormFieldProps) => {
   if (field.type === 'text') {
     const parsedValue = typeof value === 'string' ? value : ''
+    if (field.multiline) {
+      return (
+        <InputTextarea
+          value={parsedValue}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={field.placeholder || ''}
+        />
+      )
+    }
     return (
       <InputText
         value={parsedValue}


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Renders action-form text fields declared with `multiline: true` as a textarea instead of a single-line input.

## Technical details
<!-- Please state any technical details such as limitations -->

- `SimpleFormDialog` text-field branch now checks `field.multiline` and renders `InputTextarea` from `@ynput/ayon-react-components`, otherwise the existing `InputText`.
- No explicit `rows` — browser default applies; the textarea remains resizable.

## Additional context
<!-- Add any other context or screenshots here. -->

Closes #1954
