### PR TITLE
Projects: Right-click thumbnail to upload

### DIFF
--- a/src/pages/ProjectDashboard/panels/ProjectDetails/ProjectThumbnailUploader.tsx
+++ b/src/pages/ProjectDashboard/panels/ProjectDetails/ProjectThumbnailUploader.tsx
@@ -6,6 +6,7 @@ import { Icon } from '@ynput/ayon-react-components'
 import { toast } from 'react-toastify'
 import api from '@shared/api'
 import { Thumbnail } from '@shared/components'
+import { useCreateContextMenu } from '@shared/containers'
 import * as Styled from './ProjectThumbnailUploader.styled'
 
 export interface ProjectThumbnailUploaderProps {
@@ -158,6 +159,19 @@ export const ProjectThumbnailUploader = ({
     fileInputRef.current?.click()
   }
 
+  const [ctxMenuShow] = useCreateContextMenu()
+
+  const handleContextMenu = (event: React.MouseEvent) => {
+    if (disabled) return
+    ctxMenuShow(event, [
+      {
+        label: 'Upload thumbnail',
+        icon: 'add_photo_alternate',
+        command: openFilePicker,
+      },
+    ])
+  }
+
   return (
     <Styled.Wrapper
       onDragEnter={handleDragEnter}
@@ -167,6 +181,7 @@ export const ProjectThumbnailUploader = ({
     >
       <Styled.ThumbnailSlot
         onClick={disabled ? undefined : openFilePicker}
+        onContextMenu={disabled ? undefined : handleContextMenu}
         style={disabled ? { cursor: 'default' } : undefined}
       >
         <Thumbnail


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Adds a right-click context menu on the project thumbnail with an "Upload thumbnail" action, mirroring the entity thumbnail behaviour.

## Technical details
<!-- Please state any technical details such as limitations -->

- `ProjectThumbnailUploader.tsx` now uses `useCreateContextMenu` from `@shared/containers` and attaches `onContextMenu` to `Styled.ThumbnailSlot`.
- The single menu item reuses the existing `openFilePicker`, so left-click and drag-drop upload remain unchanged.
- Handler is a no-op when the uploader is `disabled`.

## Additional context
<!-- Add any other context or screenshots here. -->

Closes #1989
