### PR TITLE
Fix frame navigation keyboard shortcuts in video player

### DIFF
--- a/src/containers/VideoPlayer/hooks/useGoToFrame.ts
+++ b/src/containers/VideoPlayer/hooks/useGoToFrame.ts
@@ -15,7 +15,7 @@ const useGoToFrame = ({ setCurrentTime, frameRate, duration, videoElement }: Pro
 
   useEffect(() => {
     if (frame !== null) {
-      const time = Math.max(0, Math.min(duration, frame / frameRate))
+      const time = Math.max(0, Math.min(duration, (frame + 0.5) / frameRate))
       videoElement.currentTime = time
       setCurrentTime(time)
       dispatch(goToFrame(null))

--- a/src/containers/VideoPlayer/hooks/useVideoPlayback.ts
+++ b/src/containers/VideoPlayer/hooks/useVideoPlayback.ts
@@ -11,7 +11,7 @@ const useVideoPlayback = (
 
   const frameCallbackRef = useRef<(() => void) | null>(null)
 
-  const currentFrame = Math.round(currentTime * frameRate)
+  const currentFrame = Math.floor(currentTime * frameRate)
   const frameCount = Math.round(duration * frameRate)
 
   // requestVideoFrameCallback loop to track currentTime

--- a/src/containers/VideoPlayer/hooks/useVideoSeeking.ts
+++ b/src/containers/VideoPlayer/hooks/useVideoSeeking.ts
@@ -32,7 +32,7 @@ const useVideoSeeking = (
   }
 
   const seekToFrame = (newFrame: number) => {
-    const newTime = newFrame / frameRate
+    const newTime = (newFrame + 0.5) / frameRate
     seekToTime(newTime)
   }
 
@@ -76,7 +76,7 @@ const useVideoSeeking = (
     if (isTransitioning.current) return
     const rawTime = videoRef.current?.currentTime
     if (rawTime == null) return
-    initialPosition.current = Math.round(rawTime * frameRate) / frameRate
+    initialPosition.current = (Math.floor(rawTime * frameRate) + 0.5) / frameRate
     seekToTime(initialPosition.current)
     setTimeout(() => {
       if (videoRef.current?.paused) {


### PR DESCRIPTION
## Summary

Left/right arrow keyboard shortcuts for frame-by-frame navigation in the browser review player are broken on Chrome (Windows). Left arrow alternates between stepping 1 and 2 frames back. Right arrow only advances on frames that are multiples of 3.

## Root Cause

The frame↔time round-trip loses precision due to IEEE 754 floating-point arithmetic.

The cycle is: `currentFrame → time → browser seek → reported time → currentFrame`. Each arrow press converts `frame / frameRate` to set `currentTime`, then converts back via `Math.round(currentTime * frameRate)`. At common frame rates (e.g. 24fps), most frame times are repeating binary fractions — the browser may report a slightly different `currentTime` after seeking, causing `Math.round` to land on the wrong frame.

**Why multiples of 3 work at 24fps:** `3/24 = 1/8`, `6/24 = 1/4`, etc. — these are exact binary fractions, so the round-trip is lossless. Non-multiples of 3 produce repeating fractions that are vulnerable to rounding drift.

## Fix

Two complementary changes across 3 files (4 one-line edits):

1. **`Math.floor` instead of `Math.round` for time→frame** (`useVideoPlayback.ts`): A video frame occupies the interval `[frame/fps, (frame+1)/fps)`. `Math.floor` correctly maps any time within that interval to the frame number. `Math.round` shifts the boundary to the midpoint, causing off-by-one errors near frame edges.

2. **Seek to frame midpoint instead of boundary** (`useVideoSeeking.ts`, `useGoToFrame.ts`): `(frame + 0.5) / frameRate` instead of `frame / frameRate`. This lands the seek target in the center of the frame's time interval, giving maximum tolerance for browser imprecision. Applied consistently in `seekToFrame`, `handlePause` snap, and `useGoToFrame`.

## Changed Files

- `src/containers/VideoPlayer/hooks/useVideoPlayback.ts` — `Math.round` → `Math.floor` for `currentFrame`
- `src/containers/VideoPlayer/hooks/useVideoSeeking.ts` — midpoint seek in `seekToFrame` and `handlePause`
- `src/containers/VideoPlayer/hooks/useGoToFrame.ts` — midpoint seek

## Testing

- [ ] Frame-step forward (→) advances exactly 1 frame on every frame, not just multiples of 3
- [ ] Frame-step backward (←) moves exactly 1 frame back consistently, no alternating 1/2 behavior
- [ ] Shift+Arrow 5-frame jumps still work correctly
- [ ] Scrubbing via trackbar still lands on correct frames
- [ ] Play/pause snaps to correct frame
- [ ] Timecode display matches expected frame number
- [ ] Test at 24fps, 25fps, 29.97fps, and 30fps content
- [ ] Test on Chrome (Windows), Firefox, Safari