### PR TITLE
Comments: fix copy/paste of mentions

### DIFF
--- a/shared/package.json
+++ b/shared/package.json
@@ -139,7 +139,7 @@
     "quill-magic-url": "4.2.0",
     "react-markdown": "10.1.0",
     "react-perfect-scrollbar": "1.5.8",
-    "react-quill-ayon": "2.0.3",
+    "react-quill-ayon": "2.0.2",
     "react-toastify": "9.1.3",
     "rehype-raw": "7.0.0",
     "remark-directive": "3.0.1",

--- a/shared/src/containers/Feed/components/ActivityComment/ActivityComment.styled.ts
+++ b/shared/src/containers/Feed/components/ActivityComment/ActivityComment.styled.ts
@@ -88,6 +88,7 @@ export const Body = styled.div`
     .reference {
       margin-right: -2px;
       top: 5px;
+      user-select: all;
     }
 
     /* target empty lines with &nbsp; or br */

--- a/shared/src/containers/Feed/components/ActivityComment/ActivityMarkdownComponents.tsx
+++ b/shared/src/containers/Feed/components/ActivityComment/ActivityMarkdownComponents.tsx
@@ -113,6 +113,8 @@ export const aTag = (
       onMouseEnter={(e, pos) => onReferenceTooltip({ type, id: domSafeId, label, name: id, pos })}
       categoryPrimary={categoryPrimary}
       categorySecondary={categorySecondary}
+      data-mention-value={`${type}:${id}`}
+      data-mention-label={label}
     >
       {label}
     </ActivityReference>

--- a/shared/src/containers/Feed/components/ActivityComment/CommentWrapper.tsx
+++ b/shared/src/containers/Feed/components/ActivityComment/CommentWrapper.tsx
@@ -1,8 +1,69 @@
-import React, { FC, ReactElement } from 'react'
+import React, { FC, useCallback } from 'react'
 
 const removeAts = (text: string): string => {
   // remove @ if followed by @ or [
   return text.replace(/@(?=@|\[)/g, '')
+}
+
+const HTML_ESCAPES: Record<string, string> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+}
+const escapeHtml = (s: string) => s.replace(/[&<>"]/g, (c) => HTML_ESCAPES[c])
+const encodeIdSpaces = (s: string) => s.replaceAll(' ', '%20')
+
+const serializeSelection = (root: HTMLElement, range: Range) => {
+  const fragment = range.cloneContents()
+  if (!fragment.querySelector('[data-mention-value]')) return null
+
+  let text = ''
+  let html = ''
+
+  const walk = (node: Node) => {
+    if (node.nodeType === Node.TEXT_NODE) {
+      const data = (node as Text).data
+      text += data
+      html += escapeHtml(data)
+      return
+    }
+    if (node.nodeType === Node.DOCUMENT_FRAGMENT_NODE) {
+      node.childNodes.forEach(walk)
+      return
+    }
+    if (node.nodeType !== Node.ELEMENT_NODE) return
+    const el = node as HTMLElement
+
+    const mentionValue = el.getAttribute('data-mention-value')
+    if (mentionValue) {
+      const label = el.getAttribute('data-mention-label') || (el.textContent || '').trim()
+      if (label) {
+        const encoded = encodeIdSpaces(mentionValue)
+        text += `[${label}](${encoded})`
+        html += `<a href="@${escapeHtml(encoded)}">@${escapeHtml(label)}</a>`
+      }
+      return
+    }
+
+    if (el.tagName === 'BR') {
+      text += '\n'
+      html += '<br>'
+      return
+    }
+
+    if (el.tagName === 'P' || el.tagName === 'DIV') {
+      if (text && !text.endsWith('\n')) text += '\n'
+      node.childNodes.forEach(walk)
+      return
+    }
+
+    node.childNodes.forEach(walk)
+  }
+
+  walk(fragment)
+  if (!text) return null
+  return { text, html }
 }
 
 const CommentWrapper: FC<{ children: React.ReactNode }> = ({ children }) => {
@@ -25,7 +86,22 @@ const CommentWrapper: FC<{ children: React.ReactNode }> = ({ children }) => {
     }
   })
 
-  return parsedChildren
+  const handleCopy = useCallback((e: React.ClipboardEvent<HTMLDivElement>) => {
+    const sel = window.getSelection()
+    if (!sel || sel.rangeCount === 0 || sel.isCollapsed) return
+    const range = sel.getRangeAt(0)
+    const root = e.currentTarget
+    if (!root.contains(range.startContainer) || !root.contains(range.endContainer)) return
+
+    const result = serializeSelection(root, range)
+    if (!result) return
+
+    e.preventDefault()
+    e.clipboardData.setData('text/plain', result.text)
+    e.clipboardData.setData('text/html', result.html)
+  }, [])
+
+  return <div onCopy={handleCopy}>{parsedChildren}</div>
 }
 
 export default CommentWrapper

--- a/shared/src/containers/Feed/components/ActivityReference/ActivityReference.tsx
+++ b/shared/src/containers/Feed/components/ActivityReference/ActivityReference.tsx
@@ -13,6 +13,8 @@ interface ActivityReferenceProps extends Omit<React.HTMLAttributes<HTMLElement>,
   onMouseEnter?: (e: React.MouseEvent<HTMLElement>, pos: { left: number; top: number }) => void
   categoryPrimary?: string
   categorySecondary?: string
+  'data-mention-value'?: string
+  'data-mention-label'?: string
 }
 
 const ActivityReference: React.FC<ActivityReferenceProps> = ({

--- a/shared/src/containers/Feed/components/CommentInput/CommentInput.styled.ts
+++ b/shared/src/containers/Feed/components/CommentInput/CommentInput.styled.ts
@@ -104,7 +104,7 @@ export const Comment = styled.div<CommentProps>`
   .ql-editor {
     .mention {
       border-radius: var(--border-radius-m);
-      user-select: none;
+      user-select: text;
       padding: 0 4px;
       margin-right: -2px;
       /* remove underline */

--- a/shared/src/containers/Feed/components/CommentInput/CommentInput.tsx
+++ b/shared/src/containers/Feed/components/CommentInput/CommentInput.tsx
@@ -348,16 +348,14 @@ const CommentInput: FC<CommentInputProps> = ({
             search: mentionSearch?.toLowerCase(),
           })
         }
-      } else {
-        // just deleting any text
+      } else if (isDelete) {
+        // backspace inside a mention deletes the whole mention
         const quill = editorRef.current.getEditor()
         const currentSelection = quill.getSelection(false)
         const currentFormat = quill.getFormat(currentSelection?.index, currentSelection?.length)
         if (currentFormat.mention) {
-          // if format is mention, delete the whole mention
           const [lineBlock] = quill.getLine(currentSelection.index - 1) || []
           const ops = lineBlock?.cache?.delta?.ops || []
-          // get last op with attributes mention: true
           const lastMentionOp = ops.reverse().find((op: any) => op.attributes?.mention)
           if (lastMentionOp) {
             const mentionLength = lastMentionOp.insert.length
@@ -591,6 +589,7 @@ const CommentInput: FC<CommentInputProps> = ({
           onUpload: handleFileUploaded,
           onUploadProgress: handleFileProgress,
         },
+        mentionTypeOptions,
       }),
     [projectName, setFiles, setFilesUploading],
   )

--- a/shared/src/containers/Feed/components/CommentInput/modules/MentionClipboard.ts
+++ b/shared/src/containers/Feed/components/CommentInput/modules/MentionClipboard.ts
@@ -1,0 +1,172 @@
+import { Quill } from 'react-quill-ayon'
+import type QuillType from 'quill'
+import type DeltaStatic from 'quill-delta'
+
+const Delta = Quill.import('delta') as unknown as new () => DeltaStatic
+
+type TypeOption = { id: string; isCircle?: boolean }
+type TypeOptions = Record<string, TypeOption>
+
+interface MentionClipboardOptions {
+  typeOptions?: TypeOptions
+  refTypes?: readonly string[]
+}
+
+const DEFAULT_REF_TYPES = [
+  'user',
+  'team',
+  'task',
+  'version',
+  'folder',
+  'representation',
+  'workfile',
+  'product',
+] as const
+
+const HTML_ESCAPES: Record<string, string> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+}
+const escapeHtml = (s: string) => s.replace(/[&<>"]/g, (c) => HTML_ESCAPES[c])
+
+const refTypeToPrefix = (refType: string, options: TypeOptions) =>
+  Object.entries(options).find(([, v]) => v.id === refType)?.[0] || '@'
+
+// Roundtrip mentions through the clipboard:
+//   <MENTION data-value="type:id">@label</MENTION>  ⇄  [label](type:id)
+class MentionClipboard {
+  private quill: QuillType
+  private root: HTMLElement
+  private typeOptions: TypeOptions
+  private refTypes: readonly string[]
+  private mentionMdRe: RegExp
+
+  constructor(quill: QuillType, options?: MentionClipboardOptions) {
+    this.quill = quill
+    this.root = quill.root
+    this.typeOptions = options?.typeOptions ?? {}
+    this.refTypes = options?.refTypes ?? DEFAULT_REF_TYPES
+    this.mentionMdRe = new RegExp(
+      `\\[([^\\]\\n]+)\\]\\((${this.refTypes.join('|')}):([^)\\s]+)\\)`,
+      'g',
+    )
+
+    this.matchAnchor = this.matchAnchor.bind(this)
+    this.handleCopy = this.handleCopy.bind(this)
+    this.handlePaste = this.handlePaste.bind(this)
+
+    // fallback for external HTML pastes that bypass our plain-text branch
+    if (quill.clipboard && (quill.clipboard as any).addMatcher) {
+      ;(quill.clipboard as any).addMatcher('A', this.matchAnchor)
+    }
+    // capture phase so we transform clipboardData before Quill's bubble-phase clipboard fires
+    this.root.addEventListener('copy', this.handleCopy, true)
+    this.root.addEventListener('paste', this.handlePaste, true)
+  }
+
+  private matchAnchor(node: HTMLAnchorElement, delta: DeltaStatic) {
+    const href = (node.getAttribute('href') || '').replace(/^@/, '')
+    const refType = href.split(':')[0]
+    if (!this.refTypes.includes(refType)) return delta
+    const label = node.textContent || ''
+    if (!label) return delta
+    return new Delta().insert(label, { mention: href })
+  }
+
+  private handleCopy(e: ClipboardEvent) {
+    const sel = window.getSelection()
+    if (!sel || sel.rangeCount === 0 || sel.isCollapsed) return
+    const range = sel.getRangeAt(0)
+    if (!this.root.contains(range.startContainer) || !this.root.contains(range.endContainer)) return
+
+    let text = ''
+    let html = ''
+    const walk = (node: Node) => {
+      if (node.nodeType === Node.TEXT_NODE) {
+        const data = (node as Text).data
+        text += data
+        html += escapeHtml(data)
+        return
+      }
+      if (node.nodeType === Node.DOCUMENT_FRAGMENT_NODE) {
+        node.childNodes.forEach(walk)
+        return
+      }
+      if (node.nodeType !== Node.ELEMENT_NODE) return
+      const el = node as HTMLElement
+      if (el.tagName === 'MENTION') {
+        const value = el.getAttribute('data-value') || ''
+        const label = (el.textContent || '').replace(/^@/, '')
+        if (value && label) {
+          text += `[${label}](${value})`
+          html += `<a href="@${escapeHtml(value)}">@${escapeHtml(label)}</a>`
+        }
+        return
+      }
+      if (el.tagName === 'A') {
+        const href = (el.getAttribute('href') || '').replace(/^@/, '')
+        const refType = href.split(':')[0]
+        const label = (el.textContent || '').replace(/^@/, '')
+        if (this.refTypes.includes(refType) && label) {
+          text += `[${label}](${href})`
+          html += `<a href="@${escapeHtml(href)}">@${escapeHtml(label)}</a>`
+          return
+        }
+      }
+      if (el.tagName === 'BR') {
+        text += '\n'
+        html += '<br>'
+        return
+      }
+      node.childNodes.forEach(walk)
+    }
+    walk(range.cloneContents())
+
+    if (!text) return
+    // stop Quill's clipboard from also handling this event
+    e.stopImmediatePropagation()
+    e.clipboardData?.setData('text/plain', text)
+    e.clipboardData?.setData('text/html', html)
+    e.preventDefault()
+  }
+
+  private handlePaste(e: ClipboardEvent) {
+    const text = e.clipboardData?.getData('text/plain')
+    if (!text) return
+    const matches = [...text.matchAll(this.mentionMdRe)]
+    if (!matches.length) return
+
+    const delta = new Delta()
+    let last = 0
+    for (const m of matches) {
+      const start = m.index ?? 0
+      const before = text.slice(last, start)
+      if (before) delta.insert(before)
+      const [, label, refType, rawId] = m
+      let id = rawId
+      try {
+        id = decodeURIComponent(rawId)
+      } catch {
+        /* keep raw */
+      }
+      const prefix = refTypeToPrefix(refType, this.typeOptions)
+      delta.insert(prefix + label, { mention: `${refType}:${id}` })
+      last = start + m[0].length
+    }
+    const tail = text.slice(last)
+    if (tail) delta.insert(tail)
+
+    e.stopImmediatePropagation()
+    e.preventDefault()
+    const selection = this.quill.getSelection(true)
+    if (!selection) return
+    const change = new Delta().retain(selection.index)
+    if (selection.length) change.delete(selection.length)
+    this.quill.updateContents(change.concat(delta), 'user')
+    this.quill.setSelection(selection.index + delta.length(), 0, 'user')
+  }
+}
+
+export default MentionClipboard

--- a/shared/src/containers/Feed/components/CommentInput/modules/MentionClipboard.ts
+++ b/shared/src/containers/Feed/components/CommentInput/modules/MentionClipboard.ts
@@ -81,8 +81,15 @@ class MentionClipboard {
     const range = sel.getRangeAt(0)
     if (!this.root.contains(range.startContainer) || !this.root.contains(range.endContainer)) return
 
+    const fragment = range.cloneContents()
+    // only preempt Quill's clipboard when the selection actually contains a mention;
+    // otherwise the default handler preserves block formatting correctly
+    if (!fragment.querySelector('MENTION, a[href^="@"]')) return
+
     let text = ''
     let html = ''
+    // match quillToMarkdown encoding: only spaces, so plain-text round-trips through the paste regex
+    const encodeIdSpaces = (s: string) => s.replaceAll(' ', '%20')
     const walk = (node: Node) => {
       if (node.nodeType === Node.TEXT_NODE) {
         const data = (node as Text).data
@@ -98,20 +105,22 @@ class MentionClipboard {
       const el = node as HTMLElement
       if (el.tagName === 'MENTION') {
         const value = el.getAttribute('data-value') || ''
-        const label = (el.textContent || '').replace(/^@/, '')
+        const label = (el.textContent || '').replace(/^@+/, '')
         if (value && label) {
-          text += `[${label}](${value})`
-          html += `<a href="@${escapeHtml(value)}">@${escapeHtml(label)}</a>`
+          const encoded = encodeIdSpaces(value)
+          text += `[${label}](${encoded})`
+          html += `<a href="@${escapeHtml(encoded)}">@${escapeHtml(label)}</a>`
         }
         return
       }
       if (el.tagName === 'A') {
         const href = (el.getAttribute('href') || '').replace(/^@/, '')
         const refType = href.split(':')[0]
-        const label = (el.textContent || '').replace(/^@/, '')
+        const label = (el.textContent || '').replace(/^@+/, '')
         if (this.refTypes.includes(refType) && label) {
-          text += `[${label}](${href})`
-          html += `<a href="@${escapeHtml(href)}">@${escapeHtml(label)}</a>`
+          const encoded = encodeIdSpaces(href)
+          text += `[${label}](${encoded})`
+          html += `<a href="@${escapeHtml(encoded)}">@${escapeHtml(label)}</a>`
           return
         }
       }
@@ -122,7 +131,7 @@ class MentionClipboard {
       }
       node.childNodes.forEach(walk)
     }
-    walk(range.cloneContents())
+    walk(fragment)
 
     if (!text) return
     // stop Quill's clipboard from also handling this event
@@ -166,6 +175,8 @@ class MentionClipboard {
     if (selection.length) change.delete(selection.length)
     this.quill.updateContents(change.concat(delta), 'user')
     this.quill.setSelection(selection.index + delta.length(), 0, 'user')
+    // clear lingering mention format so the next typed char isn't absorbed into the trailing mention
+    this.quill.format('mention', false, 'user')
   }
 }
 

--- a/shared/src/containers/Feed/components/CommentInput/modules/index.ts
+++ b/shared/src/containers/Feed/components/CommentInput/modules/index.ts
@@ -3,8 +3,10 @@
 import { Quill } from 'react-quill-ayon'
 import MagicUrl from 'quill-magic-url'
 import ImageUploader from './ImageUploader'
+import MentionClipboard from './MentionClipboard'
 Quill.register('modules/imageUploader', ImageUploader)
 Quill.register('modules/magicUrl', MagicUrl)
+Quill.register('modules/mentionClipboard', MentionClipboard)
 
 // override icons with material icons
 const getIcon = (icon) => '<span class="material-symbols-outlined icon">' + icon + '</span>'
@@ -32,19 +34,20 @@ export const quillFormats = [
   'mention',
 ]
 
-export const getModules = ({ imageUploader, disableImageUpload = false }) => {
+export const getModules = ({ imageUploader, mentionTypeOptions, disableImageUpload = false }) => {
   const toolbar = [
     [{ header: 2 }, 'bold', 'italic', 'link', 'code-block'],
     [{ list: 'ordered' }, { list: 'bullet' }, { list: 'check' }],
   ]
-  
+
   if (!disableImageUpload) {
     toolbar.push(['image'])
   }
-  
+
   return {
     toolbar,
     imageUploader,
     magicUrl: true,
+    mentionClipboard: { typeOptions: mentionTypeOptions },
   }
 }

--- a/shared/yarn.lock
+++ b/shared/yarn.lock
@@ -2597,7 +2597,7 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash@4.18.1:
+lodash@4.18.1, lodash@^4.17.4:
   version "4.18.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
   integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
@@ -3485,10 +3485,10 @@ quill-magic-url@4.2.0:
     normalize-url "^4.5.1"
     quill-delta "^3.6.2"
 
-quill@2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/quill/-/quill-2.0.2.tgz#5b26bc10a74e9f7fdcfdb5156b3133a3ebf0a814"
-  integrity sha512-QfazNrhMakEdRG57IoYFwffUIr04LWJxbS/ZkidRFXYCQt63c1gK6Z7IHUXMx/Vh25WgPBU42oBaNzQ0K1R/xw==
+quill@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/quill/-/quill-2.0.3.tgz#752765a31d5a535cdc5717dc49d4e50099365eb1"
+  integrity sha512-xEYQBqfYx/sfb33VJiKnSJp8ehloavImQ2A6564GAbqG55PGw1dAWUn1MUbQB62t0azawUS2CZZhWCjO8gRvTw==
   dependencies:
     eventemitter3 "^5.0.1"
     lodash-es "^4.17.21"
@@ -3525,13 +3525,13 @@ react-perfect-scrollbar@1.5.8:
     perfect-scrollbar "^1.5.0"
     prop-types "^15.6.1"
 
-react-quill-ayon@2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/react-quill-ayon/-/react-quill-ayon-2.0.3.tgz#4c5c86805a1fc5267ba69249d0faef9b1038bbe9"
-  integrity sha512-lkKU618tglDJQSGtfwz1/SfSOAr5BWoTGdSUQD43u9WvtNH727ZZhg5+42b/bt5Lk8itBdDfn+P/ThKKXWYYrA==
+react-quill-ayon@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/react-quill-ayon/-/react-quill-ayon-2.0.2.tgz#8a408fa85ba8cdd9f686933e758fcd66b3916f35"
+  integrity sha512-42OqYieo522dbVrml5lXGZ57czk6ctBcdIG4tCYzyZYPgyc28WoC+AR7UjvdYaQlAj9jy3gpp8kcJHXcRUffYA==
   dependencies:
-    lodash "4.18.1"
-    quill "2.0.2"
+    lodash "^4.17.4"
+    quill "^2.0.2"
 
 react-refresh@^0.17.0:
   version "0.17.0"


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Fixes copy/paste of mentions in the comment input so pasted mentions stay clickable and keep the linked entity, instead of degrading to plain `@name` text. Also fixes a related bug where pressing space right after a mention deleted it.

## Technical details
<!-- Please state any technical details such as limitations -->

- New `MentionClipboard` Quill module (`shared/src/containers/Feed/components/CommentInput/modules/MentionClipboard.ts`) registers capture-phase copy/paste listeners on `quill.root`. On copy it serialises `<MENTION>` blots to markdown link form `[label](type:id)`; on paste it parses the same form and re-inserts mention-attributed deltas. Falls back to the Quill `A` clipboard matcher for external HTML pastes.
- Wired through `modules/index.ts` (`getModules`) with `mentionTypeOptions` passed from `CommentInput` so prefix mapping (`@` / `@@` / `@@@`) is shared with the rest of the input.
- `CommentInput.handleChange`: the auto-delete-whole-mention branch is now gated by `isDelete`. It was firing on any change at a mention-formatted cursor position, so a space typed right after a pasted (non-trailing-space) mention would inherit the mention format and trigger deletion of the whole mention.
- Pins `react-quill-ayon` to `2.0.2` to fix an unrelated regression introduced in `2.0.3`.

## Additional context
<!-- Add any other context or screenshots here. -->

