### PR TITLE
Pipeline installer: launcher select shows fallback platforms

### DIFF
--- a/src/components/PlatformSelect/PlatformSelect.tsx
+++ b/src/components/PlatformSelect/PlatformSelect.tsx
@@ -1,4 +1,5 @@
 import { forwardRef } from 'react'
+import clsx from 'clsx'
 import styled from 'styled-components'
 import AddonCard from '@components/AddonCard/AddonCard'
 import { getPlatformIcon, getPlatformLabel } from '@pages/AccountPage/DownloadsPage/DownloadsPage'
@@ -15,12 +16,23 @@ interface PlatformSelectProps extends Omit<React.HTMLAttributes<HTMLDivElement>,
   platforms: string[]
   selected: string[]
   onSelect: (platform: string) => void
+  isLoading?: boolean
+  placeholderCount?: number
 }
 
 const linuxInfo = 'This will install Rocky 9 specific environment that should be compatible with all EL9 linux variants'
 
 const PlatformSelect = forwardRef<HTMLDivElement, PlatformSelectProps>(
-  ({ platforms, selected, onSelect, ...props }, ref) => {
+  ({ platforms, selected, onSelect, isLoading, placeholderCount = 3, ...props }, ref) => {
+    if (isLoading) {
+      return (
+        <Container ref={ref} {...props}>
+          {Array.from({ length: placeholderCount }).map((_, i) => (
+            <AddonCard key={`placeholder-${i}`} icon="" className={clsx('loading')} />
+          ))}
+        </Container>
+      )
+    }
     return (
       <Container ref={ref} {...props}>
         {platforms.map((platform) => (

--- a/src/containers/ReleaseInstallerDialog/forms/ReleaseInstallerPlatforms.tsx
+++ b/src/containers/ReleaseInstallerDialog/forms/ReleaseInstallerPlatforms.tsx
@@ -12,6 +12,8 @@ interface ReleaseInstallerPlatformsProps {
   onConfirm: (selected: string[]) => void
 }
 
+const DEFAULT_PLATFORMS = ['windows', 'linux', 'darwin']
+
 export const ReleaseInstallerPlatforms: FC<ReleaseInstallerPlatformsProps> = ({
   releaseInstallers,
   releaseForm,
@@ -38,13 +40,19 @@ export const ReleaseInstallerPlatforms: FC<ReleaseInstallerPlatformsProps> = ({
 
   const handleConfirm = () => onConfirm(selected)
 
+  // fall back to standard platforms so the user always has options, even when
+  // the release manifest has no installers — install pipeline filters by manifest anyway
+  const manifestPlatforms = releaseInstallers.map((i) => i.platform)
+  const platforms = manifestPlatforms.length ? manifestPlatforms : DEFAULT_PLATFORMS
+
   return (
     <>
       <span>Select launcher platforms</span>
       <PlatformSelect
-        platforms={releaseInstallers.map((i) => i.platform)}
+        platforms={platforms}
         selected={selected}
         onSelect={handleSelectPlatform}
+        isLoading={isLoading}
       />
       <Footer onCancel={onCancel} onConfirm={handleConfirm} />
     </>


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Fixes blank "Select launcher platforms" step in the Install pipeline release dialog when the release manifest returns no installers, and adds a loading skeleton so the user no longer sees an empty list mid-fetch.

## Technical details
<!-- Please state any technical details such as limitations -->

- `PlatformSelect` now accepts `isLoading` + `placeholderCount` and renders skeleton `AddonCard`s while loading, matching the `AddonsSelectGrid` pattern.
- `ReleaseInstallerPlatforms` falls back to `['windows', 'linux', 'darwin']` when `releaseInstallers` is empty; `getReleaseInstallUrls` already filters by the manifest, so unmatched selections install nothing harmful.

## Additional context
<!-- Add any other context or screenshots here. -->

Closes #1978
