### PR TITLE
User invites

### DIFF
--- a/shared/src/api/generated/graphql.ts
+++ b/shared/src/api/generated/graphql.ts
@@ -1365,7 +1365,8 @@ export type UserNode = {
   deleted: Scalars['Boolean']['output'];
   disablePasswordLogin: Scalars['Boolean']['output'];
   hasPassword: Scalars['Boolean']['output'];
-  inviteSent?: Maybe<Scalars['DateTime']['output']>;
+  inviteAcceptedAt?: Maybe<Scalars['DateTime']['output']>;
+  inviteSentAt?: Maybe<Scalars['DateTime']['output']>;
   isAdmin: Scalars['Boolean']['output'];
   isDeveloper: Scalars['Boolean']['output'];
   isGuest: Scalars['Boolean']['output'];

--- a/shared/src/api/generated/graphql.ts
+++ b/shared/src/api/generated/graphql.ts
@@ -1365,6 +1365,7 @@ export type UserNode = {
   deleted: Scalars['Boolean']['output'];
   disablePasswordLogin: Scalars['Boolean']['output'];
   hasPassword: Scalars['Boolean']['output'];
+  inviteSent?: Maybe<Scalars['DateTime']['output']>;
   isAdmin: Scalars['Boolean']['output'];
   isDeveloper: Scalars['Boolean']['output'];
   isGuest: Scalars['Boolean']['output'];

--- a/shared/src/api/generated/users.ts
+++ b/shared/src/api/generated/users.ts
@@ -36,6 +36,20 @@ const injectedRtkApi = api.injectEndpoints({
     deleteAvatar: build.mutation<DeleteAvatarApiResponse, DeleteAvatarApiArg>({
       query: (queryArg) => ({ url: `/api/users/${queryArg.userName}/avatar`, method: 'DELETE' }),
     }),
+    inviteUser: build.mutation<InviteUserApiResponse, InviteUserApiArg>({
+      query: (queryArg) => ({
+        url: `/api/users/${queryArg.userName}/invite`,
+        method: 'POST',
+        body: queryArg.inviteUserRequest,
+      }),
+    }),
+    acceptInvite: build.mutation<AcceptInviteApiResponse, AcceptInviteApiArg>({
+      query: (queryArg) => ({
+        url: `/api/users/acceptInvite`,
+        method: 'POST',
+        body: queryArg.acceptInviteRequest,
+      }),
+    }),
     passwordResetRequest: build.mutation<
       PasswordResetRequestApiResponse,
       PasswordResetRequestApiArg
@@ -199,6 +213,15 @@ export type DeleteAvatarApiResponse = /** status 200 Successful Response */ any
 export type DeleteAvatarApiArg = {
   userName: string
 }
+export type InviteUserApiResponse = /** status 200 Successful Response */ any
+export type InviteUserApiArg = {
+  userName: string
+  inviteUserRequest: InviteUserRequest
+}
+export type AcceptInviteApiResponse = /** status 200 Successful Response */ LoginResponseModel
+export type AcceptInviteApiArg = {
+  acceptInviteRequest: AcceptInviteRequest
+}
 export type PasswordResetRequestApiResponse = /** status 200 Successful Response */ any
 export type PasswordResetRequestApiArg = {
   passwordResetRequestModel: PasswordResetRequestModel
@@ -322,6 +345,9 @@ export type ApiKeyPatchModel = {
   label?: string
   expires?: number
 }
+export type InviteUserRequest = {
+  message?: string
+}
 export type PasswordResetRequestModel = {
   email: string
 }
@@ -353,6 +379,10 @@ export type LoginResponseModel = {
   user?: UserModel
   /** URL to redirect the user after login */
   redirectUrl?: string
+}
+export type AcceptInviteRequest = {
+  token: string
+  password?: string
 }
 export type PasswordResetModel = {
   token: string

--- a/shared/src/api/queries/users/getUsers.ts
+++ b/shared/src/api/queries/users/getUsers.ts
@@ -46,7 +46,8 @@ const USERS_QUERY = `
           defaultAccessGroups
           hasPassword
           disablePasswordLogin
-          inviteSent
+          inviteSentAt
+          inviteAcceptedAt
           createdAt
           updatedAt
           apiKeyPreview

--- a/shared/src/api/queries/users/getUsers.ts
+++ b/shared/src/api/queries/users/getUsers.ts
@@ -46,6 +46,7 @@ const USERS_QUERY = `
           defaultAccessGroups
           hasPassword
           disablePasswordLogin
+          inviteSent
           createdAt
           updatedAt
           apiKeyPreview

--- a/shared/src/api/queries/users/updateUsers.ts
+++ b/shared/src/api/queries/users/updateUsers.ts
@@ -13,6 +13,16 @@ const updateUserApi = usersApi.enhanceEndpoints({
         { type: 'user', id: 'LIST' },
       ],
     },
+    inviteUser: {
+      transformErrorResponse: (res) => res.data,
+      invalidatesTags: (_result, _error, { userName }) => [
+        { type: 'user', id: userName },
+        { type: 'user', id: 'LIST' },
+      ],
+    },
+    acceptInvite: {
+      transformErrorResponse: (res) => res.data,
+    },
     setFrontendPreferences: {
       // @ts-expect-error - disableInvalidations is not in the api
       invalidatesTags: (_result, _error, { userName, disableInvalidations }) =>
@@ -147,5 +157,7 @@ export const {
   useUpdateUserAPIKeyMutation,
   useInvalidateUserSessionMutation,
   useSetFrontendPreferencesMutation,
+  useInviteUserMutation,
+  useAcceptInviteMutation,
 } = updateUser2
 export { updateUser2 as userQueries }

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -20,6 +20,7 @@ import ErrorPage from '@pages/ErrorPage'
 import LoadingPage from '@pages/LoadingPage'
 import OnBoardingPage from '@pages/OnBoarding'
 const PasswordResetPage = lazy(() => import('@pages/PasswordResetPage'))
+const AcceptInvitePage = lazy(() => import('@pages/AcceptInvitePage'))
 
 // components
 import ShareDialog from '@components/ShareDialog'
@@ -313,6 +314,9 @@ const App = () => {
 
   if (window.location.pathname.startsWith('/passwordReset')) {
     if (!user.name) return <PasswordResetPage />
+    else window.history.replaceState({}, document.title, '/')
+  } else if (window.location.pathname.startsWith('/acceptInvite')) {
+    if (!user.name) return <AcceptInvitePage />
     else window.history.replaceState({}, document.title, '/')
   }
 

--- a/src/components/DetailHeader.jsx
+++ b/src/components/DetailHeader.jsx
@@ -33,13 +33,14 @@ const DialogStyled = styled(Dialog)`
   }
 `
 
-const DetailHeader = ({ children, onClose, style, context, dialogTitle = '' }) => {
+const DetailHeader = ({ children, onClose, style, context, dialogTitle = '', rightActions }) => {
   const [showContext, setShowContext] = useState(false)
 
   return (
     <HeaderStyled style={style}>
       <div style={{ overflow: 'hidden' }}>{children}</div>
-      {context && (
+      {rightActions}
+      {context && !rightActions && (
         <Button
           icon="more_vert"
           variant="text"
@@ -65,6 +66,7 @@ DetailHeader.propTypes = {
   onClose: PropTypes.func,
   style: PropTypes.object,
   dialogTitle: PropTypes.string,
+  rightActions: PropTypes.node,
 }
 
 export default DetailHeader

--- a/src/components/User/UserDetailsHeader.jsx
+++ b/src/components/User/UserDetailsHeader.jsx
@@ -1,7 +1,12 @@
-import React from 'react'
+import React, { useMemo, useRef, useState } from 'react'
 import PropTypes from 'prop-types'
+import clsx from 'clsx'
 import DetailHeader from '../DetailHeader'
-import { UserImagesStacked } from '@ynput/ayon-react-components'
+import { Button, Dialog, Icon, UserImagesStacked } from '@ynput/ayon-react-components'
+import { Menu, MenuContainer } from '@shared/components'
+import { useMenuContext } from '@shared/context'
+import CodeEditor from '@uiw/react-textarea-code-editor'
+import { copyToClipboard } from '@shared/util'
 import styled from 'styled-components'
 
 const SubHeader = styled.span`
@@ -11,7 +16,7 @@ const SubHeader = styled.span`
   text-overflow: ellipsis;
 `
 
-const UserDetailsHeader = ({ users = [], onClose, subTitle = '', style = {} }) => {
+const UserDetailsHeader = ({ users = [], onClose, subTitle = '', style = {}, menuItems }) => {
   // a single user
   const singleUserEdit = users.length === 1 ? users[0] || ' ' : null
 
@@ -19,19 +24,116 @@ const UserDetailsHeader = ({ users = [], onClose, subTitle = '', style = {} }) =
 
   const title = singleUserEdit ? getUserName(singleUserEdit) : `${users.length} Users Selected`
 
-  return (
-    <DetailHeader onClose={onClose} context={users} dialogTitle="User Context" style={style}>
-      <UserImagesStacked
-        users={users.map((user) => ({
-          avatarUrl: user.name && `/api/users/${user.name}/avatar`,
-          self: user?.self,
-        }))}
+  const buttonRef = useRef(null)
+  const { menuOpen, toggleMenuOpen, setMenuOpen } = useMenuContext()
+  const [showContext, setShowContext] = useState(false)
+
+  const menuId = useMemo(() => {
+    const seed = users.map((u) => u?.name).filter(Boolean).join(',') || 'none'
+    return `user-detail-more-menu-${seed}`
+  }, [users])
+
+  const isOpen = menuOpen === menuId
+  const hasMenu = Array.isArray(menuItems) && menuItems.length > 0
+  const fullItems = hasMenu
+    ? [
+        ...menuItems,
+        {
+          id: 'view-data',
+          label: 'View data',
+          icon: 'data_object',
+          onClick: () => setShowContext(true),
+        },
+      ]
+    : []
+
+  const rawJson = useMemo(() => {
+    try {
+      return JSON.stringify(users, null, 2)
+    } catch {
+      return String(users)
+    }
+  }, [users])
+
+  const rightActions = hasMenu ? (
+    <>
+      <Button
+        ref={buttonRef}
+        icon="more_horiz"
+        variant="text"
+        data-tooltip="More actions"
+        aria-label="More actions"
+        className={clsx({ active: isOpen })}
+        onClick={() => toggleMenuOpen(menuId)}
       />
-      <div>
-        <h2>{title}</h2>
-        <SubHeader>{subTitle}</SubHeader>
-      </div>
-    </DetailHeader>
+      <MenuContainer id={menuId} target={buttonRef.current} align="right">
+        <Menu menu={fullItems} onClose={() => setMenuOpen(false)} />
+      </MenuContainer>
+    </>
+  ) : null
+
+  return (
+    <>
+      <DetailHeader
+        onClose={onClose}
+        context={hasMenu ? undefined : users}
+        dialogTitle="User Context"
+        style={style}
+        rightActions={rightActions}
+      >
+        <UserImagesStacked
+          users={users.map((user) => ({
+            avatarUrl: user.name && `/api/users/${user.name}/avatar`,
+            self: user?.self,
+          }))}
+        />
+        <div>
+          <h2>{title}</h2>
+          <SubHeader>{subTitle}</SubHeader>
+        </div>
+      </DetailHeader>
+      {hasMenu && showContext && (
+        <Dialog
+          header="User Context"
+          isOpen
+          onClose={() => setShowContext(false)}
+          size="lg"
+          style={{ width: '50vw' }}
+        >
+          <style>{`
+            .details-dialog__code { position: relative; }
+            .details-dialog__copy { position: absolute; right: 12px; top: 24px; z-index: 10; background: rgba(0,0,0,0.5); border-radius: 4px; padding: 6px; cursor: pointer; display: none; align-items: center; justify-content: center; }
+            .details-dialog__code:hover .details-dialog__copy, .details-dialog__code:focus-within .details-dialog__copy { display: flex; }
+            .w-tc-editor .token.property { color: #c9a5f7 !important; }
+            .w-tc-editor .token.string { color: #6bc985 !important; }
+            .w-tc-editor .token.number { color: #e5a66b !important; }
+            .w-tc-editor .token.boolean { color: #e5a66b !important; }
+            .w-tc-editor .token.null { color: #7a8a99 !important; }
+            .w-tc-editor .token.punctuation { color: #b0bec5 !important; }
+            .w-tc-editor .token.operator { color: #b0bec5 !important; }
+            .details-dialog__code .w-tc-editor textarea { display: none !important; }
+          `}</style>
+          <div className="details-dialog__code">
+            <div
+              role="button"
+              aria-label="Copy JSON"
+              onClick={() => copyToClipboard(rawJson)}
+              className="details-dialog__copy"
+            >
+              <Icon icon="content_copy" data-tooltip="Copy to clipboard" />
+            </div>
+            <CodeEditor
+              wrap="off"
+              value={rawJson}
+              language="json"
+              placeholder="Please enter JS code."
+              readOnly
+              data-color-mode="dark"
+            />
+          </div>
+        </Dialog>
+      )}
+    </>
   )
 }
 
@@ -40,6 +142,7 @@ UserDetailsHeader.propTypes = {
   onClose: PropTypes.func,
   subTitle: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   style: PropTypes.object,
+  menuItems: PropTypes.array,
 }
 
 export default UserDetailsHeader

--- a/src/pages/AcceptInvitePage.tsx
+++ b/src/pages/AcceptInvitePage.tsx
@@ -1,17 +1,19 @@
 import { useDispatch } from 'react-redux'
 import { login } from '@state/user'
-import api, { useAcceptInviteMutation } from '@shared/api'
+import api, { useAcceptInviteMutation, useGetSiteInfoQuery } from '@shared/api'
 import { toast } from 'react-toastify'
 import { useEffect, useState } from 'react'
 import * as Styled from '@pages/LoginPage/LoginPage.styled'
 import { Button, InputPassword, Panel } from '@ynput/ayon-react-components'
 import DocumentTitle from '@components/DocumentTitle/DocumentTitle'
+import LoginTerms from './LoginPage/LoginTerms'
 
 interface AcceptInviteFormProps {
   token: string
+  logo?: string
 }
 
-const AcceptInviteForm = ({ token }: AcceptInviteFormProps) => {
+const AcceptInviteForm = ({ token, logo }: AcceptInviteFormProps) => {
   const [password, setPassword] = useState('')
   const [confirmPassword, setConfirmPassword] = useState('')
   const [loading, setLoading] = useState(true)
@@ -36,7 +38,10 @@ const AcceptInviteForm = ({ token }: AcceptInviteFormProps) => {
     return (
       <>
         <h1>Invalid invite</h1>
-        <p>This invite link is invalid or has expired. Ask the person who invited you to send a new one.</p>
+        <p>
+          This invite link is invalid or has expired. Ask the person who invited you to send a new
+          one.
+        </p>
         <a href="/login">Back to login page</a>
       </>
     )
@@ -62,8 +67,16 @@ const AcceptInviteForm = ({ token }: AcceptInviteFormProps) => {
 
   return (
     <>
-      <h1>Set a password for your AYON account</h1>
-      <p>Choose a password to finish activating your account and log in.</p>
+      {logo && (
+        <Styled.Logo
+          src={logo}
+          style={{ maxWidth: '100%', height: 'auto', maxHeight: 64, objectFit: 'contain' }}
+        />
+      )}
+      <Styled.Title>You have been invited to join AYON</Styled.Title>
+      <Styled.SubTitle>
+        Please set a password to finish activating your account and log in.
+      </Styled.SubTitle>
       <form onSubmit={handleSubmit}>
         <InputPassword
           autoFocus
@@ -86,11 +99,13 @@ const AcceptInviteForm = ({ token }: AcceptInviteFormProps) => {
           <p style={{ color: 'var(--md-sys-color-error)', margin: 0 }}>Passwords do not match.</p>
         )}
 
-        <Button
-          label={<strong>Set password and log in</strong>}
-          type="submit"
-          disabled={!password || password !== confirmPassword}
-        />
+        <Styled.Note>
+          Password must be at least 8 characters and contain digits and special characters.
+        </Styled.Note>
+        <Button type="submit" variant="filled" disabled={!password || password !== confirmPassword}>
+          Set password and log in
+        </Button>
+        <LoginTerms />
       </form>
     </>
   )
@@ -100,14 +115,21 @@ const AcceptInvitePage = () => {
   const urlParams = new URLSearchParams(window.location.search)
   const token = urlParams.get('token')
 
+  const { data: info, isLoading: isLoadingInfo } = useGetSiteInfoQuery({ full: true })
+  const { loginPageBrand = '', loginPageBackground = '' } = info || {}
+
+  if (isLoadingInfo) return 'Loading...'
+
   return (
     <>
       <DocumentTitle title="Accept invite • AYON" />
       <main className="center">
+        {loginPageBackground && <Styled.BG src={loginPageBackground} />}
+        <Styled.AyonNav src="/AYON.svg" />
         <Styled.LoginForm>
           <Panel>
             {token ? (
-              <AcceptInviteForm token={token} />
+              <AcceptInviteForm token={token} logo={loginPageBrand || '/AYON.svg'} />
             ) : (
               <>
                 <h1>Missing invite token</h1>

--- a/src/pages/AcceptInvitePage.tsx
+++ b/src/pages/AcceptInvitePage.tsx
@@ -1,0 +1,126 @@
+import axios from 'axios'
+import { useDispatch } from 'react-redux'
+import { login } from '@state/user'
+import api from '@shared/api'
+import { toast } from 'react-toastify'
+import { useState, useEffect } from 'react'
+import * as Styled from '@pages/LoginPage/LoginPage.styled'
+import { InputPassword, Button, Panel } from '@ynput/ayon-react-components'
+import DocumentTitle from '@components/DocumentTitle/DocumentTitle'
+
+
+interface AcceptInviteFormProps {
+  token: string
+}
+
+const AcceptInviteForm = ({ token }:AcceptInviteFormProps) => {
+  const [password, setPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [loading, setLoading] = useState(true)
+  const [tokenOk, setTokenOk] = useState(false)
+  const dispatch = useDispatch()
+
+  useEffect(() => {
+    // Check if token is valid
+    // passwordReset will return 200 if token is valid,
+    // if a password is not set, it won't be changed
+    axios
+      .post('/api/users/acceptInvite', { token })
+      .then(() => setTokenOk(true))
+      .catch(() => {})
+      .finally(() => setLoading(false))
+  }, [token])
+
+  if (loading) {
+    return <p>Loading...</p>
+  }
+
+  if (!tokenOk) {
+    return <p>Invalid invite token</p>
+  }
+
+  const handleSubmit = (e) => {
+    e.preventDefault()
+    axios
+      .post('/api/users/acceptInvite', { token, password })
+      .then((response) => {
+        const data = response.data
+        dispatch(login({ user: data.user, accessToken: data.token }))
+        dispatch(api.util.resetApiState())
+        toast.success('Password set successfully')
+        window.history.replaceState({}, '', '/')
+      })
+      .catch((err) => {
+        console.error(err)
+        toast.error(err.response?.data?.detail || 'Unable to set password')
+      })
+  }
+
+  return (
+    <>
+      <h1>Create a new password</h1>
+      <p>Enter a new password for your account.</p>
+      <form onSubmit={handleSubmit}>
+        <InputPassword
+          autoFocus
+          placeholder="Enter your new password"
+          name="password"
+          aria-label="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+
+        <InputPassword
+          placeholder="Confirm your new password"
+          name="confirmPassword"
+          aria-label="Confirm Password"
+          value={confirmPassword}
+          onChange={(e) => setConfirmPassword(e.target.value)}
+        />
+        <Button
+          label="Set new password and log in"
+          type="submit"
+          disabled={!password || password !== confirmPassword}
+        />
+      </form>
+    </>
+  )
+}
+
+const AcceptInvitePage = () => {
+  //get token from query string
+  const urlParams = new URLSearchParams(window.location.search)
+  const token = urlParams.get('token')
+
+  if(!token) {
+    return (
+      <>
+        <DocumentTitle title="Password reset • AYON" />
+        <main className="center">
+          <Styled.LoginForm>
+            <Panel>
+              <p>Missing password reset token</p>
+            </Panel>
+          </Styled.LoginForm>
+        </main>
+      </>
+    )
+  }
+
+
+  return (
+    <>
+      <DocumentTitle title="Password reset • AYON" />
+      <main className="center">
+      <Styled.LoginForm>
+        <Panel>
+          <AcceptInviteForm token={token} />
+        </Panel>
+      </Styled.LoginForm>
+    </main>
+    </>
+  )
+}
+
+export default AcceptInvitePage
+

--- a/src/pages/AcceptInvitePage.tsx
+++ b/src/pages/AcceptInvitePage.tsx
@@ -1,65 +1,68 @@
-import axios from 'axios'
 import { useDispatch } from 'react-redux'
 import { login } from '@state/user'
-import api from '@shared/api'
+import api, { useAcceptInviteMutation } from '@shared/api'
 import { toast } from 'react-toastify'
-import { useState, useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import * as Styled from '@pages/LoginPage/LoginPage.styled'
-import { InputPassword, Button, Panel } from '@ynput/ayon-react-components'
+import { Button, InputPassword, Panel } from '@ynput/ayon-react-components'
 import DocumentTitle from '@components/DocumentTitle/DocumentTitle'
-
 
 interface AcceptInviteFormProps {
   token: string
 }
 
-const AcceptInviteForm = ({ token }:AcceptInviteFormProps) => {
+const AcceptInviteForm = ({ token }: AcceptInviteFormProps) => {
   const [password, setPassword] = useState('')
   const [confirmPassword, setConfirmPassword] = useState('')
   const [loading, setLoading] = useState(true)
   const [tokenOk, setTokenOk] = useState(false)
   const dispatch = useDispatch()
+  const [acceptInvite] = useAcceptInviteMutation()
 
   useEffect(() => {
-    // Check if token is valid
-    // passwordReset will return 200 if token is valid,
-    // if a password is not set, it won't be changed
-    axios
-      .post('/api/users/acceptInvite', { token })
+    // Probe token: backend returns 200 + "Token is valid" when password omitted.
+    acceptInvite({ acceptInviteRequest: { token } })
+      .unwrap()
       .then(() => setTokenOk(true))
       .catch(() => {})
       .finally(() => setLoading(false))
-  }, [token])
+  }, [token, acceptInvite])
 
   if (loading) {
     return <p>Loading...</p>
   }
 
   if (!tokenOk) {
-    return <p>Invalid invite token</p>
+    return (
+      <>
+        <h1>Invalid invite</h1>
+        <p>This invite link is invalid or has expired. Ask the person who invited you to send a new one.</p>
+        <a href="/login">Back to login page</a>
+      </>
+    )
   }
 
-  const handleSubmit = (e) => {
+  const passwordsMismatch = !!confirmPassword && password !== confirmPassword
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
-    axios
-      .post('/api/users/acceptInvite', { token, password })
-      .then((response) => {
-        const data = response.data
-        dispatch(login({ user: data.user, accessToken: data.token }))
-        dispatch(api.util.resetApiState())
-        toast.success('Password set successfully')
-        window.history.replaceState({}, '', '/')
-      })
-      .catch((err) => {
-        console.error(err)
-        toast.error(err.response?.data?.detail || 'Unable to set password')
-      })
+    try {
+      const data = await acceptInvite({ acceptInviteRequest: { token, password } }).unwrap()
+      dispatch(login({ user: data.user, accessToken: data.token }))
+      dispatch(api.util.resetApiState())
+      toast.success('Password set. Welcome to AYON.')
+      window.history.replaceState({}, '', '/')
+    } catch (err) {
+      console.error(err)
+      const detail = (err as { data?: { detail?: string } })?.data?.detail
+      toast.error(detail || 'Unable to set password')
+    }
   }
 
   return (
     <>
-      <h1>Create a new password</h1>
-      <p>Enter a new password for your account.</p>
+      <h1>Set a password for your AYON account</h1>
+      <p>Choose a password to finish activating your account and log in.</p>
       <form onSubmit={handleSubmit}>
         <InputPassword
           autoFocus
@@ -77,8 +80,13 @@ const AcceptInviteForm = ({ token }:AcceptInviteFormProps) => {
           value={confirmPassword}
           onChange={(e) => setConfirmPassword(e.target.value)}
         />
+
+        {passwordsMismatch && (
+          <p style={{ color: 'var(--md-sys-color-error)', margin: 0 }}>Passwords do not match.</p>
+        )}
+
         <Button
-          label="Set new password and log in"
+          label={<strong>Set password and log in</strong>}
           type="submit"
           disabled={!password || password !== confirmPassword}
         />
@@ -88,39 +96,29 @@ const AcceptInviteForm = ({ token }:AcceptInviteFormProps) => {
 }
 
 const AcceptInvitePage = () => {
-  //get token from query string
   const urlParams = new URLSearchParams(window.location.search)
   const token = urlParams.get('token')
 
-  if(!token) {
-    return (
-      <>
-        <DocumentTitle title="Password reset • AYON" />
-        <main className="center">
-          <Styled.LoginForm>
-            <Panel>
-              <p>Missing password reset token</p>
-            </Panel>
-          </Styled.LoginForm>
-        </main>
-      </>
-    )
-  }
-
-
   return (
     <>
-      <DocumentTitle title="Password reset • AYON" />
+      <DocumentTitle title="Accept invite • AYON" />
       <main className="center">
-      <Styled.LoginForm>
-        <Panel>
-          <AcceptInviteForm token={token} />
-        </Panel>
-      </Styled.LoginForm>
-    </main>
+        <Styled.LoginForm>
+          <Panel>
+            {token ? (
+              <AcceptInviteForm token={token} />
+            ) : (
+              <>
+                <h1>Missing invite token</h1>
+                <p>This page expects an invite link. Open the link from your invitation email.</p>
+                <a href="/login">Back to login page</a>
+              </>
+            )}
+          </Panel>
+        </Styled.LoginForm>
+      </main>
     </>
   )
 }
 
 export default AcceptInvitePage
-

--- a/src/pages/AcceptInvitePage.tsx
+++ b/src/pages/AcceptInvitePage.tsx
@@ -54,7 +54,8 @@ const AcceptInviteForm = ({ token }: AcceptInviteFormProps) => {
       window.history.replaceState({}, '', '/')
     } catch (err) {
       console.error(err)
-      const detail = (err as { data?: { detail?: string } })?.data?.detail
+      const e = err as { detail?: string; data?: { detail?: string } }
+      const detail = e?.detail || e?.data?.detail
       toast.error(detail || 'Unable to set password')
     }
   }

--- a/src/pages/AcceptInvitePage.tsx
+++ b/src/pages/AcceptInvitePage.tsx
@@ -8,12 +8,38 @@ import { Button, InputPassword, Panel } from '@ynput/ayon-react-components'
 import DocumentTitle from '@components/DocumentTitle/DocumentTitle'
 import LoginTerms from './LoginPage/LoginTerms'
 
+const AcceptInviteSkeleton = ({ logo }: { logo?: string }) => (
+  <>
+    {logo && (
+      <Styled.Logo
+        src={logo}
+        style={{ maxWidth: '100%', height: 'auto', maxHeight: 64, objectFit: 'contain' }}
+      />
+    )}
+    <Styled.Title className="loading">You have been invited to join AYON</Styled.Title>
+    <Styled.SubTitle className="loading">
+      Please set a password to finish activating your account and log in.
+    </Styled.SubTitle>
+    <div style={{ display: 'flex', flexDirection: 'column', width: '100%', gap: 'var(--base-gap-large)' }}>
+      <InputPassword className="loading" placeholder="Enter your new password" readOnly />
+      <InputPassword className="loading" placeholder="Confirm your new password" readOnly />
+      <Styled.Note className="loading">
+        Password must be at least 8 characters and contain digits and special characters.
+      </Styled.Note>
+      <Button className="loading" variant="filled" disabled>
+        Set password and log in
+      </Button>
+    </div>
+  </>
+)
+
 interface AcceptInviteFormProps {
   token: string
   logo?: string
+  ssoLabel?: string
 }
 
-const AcceptInviteForm = ({ token, logo }: AcceptInviteFormProps) => {
+const AcceptInviteForm = ({ token, logo, ssoLabel }: AcceptInviteFormProps) => {
   const [password, setPassword] = useState('')
   const [confirmPassword, setConfirmPassword] = useState('')
   const [loading, setLoading] = useState(true)
@@ -31,7 +57,7 @@ const AcceptInviteForm = ({ token, logo }: AcceptInviteFormProps) => {
   }, [token, acceptInvite])
 
   if (loading) {
-    return <p>Loading...</p>
+    return <AcceptInviteSkeleton logo={logo} />
   }
 
   if (!tokenOk) {
@@ -105,6 +131,11 @@ const AcceptInviteForm = ({ token, logo }: AcceptInviteFormProps) => {
         <Button type="submit" variant="filled" disabled={!password || password !== confirmPassword}>
           Set password and log in
         </Button>
+        {ssoLabel && (
+          <Styled.Note style={{ textAlign: 'center' }}>
+            Or <a href="/login">{ssoLabel}</a> instead.
+          </Styled.Note>
+        )}
         <LoginTerms />
       </form>
     </>
@@ -116,9 +147,15 @@ const AcceptInvitePage = () => {
   const token = urlParams.get('token')
 
   const { data: info, isLoading: isLoadingInfo } = useGetSiteInfoQuery({ full: true })
-  const { loginPageBrand = '', loginPageBackground = '' } = info || {}
-
-  if (isLoadingInfo) return 'Loading...'
+  const { loginPageBrand = '', loginPageBackground = '', ssoOptions = [] } = info || {}
+  const visibleSso = ssoOptions.filter((opt) => !opt.hidden)
+  const capitalize = (s: string) => (s ? s[0].toUpperCase() + s.slice(1) : s)
+  const ssoLabel =
+    visibleSso.length === 1
+      ? capitalize(visibleSso[0].title || `sign in with ${visibleSso[0].name}`)
+      : visibleSso.length > 1
+        ? 'Use another sign-in method'
+        : undefined
 
   return (
     <>
@@ -128,8 +165,10 @@ const AcceptInvitePage = () => {
         <Styled.AyonNav src="/AYON.svg" />
         <Styled.LoginForm>
           <Panel>
-            {token ? (
-              <AcceptInviteForm token={token} logo={loginPageBrand || '/AYON.svg'} />
+            {isLoadingInfo ? (
+              <AcceptInviteSkeleton logo="/AYON.svg" />
+            ) : token ? (
+              <AcceptInviteForm token={token} logo={loginPageBrand || '/AYON.svg'} ssoLabel={ssoLabel} />
             ) : (
               <>
                 <h1>Missing invite token</h1>

--- a/src/pages/LoginPage/LoginPage.jsx
+++ b/src/pages/LoginPage/LoginPage.jsx
@@ -12,6 +12,7 @@ import DocumentTitle from '@components/DocumentTitle/DocumentTitle'
 import * as Styled from './LoginPage.styled'
 import remarkGfm from 'remark-gfm'
 import Markdown from 'react-markdown'
+import LoginTerms from './LoginTerms'
 
 const LoginPage = ({ isFirstTime = false }) => {
   const dispatch = useDispatch()
@@ -34,7 +35,6 @@ const LoginPage = ({ isFirstTime = false }) => {
   const { data: info = {}, isLoading: isLoadingInfo } = useGetSiteInfoQuery({ full: true })
   const { motd, loginPageBrand = '', loginPageBackground = '' } = info
 
-
   // store the current url in local storage to preserve the redirect across auth flows
 
   useEffect(() => {
@@ -42,7 +42,6 @@ const LoginPage = ({ isFirstTime = false }) => {
     console.debug('Storing preferred URL in local storage:', window.location.href)
     localStorage.setItem('auth-preferred-url', window.location.href)
   }, [])
-
 
   // Password login handler
 
@@ -71,11 +70,9 @@ const LoginPage = ({ isFirstTime = false }) => {
 
     localStorage.removeItem('auth-preferred-url')
     toast.info(response.data.detail)
-    dispatch(login({ user: response.data.user, accessToken: response.data.token, }))
+    dispatch(login({ user: response.data.user, accessToken: response.data.token }))
     dispatch(api.util.resetApiState())
   } // handleSubmit
-
-
 
   const handleSSOCallback = async (ssoOptions) => {
     // First we check if there's a provider name in the URL
@@ -85,7 +82,7 @@ const LoginPage = ({ isFirstTime = false }) => {
     console.debug('handleSSOCallback', provider)
 
     // If we don't have any SSO options, we can't proceed. Abort
-    if (!ssoOptions?.length && provider !== "_token") return
+    if (!ssoOptions?.length && provider !== '_token') return
 
     // Get the query string from the URL to use in the callback
     const qs = new URLSearchParams(window.location.search)
@@ -93,20 +90,18 @@ const LoginPage = ({ isFirstTime = false }) => {
     // If the query string is empty, we can't proceed. Abort
     if (!qs.toString()) return
 
-
     // Clear the query string from the URL
     // This is important to avoid confusion with the next login attempts
     // (we don't want to keep the query string in the URL after login)
-    
-    window.history.replaceState({}, '', window.location.pathname)
 
+    window.history.replaceState({}, '', window.location.pathname)
 
     // Get the provider config
     // We need to handle the situation ssoOptions is undefined.
     // That happens, when user is already logged in
     // but wants to re-login using a token
     let providerConfig = (info?.ssoOptions || []).find((o) => o.name === provider)
-    if (provider === "_token") {
+    if (provider === '_token') {
       // special case for token auth
       // we don't have a providerConfig for this, but we can still proceed
       providerConfig = {
@@ -144,7 +139,7 @@ const LoginPage = ({ isFirstTime = false }) => {
     }
 
     // If we have a response and it contains user data, we're good to go
-    
+
     let user = null
     let accessToken = null
 
@@ -166,13 +161,12 @@ const LoginPage = ({ isFirstTime = false }) => {
       success = false
     }
 
-
     if (success) {
       // Still, we need to figure out where to redirect the user after login
-      // At this point we may have redirect URL from the response, but that 
+      // At this point we may have redirect URL from the response, but that
       // is optional and used sparsely.
 
-      if ((!redirectUrl) && localStorage.getItem('auth-preferred-url')) {
+      if (!redirectUrl && localStorage.getItem('auth-preferred-url')) {
         redirectUrl = localStorage.getItem('auth-preferred-url')
       }
 
@@ -185,8 +179,6 @@ const LoginPage = ({ isFirstTime = false }) => {
       localStorage.removeItem('auth-preferred-url')
       dispatch(login({ user, accessToken, redirectUrl }))
       dispatch(api.util.resetApiState())
-
-
     } else {
       // we don't want to retry!
       // Clear everything
@@ -194,9 +186,7 @@ const LoginPage = ({ isFirstTime = false }) => {
       setIsLoading(false)
       localStorage.removeItem('auth-preferred-url')
     }
-
   } // handleSSOCallback
-
 
   // Handle SSO callback after redirection from SSO provider
   // (this needs to be called after sso options are loaded)
@@ -205,18 +195,17 @@ const LoginPage = ({ isFirstTime = false }) => {
     handleSSOCallback(info.ssoOptions)
   }, [info.ssoOptions])
 
-
   //
   // Render logic (what are we showing?)
   //
 
   // Should we show the password login?
 
-  let showPasswordLogin = (
-    showAllProviders
-    || !info?.hidePasswordAuth
-    || (featuredProviders?.length && featuredProviders.includes('password'))
-  ) || null
+  let showPasswordLogin =
+    showAllProviders ||
+    !info?.hidePasswordAuth ||
+    (featuredProviders?.length && featuredProviders.includes('password')) ||
+    null
 
   // Should we show "Show all login options" button?
 
@@ -228,7 +217,11 @@ const LoginPage = ({ isFirstTime = false }) => {
     if (!info.ssoOptions?.length) return null
 
     return info.ssoOptions
-      .filter(({ name, hidden }) => !hidden && (!featuredProviders?.length || featuredProviders.includes(name) || showAllProviders))
+      .filter(
+        ({ name, hidden }) =>
+          !hidden &&
+          (!featuredProviders?.length || featuredProviders.includes(name) || showAllProviders),
+      )
       .map(({ name, title, url, args, redirectKey, icon, color, textColor }) => {
         const queryDict = { ...args }
         const redirect_uri = `${window.location.origin}/login/${name}`
@@ -254,7 +247,6 @@ const LoginPage = ({ isFirstTime = false }) => {
 
   if (isLoading || isLoadingInfo) return isFirstTime ? null : <LoadingPage />
 
-
   //
   // Render the login page
   //
@@ -263,76 +255,70 @@ const LoginPage = ({ isFirstTime = false }) => {
     <>
       <DocumentTitle title="Login • AYON" />
       <main className="center">
-      {loginPageBackground && <Styled.BG src={loginPageBackground} />}
-      <Styled.LoginForm>
-        {(motd || loginPageBrand) && (
+        {loginPageBackground && <Styled.BG src={loginPageBackground} />}
+        <Styled.LoginForm>
+          {(motd || loginPageBrand) && (
+            <Panel>
+              {loginPageBrand && <Styled.Logo src={loginPageBrand} />}
+              <Styled.MessageMarkdown>
+                <Markdown remarkPlugins={remarkGfm}>{motd}</Markdown>
+              </Styled.MessageMarkdown>
+            </Panel>
+          )}
           <Panel>
-            {loginPageBrand && <Styled.Logo src={loginPageBrand} />}
-            <Styled.MessageMarkdown>
-              <Markdown remarkPlugins={remarkGfm}>{motd}</Markdown>
-            </Styled.MessageMarkdown>
-          </Panel>
-        )}
-        <Panel>
-          <Styled.Ayon src="/AYON.svg" />
+            <Styled.Ayon src="/AYON.svg" />
 
-          <Styled.Methods>
-            {showPasswordLogin ? (
-              <form onSubmit={handleSubmit}>
-                <label id="username">Username</label>
-                <InputText
-                  autoFocus
-                  placeholder="Enter your username"
-                  name="username"
-                  aria-label="Username"
-                  value={name}
-                  onChange={(e) => setName(e.target.value)}
-                />
-                <label id="password">Password</label>
-                <InputPassword
-                  placeholder="Enter password"
-                  name="password"
-                  aria-label="Password"
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                />
-                <Button type="submit">
-                  <span className="label">Login with password</span>
-                </Button>
-              </form>
-            ) : (
+            <Styled.Methods>
+              {showPasswordLogin ? (
+                <form onSubmit={handleSubmit}>
+                  <label id="username">Username</label>
+                  <InputText
+                    autoFocus
+                    placeholder="Enter your username"
+                    name="username"
+                    aria-label="Username"
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                  />
+                  <label id="password">Password</label>
+                  <InputPassword
+                    placeholder="Enter password"
+                    name="password"
+                    aria-label="Password"
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                  />
+                  <Button type="submit">
+                    <span className="label">Login with password</span>
+                  </Button>
+                </form>
+              ) : (
                 <>
-                {/* we need a margin between the logo and the SSO buttons */}
-                <div style={{ marginBottom: '8px' }} />
+                  {/* we need a margin between the logo and the SSO buttons */}
+                  <div style={{ marginBottom: '8px' }} />
                 </>
+              )}
+
+              {ssoButtons}
+            </Styled.Methods>
+            {info?.passwordRecoveryAvailable && showPasswordLogin && (
+              <a href="/passwordReset" style={{ margin: '8px 0' }}>
+                Reset password
+              </a>
             )}
-
-            {ssoButtons}
-
-          </Styled.Methods>
-          {info?.passwordRecoveryAvailable && showPasswordLogin && (
-            <a href="/passwordReset" style={{ margin: '8px 0' }}>
-              Reset password
-            </a>
-          )}
-          {showAllButton && (
-            <Button style={{ width: '100%' }} variant="text" onClick={() => setShowAllProviders(true)}>
-              Show all login options
-            </Button>
-          )}
-          <Styled.TandCs>
-            By logging in you agree to our{' '}
-            <a href={'https://ynput.io/terms/'} target="_blank">
-              Terms of Service
-            </a>{' '}
-            and{' '}
-            <a href={'https://ynput.io/privacy-policy'} target="_blank">
-              Privacy Policy
-            </a>
-          </Styled.TandCs>
-        </Panel>
-      </Styled.LoginForm>
-    </main>
+            {showAllButton && (
+              <Button
+                style={{ width: '100%' }}
+                variant="text"
+                onClick={() => setShowAllProviders(true)}
+              >
+                Show all login options
+              </Button>
+            )}
+            <LoginTerms />
+          </Panel>
+        </Styled.LoginForm>
+      </main>
     </>
   )
 }

--- a/src/pages/LoginPage/LoginPage.styled.ts
+++ b/src/pages/LoginPage/LoginPage.styled.ts
@@ -1,4 +1,3 @@
-import Markdown from 'react-markdown'
 import styled from 'styled-components'
 import { markdownStyle } from './markdown'
 import { theme } from '@ynput/ayon-react-components'
@@ -94,6 +93,13 @@ export const Methods = styled.div`
 export const Ayon = styled.img`
   height: 60px;
 `
+
+export const AyonNav = styled.img`
+  height: 32px;
+  position: absolute;
+  top: 16px;
+  left: 16px;
+`
 export const Logo = styled.img`
   max-height: 100%;
   width: 100%;
@@ -124,4 +130,17 @@ export const TandCs = styled.p`
     color: var(--md-sys-color-outline);
     ${theme.bodySmall}
   }
+`
+
+export const Title = styled.h1`
+  ${theme.titleMedium}
+`
+
+export const SubTitle = styled.span`
+  ${theme.bodyMedium}
+`
+
+export const Note = styled.span`
+  ${theme.labelMedium}
+  color: var(--md-sys-color-outline);
 `

--- a/src/pages/LoginPage/LoginTerms.tsx
+++ b/src/pages/LoginPage/LoginTerms.tsx
@@ -1,0 +1,18 @@
+import * as Styled from './LoginPage.styled'
+
+const LoginTerms = () => {
+  return (
+    <Styled.TandCs>
+      By logging in you agree to our{' '}
+      <a href={'https://ynput.io/terms/'} target="_blank">
+        Terms of Service
+      </a>{' '}
+      and{' '}
+      <a href={'https://ynput.io/privacy-policy'} target="_blank">
+        Privacy Policy
+      </a>
+    </Styled.TandCs>
+  )
+}
+
+export default LoginTerms

--- a/src/pages/SettingsPage/UsersSettings/DeleteUserDialog.styled.ts
+++ b/src/pages/SettingsPage/UsersSettings/DeleteUserDialog.styled.ts
@@ -8,7 +8,8 @@ export const FooterContainer = styled.div`
 `
 
 export const FooterLabel = styled.label`
-margin: 2px 0 14px 0;`
+  margin: 2px 0 14px 0;
+`
 
 export const FooterActions = styled.div`
   display: flex;
@@ -23,6 +24,7 @@ export const ConfirmInput = styled(InputText)`
 `
 
 export const StyledDialog = styled(Dialog)`
+  max-height: 600px;
   .body {
     overflow: hidden;
     display: flex;

--- a/src/pages/SettingsPage/UsersSettings/InvitationStatus.tsx
+++ b/src/pages/SettingsPage/UsersSettings/InvitationStatus.tsx
@@ -19,33 +19,62 @@ export const getInvitationState = (user: InvitationFields): InvitationState => {
   return Date.now() - sentMs > INVITE_TTL_MS ? 'expired' : 'pending'
 }
 
-const Pill = styled.span<{ $state: Exclude<InvitationState, 'none'> }>`
+const Pill = styled.span<{ $state: Exclude<InvitationState, 'none'>; $plain?: boolean }>`
   display: inline-flex;
   align-items: center;
   gap: var(--base-gap-small);
   font-size: 0.9rem;
   white-space: nowrap;
 
-  .icon {
-    ${({ $state }) => {
-      if ($state === 'pending') return `color: var(--md-sys-color-primary);`
-      if ($state === 'accepted') return `color: var(--md-sys-color-tertiary);`
-      return `color: var(--md-sys-color-warning);`
-    }}
-  }
+  ${({ $plain, $state }) =>
+    $plain
+      ? `
+        .icon {
+          ${
+            $state === 'pending'
+              ? 'color: var(--md-sys-color-primary);'
+              : $state === 'accepted'
+                ? 'color: var(--md-sys-color-tertiary);'
+                : 'color: var(--md-sys-color-warning);'
+          }
+        }
+      `
+      : `
+        height: 32px;
+        padding: 0 8px;
+        border-radius: var(--border-radius-m);
+        .icon { color: inherit; }
+        ${
+          $state === 'pending'
+            ? `
+              background-color: var(--md-sys-color-primary-container);
+              color: var(--md-sys-color-on-primary-container);
+            `
+            : $state === 'accepted'
+              ? `
+                background-color: var(--md-sys-color-tertiary-container);
+                color: var(--md-sys-color-on-tertiary-container);
+              `
+              : `
+                background-color: var(--md-sys-color-warning-container);
+                color: var(--md-sys-color-on-warning-container);
+              `
+        }
+      `}
 `
 
 interface InvitationStatusProps {
   user: InvitationFields
+  plain?: boolean
 }
 
-export const InvitationStatus: FC<InvitationStatusProps> = ({ user }) => {
+export const InvitationStatus: FC<InvitationStatusProps> = ({ user, plain }) => {
   const state = getInvitationState(user)
   if (state === 'none') return null
 
   if (state === 'accepted') {
     return (
-      <Pill $state="accepted">
+      <Pill $state="accepted" $plain={plain}>
         <Icon icon="check_circle" />
         {`Accepted - ${formatDistance(new Date(user.inviteAcceptedAt!), new Date(), { addSuffix: true })}`}
       </Pill>
@@ -57,7 +86,7 @@ export const InvitationStatus: FC<InvitationStatusProps> = ({ user }) => {
 
   if (state === 'expired') {
     return (
-      <Pill $state="expired">
+      <Pill $state="expired" $plain={plain}>
         <Icon icon="cancel" />
         {`Expired - sent ${sentText}`}
       </Pill>
@@ -65,7 +94,7 @@ export const InvitationStatus: FC<InvitationStatusProps> = ({ user }) => {
   }
 
   return (
-    <Pill $state="pending">
+    <Pill $state="pending" $plain={plain}>
       <Icon icon="hourglass" />
       {`Pending - Sent ${sentText}`}
     </Pill>

--- a/src/pages/SettingsPage/UsersSettings/InvitationStatus.tsx
+++ b/src/pages/SettingsPage/UsersSettings/InvitationStatus.tsx
@@ -23,32 +23,16 @@ const Pill = styled.span<{ $state: Exclude<InvitationState, 'none'> }>`
   display: inline-flex;
   align-items: center;
   gap: var(--base-gap-small);
-  height: 32px;
-  padding: 0 8px;
-  border-radius: var(--border-radius-m);
   font-size: 0.9rem;
   white-space: nowrap;
 
   .icon {
-    color: inherit;
+    ${({ $state }) => {
+      if ($state === 'pending') return `color: var(--md-sys-color-primary);`
+      if ($state === 'accepted') return `color: var(--md-sys-color-tertiary);`
+      return `color: var(--md-sys-color-warning);`
+    }}
   }
-
-  ${({ $state }) => {
-    if ($state === 'pending')
-      return `
-        background-color: var(--md-sys-color-primary-container);
-        color: var(--md-sys-color-on-primary-container);
-      `
-    if ($state === 'accepted')
-      return `
-        background-color: var(--md-sys-color-tertiary-container);
-        color: var(--md-sys-color-on-tertiary-container);
-      `
-    return `
-      background-color: var(--md-sys-color-warning-container);
-      color: var(--md-sys-color-on-warning-container);
-    `
-  }}
 `
 
 interface InvitationStatusProps {

--- a/src/pages/SettingsPage/UsersSettings/InvitationStatus.tsx
+++ b/src/pages/SettingsPage/UsersSettings/InvitationStatus.tsx
@@ -1,0 +1,90 @@
+import { FC } from 'react'
+import styled from 'styled-components'
+import { Icon } from '@ynput/ayon-react-components'
+import { formatDistance } from 'date-fns'
+
+const INVITE_TTL_MS = 7 * 24 * 60 * 60 * 1000
+
+export type InvitationState = 'none' | 'pending' | 'accepted' | 'expired'
+
+type InvitationFields = {
+  inviteSentAt?: string | null
+  inviteAcceptedAt?: string | null
+}
+
+export const getInvitationState = (user: InvitationFields): InvitationState => {
+  if (user.inviteAcceptedAt) return 'accepted'
+  if (!user.inviteSentAt) return 'none'
+  const sentMs = new Date(user.inviteSentAt).getTime()
+  return Date.now() - sentMs > INVITE_TTL_MS ? 'expired' : 'pending'
+}
+
+const Pill = styled.span<{ $state: Exclude<InvitationState, 'none'> }>`
+  display: inline-flex;
+  align-items: center;
+  gap: var(--base-gap-small);
+  padding: 2px 8px;
+  border-radius: var(--border-radius-m);
+  font-size: 0.9rem;
+  white-space: nowrap;
+
+  .icon {
+    color: inherit;
+  }
+
+  ${({ $state }) => {
+    if ($state === 'pending')
+      return `
+        background-color: var(--md-sys-color-primary-container);
+        color: var(--md-sys-color-on-primary-container);
+      `
+    if ($state === 'accepted')
+      return `
+        background-color: var(--md-sys-color-tertiary-container);
+        color: var(--md-sys-color-on-tertiary-container);
+      `
+    return `
+      background-color: var(--md-sys-color-warning-container);
+      color: var(--md-sys-color-on-warning-container);
+    `
+  }}
+`
+
+interface InvitationStatusProps {
+  user: InvitationFields
+}
+
+export const InvitationStatus: FC<InvitationStatusProps> = ({ user }) => {
+  const state = getInvitationState(user)
+  if (state === 'none') return null
+
+  if (state === 'accepted') {
+    return (
+      <Pill $state="accepted">
+        <Icon icon="check_circle" />
+        {`Accepted - ${formatDistance(new Date(user.inviteAcceptedAt!), new Date(), { addSuffix: true })}`}
+      </Pill>
+    )
+  }
+
+  const sent = new Date(user.inviteSentAt!)
+  const sentText = formatDistance(sent, new Date(), { addSuffix: true })
+
+  if (state === 'expired') {
+    return (
+      <Pill $state="expired">
+        <Icon icon="cancel" />
+        {`Expired - sent ${sentText}`}
+      </Pill>
+    )
+  }
+
+  return (
+    <Pill $state="pending">
+      <Icon icon="hourglass" />
+      {`Pending - Sent ${sentText}`}
+    </Pill>
+  )
+}
+
+export default InvitationStatus

--- a/src/pages/SettingsPage/UsersSettings/InvitationStatus.tsx
+++ b/src/pages/SettingsPage/UsersSettings/InvitationStatus.tsx
@@ -23,7 +23,8 @@ const Pill = styled.span<{ $state: Exclude<InvitationState, 'none'> }>`
   display: inline-flex;
   align-items: center;
   gap: var(--base-gap-small);
-  padding: 2px 8px;
+  height: 32px;
+  padding: 0 8px;
   border-radius: var(--border-radius-m);
   font-size: 0.9rem;
   white-space: nowrap;

--- a/src/pages/SettingsPage/UsersSettings/InviteUserDialog.tsx
+++ b/src/pages/SettingsPage/UsersSettings/InviteUserDialog.tsx
@@ -9,7 +9,8 @@ import * as Styled from './DeleteUserDialog.styled'
 export type InviteCandidate = {
   name: string
   attrib?: { email?: string; fullName?: string }
-  inviteSent?: string | null
+  inviteSentAt?: string | null
+  inviteAcceptedAt?: string | null
   active?: boolean
 }
 
@@ -112,12 +113,17 @@ const InviteUserDialog = ({ isOpen, onHide, selectedUserList }: Props) => {
                   {u.name}
                   {u.attrib?.email && <span style={{ opacity: 0.6 }}> — {u.attrib.email}</span>}
                 </span>
-                {u.inviteSent && (
+                {u.inviteAcceptedAt ? (
+                  <span style={{ opacity: 0.6 }}>
+                    Accepted{' '}
+                    {formatDistance(new Date(u.inviteAcceptedAt), new Date(), { addSuffix: true })}
+                  </span>
+                ) : u.inviteSentAt ? (
                   <span style={{ opacity: 0.6 }}>
                     Last invited{' '}
-                    {formatDistance(new Date(u.inviteSent), new Date(), { addSuffix: true })}
+                    {formatDistance(new Date(u.inviteSentAt), new Date(), { addSuffix: true })}
                   </span>
-                )}
+                ) : null}
               </div>
             ))}
           </Styled.UserList>

--- a/src/pages/SettingsPage/UsersSettings/InviteUserDialog.tsx
+++ b/src/pages/SettingsPage/UsersSettings/InviteUserDialog.tsx
@@ -10,6 +10,7 @@ export type InviteCandidate = {
   name: string
   attrib?: { email?: string; fullName?: string }
   inviteSent?: string | null
+  active?: boolean
 }
 
 type Props = {
@@ -24,15 +25,13 @@ const InviteUserDialog = ({ isOpen, onHide, selectedUserList }: Props) => {
 
   if (!isOpen) return null
 
-  const invitable = selectedUserList.filter((u) => !!u.attrib?.email)
-  const skipped = selectedUserList.filter((u) => !u.attrib?.email)
+  const invitable = selectedUserList.filter((u) => !!u.attrib?.email && u.active)
+  const skipped = selectedUserList.filter((u) => !u.attrib?.email || !u.active)
 
   const handleSend = async () => {
     setSending(true)
     const results = await Promise.allSettled(
-      invitable.map((u) =>
-        inviteUser({ userName: u.name, inviteUserRequest: {} }).unwrap(),
-      ),
+      invitable.map((u) => inviteUser({ userName: u.name, inviteUserRequest: {} }).unwrap()),
     )
     setSending(false)
 
@@ -57,11 +56,7 @@ const InviteUserDialog = ({ isOpen, onHide, selectedUserList }: Props) => {
     onHide()
   }
 
-  const headerCount = invitable.length || selectedUserList.length
-  const header =
-    headerCount === 1
-      ? `Invite ${(invitable[0] ?? selectedUserList[0]).name}`
-      : `Invite ${invitable.length} of ${selectedUserList.length} users`
+  const header = 'Invite users to AYON by email'
 
   return (
     <Styled.StyledDialog
@@ -73,7 +68,12 @@ const InviteUserDialog = ({ isOpen, onHide, selectedUserList }: Props) => {
             <Button label="Cancel" onClick={onHide} disabled={sending} />
             <Button
               variant="filled"
-              label={sending ? 'Sending...' : 'Send invite'}
+              label={
+                sending
+                  ? 'Sending...'
+                  : `Send ${invitable.length} ${invitable.length > 1 ? 'invites' : 'invite'}`
+              }
+              icon="send"
               onClick={handleSend}
               disabled={sending || invitable.length === 0}
             />
@@ -89,15 +89,14 @@ const InviteUserDialog = ({ isOpen, onHide, selectedUserList }: Props) => {
           variant="warning"
           message={
             invitable.length === 0
-              ? 'None of the selected users have an email. Nothing to send.'
-              : `${invitable.length} of ${selectedUserList.length} will be invited — ${skipped.length} have no email.`
+              ? 'None of the selected users are active and have an email.'
+              : `${invitable.length} of ${selectedUserList.length} will be invited — ${skipped.length} skipped (no email or inactive).`
           }
         />
       )}
 
       {invitable.length > 0 && (
         <>
-          <Styled.FooterLabel>Will be invited</Styled.FooterLabel>
           <Styled.UserList>
             {invitable.map((u) => (
               <div
@@ -111,9 +110,7 @@ const InviteUserDialog = ({ isOpen, onHide, selectedUserList }: Props) => {
               >
                 <span>
                   {u.name}
-                  {u.attrib?.email && (
-                    <span style={{ opacity: 0.6 }}> — {u.attrib.email}</span>
-                  )}
+                  {u.attrib?.email && <span style={{ opacity: 0.6 }}> — {u.attrib.email}</span>}
                 </span>
                 {u.inviteSent && (
                   <span style={{ opacity: 0.6 }}>
@@ -129,10 +126,13 @@ const InviteUserDialog = ({ isOpen, onHide, selectedUserList }: Props) => {
 
       {skipped.length > 0 && (
         <>
-          <Styled.FooterLabel style={{ marginTop: 16 }}>Skipped (no email)</Styled.FooterLabel>
+          <Styled.FooterLabel style={{ marginTop: 16 }}>Skipped</Styled.FooterLabel>
           <Styled.UserList>
             {skipped.map((u) => (
-              <div key={u.name}>{u.name}</div>
+              <div key={u.name}>
+                {u.name}
+                <span style={{ opacity: 0.6 }}>{!u.active ? ' — inactive' : ' — no email'}</span>
+              </div>
             ))}
           </Styled.UserList>
         </>

--- a/src/pages/SettingsPage/UsersSettings/InviteUserDialog.tsx
+++ b/src/pages/SettingsPage/UsersSettings/InviteUserDialog.tsx
@@ -1,0 +1,144 @@
+import { useState } from 'react'
+import { toast } from 'react-toastify'
+import { formatDistance } from 'date-fns'
+import { Button } from '@ynput/ayon-react-components'
+import { useInviteUserMutation } from '@shared/api'
+import InfoMessage from '@components/InfoMessage'
+import * as Styled from './DeleteUserDialog.styled'
+
+export type InviteCandidate = {
+  name: string
+  attrib?: { email?: string; fullName?: string }
+  inviteSent?: string | null
+}
+
+type Props = {
+  isOpen: boolean
+  onHide: () => void
+  selectedUserList: InviteCandidate[]
+}
+
+const InviteUserDialog = ({ isOpen, onHide, selectedUserList }: Props) => {
+  const [sending, setSending] = useState(false)
+  const [inviteUser] = useInviteUserMutation()
+
+  if (!isOpen) return null
+
+  const invitable = selectedUserList.filter((u) => !!u.attrib?.email)
+  const skipped = selectedUserList.filter((u) => !u.attrib?.email)
+
+  const handleSend = async () => {
+    setSending(true)
+    const results = await Promise.allSettled(
+      invitable.map((u) =>
+        inviteUser({ userName: u.name, inviteUserRequest: {} }).unwrap(),
+      ),
+    )
+    setSending(false)
+
+    const succeeded = results.filter((r) => r.status === 'fulfilled').length
+    const failed = results.length - succeeded
+
+    if (succeeded) {
+      toast.success(`Sent ${succeeded} invite${succeeded === 1 ? '' : 's'}`)
+    }
+    if (failed) {
+      results.forEach((r, i) => {
+        if (r.status === 'rejected') {
+          const detail =
+            (r as PromiseRejectedResult).reason?.detail ||
+            (r as PromiseRejectedResult).reason?.message ||
+            'Invite failed'
+          toast.error(`${invitable[i].name}: ${detail}`)
+        }
+      })
+      return
+    }
+    onHide()
+  }
+
+  const headerCount = invitable.length || selectedUserList.length
+  const header =
+    headerCount === 1
+      ? `Invite ${(invitable[0] ?? selectedUserList[0]).name}`
+      : `Invite ${invitable.length} of ${selectedUserList.length} users`
+
+  return (
+    <Styled.StyledDialog
+      size="md"
+      header={header}
+      footer={
+        <Styled.FooterContainer>
+          <Styled.FooterActions>
+            <Button label="Cancel" onClick={onHide} disabled={sending} />
+            <Button
+              variant="filled"
+              label={sending ? 'Sending...' : 'Send invite'}
+              onClick={handleSend}
+              disabled={sending || invitable.length === 0}
+            />
+          </Styled.FooterActions>
+        </Styled.FooterContainer>
+      }
+      isOpen={true}
+      onClose={onHide}
+    >
+      {skipped.length > 0 && (
+        <InfoMessage
+          style={{ marginBottom: 16 }}
+          variant="warning"
+          message={
+            invitable.length === 0
+              ? 'None of the selected users have an email. Nothing to send.'
+              : `${invitable.length} of ${selectedUserList.length} will be invited — ${skipped.length} have no email.`
+          }
+        />
+      )}
+
+      {invitable.length > 0 && (
+        <>
+          <Styled.FooterLabel>Will be invited</Styled.FooterLabel>
+          <Styled.UserList>
+            {invitable.map((u) => (
+              <div
+                key={u.name}
+                style={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  gap: 8,
+                  padding: '2px 0',
+                }}
+              >
+                <span>
+                  {u.name}
+                  {u.attrib?.email && (
+                    <span style={{ opacity: 0.6 }}> — {u.attrib.email}</span>
+                  )}
+                </span>
+                {u.inviteSent && (
+                  <span style={{ opacity: 0.6 }}>
+                    Last invited{' '}
+                    {formatDistance(new Date(u.inviteSent), new Date(), { addSuffix: true })}
+                  </span>
+                )}
+              </div>
+            ))}
+          </Styled.UserList>
+        </>
+      )}
+
+      {skipped.length > 0 && (
+        <>
+          <Styled.FooterLabel style={{ marginTop: 16 }}>Skipped (no email)</Styled.FooterLabel>
+          <Styled.UserList>
+            {skipped.map((u) => (
+              <div key={u.name}>{u.name}</div>
+            ))}
+          </Styled.UserList>
+        </>
+      )}
+    </Styled.StyledDialog>
+  )
+}
+
+export default InviteUserDialog

--- a/src/pages/SettingsPage/UsersSettings/UserLicenseForm.tsx
+++ b/src/pages/SettingsPage/UsersSettings/UserLicenseForm.tsx
@@ -1,13 +1,27 @@
 import { useGetUserPoolsQuery, UserPoolModel } from '@shared/api'
-import { Dropdown, FormLayout, FormRow, InputSwitch } from '@ynput/ayon-react-components'
+import { Button, Dropdown, FormLayout, FormRow, InputSwitch } from '@ynput/ayon-react-components'
 import { FC } from 'react'
 import styled from 'styled-components'
+import InvitationStatus, { getInvitationState } from './InvitationStatus'
 
 const FormRowStyled = styled(FormRow)`
   .label {
     min-width: 160px;
   }
 `
+
+const InvitationRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: var(--base-gap-large);
+  flex-wrap: wrap;
+`
+
+interface InvitationUser {
+  inviteSentAt?: string | null
+  inviteAcceptedAt?: string | null
+  attrib?: { email?: string }
+}
 
 interface UserLicenseFormProps {
   active: boolean
@@ -16,6 +30,10 @@ interface UserLicenseFormProps {
   isDisabled?: boolean
   onActiveChange: (value: boolean) => void
   onPoolChange: (value: string) => void
+  user?: InvitationUser | null
+  onInvite?: () => void
+  isInviting?: boolean
+  inviteDisabled?: boolean
 }
 
 const UserLicenseForm: FC<UserLicenseFormProps> = ({
@@ -25,6 +43,10 @@ const UserLicenseForm: FC<UserLicenseFormProps> = ({
   isDisabled,
   onActiveChange,
   onPoolChange,
+  user,
+  onInvite,
+  isInviting,
+  inviteDisabled,
 }) => {
   // GET LICENSE USER POOLS
   const { data: userPools = [], isLoading: isLoadingPools } = useGetUserPoolsQuery()
@@ -62,6 +84,26 @@ const UserLicenseForm: FC<UserLicenseFormProps> = ({
               data-tooltip-as="markdown"
               onChange={(value) => onPoolChange(value[0])}
             />
+          </FormRowStyled>
+        )}
+        {user && onInvite && (
+          <FormRowStyled label="Invitation">
+            <InvitationRow>
+              <Button
+                label={
+                  isInviting
+                    ? 'Sending...'
+                    : getInvitationState(user) === 'pending'
+                      ? 'Resend'
+                      : 'Invite'
+                }
+                icon="mail"
+                onClick={onInvite}
+                disabled={inviteDisabled || isInviting || !user.attrib?.email}
+                data-tooltip={!user.attrib?.email ? 'User has no email' : undefined}
+              />
+              <InvitationStatus user={user} />
+            </InvitationRow>
           </FormRowStyled>
         )}
       </FormLayout>

--- a/src/pages/SettingsPage/UsersSettings/UserLicenseForm.tsx
+++ b/src/pages/SettingsPage/UsersSettings/UserLicenseForm.tsx
@@ -32,7 +32,6 @@ interface UserLicenseFormProps {
   onPoolChange: (value: string) => void
   user?: InvitationUser | null
   onInvite?: () => void
-  isInviting?: boolean
   inviteDisabled?: boolean
 }
 
@@ -45,7 +44,6 @@ const UserLicenseForm: FC<UserLicenseFormProps> = ({
   onPoolChange,
   user,
   onInvite,
-  isInviting,
   inviteDisabled,
 }) => {
   // GET LICENSE USER POOLS
@@ -90,17 +88,10 @@ const UserLicenseForm: FC<UserLicenseFormProps> = ({
           <FormRowStyled label="Invitation">
             <InvitationRow>
               <Button
-                label={
-                  isInviting
-                    ? 'Sending...'
-                    : getInvitationState(user) === 'pending'
-                      ? 'Resend'
-                      : 'Invite'
-                }
+                label={getInvitationState(user) === 'pending' ? 'Resend' : 'Invite'}
                 icon="mail"
                 onClick={onInvite}
-                disabled={inviteDisabled || isInviting || !user.attrib?.email}
-                data-tooltip={!user.attrib?.email ? 'User has no email' : undefined}
+                disabled={inviteDisabled}
               />
               <InvitationStatus user={user} />
             </InvitationRow>

--- a/src/pages/SettingsPage/UsersSettings/UserList.jsx
+++ b/src/pages/SettingsPage/UsersSettings/UserList.jsx
@@ -113,11 +113,9 @@ const UserList = ({
     const ctxSelection = userList.filter((u) => newSelectedUsers.includes(u.name))
     const ctxHasInvitable = ctxSelection.some((u) => !!u.attrib?.email)
     const inviteLabel =
-      ctxSelection.length === 1
-        ? ctxSelection[0]?.inviteSentAt
-          ? 'Resend invite'
-          : 'Invite user'
-        : 'Invite users'
+      ctxSelection.length === 1 && getInvitationState(ctxSelection[0]) === 'pending'
+        ? 'Resend'
+        : 'Invite'
 
     return [
       {

--- a/src/pages/SettingsPage/UsersSettings/UserList.jsx
+++ b/src/pages/SettingsPage/UsersSettings/UserList.jsx
@@ -12,6 +12,17 @@ import clsx from 'clsx'
 import useTableLoadingData from '@hooks/useTableLoadingData'
 import { useGetUserPoolsQuery } from '@shared/api'
 import { accessGroupsSortFunction, userPoolSortFunction } from './tableSorting'
+import InvitationStatus, { getInvitationState } from './InvitationStatus'
+
+const INVITE_SORT_RANK = { none: 0, expired: 1, pending: 2, accepted: 3 }
+
+const inviteStatusSortFunction = (event) => {
+  const { data, order } = event
+  return [...data].sort((a, b) => {
+    const diff = INVITE_SORT_RANK[getInvitationState(a)] - INVITE_SORT_RANK[getInvitationState(b)]
+    return order === 1 ? diff : -diff
+  })
+}
 
 const StyledProfileRow = styled.div`
   display: flex;
@@ -103,7 +114,7 @@ const UserList = ({
     const ctxHasInvitable = ctxSelection.some((u) => !!u.attrib?.email)
     const inviteLabel =
       ctxSelection.length === 1
-        ? ctxSelection[0]?.inviteSent
+        ? ctxSelection[0]?.inviteSentAt
           ? 'Resend invite'
           : 'Invite user'
         : 'Invite users'
@@ -214,17 +225,18 @@ const UserList = ({
             resizeable
           />
           <Column
-            header="Guest (legacy)"
-            body={(rowData) => (rowData.isGuest ? 'yes' : '')}
-            field="isGuest"
-            sortable
-            resizeable
-          />
-          <Column
             header="Active"
             body={(rowData) => (rowData.active ? 'yes' : '')}
             field="active"
             sortable
+            resizeable
+          />
+          <Column
+            header="Invitation"
+            field="inviteSentAt"
+            body={(rowData) => <InvitationStatus user={rowData} />}
+            sortable
+            sortFunction={inviteStatusSortFunction}
             resizeable
           />
         </DataTable>

--- a/src/pages/SettingsPage/UsersSettings/UserList.jsx
+++ b/src/pages/SettingsPage/UsersSettings/UserList.jsx
@@ -67,9 +67,11 @@ const UserList = ({
   setShowRenameUser,
   setShowDeleteUser,
   setShowSetPassword,
+  setShowInviteUser,
   isLoading,
   onSelectUsers,
   isSelfSelected,
+  managerDisabled,
 }) => {
   // GET LICENSE USER POOLS
   const { data: userPools = [] } = useGetUserPoolsQuery()
@@ -97,6 +99,15 @@ const UserList = ({
 
   // IDEA: Can these go into the details panel as well?
   const ctxMenuItems = (newSelectedUsers) => {
+    const ctxSelection = userList.filter((u) => newSelectedUsers.includes(u.name))
+    const ctxHasInvitable = ctxSelection.some((u) => !!u.attrib?.email)
+    const inviteLabel =
+      ctxSelection.length === 1
+        ? ctxSelection[0]?.inviteSent
+          ? 'Resend invite'
+          : 'Invite user'
+        : 'Invite users'
+
     return [
       {
         label: 'Set username',
@@ -109,6 +120,12 @@ const UserList = ({
         disabled: selection.length !== 1,
         command: () => setShowSetPassword(true),
         icon: 'key',
+      },
+      {
+        label: inviteLabel,
+        disabled: !ctxHasInvitable || managerDisabled,
+        command: () => setShowInviteUser(true),
+        icon: 'mail',
       },
       {
         label: 'Delete selected',

--- a/src/pages/SettingsPage/UsersSettings/UserList.jsx
+++ b/src/pages/SettingsPage/UsersSettings/UserList.jsx
@@ -232,7 +232,7 @@ const UserList = ({
           <Column
             header="Invitation"
             field="inviteSentAt"
-            body={(rowData) => <InvitationStatus user={rowData} />}
+            body={(rowData) => <InvitationStatus user={rowData} plain />}
             sortable
             sortFunction={inviteStatusSortFunction}
             resizeable

--- a/src/pages/SettingsPage/UsersSettings/UsersSettings.jsx
+++ b/src/pages/SettingsPage/UsersSettings/UsersSettings.jsx
@@ -235,7 +235,6 @@ const UsersSettings = () => {
               data-shortcut="n"
             />
             <Button onClick={openNewServiceUser} label="Add Service User" icon="person_add" />
-            <UsersOverview users={userList} />
             <form style={{ flex: 1 }} autoComplete="off" onSubmit={(e) => e.preventDefault()}>
               <InputText
                 style={{ width: '100%', minWidth: 150 }}
@@ -245,6 +244,7 @@ const UsersSettings = () => {
                 autoComplete="search-users"
               />
             </form>
+            <UsersOverview users={userList} />
             <Button
               onClick={() => setShowInviteUser(true)}
               label="Send Invite"
@@ -289,6 +289,7 @@ const UsersSettings = () => {
                   selectedUsers={selectedUsers}
                   setShowSetPassword={setShowSetPassword}
                   setShowDeleteUser={setShowDeleteUser}
+                  setShowInviteUser={setShowInviteUser}
                   setSelectedUsers={setSelectedUsers}
                   isSelfSelected={isSelfSelected}
                   selectedUserList={selectedUserList}

--- a/src/pages/SettingsPage/UsersSettings/UsersSettings.jsx
+++ b/src/pages/SettingsPage/UsersSettings/UsersSettings.jsx
@@ -249,11 +249,7 @@ const UsersSettings = () => {
               onClick={() => setShowInviteUser(true)}
               label="Send Invite"
               icon="mail"
-              disabled={
-                !selectedUsers.length ||
-                !selectedUserList.some((u) => !!u.attrib?.email) ||
-                managerDisabled
-              }
+              disabled={!selectedUsers.length}
             />
             <ImportDialogButton importContext="user" />
             <Button label="Licenses" icon="groups" onClick={() => setShowLicenses(true)} />

--- a/src/pages/SettingsPage/UsersSettings/UsersSettings.jsx
+++ b/src/pages/SettingsPage/UsersSettings/UsersSettings.jsx
@@ -21,6 +21,7 @@ import NewServiceUser from './newServiceUser'
 import { useGetAccessGroupsQuery } from '@queries/accessGroups/getAccessGroups'
 import Shortcuts from '@containers/Shortcuts'
 import DeleteUserDialog from './DeleteUserDialog'
+import InviteUserDialog from './InviteUserDialog'
 import LicensesDialog from '@components/LicensesDialog/LicensesDialog'
 import { useQueryParam } from 'use-query-params'
 import ImportDialogButton from '@containers/ImportDialog/ImportDialogButton'
@@ -77,6 +78,7 @@ const UsersSettings = () => {
   const [showNewServiceUser, setShowNewServiceUser] = useState(false)
   const [showRenameUser, setShowRenameUser] = useState(false)
   const [showDeleteUser, setShowDeleteUser] = useState(false)
+  const [showInviteUser, setShowInviteUser] = useState(false)
   const [showSetPassword, setShowSetPassword] = useState(false)
   const [showLicenses, setShowLicenses] = useQueryParam('licenses', false)
 
@@ -225,7 +227,14 @@ const UsersSettings = () => {
       <main>
         <Section>
           <Toolbar>
-            <Button label="Licenses" onClick={() => setShowLicenses(true)} />
+            <Button
+              onClick={openNewUser}
+              label="Add New User"
+              icon="person_add"
+              variant="filled"
+              data-shortcut="n"
+            />
+            <Button onClick={openNewServiceUser} label="Add Service User" icon="person_add" />
             <UsersOverview users={userList} />
             <form style={{ flex: 1 }} autoComplete="off" onSubmit={(e) => e.preventDefault()}>
               <InputText
@@ -236,20 +245,18 @@ const UsersSettings = () => {
                 autoComplete="search-users"
               />
             </form>
+            <Button
+              onClick={() => setShowInviteUser(true)}
+              label="Send Invite"
+              icon="mail"
+              disabled={
+                !selectedUsers.length ||
+                !selectedUserList.some((u) => !!u.attrib?.email) ||
+                managerDisabled
+              }
+            />
             <ImportDialogButton importContext="user" />
-            <Button
-              onClick={() => setShowDeleteUser(selectedUsers)}
-              label="Delete Users"
-              icon="person_remove"
-              disabled={!selectedUsers.length || isSelfSelected || managerDisabled}
-            />
-            <Button onClick={openNewServiceUser} label="Add Service User" icon="person_add" />
-            <Button
-              onClick={openNewUser}
-              label="Add New User"
-              icon="person_add"
-              data-shortcut="n"
-            />
+            <Button label="Licenses" icon="groups" onClick={() => setShowLicenses(true)} />
           </Toolbar>
           <Splitter
             style={{ width: '100%', height: '100%' }}
@@ -269,8 +276,10 @@ const UsersSettings = () => {
                   setShowSetPassword,
                   setShowRenameUser,
                   setShowDeleteUser,
+                  setShowInviteUser,
                   isLoading,
                   isSelfSelected,
+                  managerDisabled,
                 }}
               />
             </SplitterPanel>
@@ -283,6 +292,7 @@ const UsersSettings = () => {
                   setShowRenameUser={setShowRenameUser}
                   selectedUsers={selectedUsers}
                   setShowSetPassword={setShowSetPassword}
+                  setShowDeleteUser={setShowDeleteUser}
                   setSelectedUsers={setSelectedUsers}
                   isSelfSelected={isSelfSelected}
                   selectedUserList={selectedUserList}
@@ -309,6 +319,14 @@ const UsersSettings = () => {
             onHide={() => setShowDeleteUser(false)}
             onDelete={() => handleDelete(selectedUsers)}
             onDisable={() => handleDisable(selectedUsers)}
+          />
+        )}
+
+        {showInviteUser && (
+          <InviteUserDialog
+            isOpen={showInviteUser}
+            selectedUserList={selectedUserList}
+            onHide={() => setShowInviteUser(false)}
           />
         )}
 

--- a/src/pages/SettingsPage/UsersSettings/userDetail.jsx
+++ b/src/pages/SettingsPage/UsersSettings/userDetail.jsx
@@ -9,7 +9,7 @@ import {
   LockedInput,
   SaveButton,
 } from '@ynput/ayon-react-components'
-import { useUpdateUsersMutation, useInviteUserMutation } from '@shared/api'
+import { useUpdateUsersMutation } from '@shared/api'
 import { updateUserData, updateUserAttribs } from '@state/user'
 import styled from 'styled-components'
 import ayonClient from '@/ayon'
@@ -196,6 +196,7 @@ const UserDetail = ({
   selectedUsers,
   setShowSetPassword,
   setShowDeleteUser,
+  setShowInviteUser,
   setSelectedUsers,
   isSelfSelected,
   selectedUserList,
@@ -288,19 +289,10 @@ const UserDetail = ({
   ]
 
   const [updateUsers, { isLoading: isUpdating }] = useUpdateUsersMutation()
-  const [inviteUser, { isLoading: isInviting }] = useInviteUserMutation()
 
-  const handleInvite = async () => {
+  const handleInvite = () => {
     if (!singleUserEdit) return
-    try {
-      await inviteUser({
-        userName: singleUserEdit.name,
-        inviteUserRequest: {},
-      }).unwrap()
-      toast.success(`Invite sent to ${singleUserEdit.attrib?.email || singleUserEdit.name}`)
-    } catch (err) {
-      toast.error(err?.data?.detail || err?.message || 'Invite failed')
-    }
+    setShowInviteUser?.(true)
   }
 
   //
@@ -467,10 +459,7 @@ const UserDetail = ({
                 isDisabled={isSelfSelected}
                 user={singleUserEdit}
                 onInvite={handleInvite}
-                isInviting={isInviting}
-                inviteDisabled={
-                  managerDisabled || !singleUserEdit?.active || !singleUserEdit?.attrib?.email
-                }
+                inviteDisabled={managerDisabled}
               />
             </Panel>
           )}

--- a/src/pages/SettingsPage/UsersSettings/userDetail.jsx
+++ b/src/pages/SettingsPage/UsersSettings/userDetail.jsx
@@ -9,9 +9,8 @@ import {
   LockedInput,
   SaveButton,
 } from '@ynput/ayon-react-components'
-import { useUpdateUsersMutation } from '@shared/api'
+import { useUpdateUsersMutation, useInviteUserMutation } from '@shared/api'
 import { updateUserData, updateUserAttribs } from '@state/user'
-import { formatDistance } from 'date-fns'
 import styled from 'styled-components'
 import ayonClient from '@/ayon'
 import UserAttribForm from './UserAttribForm'
@@ -289,6 +288,20 @@ const UserDetail = ({
   ]
 
   const [updateUsers, { isLoading: isUpdating }] = useUpdateUsersMutation()
+  const [inviteUser, { isLoading: isInviting }] = useInviteUserMutation()
+
+  const handleInvite = async () => {
+    if (!singleUserEdit) return
+    try {
+      await inviteUser({
+        userName: singleUserEdit.name,
+        inviteUserRequest: {},
+      }).unwrap()
+      toast.success(`Invite sent to ${singleUserEdit.attrib?.email || singleUserEdit.name}`)
+    } catch (err) {
+      toast.error(err?.data?.detail || err?.message || 'Invite failed')
+    }
+  }
 
   //
   // API
@@ -433,15 +446,6 @@ const UserDetail = ({
                   disabled={managerDisabled}
                 />
               </FormRow>
-              {singleUserEdit.inviteSent && (
-                <FormRow label="Invited" key="Invited">
-                  <span style={{ opacity: 0.7 }}>
-                    {formatDistance(new Date(singleUserEdit.inviteSent), new Date(), {
-                      addSuffix: true,
-                    })}
-                  </span>
-                </FormRow>
-              )}
               {formData && (
                 <UserAttribForm
                   formData={formData}
@@ -461,6 +465,12 @@ const UserDetail = ({
                 isPoolMixed={formData._mixedFields.includes('userPool')}
                 onPoolChange={(value) => setFormData({ ...formData, userPool: value })}
                 isDisabled={isSelfSelected}
+                user={singleUserEdit}
+                onInvite={handleInvite}
+                isInviting={isInviting}
+                inviteDisabled={
+                  managerDisabled || !singleUserEdit?.active || !singleUserEdit?.attrib?.email
+                }
               />
             </Panel>
           )}

--- a/src/pages/SettingsPage/UsersSettings/userDetail.jsx
+++ b/src/pages/SettingsPage/UsersSettings/userDetail.jsx
@@ -11,6 +11,7 @@ import {
 } from '@ynput/ayon-react-components'
 import { useUpdateUsersMutation } from '@shared/api'
 import { updateUserData, updateUserAttribs } from '@state/user'
+import { formatDistance } from 'date-fns'
 import styled from 'styled-components'
 import ayonClient from '@/ayon'
 import UserAttribForm from './UserAttribForm'
@@ -195,6 +196,7 @@ const UserDetail = ({
   setShowRenameUser,
   selectedUsers,
   setShowSetPassword,
+  setShowDeleteUser,
   setSelectedUsers,
   isSelfSelected,
   selectedUserList,
@@ -272,6 +274,19 @@ const UserDetail = ({
   const singleUserEdit = selectedUsers.length === 1 ? formUsers[0] : null
   // check if any users have the userLevel of service
   const hasServiceUser = formUsers.some((user) => user.isService)
+
+  const deleteLabel = formUsers.length === 1 ? 'Delete user' : 'Delete users'
+
+  const headerMenuItems = [
+    {
+      id: 'delete',
+      label: deleteLabel,
+      icon: 'delete',
+      danger: true,
+      disabled: !selectedUsers.length || isSelfSelected || managerDisabled,
+      onClick: () => setShowDeleteUser?.(selectedUsers),
+    },
+  ]
 
   const [updateUsers, { isLoading: isUpdating }] = useUpdateUsersMutation()
 
@@ -392,6 +407,7 @@ const UserDetail = ({
         users={formUsers}
         onClose={onClose}
         subTitle={headerAccessGroups.length ? headerAccessGroups.join(', ') : 'No AccessGroups'}
+        menuItems={headerMenuItems}
       />
       {hasServiceUser && singleUserEdit ? (
         <FormsStyled>
@@ -417,6 +433,15 @@ const UserDetail = ({
                   disabled={managerDisabled}
                 />
               </FormRow>
+              {singleUserEdit.inviteSent && (
+                <FormRow label="Invited" key="Invited">
+                  <span style={{ opacity: 0.7 }}>
+                    {formatDistance(new Date(singleUserEdit.inviteSent), new Date(), {
+                      addSuffix: true,
+                    })}
+                  </span>
+                </FormRow>
+              )}
               {formData && (
                 <UserAttribForm
                   formData={formData}


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Managers can invite users by email. Recipients open the tokenised link, set their own password on `/acceptInvite`, and are logged in.

## Technical details
<!-- Please state any technical details such as limitations -->

- Wires backend `/api/users/{name}/invite` + `/acceptInvite` (ynput/ayon-backend#934) via generated `useInviteUserMutation` / `useAcceptInviteMutation` with user-list cache invalidation.
- Invite entry points: toolbar button, right-click context menu, detail-panel dropdown, all gated on `attrib.email` and existing `managerDisabled` rules.
- `inviteSent` added to `USERS_QUERY` so the detail panel shows "Invited X ago".

## Additional context
<!-- Add any other context or screenshots here. -->
<img width="2938" height="764" alt="Screenshot 2026-05-21 at 10 01 12" src="https://github.com/user-attachments/assets/482e0a27-770c-4175-b167-7092e1546e8e" />
<img width="1913" height="879" alt="Screenshot 2026-05-21 at 10 01 04" src="https://github.com/user-attachments/assets/7176dbf2-9388-4b6a-8656-f7bdd4e7dd18" />

Depends on ynput/ayon-backend#934.
