### PR TITLE
Home: Details panel can become 0 width

### DIFF
--- a/src/features/dashboard.js
+++ b/src/features/dashboard.js
@@ -16,7 +16,6 @@ const dashboardSlice = createSlice({
       assignees: getInitialStateLocalStorage('dashboard-tasks-assignees', []),
       assigneesFilter: getInitialStateLocalStorage('dashboard-tasks-assigneesFilter', 'me'),
       collapsedColumns: getInitialStateLocalStorage('dashboard-tasks-collapsedColumns', []),
-      draggingIds: [],
     },
   },
   reducers: {
@@ -64,12 +63,6 @@ const dashboardSlice = createSlice({
       state.tasks.assigneesFilter = 'me'
       state.tasks.collapsedColumns = []
     },
-    onDraggingStart: (state, { payload }) => {
-      state.tasks.draggingIds = payload
-    },
-    onDraggingEnd: (state) => {
-      state.tasks.draggingIds = []
-    },
   },
 })
 
@@ -84,8 +77,6 @@ export const {
   onCollapsedColumnsChanged,
   onPrefetchIds,
   onClearDashboard,
-  onDraggingStart,
-  onDraggingEnd,
 } = dashboardSlice.actions
 export default dashboardSlice.reducer
 

--- a/src/pages/UserDashboardPage/UserDashboardTasks/UserDashboardKanBan.jsx
+++ b/src/pages/UserDashboardPage/UserDashboardTasks/UserDashboardKanBan.jsx
@@ -16,12 +16,7 @@ import { toast } from 'react-toastify'
 
 import ColumnsWrapper from './ColumnsWrapper'
 import DashboardTasksToolbar from './DashboardTasksToolbar/DashboardTasksToolbar'
-import {
-  onCollapsedColumnsChanged,
-  onDraggingEnd,
-  onDraggingStart,
-  onTaskSelected,
-} from '@state/dashboard'
+import { onCollapsedColumnsChanged, onTaskSelected } from '@state/dashboard'
 import KanBanCardOverlay from './KanBanCard/KanBanCardOverlay'
 import { StringParam, useQueryParam, withDefault } from 'use-query-params'
 import UserDashboardList from './UserDashboardList/UserDashboardList'
@@ -213,15 +208,6 @@ const UserDashboardKanBan = ({
   const [activeDraggingId, setActiveDraggingId] = useState(null)
 
   const handleDragStart = (event) => {
-    const isSelected = selectedTasks.includes(event.active.id)
-
-    let draggingTasks = []
-    // set dragging id
-    if (isSelected) draggingTasks = selectedTasks
-    else draggingTasks = [event.active.id]
-
-    dispatch(onDraggingStart(draggingTasks))
-
     setActiveDraggingId(event.active.id)
     // select card
     if (!selectedTasks.includes(event.active.id)) {
@@ -232,13 +218,10 @@ const UserDashboardKanBan = ({
   }
 
   const handleDragCancel = (event) => {
-    dispatch(onDraggingEnd())
     setActiveDraggingId(null)
   }
 
   const handleDragEnd = async (event) => {
-    dispatch(onDraggingEnd())
-
     setActiveDraggingId(null)
     // first check if field can be edited on task
     if (splitByField.isEditable === false)

--- a/src/pages/UserDashboardPage/UserDashboardTasks/UserDashboardKanBan.jsx
+++ b/src/pages/UserDashboardPage/UserDashboardTasks/UserDashboardKanBan.jsx
@@ -32,6 +32,7 @@ const UserDashboardKanBan = ({
   priorities,
   projectUsers = [],
   isLoadingProjectUsers,
+  onDragStateChange,
 }) => {
   const dispatch = useDispatch()
 
@@ -208,6 +209,7 @@ const UserDashboardKanBan = ({
   const [activeDraggingId, setActiveDraggingId] = useState(null)
 
   const handleDragStart = (event) => {
+    onDragStateChange?.(true)
     setActiveDraggingId(event.active.id)
     // select card
     if (!selectedTasks.includes(event.active.id)) {
@@ -218,10 +220,12 @@ const UserDashboardKanBan = ({
   }
 
   const handleDragCancel = () => {
+    onDragStateChange?.(false)
     setActiveDraggingId(null)
   }
 
   const handleDragEnd = async (event) => {
+    onDragStateChange?.(false)
     setActiveDraggingId(null)
     // first check if field can be edited on task
     if (splitByField.isEditable === false)

--- a/src/pages/UserDashboardPage/UserDashboardTasks/UserDashboardKanBan.jsx
+++ b/src/pages/UserDashboardPage/UserDashboardTasks/UserDashboardKanBan.jsx
@@ -32,7 +32,6 @@ const UserDashboardKanBan = ({
   priorities,
   projectUsers = [],
   isLoadingProjectUsers,
-  onDragStateChange,
 }) => {
   const dispatch = useDispatch()
 
@@ -209,7 +208,6 @@ const UserDashboardKanBan = ({
   const [activeDraggingId, setActiveDraggingId] = useState(null)
 
   const handleDragStart = (event) => {
-    onDragStateChange?.(true)
     setActiveDraggingId(event.active.id)
     // select card
     if (!selectedTasks.includes(event.active.id)) {
@@ -220,12 +218,10 @@ const UserDashboardKanBan = ({
   }
 
   const handleDragCancel = () => {
-    onDragStateChange?.(false)
     setActiveDraggingId(null)
   }
 
   const handleDragEnd = async (event) => {
-    onDragStateChange?.(false)
     setActiveDraggingId(null)
     // first check if field can be edited on task
     if (splitByField.isEditable === false)

--- a/src/pages/UserDashboardPage/UserDashboardTasks/UserDashboardKanBan.jsx
+++ b/src/pages/UserDashboardPage/UserDashboardTasks/UserDashboardKanBan.jsx
@@ -217,7 +217,7 @@ const UserDashboardKanBan = ({
     }
   }
 
-  const handleDragCancel = (event) => {
+  const handleDragCancel = () => {
     setActiveDraggingId(null)
   }
 

--- a/src/pages/UserDashboardPage/UserDashboardTasks/UserTasksContainer.jsx
+++ b/src/pages/UserDashboardPage/UserDashboardTasks/UserTasksContainer.jsx
@@ -12,7 +12,7 @@ import { EmptyPlaceholder } from '@shared/components'
 import { parseProjectFolderRowId } from '@containers/ProjectsList/buildProjectsTableData'
 
 import UserDashboardKanBan from './UserDashboardKanBan'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo } from 'react'
 import { onAssigneesChanged, onTaskSelected } from '@state/dashboard'
 import { SplitterPanel } from 'primereact/splitter'
 import { getIntersectionFields, getMergedFields } from '../util'
@@ -55,22 +55,6 @@ const UserTasksContainer = ({ projectsInfo = {}, isLoadingInfo }) => {
   const assigneesState = useSelector((state) => state.dashboard.tasks.assignees)
   const assigneesFilter = useSelector((state) => state.dashboard.tasks.assigneesFilter)
   const handleOpenViewer = (args) => dispatch(openViewer(args))
-
-  const [isDragging, setIsDragging] = useState(false)
-  const handleDragStateChange = useCallback((dragging) => setIsDragging(dragging), [])
-
-  // Safety net: if dnd-kit fails to fire dragEnd/dragCancel (view switch mid-drag,
-  // double-click race), a global pointerup forces the panel back to visible.
-  useEffect(() => {
-    if (!isDragging) return
-    const reset = () => setIsDragging(false)
-    window.addEventListener('pointerup', reset)
-    window.addEventListener('pointercancel', reset)
-    return () => {
-      window.removeEventListener('pointerup', reset)
-      window.removeEventListener('pointercancel', reset)
-    }
-  }, [isDragging])
 
   let assignees = []
   switch (assigneesFilter) {
@@ -271,7 +255,6 @@ const UserTasksContainer = ({ projectsInfo = {}, isLoadingInfo }) => {
           priorities={priorities}
           projectUsers={projectUsers}
           isLoadingProjectUsers={isLoadingProjectUsers}
-          onDragStateChange={handleDragStateChange}
         />
         <RelatedTasksModule
           isPanelOpen={isPanelOpen}
@@ -284,12 +267,10 @@ const UserTasksContainer = ({ projectsInfo = {}, isLoadingInfo }) => {
 
       <SplitterPanel
         size={1}
-        className={clsx('details-panel-splitter', 'details', { dragging: isDragging })}
+        className={clsx('details-panel-splitter', 'details')}
         style={{
-          maxWidth: isDragging
-            ? 0
-            : `clamp(${detailsMinWidth}px, ${detailsMaxWidth}, ${detailsMaxMaxWidth}px)`,
-          minWidth: isDragging ? 0 : detailsMinWidth,
+          maxWidth: `clamp(${detailsMinWidth}px, ${detailsMaxWidth}, ${detailsMaxMaxWidth}px)`,
+          minWidth: detailsMinWidth,
         }}
       >
         {/* Lists are project-scoped — only resolve a context when the selection is in

--- a/src/pages/UserDashboardPage/UserDashboardTasks/UserTasksContainer.jsx
+++ b/src/pages/UserDashboardPage/UserDashboardTasks/UserTasksContainer.jsx
@@ -14,25 +14,14 @@ import { parseProjectFolderRowId } from '@containers/ProjectsList/buildProjectsT
 import UserDashboardKanBan from './UserDashboardKanBan'
 import { useEffect, useMemo } from 'react'
 import { onAssigneesChanged, onTaskSelected } from '@state/dashboard'
-import { Splitter, SplitterPanel } from 'primereact/splitter'
+import { SplitterPanel } from 'primereact/splitter'
 import { getIntersectionFields, getMergedFields } from '../util'
 import transformKanbanTasks from './transformKanbanTasks'
-import styled from 'styled-components'
 import clsx from 'clsx'
 import { openViewer } from '@state/viewer'
 import RelatedTasksModule from './RelatedTasks'
 import DetailsPanelSplitter from '@components/DetailsPanelSplitter'
 import { EntityListsContextBoundary } from '@pages/ProjectListsPage/context'
-
-const StyledSplitter = styled(Splitter)`
-  .details-panel-splitter {
-    /* This is a crazy hack to prevent the cursor being out of line with the dragging card */
-    &.dragging {
-      transition: max-width 0s, min-width 0s;
-      transition-delay: 0.1s;
-    }
-  }
-`
 
 export const getThumbnailUrl = ({ entityId, entityType, thumbnailId, updatedAt, projectName }) => {
   // If projectName is not provided or neither thumbnailId nor entityId and entityType are provided, return null
@@ -65,9 +54,6 @@ const UserTasksContainer = ({ projectsInfo = {}, isLoadingInfo }) => {
   const user = useSelector((state) => state.user)
   const assigneesState = useSelector((state) => state.dashboard.tasks.assignees)
   const assigneesFilter = useSelector((state) => state.dashboard.tasks.assigneesFilter)
-  const draggingIds = useSelector((state) => state.dashboard.tasks.draggingIds)
-  const isDragging = draggingIds.length > 0
-
   const handleOpenViewer = (args) => dispatch(openViewer(args))
 
   let assignees = []
@@ -281,12 +267,10 @@ const UserTasksContainer = ({ projectsInfo = {}, isLoadingInfo }) => {
 
       <SplitterPanel
         size={1}
-        className={clsx('details-panel-splitter', 'details', { dragging: isDragging })}
+        className={clsx('details-panel-splitter', 'details')}
         style={{
-          maxWidth: isDragging
-            ? 0
-            : `clamp(${detailsMinWidth}px, ${detailsMaxWidth}, ${detailsMaxMaxWidth}px)`,
-          minWidth: isDragging ? 0 : detailsMinWidth,
+          maxWidth: `clamp(${detailsMinWidth}px, ${detailsMaxWidth}, ${detailsMaxMaxWidth}px)`,
+          minWidth: detailsMinWidth,
         }}
       >
         {/* Lists are project-scoped — only resolve a context when the selection is in

--- a/src/pages/UserDashboardPage/UserDashboardTasks/UserTasksContainer.jsx
+++ b/src/pages/UserDashboardPage/UserDashboardTasks/UserTasksContainer.jsx
@@ -12,7 +12,7 @@ import { EmptyPlaceholder } from '@shared/components'
 import { parseProjectFolderRowId } from '@containers/ProjectsList/buildProjectsTableData'
 
 import UserDashboardKanBan from './UserDashboardKanBan'
-import { useEffect, useMemo } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { onAssigneesChanged, onTaskSelected } from '@state/dashboard'
 import { SplitterPanel } from 'primereact/splitter'
 import { getIntersectionFields, getMergedFields } from '../util'
@@ -55,6 +55,22 @@ const UserTasksContainer = ({ projectsInfo = {}, isLoadingInfo }) => {
   const assigneesState = useSelector((state) => state.dashboard.tasks.assignees)
   const assigneesFilter = useSelector((state) => state.dashboard.tasks.assigneesFilter)
   const handleOpenViewer = (args) => dispatch(openViewer(args))
+
+  const [isDragging, setIsDragging] = useState(false)
+  const handleDragStateChange = useCallback((dragging) => setIsDragging(dragging), [])
+
+  // Safety net: if dnd-kit fails to fire dragEnd/dragCancel (view switch mid-drag,
+  // double-click race), a global pointerup forces the panel back to visible.
+  useEffect(() => {
+    if (!isDragging) return
+    const reset = () => setIsDragging(false)
+    window.addEventListener('pointerup', reset)
+    window.addEventListener('pointercancel', reset)
+    return () => {
+      window.removeEventListener('pointerup', reset)
+      window.removeEventListener('pointercancel', reset)
+    }
+  }, [isDragging])
 
   let assignees = []
   switch (assigneesFilter) {
@@ -255,6 +271,7 @@ const UserTasksContainer = ({ projectsInfo = {}, isLoadingInfo }) => {
           priorities={priorities}
           projectUsers={projectUsers}
           isLoadingProjectUsers={isLoadingProjectUsers}
+          onDragStateChange={handleDragStateChange}
         />
         <RelatedTasksModule
           isPanelOpen={isPanelOpen}
@@ -267,10 +284,12 @@ const UserTasksContainer = ({ projectsInfo = {}, isLoadingInfo }) => {
 
       <SplitterPanel
         size={1}
-        className={clsx('details-panel-splitter', 'details')}
+        className={clsx('details-panel-splitter', 'details', { dragging: isDragging })}
         style={{
-          maxWidth: `clamp(${detailsMinWidth}px, ${detailsMaxWidth}, ${detailsMaxMaxWidth}px)`,
-          minWidth: detailsMinWidth,
+          maxWidth: isDragging
+            ? 0
+            : `clamp(${detailsMinWidth}px, ${detailsMaxWidth}, ${detailsMaxMaxWidth}px)`,
+          minWidth: isDragging ? 0 : detailsMinWidth,
         }}
       >
         {/* Lists are project-scoped — only resolve a context when the selection is in


### PR DESCRIPTION


<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Fixes the Home details panel occasionally collapsing to 0 width after clicking or dragging task cards on the Kanban view.

## Technical details
<!-- Please state any technical details such as limitations -->

- Removes the `isDragging ? 0 : ...` width collapse on the details `SplitterPanel` in `UserTasksContainer.jsx`. The 2024 cursor-alignment workaround is obsolete now that `DragOverlay` (via `KanBanCardOverlay`) tracks the cursor itself. Any drag-start without a paired drag-end (double-click race, view switch, dnd-kit edge case) used to leave the panel stranded at width 0.
- Drops the orphan `draggingIds` state, `onDraggingStart` / `onDraggingEnd` reducers, and their dispatches in `UserDashboardKanBan.jsx`'s drag handlers — no remaining consumers.
- Cleans up the dead `StyledSplitter` block that targeted the removed `.dragging` className.

## Additional context
<!-- Add any other context or screenshots here. -->

Closes #2005
