### PR TITLE
Overview: include empty folders in search results

### DIFF
--- a/shared/src/containers/ProjectTreeTable/hooks/useFetchOverviewData.ts
+++ b/shared/src/containers/ProjectTreeTable/hooks/useFetchOverviewData.ts
@@ -121,7 +121,7 @@ export const useFetchOverviewData = ({
         taskFilter: taskFilters.filter?.conditions?.length ? taskFilters.filter : undefined,
         taskSearch: taskFilters.search,
         folderFilter: folderFilters.filter?.conditions?.length ? folderFilters.filter : undefined,
-        folderSearch: folderFilters.search,
+        folderSearch: folderFilters.search || taskFilters.search,
       },
     },
     {


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Empty folders matching free-text search now appear in Overview results. Previously the folder lookup used `taskSearch` only, so a folder whose name matched the query but had no tasks was hidden.

## Technical details
<!-- Please state any technical details such as limitations -->

- `useFetchOverviewData` now sends `folderSearch: folderFilters.search || taskFilters.search` to `/folders/search`, so the backend can resolve folders by their own name/path when the search is unscoped task text.


## Additional context
<!-- Add any other context or screenshots here. -->

But beckend returning the empty array
