### PR TITLE
Overview: unified folder and task search

### DIFF
--- a/shared/src/api/generated/folders.ts
+++ b/shared/src/api/generated/folders.ts
@@ -325,6 +325,8 @@ export type FolderSearchRequest = {
   folderFilter?: QueryFilter
   /** 'fulltext' search used to resolve the folders */
   folderSearch?: string
+  /** Unified 'fulltext' search applied to both tasks and folders */
+  search?: string
 }
 export type HierarchyFolderModel = {
   /** Folder ID */

--- a/shared/src/containers/ProjectTreeTable/hooks/useFetchOverviewData.ts
+++ b/shared/src/containers/ProjectTreeTable/hooks/useFetchOverviewData.ts
@@ -467,7 +467,10 @@ export const useFetchOverviewData = ({
       }
 
       if (tasksByFolderMap.has(folderId)) {
-        tasksByFolderMap.get(folderId)!.push(taskId)
+        // dedup like tasksMap — resolvedTasks can contain the same task twice
+        // (overlapping infinite-query pages, or a task in multiple groups)
+        const folderTaskIds = tasksByFolderMap.get(folderId)!
+        if (!folderTaskIds.includes(taskId)) folderTaskIds.push(taskId)
       } else {
         tasksByFolderMap.set(folderId, [taskId])
       }

--- a/shared/src/containers/ProjectTreeTable/hooks/useFetchOverviewData.ts
+++ b/shared/src/containers/ProjectTreeTable/hooks/useFetchOverviewData.ts
@@ -119,9 +119,8 @@ export const useFetchOverviewData = ({
       projectName,
       folderSearchRequest: {
         taskFilter: taskFilters.filter?.conditions?.length ? taskFilters.filter : undefined,
-        taskSearch: taskFilters.search,
         folderFilter: folderFilters.filter?.conditions?.length ? folderFilters.filter : undefined,
-        folderSearch: folderFilters.search,
+        search: taskFilters.search,
       },
     },
     {


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Switches the Overview folder-resolution query to the backend's new unified `search` param so free-text search matches tasks and folders in one pass, keeping empty folders that match by name visible.

## Technical details
<!-- Please state any technical details such as limitations -->

- `useFetchOverviewData.ts` now sends a single `search` on the folder search request instead of separate

## Additional context
<!-- Add any other context or screenshots here. -->

<img width="921" height="392" alt="Screenshot 2026-06-01 at 16 00 08" src="https://github.com/user-attachments/assets/d5879206-0bb8-4f18-9dc0-60da557571f5" />
