### PR TITLE
Lists realtime updates fixes

### DIFF
--- a/shared/src/api/queries/entityLists/getLists.ts
+++ b/shared/src/api/queries/entityLists/getLists.ts
@@ -24,6 +24,40 @@ import {
   ListsPageParam,
 } from './types'
 
+// Helper function to batch pub/sub messages to avoid constant cache updates
+export function createBatchedCacheUpdater<TMessage, TDraft>(
+  updateCachedData: (updater: (draft: TDraft) => void) => void,
+  applyBatch: (draft: TDraft, batch: { topic: string; message: TMessage }[]) => void,
+  delay = 5000,
+) {
+  let queue: { topic: string; message: TMessage }[] = []
+  let timeout: ReturnType<typeof setTimeout> | null = null
+
+  const handler = (topic: string, message: TMessage) => {
+    queue.push({ topic, message })
+    if (!timeout) {
+      timeout = setTimeout(() => {
+        const batch = [...queue]
+        queue = []
+        timeout = null
+        if (batch.length > 0) {
+          updateCachedData((draft) => applyBatch(draft, batch))
+        }
+      }, delay)
+    }
+  }
+
+  handler.clear = () => {
+    if (timeout) {
+      clearTimeout(timeout)
+      timeout = null
+    }
+    queue = []
+  }
+
+  return handler
+}
+
 // Helper function to safely parse entity list data field from JSON string to object
 const parseJSON = (data: string | null | undefined): Record<string, any> => {
   if (!data) return {}
@@ -171,68 +205,69 @@ const getListsGqlApiInjected = getListsGqlApiEnhanced.injectEndpoints({
         { cacheDataLoaded, cacheEntryRemoved, updateCachedData },
       ) {
         const topics = ['entity_list.changed', 'entity_list.created', 'entity_list.deleted']
+        let handlePubSub: any = null
         try {
           // wait for the initial query to resolve before proceeding
           await cacheDataLoaded
 
-          const handlePubSub = (topic: string, message: ListItemMessage) => {
-            const summary = message.summary
-            const id = summary.id
-            if (!id) return
+          handlePubSub = createBatchedCacheUpdater<ListItemMessage, any>(
+            updateCachedData,
+            (draft, batch) => {
+              batch.forEach(({ topic, message }) => {
+                const summary = message.summary
+                const id = summary.id
+                if (!id) return
 
-            const getListFromSummary = (list?: EntityList): EntityList => {
-              return {
-                // defaults
-                projectName: projectName,
-                tags: [],
-                data: {},
-                allAttrib: '',
-                attrib: {},
-                createdAt: new Date().toISOString(),
-                updatedAt: '',
-                active: true,
-                access: '',
-                accessLevel: 30, // default admin
-                // existing data
-                ...(list || {}),
-                // new data
-                id: summary.id as string,
-                label: summary.label,
-                entityType: summary.entity_type,
-                entityListType: summary.entity_list_type,
-                count: summary.count,
-              }
-            }
+                const getListFromSummary = (list?: EntityList): EntityList => {
+                  return {
+                    // defaults
+                    projectName: projectName,
+                    tags: [],
+                    data: {},
+                    allAttrib: '',
+                    attrib: {},
+                    createdAt: new Date().toISOString(),
+                    updatedAt: '',
+                    active: true,
+                    access: '',
+                    accessLevel: 30, // default admin
+                    // existing data
+                    ...(list || {}),
+                    // new data
+                    id: summary.id as string,
+                    label: summary.label,
+                    entityType: summary.entity_type,
+                    entityListType: summary.entity_list_type,
+                    count: summary.count,
+                  }
+                }
 
-            if (topic === 'entity_list.changed') {
-              // update the data of existing list in cache
-              updateCachedData((draft) => {
-                const list = draft.pages.flatMap((page) => page.lists).find((l) => l.id === id)
-                if (!list) return
-                const newList = getListFromSummary(list)
+                if (topic === 'entity_list.changed') {
+                  // update the data of existing list in cache
+                  const list = draft.pages
+                    .flatMap((page: any) => page.lists)
+                    .find((l: any) => l.id === id)
+                  if (!list) return
+                  const newList = getListFromSummary(list)
 
-                Object.assign(list, newList)
-              })
-            } else if (topic === 'entity_list.created') {
-              // Add new list to the cache using basic summary
-              updateCachedData((draft) => {
-                const newList = getListFromSummary()
-                // Insert the new list at the beginning of the first page
-                if (draft.pages.length !== 0) {
-                  draft.pages[0].lists.unshift(newList)
-                } else {
-                  // if there are no page yet, don't do anything - the user should refresh the page
+                  Object.assign(list, newList)
+                } else if (topic === 'entity_list.created') {
+                  // Add new list to the cache using basic summary
+                  const newList = getListFromSummary()
+                  // Insert the new list at the beginning of the first page
+                  if (draft.pages.length !== 0) {
+                    draft.pages[0].lists.unshift(newList)
+                  }
+                } else if (topic === 'entity_list.deleted') {
+                  // delete the list from the cache
+                  draft.pages.forEach((page: any) => {
+                    page.lists = page.lists.filter((l: any) => l.id !== id)
+                  })
                 }
               })
-            } else if (topic === 'entity_list.deleted') {
-              // delete the list from the cache
-              updateCachedData((draft) => {
-                draft.pages.forEach((page) => {
-                  page.lists = page.lists.filter((l) => l.id !== id)
-                })
-              })
-            }
-          }
+            },
+            10000, // 10 seconds debounce/batch window
+          )
 
           topics.forEach((topic) => PubSub.subscribe(topic, handlePubSub))
         } catch {
@@ -243,6 +278,7 @@ const getListsGqlApiInjected = getListsGqlApiEnhanced.injectEndpoints({
         await cacheEntryRemoved
         // perform cleanup steps once the `cacheEntryRemoved` promise resolves
         topics.forEach((t) => PubSub.unsubscribe(t))
+        if (handlePubSub && typeof handlePubSub.clear === 'function') handlePubSub.clear()
       },
     }),
     getListItemsInfinite: build.infiniteQuery<

--- a/shared/src/api/queries/entityLists/getLists.ts
+++ b/shared/src/api/queries/entityLists/getLists.ts
@@ -6,6 +6,7 @@ import {
   TagTypesFromApi,
 } from '@reduxjs/toolkit/query'
 import type {
+  EntityList,
   GetListItemsQuery,
   GetListItemsQueryVariables,
   GetListsItemsForReviewSessionQuery,
@@ -166,41 +167,74 @@ const getListsGqlApiInjected = getListsGqlApiEnhanced.injectEndpoints({
         ]
       },
       async onCacheEntryAdded(
-        _args,
-        { cacheDataLoaded, cacheEntryRemoved, dispatch, updateCachedData },
+        { projectName },
+        { cacheDataLoaded, cacheEntryRemoved, updateCachedData },
       ) {
-        let token
+        const topics = ['entity_list.changed', 'entity_list.created', 'entity_list.deleted']
         try {
           // wait for the initial query to resolve before proceeding
           await cacheDataLoaded
 
           const handlePubSub = (topic: string, message: ListItemMessage) => {
-            if (topic !== 'entity_list.changed') return
             const summary = message.summary
             const id = summary.id
             if (!id) return
 
-            // We have all the data we need to update the cache
-            updateCachedData((draft) => {
-              const list = draft.pages.flatMap((page) => page.lists).find((l) => l.id === id)
-              if (!list) return
-              const newList = {
-                ...list,
+            const getListFromSummary = (list?: EntityList): EntityList => {
+              return {
+                // defaults
+                projectName: projectName,
+                tags: [],
+                data: {},
+                allAttrib: '',
+                attrib: {},
+                createdAt: new Date().toISOString(),
+                updatedAt: '',
+                active: true,
+                access: '',
+                accessLevel: 30, // default admin
+                // existing data
+                ...(list || {}),
+                // new data
+                id: summary.id as string,
                 label: summary.label,
                 entityType: summary.entity_type,
                 entityListType: summary.entity_list_type,
                 count: summary.count,
               }
+            }
 
-              Object.assign(list, newList)
-            })
-            // NOTE: We have to invalidate here as we don't know if other fields are updated not included in the updateCachedData
-            // invalidates lists list cache
-            dispatch(gqlApi.util.invalidateTags([{ type: 'entityList', id: `LIST` }]))
+            if (topic === 'entity_list.changed') {
+              // update the data of existing list in cache
+              updateCachedData((draft) => {
+                const list = draft.pages.flatMap((page) => page.lists).find((l) => l.id === id)
+                if (!list) return
+                const newList = getListFromSummary(list)
+
+                Object.assign(list, newList)
+              })
+            } else if (topic === 'entity_list.created') {
+              // Add new list to the cache using basic summary
+              updateCachedData((draft) => {
+                const newList = getListFromSummary()
+                // Insert the new list at the beginning of the first page
+                if (draft.pages.length !== 0) {
+                  draft.pages[0].lists.unshift(newList)
+                } else {
+                  // if there are no page yet, don't do anything - the user should refresh the page
+                }
+              })
+            } else if (topic === 'entity_list.deleted') {
+              // delete the list from the cache
+              updateCachedData((draft) => {
+                draft.pages.forEach((page) => {
+                  page.lists = page.lists.filter((l) => l.id !== id)
+                })
+              })
+            }
           }
 
-          // sub to websocket topic
-          token = PubSub.subscribe('entity_list.changed', handlePubSub)
+          topics.forEach((topic) => PubSub.subscribe(topic, handlePubSub))
         } catch {
           // no-op in case `cacheEntryRemoved` resolves before `cacheDataLoaded`,
           // in which case `cacheDataLoaded` will throw
@@ -208,7 +242,7 @@ const getListsGqlApiInjected = getListsGqlApiEnhanced.injectEndpoints({
         // cacheEntryRemoved will resolve when the cache subscription is no longer active
         await cacheEntryRemoved
         // perform cleanup steps once the `cacheEntryRemoved` promise resolves
-        PubSub.unsubscribe(token)
+        topics.forEach((t) => PubSub.unsubscribe(t))
       },
     }),
     getListItemsInfinite: build.infiniteQuery<

--- a/shared/src/api/queries/entityLists/getLists.ts
+++ b/shared/src/api/queries/entityLists/getLists.ts
@@ -107,6 +107,10 @@ const getListsGqlApiEnhanced = gqlApi.enhanceEndpoints<TagTypes, UpdatedDefiniti
     },
     GetListItems: {
       transformResponse: (response: GetListItemsQuery): GetListItemsResult => {
+        const firstEdge = response.project.entityLists.edges[0]
+        if (!firstEdge) {
+          throw new Error('List does not exist, was it deleted?')
+        }
         return {
           items: response.project.entityLists.edges.flatMap((listEdge) =>
             listEdge.node.items.edges.map(({ node, ...edge }) => {
@@ -117,7 +121,7 @@ const getListsGqlApiEnhanced = gqlApi.enhanceEndpoints<TagTypes, UpdatedDefiniti
               } as GetListItemsResult['items'][number]
             }),
           ),
-          pageInfo: response.project.entityLists.edges[0].node.items.pageInfo,
+          pageInfo: firstEdge.node.items.pageInfo,
         }
       },
     },

--- a/shared/src/api/queries/entityLists/types.ts
+++ b/shared/src/api/queries/entityLists/types.ts
@@ -93,12 +93,12 @@ export type ListItemsPageParam = {
 export type ListItemMessage = {
   project: string
   summary: {
-    count: number
-    entity_list_type: string
-    entity_type: string
+    count: EntityList['count']
+    entity_list_type: EntityList['entityListType']
+    entity_type: EntityList['entityType']
     id?: string
     entityId?: string
-    label: string
+    label: EntityList['label']
   }
 }
 

--- a/shared/src/components/EmptyPlaceholder/EmptyPlaceholder.tsx
+++ b/shared/src/components/EmptyPlaceholder/EmptyPlaceholder.tsx
@@ -52,6 +52,7 @@ export interface EmptyPlaceholderProps extends React.HTMLAttributes<HTMLDivEleme
   icon?: string
   message?: string
   error?: any
+  ynputError?: boolean
   pt?: {
     error?: React.HTMLAttributes<HTMLDivElement>
   }
@@ -61,6 +62,7 @@ export const EmptyPlaceholder: FC<EmptyPlaceholderProps> = ({
   icon,
   message,
   error,
+  ynputError = true,
   children,
   pt,
   className,
@@ -74,7 +76,9 @@ export const EmptyPlaceholder: FC<EmptyPlaceholderProps> = ({
         <span className="error-message" {...pt?.error}>
           ERROR: {JSON.stringify(error)}
         </span>
-        <span>This should not happen. Please send a screenshot to the Ynput team!</span>
+        {ynputError && (
+          <span>This should not happen. Please send a screenshot to the Ynput team!</span>
+        )}
         {children}
       </Placeholder>
     )

--- a/src/pages/ProjectListsPage/components/ListItemsTable/ListItemsTable.tsx
+++ b/src/pages/ProjectListsPage/components/ListItemsTable/ListItemsTable.tsx
@@ -28,7 +28,7 @@ const ListItemsTable: FC<ListItemsTableProps> = ({
 }) => {
   const { projectName } = useProjectContext()
   const { selectedLists, selectedList } = useListsContext()
-  const { isError, fetchNextPage, resetFilters } = useListItemsDataContext()
+  const { isError, error, fetchNextPage, resetFilters } = useListItemsDataContext()
   const scope = `lists-${projectName}`
 
   const [hiddenColumns, readOnly] = useMemo(
@@ -36,26 +36,27 @@ const ListItemsTable: FC<ListItemsTableProps> = ({
     [selectedList],
   )
 
-  if (!selectedList) return (
-    <EmptyPlaceholder
-      message="Start by selecting or importing a list."
-    >
-      <ImportDialogButton
-        importContext="entity_list_item"
-        projectName={projectName}
-      />
-    </EmptyPlaceholder>
-  )
+  if (!selectedList)
+    return (
+      <EmptyPlaceholder message="Start by selecting or importing a list.">
+        <ImportDialogButton importContext="entity_list_item" projectName={projectName} />
+      </EmptyPlaceholder>
+    )
 
   if (selectedLists.length > 1)
     return <EmptyPlaceholder message="Please select one list to view its items." />
 
-  if (isError)
+  if (isError) {
+    const errorMessage =
+      error instanceof Error
+        ? error.message
+        : (error as any)?.message ?? 'Error loading list items.'
     return (
-      <EmptyPlaceholder error={'Error loading list items.'}>
+      <EmptyPlaceholder error={errorMessage} ynputError={false}>
         <Button label="Reset" icon="replay" onClick={resetFilters} />
       </EmptyPlaceholder>
     )
+  }
 
   return (
     <div style={{ position: 'relative', width: '100%', height: '100%' }}>

--- a/src/pages/ProjectListsPage/components/ListsShortcuts.tsx
+++ b/src/pages/ProjectListsPage/components/ListsShortcuts.tsx
@@ -52,23 +52,15 @@ const ListsShortcuts: FC<ListsShortcutsProps> = ({}) => {
         selectedRowIds.every((selected) => parseListFolderRowId(selected))
       const hasMultipleSelected = selectedRowIds.length > 1
       const firstSelectedRow = selectedRowIds[0]
-      const isFirstRowFolder = !!parseListFolderRowId(firstSelectedRow)
+      const selectedFolderId = parseListFolderRowId(firstSelectedRow)
+      const isFirstRowFolder = !!selectedFolderId
 
       // Handle different key combinations
       if (key === 'n' && !isMeta && !isShift && !isAlt) {
         // 'n' - Create new list
-        // Only allow if no selection, single folder selected, or only folders selected
-        if (selectedRowIds.length === 0) {
-          // No selection, create list at root level
-          e.preventDefault()
-          openNewList()
-          actionExecuted = true
-        } else if (allSelectedRowsAreFolders && !hasMultipleSelected) {
-          // Single folder selected, create list inside that folder
-          e.preventDefault()
-          openNewList({ entityListFolderId: selectedFolderIds[0] })
-          actionExecuted = true
-        }
+        e.preventDefault()
+        openNewList()
+        actionExecuted = true
       } else if (key === 'f' && !isMeta && !isShift && !isAlt) {
         // 'f' - Create folder
         e.preventDefault()

--- a/src/pages/ProjectListsPage/components/ListsTable/ListsTableHeader.tsx
+++ b/src/pages/ProjectListsPage/components/ListsTable/ListsTableHeader.tsx
@@ -239,14 +239,17 @@ const ListsTableHeader: FC<ListsTableHeaderProps> = ({
     {
       id: 'new-list',
       label: isReview
-        ? isStoryboards ? 'Create storyboard' : 'Create review session'
+        ? isStoryboards
+          ? 'Create storyboard'
+          : 'Create review session'
         : 'Create list',
       icon: 'add',
       shortcut: 'N',
       onClick: async () => {
         if (isStoryboards) {
-          const label = prompt("What would you like to call the storyboard?")
-            || `Storyboard - ${new Date().toLocaleString()}`
+          const label =
+            prompt('What would you like to call the storyboard?') ||
+            `Storyboard - ${new Date().toLocaleString()}`
 
           const { data, error } = await createList({
             projectName,
@@ -254,7 +257,7 @@ const ListsTableHeader: FC<ListsTableHeaderProps> = ({
           })
 
           if (error) {
-            return toast.error("Error creating storyboard")
+            return toast.error('Error creating storyboard')
           }
 
           setSearchParams({
@@ -264,13 +267,7 @@ const ListsTableHeader: FC<ListsTableHeaderProps> = ({
 
           return
         }
-        // If a single folder is selected, create list inside that folder
-        if (selectedFolders.length === 1) {
-          openNewList({ entityListFolderId: selectedFolders[0] })
-        } else {
-          // No selection or multiple folders, create at root level
-          openNewList()
-        }
+        openNewList()
       },
       isPinned: true,
       buttonProps: {

--- a/src/pages/ProjectListsPage/context/ListItemsDataContext.tsx
+++ b/src/pages/ProjectListsPage/context/ListItemsDataContext.tsx
@@ -30,6 +30,7 @@ export interface ListItemsDataContextValue {
   isLoadingAll: boolean
   isLoadingMore: boolean
   isError?: boolean
+  error?: unknown
   isInitialized: boolean
   // filters
   listItemsFilters: QueryFilter
@@ -60,10 +61,10 @@ interface ListItemsDataProviderProps {
 }
 
 const reviewSortKeys = new Map([
-  ["task", "task_id"],
-  ["product", "product_id"],
-  ["path", "name"],
-  ["versionAuthor", "author"],
+  ['task', 'task_id'],
+  ['product', 'product_id'],
+  ['path', 'name'],
+  ['versionAuthor', 'author'],
 ])
 
 // fetch all items and provide methods to update the items
@@ -111,10 +112,12 @@ export const ListItemsDataProvider = ({ children }: ListItemsDataProviderProps) 
     const sorting = selectedList?.data.sorting
     if (!sorting) return null
 
-    return [{
-      id: reviewSortKeys.get(sorting.property) ?? sorting.property,
-      desc: sorting.order,
-    }]
+    return [
+      {
+        id: reviewSortKeys.get(sorting.property) ?? sorting.property,
+        desc: sorting.order,
+      },
+    ]
   }, [isReview, selectedList?.data.sorting])
 
   const {
@@ -122,6 +125,7 @@ export const ListItemsDataProvider = ({ children }: ListItemsDataProviderProps) 
     isLoading,
     isFetchingNextPage,
     isError,
+    error,
     fetchNextPage,
     refetch,
   } = useGetListItemsData({
@@ -204,6 +208,7 @@ export const ListItemsDataProvider = ({ children }: ListItemsDataProviderProps) 
         isLoadingAll: isLoading || isLoadingData,
         isLoadingMore: isFetchingNextPage,
         isError,
+        error,
         fetchNextPage,
         // filters
         listItemsFilters,

--- a/src/pages/ProjectListsPage/context/ListsProvider.tsx
+++ b/src/pages/ProjectListsPage/context/ListsProvider.tsx
@@ -75,12 +75,20 @@ export const ListsProvider = ({ children, isReview, isStoryboards }: ListsProvid
   const reviewVersion = matchedAddons.get('review')
 
   const rowSelection = useMemo(
-    () => (isReview
-      ? isStoryboards ? unstableStoryboardSelection : unstableReviewSelection
-      : unstableListSelection
-    ),
+    () =>
+      isReview
+        ? isStoryboards
+          ? unstableStoryboardSelection
+          : unstableReviewSelection
+        : unstableListSelection,
     // Simpler dependencies: unstableListSelection and unstableReviewSelection are stable state references
-    [unstableListSelection, unstableReviewSelection, unstableStoryboardSelection, isReview, isStoryboards],
+    [
+      unstableListSelection,
+      unstableReviewSelection,
+      unstableStoryboardSelection,
+      isReview,
+      isStoryboards,
+    ],
   )
 
   const setRowSelection = useCallback(
@@ -105,7 +113,10 @@ export const ListsProvider = ({ children, isReview, isStoryboards }: ListsProvid
     [JSON.stringify(rowSelection)],
   )
 
-  const selectedLists = selectedRows.filter((id) => !parseListFolderRowId(id)).map((id) => listsMap.get(id)).filter((list) => !!list)
+  const selectedLists = selectedRows
+    .filter((id) => !parseListFolderRowId(id))
+    .map((id) => listsMap.get(id))
+    .filter((list) => !!list)
 
   // we can only ever fetch one list at a time
   const selectedList = selectedLists[0]
@@ -211,12 +222,15 @@ export const ListsProvider = ({ children, isReview, isStoryboards }: ListsProvid
           enhancedInit.entityListFolderIds = selectedFolderIds
           // also remove entityListFolderId if it exists
           delete enhancedInit.entityListFolderId
+        } else if (selectedList?.entityListFolderId) {
+          // If a list is selected, inherit its folder id
+          enhancedInit.entityListFolderId = selectedList.entityListFolderId || undefined
         }
       }
 
       rawOpenNewList(enhancedInit)
     },
-    [rawOpenNewList, selectedRows],
+    [rawOpenNewList, selectedRows, selectedList],
   )
 
   // UPDATE/EDIT LIST

--- a/src/pages/ProjectListsPage/hooks/useGetListItemsData.ts
+++ b/src/pages/ProjectListsPage/hooks/useGetListItemsData.ts
@@ -29,6 +29,7 @@ export interface UseGetListItemsDataReturn {
   isLoading: boolean
   isFetchingNextPage: boolean
   isError: boolean
+  error?: unknown
   fetchNextPage: () => void
   refetch: () => void
 }
@@ -72,6 +73,7 @@ const useGetListItemsData = ({
     fetchNextPage,
     hasNextPage,
     isError,
+    error,
     refetch,
   } = useGetListItemsInfiniteInfiniteQuery(
     {
@@ -185,6 +187,7 @@ const useGetListItemsData = ({
     isLoading,
     isFetchingNextPage,
     isError,
+    error,
     fetchNextPage: handleFetchNextPage,
     refetch,
   }


### PR DESCRIPTION
## Realtime updates

1. Removes query invalidation so that the lists are not refetcech on EVERY ws message.
2. Uses only the summary to update the list (with no additional API calls).
3. Handles create and delete events
4. Batches cache updates to happen one every 10 seconds in one update cache call.

## Creating new list fixes

1. Fixes issue where `n` shortcut would not work when list was already selected (which is always)
2. When a list is already selected inside a folder, the new list inherits the parent folder so the new list is put in the same folder.