### PR TITLE
fix(review): add attrib.author fallback for review table author column

### DIFF
--- a/src/pages/ProjectListsPage/hooks/useBuildListItemsTableData.ts
+++ b/src/pages/ProjectListsPage/hooks/useBuildListItemsTableData.ts
@@ -131,7 +131,7 @@ const extractAuthor = (item: EntityListItemWithLinks, entityType: string): strin
   switch (entityType) {
     case 'version':
       // @ts-expect-error - author field does exist on version list items
-      return item.author || undefined
+      return item.author || (item.attrib?.author as string) || undefined
     default:
       return ''
   }


### PR DESCRIPTION
## Description

Author column was showing empty in the review table. The `extractAuthor` function only checked `item.author`, but for some review session items the author data is stored in `item.attrib.author` instead.

## Changes

- Added fallback to `item.attrib?.author` in the `extractAuthor` function

Fixes #2016