### PR TITLE
fix: wait for selected view before slicer sync

### DIFF
--- a/shared/src/containers/Slicer/hooks/useSlicerViewSync.ts
+++ b/shared/src/containers/Slicer/hooks/useSlicerViewSync.ts
@@ -5,22 +5,17 @@ import { SliceType } from '../types'
 /**
  * Syncs the slicer's active slice type with view settings (server-side).
  *
- * - Sets isViewSyncPending=true on mount so the slicer shows loading until views are ready
+ * - Sets isViewSyncPending=true on mount so the slicer shows loading until view settings are ready
  * - On view load: silently restores sliceType from view
  * - On user-initiated slice type change: saves the new sliceType to the view
  */
 export const useSlicerViewSync = (
   viewSliceType: string | undefined,
   onUpdateSliceType: (sliceType: string) => void,
-  isLoadingViews?: boolean,
+  isLoadingViewSettings?: boolean,
 ) => {
-  const {
-    sliceType,
-    setSliceType,
-    setIsViewSyncPending,
-    setRowSelection,
-    setRowSelectionData,
-  } = useSlicerContext()
+  const { sliceType, setSliceType, setIsViewSyncPending, setRowSelection, setRowSelectionData } =
+    useSlicerContext()
   const initializedRef = useRef(false)
   const isRestoringTypeRef = useRef(false)
 
@@ -39,9 +34,9 @@ export const useSlicerViewSync = (
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  // Restore: view → slicer (only when views finish loading, not on save-triggered updates)
+  // Restore: view → slicer (only when view settings finish loading, not on save-triggered updates)
   useEffect(() => {
-    if (isLoadingViews) return
+    if (isLoadingViewSettings) return
     if (initializedRef.current) return
 
     initializedRef.current = true
@@ -55,7 +50,7 @@ export const useSlicerViewSync = (
       setRowSelectionData({})
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isLoadingViews])
+  }, [isLoadingViewSettings])
 
   // Save: slicer slice type → view (on user change)
   useEffect(() => {

--- a/shared/src/containers/Views/context/ViewsContext.tsx
+++ b/shared/src/containers/Views/context/ViewsContext.tsx
@@ -144,20 +144,22 @@ export const ViewsProvider: FC<ViewsProviderProps> = ({
   )
 
   // setting of default views
-  const [selectedView, setSelectedView, previousSelectedViewId] = useSelectedView({
-    viewType: viewType as string,
-    projectName: projectName,
-  })
+  const [selectedView, setSelectedView, previousSelectedViewId, isLoadingSelectedView] =
+    useSelectedView({
+      viewType: viewType as string,
+      projectName: projectName,
+    })
 
   const [viewSettingsChanged, setViewSettingsChanged] = useViewSettingsChanged({
     viewType: viewType as ViewType,
   })
 
   // Fetch views data and filter out base views
-  const { currentData: viewsListRaw = [], isLoading: isLoadingViews } = useListViewsQuery(
+  const { currentData: viewsListRaw = [], isLoading: isLoadingViewsList } = useListViewsQuery(
     { projectName: projectName, viewType: viewType as string },
     { skip: !viewType },
   )
+  const isLoadingViews = isLoadingViewsList || isLoadingSelectedView
 
   // Filter out base views from the list
   // Filter out studio working view if in project scope

--- a/shared/src/containers/Views/hooks/useSelectedView.tsx
+++ b/shared/src/containers/Views/hooks/useSelectedView.tsx
@@ -17,13 +17,16 @@ type Return = [
   selectedView: GetDefaultViewApiResponse | undefined,
   setSelectedView: (viewId: string) => void,
   previousSelectedViewId: string | undefined,
+  isLoadingSelectedView: boolean,
 ]
 
 export const useSelectedView = ({ viewType, projectName }: Props): Return => {
-  const { currentData: defaultView } = useGetDefaultViewQuery(
-    { viewType, projectName },
-    { skip: !viewType },
-  )
+  const {
+    currentData: defaultView,
+    isFetching,
+    isLoading,
+  } = useGetDefaultViewQuery({ viewType, projectName }, { skip: !viewType })
+  const isLoadingSelectedView = isLoading || (isFetching && !defaultView)
 
   const [setDefaultView] = useSetDefaultViewMutation()
 
@@ -53,5 +56,5 @@ export const useSelectedView = ({ viewType, projectName }: Props): Return => {
     }
   }
 
-  return [defaultView, setSelectedView, previousSelectedViewId]
+  return [defaultView, setSelectedView, previousSelectedViewId, isLoadingSelectedView]
 }


### PR DESCRIPTION
## Description of changes
Fixes #2019.

The slicer view sync now waits until the selected/default view has loaded, not just the view list. On a page refresh the view list can finish before the default view settings are available; in that window the slicer can treat its local default as user input and write it back to the working view, effectively resetting saved columns and filters.

## Technical details
- Exposes the selected view loading state from `useSelectedView`.
- Includes that state in `ViewsProvider.isLoadingViews`.
- Renames the slicer sync loading parameter to describe that it waits on view settings.

## Validation
- `git diff --cached --check`
- `prettier --check shared/src/containers/Slicer/hooks/useSlicerViewSync.ts shared/src/containers/Views/context/ViewsContext.tsx shared/src/containers/Views/hooks/useSelectedView.tsx`

Full local type/build checks are currently blocked by existing repo/tooling issues: `tsc --noEmit` reports many unrelated baseline errors, `eslint` expects the new flat config while the repo has .eslintrc, and `vite build` fails to load the config in this Windows sandbox with an access-denied directory read.