### PR TITLE
fix: reset viewer target when opening from slideout

### DIFF
--- a/src/features/viewer.ts
+++ b/src/features/viewer.ts
@@ -43,23 +43,73 @@ const initialState: ViewerState = {
   goToFrame: null,
 }
 
+const normalizeOpenViewerPayload = (payload: Partial<ViewerState>): Partial<ViewerState> => {
+  const next = { ...payload }
+  const hasVersionSelection = payload.versionIds !== undefined
+
+  if (hasVersionSelection) {
+    next.reviewableIds = payload.reviewableIds || []
+  }
+
+  if (payload.productId !== undefined) {
+    next.taskId = null
+    next.folderId = null
+    next.selectedProductId = payload.selectedProductId ?? null
+    if (!hasVersionSelection) {
+      next.versionIds = []
+      next.reviewableIds = []
+    }
+    return next
+  }
+
+  if (payload.taskId !== undefined) {
+    next.productId = null
+    next.selectedProductId = null
+    next.folderId = payload.folderId ?? null
+    if (!hasVersionSelection) {
+      next.versionIds = []
+      next.reviewableIds = []
+    }
+    return next
+  }
+
+  if (payload.folderId !== undefined) {
+    next.productId = null
+    next.taskId = null
+    next.selectedProductId = hasVersionSelection ? payload.selectedProductId ?? null : null
+    if (!hasVersionSelection) {
+      next.versionIds = []
+      next.reviewableIds = []
+    }
+    return next
+  }
+
+  return next
+}
+
 const viewerSlice = createSlice({
   name: 'viewer',
   initialState,
   reducers: {
-    openViewer: (state: ViewerState, { payload }: PayloadAction<Partial<ViewerState>>) => {
-      state.projectName = payload.projectName || state.projectName
-      state.quickView = !!payload.quickView
+    openViewer: {
+      reducer: (state: ViewerState, { payload }: PayloadAction<Partial<ViewerState>>) => {
+        state.projectName = payload.projectName || state.projectName
+        state.quickView = !!payload.quickView
 
-      if (payload.productId) state.productId = payload.productId
-      if (payload.selectedProductId) state.selectedProductId = payload.selectedProductId
-      if (payload.taskId) state.taskId = payload.taskId
-      if (payload.folderId) state.folderId = payload.folderId
+        if (payload.productId !== undefined) state.productId = payload.productId
+        if (payload.selectedProductId !== undefined)
+          state.selectedProductId = payload.selectedProductId
+        if (payload.taskId !== undefined) state.taskId = payload.taskId
+        if (payload.folderId !== undefined) state.folderId = payload.folderId
 
-      if (payload.productId || payload.taskId || payload.folderId) state.isOpen = true
+        if (payload.productId || payload.taskId || payload.folderId) state.isOpen = true
 
-      if (payload.versionIds) state.versionIds = payload.versionIds
-      if (payload.reviewableIds) state.reviewableIds = payload.reviewableIds || []
+        if (payload.versionIds !== undefined) state.versionIds = payload.versionIds
+        if (payload.reviewableIds !== undefined) state.reviewableIds = payload.reviewableIds || []
+      },
+      prepare: (payload: Partial<ViewerState>) => ({
+        payload: normalizeOpenViewerPayload(payload),
+      }),
     },
     updateProduct: (
       state: ViewerState,


### PR DESCRIPTION
Fixes #2015.

## Summary
- Normalize `openViewer` payloads before reducers/search-param middleware see them.
- Clear stale mutually exclusive viewer target IDs when opening a new product/task/folder/version target.
- Reset stale `versionIds`/`reviewableIds` when the new open action does not provide an explicit version/reviewable selection.

This keeps the URL query params and Redux viewer target aligned when clicking playable thumbnails from a details slide-out.

## Verification
- `prettier --check src/features/viewer.ts`
- `git diff --check`
- `tsc --noEmit --pretty false --project tsconfig.json` currently fails on existing repository-wide TypeScript baseline errors outside this change, for example `shared/src/api/index.ts`, `shared/src/components/DetailsPanelDetails/DetailsPanelDetails.tsx`, and `src/pages/ProjectListsPage/components/ListsTable/ListsTable.tsx`.