### PR TITLE
Kanban query invalidations

### DIFF
--- a/shared/src/api/queries/folders/getFolders.ts
+++ b/shared/src/api/queries/folders/getFolders.ts
@@ -19,15 +19,26 @@ const enhancedApi = foldersApi.enhanceEndpoints({
         { cacheDataLoaded, cacheEntryRemoved, updateCachedData, dispatch },
       ) {
         const { projectName } = args || {}
+        const patchFields = (args as any)?.patch as string[] | undefined
+
+        const topicFieldMap: Record<string, string> = {
+          'entity.folder.label_changed': 'label',
+          'entity.folder.renamed': 'name',
+          'entity.folder.type_changed': 'folderType',
+          'entity.folder.status_changed': 'status',
+          'entity.folder.tags_changed': 'tags',
+          'entity.folder.attrib_changed': 'attrib',
+        }
+
         const topics = ['entity.folder', 'entity.folder.created', 'entity.folder.deleted']
         const tokens: (string | undefined)[] = []
 
-        // Simplified trailing throttle approach:
-        // - Collect updated folder IDs for 1000ms window
-        // - If a creation topic appears, perform one full list refetch (within throttle window)
+        // Simplified trailing debounce approach:
+        // - Collect updated folder IDs for 2000ms window
+        // - If a creation topic appears, perform one full list refetch (within debounce window)
         // - Otherwise, fetch each pending event and patch existing cache entries only
-        const MIN_INTERVAL = 1000
-        const pendingEventIds = new Set<string>()
+        const MIN_INTERVAL = 2000
+        const pendingMessages = new Map<string, any>()
         let resyncFlag = false // full list refetch needed (created or deleted)
         let timer: ReturnType<typeof setTimeout> | null = null
         let processing = false
@@ -40,9 +51,8 @@ const enhancedApi = foldersApi.enhanceEndpoints({
         }
 
         const schedule = () => {
-          if (!timer) {
-            timer = setTimeout(run, MIN_INTERVAL)
-          }
+          clearTimer()
+          timer = setTimeout(run, MIN_INTERVAL)
         }
 
         // All non-created/deleted events are treated as incremental updates.
@@ -67,14 +77,14 @@ const enhancedApi = foldersApi.enhanceEndpoints({
                 /* ignore */
                 console.warn('Failed to refetch folder list on resync')
               } finally {
-                pendingEventIds.clear()
+                pendingMessages.clear()
               }
               return
             }
 
-            if (pendingEventIds.size === 0) return
-            const eventIds = Array.from(pendingEventIds)
-            pendingEventIds.clear()
+            if (pendingMessages.size === 0) return
+            const messages = Array.from(pendingMessages.values())
+            pendingMessages.clear()
             type Patch = {
               folderId: string
               partial?: Record<string, any>
@@ -82,28 +92,45 @@ const enhancedApi = foldersApi.enhanceEndpoints({
               updatedAt?: string
             }
             const patches: Patch[] = []
-            const topicFieldMap: Record<string, string> = {
-              'entity.folder.label_changed': 'label',
-              'entity.folder.renamed': 'name',
-              'entity.folder.type_changed': 'folderType',
-              'entity.folder.status_changed': 'status',
-              'entity.folder.tags_changed': 'tags',
-              'entity.folder.attrib_changed': 'attrib',
-            }
             await Promise.all(
-              eventIds.map(async (eventId) => {
+              messages.map(async (message) => {
                 try {
-                  // Fetch each event and apply incremental updates
-                  const event = await dispatch(
-                    eventsApi.endpoints.getEvent.initiate({ eventId }, { forceRefetch: true }),
-                  ).unwrap()
-                  const topic: string = event?.topic || ''
-                  const payload: any = event?.payload || {}
-                  const summary: any = event?.summary || {}
-                  const folderId: string | undefined = summary.entityId
+                  const topic = message.topic
+                  const summary = message.summary || {}
+                  const folderId = summary.entityId
                   if (!folderId) return
                   const fieldName = topicFieldMap[topic]
                   if (!fieldName) return
+
+                  // OPTIMIZATION: use value from summary if available (for root level fields)
+                  if (summary.value !== undefined && fieldName !== 'attrib') {
+                    let value = summary.value
+
+                    // Cast value to proper type
+                    if (fieldName === 'tags') {
+                      if (!Array.isArray(value)) {
+                        value = typeof value === 'string' ? value.split(',').filter(Boolean) : []
+                      }
+                    } else if (value !== null && typeof value !== 'string') {
+                      value = String(value)
+                    }
+
+                    const partial: Record<string, any> = {
+                      [fieldName]: value,
+                      updatedAt: message.updatedAt,
+                    }
+                    if (summary.parentId !== undefined) partial.parentId = summary.parentId
+                    patches.push({ folderId, partial })
+                    return
+                  }
+
+                  // Fallback: Fetch each event and apply incremental updates
+                  const eventId = message.id
+                  const event = await dispatch(
+                    eventsApi.endpoints.getEvent.initiate({ eventId }, { forceRefetch: true }),
+                  ).unwrap()
+                  const payload: any = event?.payload || {}
+                  const eventSummary: any = event?.summary || {}
                   if (
                     fieldName === 'attrib' &&
                     payload?.newValue &&
@@ -120,7 +147,8 @@ const enhancedApi = foldersApi.enhanceEndpoints({
                     const partial: Record<string, any> = { updatedAt: event.updatedAt }
                     partial[fieldName] = value
                     // parentId might accompany some changes in summary
-                    if (summary.parentId !== undefined) partial.parentId = summary.parentId
+                    if (eventSummary.parentId !== undefined)
+                      partial.parentId = eventSummary.parentId
                     patches.push({ folderId, partial })
                   }
                 } catch {
@@ -153,6 +181,10 @@ const enhancedApi = foldersApi.enhanceEndpoints({
             })
           } finally {
             processing = false
+            // If new events came in while we were processing, schedule another run
+            if (pendingMessages.size > 0 || resyncFlag) {
+              schedule()
+            }
           }
         }
 
@@ -160,16 +192,30 @@ const enhancedApi = foldersApi.enhanceEndpoints({
           await cacheDataLoaded
 
           const handlePubSub = (_topic: string, _message: any) => {
-            if (_topic.endsWith('.created') || _topic.endsWith('.deleted')) {
+            const isMembership = _topic.endsWith('.created') || _topic.endsWith('.deleted')
+
+            if (isMembership) {
+              const eventType = _topic.endsWith('.created') ? 'created' : 'deleted'
+              // Backward compatibility: If no patch filters are provided, always sync membership.
+              // If patch filters ARE provided, only sync if 'created'/'deleted' tokens are present.
+              if (patchFields && !patchFields.includes(eventType)) return
+
               resyncFlag = true
-              schedule()
-              return
+            } else {
+              const fieldName = topicFieldMap[_topic]
+              // Backward compatibility: If no patch filters are provided, allow all updates (that we have mapping for).
+              // If patch filters ARE provided, only allow fields explicitly listed in the patch array.
+              if (patchFields && (!fieldName || !patchFields.includes(fieldName))) {
+                return
+              }
+
+              const eventId = _message?.id
+              if (eventId) {
+                pendingMessages.set(eventId, _message)
+              }
             }
-            const eventId = _message?.id
-            if (eventId) {
-              pendingEventIds.add(eventId)
-              schedule()
-            }
+
+            schedule()
           }
 
           topics.forEach((t) => tokens.push(PubSub.subscribe(t, handlePubSub)))

--- a/shared/src/api/queries/userDashboard/getUserDashboard.ts
+++ b/shared/src/api/queries/userDashboard/getUserDashboard.ts
@@ -203,7 +203,8 @@ const enhancedDashboardGraphqlApi = gqlApi.enhanceEndpoints<TagTypes, UpdatedDef
 
                     // if assignees changed, check if it should be removed
                     if (payload.assignees) {
-                      const isStillAssigned = payload.assignees.some((a) => assignees?.includes(a))
+                      const isStillAssigned =
+                        !assignees?.length || payload.assignees.some((a) => assignees?.includes(a))
                       if (!isStillAssigned) {
                         draft.splice(index, 1)
                       }
@@ -358,19 +359,11 @@ const injectedDashboardRestApi = enhancedDashboardGraphqlApi.injectEndpoints({
             // hopefully this will be cached
             // it also allows for different combination of projects but still use the cache
             const responses = [
-              dispatch(
-                projectQueries.endpoints.getProject.initiate(
-                  { projectName },
-                  { forceRefetch: true },
-                ),
-              ).unwrap(),
+              dispatch(projectQueries.endpoints.getProject.initiate({ projectName })).unwrap(),
               ...(anatomy
                 ? [
                     dispatch(
-                      projectQueries.endpoints.getProjectAnatomy.initiate(
-                        { projectName },
-                        { forceRefetch: true },
-                      ),
+                      projectQueries.endpoints.getProjectAnatomy.initiate({ projectName }),
                     ).unwrap(),
                   ]
                 : []),

--- a/shared/src/api/queries/userDashboard/getUserDashboard.ts
+++ b/shared/src/api/queries/userDashboard/getUserDashboard.ts
@@ -20,6 +20,30 @@ export type KanbanProjectUserNode = Omit<
 > & { accessGroups: AccessGroups; projects: string[]; avatarUrl: string }
 export type GetKanbanProjectUsersResponse = KanbanProjectUserNode[]
 
+export interface MessageSummary {
+  entityId: string
+  entityPath: string
+  parentId: string
+  value: any
+}
+
+export interface Message {
+  id: string
+  topic: string
+  project: string
+  user: string
+  sender: string
+  senderType: string
+  description: string
+  status: string
+  progress: number
+  store: boolean
+  createdAt: string
+  updatedAt: string
+  dependsOn: string | null
+  summary: MessageSummary
+}
+
 import { DefinitionsFromApi, OverrideResultType, TagTypesFromApi } from '@reduxjs/toolkit/query'
 import getUserProjectsAccess from './getUserProjectsAccess'
 import { ThunkDispatch, UnknownAction } from '@reduxjs/toolkit'
@@ -106,7 +130,7 @@ const enhancedDashboardGraphqlApi = gqlApi.enhanceEndpoints<TagTypes, UpdatedDef
       providesTags: provideKanbanTags,
       async onCacheEntryAdded(
         { assignees = [], projects = [] } = {},
-        { updateCachedData, cacheDataLoaded, cacheEntryRemoved, dispatch },
+        { updateCachedData, cacheDataLoaded, cacheEntryRemoved, dispatch, getCacheEntry },
       ) {
         let token
         try {
@@ -116,10 +140,43 @@ const enhancedDashboardGraphqlApi = gqlApi.enhanceEndpoints<TagTypes, UpdatedDef
           const patchKanbanTask = async ({
             projects = [],
             taskIds = [],
+            payload,
           }: {
             projects: string[]
             taskIds: string[]
+            payload?: Partial<KanbanNode>
           }) => {
+            let needsFetch = false
+
+            if (payload) {
+              updateCachedData((draft) => {
+                taskIds.forEach((id) => {
+                  const index = draft.findIndex((t) => t.id === id)
+                  if (index !== -1) {
+                    // update the task
+                    Object.assign(draft[index], payload)
+
+                    // if assignees changed, check if it should be removed
+                    if (payload.assignees) {
+                      const isStillAssigned = payload.assignees.some((a) => assignees?.includes(a))
+                      if (!isStillAssigned) {
+                        draft.splice(index, 1)
+                      }
+                    }
+                  } else {
+                    // task not in cache, if it's now assigned to us, we need to fetch
+                    if (payload.assignees?.some((a) => assignees?.includes(a))) {
+                      needsFetch = true
+                    }
+                  }
+                })
+              })
+            } else {
+              needsFetch = true
+            }
+
+            if (!needsFetch) return
+
             const tasks = await getKanbanTasks({ projects, taskIds }, dispatch)
 
             // get all tasks that have been ADDED to the assignees
@@ -153,18 +210,43 @@ const enhancedDashboardGraphqlApi = gqlApi.enhanceEndpoints<TagTypes, UpdatedDef
             })
           }
 
-          const handlePubSub = async (_topic: string, message: any) => {
-            const project = message.project as string
+          const handlePubSub = async (_topic: string, message: Message) => {
+            const project = message.project
             // first check the project name as selected
             if (!projects?.includes(project)) return console.log('project not selected')
             // then get entity id
             const entityId = message.summary.entityId
             if (!entityId) return console.log('no entity id found')
 
+            // current tasks on the board
+            const cacheTasks = getCacheEntry().data ?? []
+            // entity.task.status_changed
+            const field = message.topic.split('.')[2].split('_changed')[0]
+
+            // Only patch the task for the fields status and assignees.
+            if (!['status', 'assignees'].includes(field)) return
+
+            const value = message.summary.value
+            // cast the correct type onto value based on the field
+            let castValue: any = value
+            if (field === 'status') {
+              castValue = String(value)
+            } else if (field === 'assignees') {
+              castValue = Array.isArray(value) ? (value as string[]) : []
+            }
+
+            // check this task is actually on the board
+            const isTaskOnMyBoard = cacheTasks.some((t) => t.id === entityId)
+            // if the field is assignees AND the value includes current assignees then we patch
+            const isValueMe =
+              field === 'assignees' && (castValue as string[]).some((a) => assignees?.includes(a))
+
+            if (!isTaskOnMyBoard && !isValueMe) return
             // patch task updates into kanban cache
             patchKanbanTask({
               taskIds: [entityId],
               projects: [project],
+              payload: { [field]: castValue } as Partial<KanbanNode>,
             })
           }
 

--- a/shared/src/api/queries/userDashboard/getUserDashboard.ts
+++ b/shared/src/api/queries/userDashboard/getUserDashboard.ts
@@ -133,11 +133,56 @@ const enhancedDashboardGraphqlApi = gqlApi.enhanceEndpoints<TagTypes, UpdatedDef
         { updateCachedData, cacheDataLoaded, cacheEntryRemoved, dispatch, getCacheEntry },
       ) {
         let token
+        let fetchQueue: { taskIds: string[]; projects: string[] }[] = []
+        let fetchTimeout: any = null
         try {
           // wait for the initial query to resolve before proceeding
           await cacheDataLoaded
 
-          const patchKanbanTask = async ({
+          const processFetchQueue = async () => {
+            const batch = [...fetchQueue]
+            fetchQueue = []
+            fetchTimeout = null
+
+            const taskIds = Array.from(new Set(batch.flatMap((b) => b.taskIds)))
+            const projects = Array.from(new Set(batch.flatMap((b) => b.projects)))
+
+            if (taskIds.length === 0) return
+
+            const tasks = await getKanbanTasks({ projects, taskIds }, dispatch)
+
+            // get all tasks that have been ADDED to the assignees
+            const tasksWithArgAssignees = tasks.filter((task) =>
+              task.assignees.some((assignee) => assignees?.includes(assignee)),
+            )
+            // get all tasks that have been REMOVED from the assignees
+            const tasksWithoutArgAssignees = tasks.filter(
+              (task) => !task.assignees.some((assignee) => assignees?.includes(assignee)),
+            )
+
+            // patch the kanban query by adding new tasks and remove old tasks
+            updateCachedData((draft) => {
+              // add new tasks
+              tasksWithArgAssignees.forEach((task) => {
+                const index = draft.findIndex((t) => t.id === task.id)
+                if (index === -1) {
+                  draft.push(task)
+                } else {
+                  // update the task
+                  draft[index] = task
+                }
+              })
+              // remove old tasks
+              tasksWithoutArgAssignees.forEach((task) => {
+                const index = draft.findIndex((t) => t.id === task.id)
+                if (index !== -1) {
+                  draft.splice(index, 1)
+                }
+              })
+            })
+          }
+
+          const patchKanbanTask = ({
             projects = [],
             taskIds = [],
             payload,
@@ -177,37 +222,14 @@ const enhancedDashboardGraphqlApi = gqlApi.enhanceEndpoints<TagTypes, UpdatedDef
 
             if (!needsFetch) return
 
-            const tasks = await getKanbanTasks({ projects, taskIds }, dispatch)
+            // add to queue
+            fetchQueue.push({ projects, taskIds })
 
-            // get all tasks that have been ADDED to the assignees
-            const tasksWithArgAssignees = tasks.filter((task) =>
-              task.assignees.some((assignee) => assignees?.includes(assignee)),
-            )
-            // get all tasks that have been REMOVED from the assignees
-            const tasksWithoutArgAssignees = tasks.filter(
-              (task) => !task.assignees.some((assignee) => assignees?.includes(assignee)),
-            )
-
-            // patch the kanban query by adding new tasks and remove old tasks
-            updateCachedData((draft) => {
-              // add new tasks
-              tasksWithArgAssignees.forEach((task) => {
-                const index = draft.findIndex((t) => t.id === task.id)
-                if (index === -1) {
-                  draft.push(task)
-                } else {
-                  // update the task
-                  draft[index] = task
-                }
-              })
-              // remove old tasks
-              tasksWithoutArgAssignees.forEach((task) => {
-                const index = draft.findIndex((t) => t.id === task.id)
-                if (index !== -1) {
-                  draft.splice(index, 1)
-                }
-              })
-            })
+            // debounce the fetch with a random offset
+            if (!fetchTimeout) {
+              const delay = Math.random() * 5000
+              fetchTimeout = setTimeout(processFetchQueue, delay)
+            }
           }
 
           const handlePubSub = async (_topic: string, message: Message) => {
@@ -261,6 +283,7 @@ const enhancedDashboardGraphqlApi = gqlApi.enhanceEndpoints<TagTypes, UpdatedDef
         await cacheEntryRemoved
         // perform cleanup steps once the `cacheEntryRemoved` promise resolves
         PubSub.unsubscribe(token)
+        if (fetchTimeout) clearTimeout(fetchTimeout)
       },
       // // there is only one cache for kanban
       // serializeQueryArgs: () => '',

--- a/shared/src/containers/DetailsPanel/hooks/useGetEntityPath.ts
+++ b/shared/src/containers/DetailsPanel/hooks/useGetEntityPath.ts
@@ -22,7 +22,10 @@ const useGetEntityPath = ({
   // get the folders list for the project
   const { data: { folders: projectFolders = [] } = {}, isFetching: isFetchingRaw } =
     useGetFolderListQuery(
-      { projectName: projectName, attrib: true },
+      // TODO: this is major overkill, we are only using label, name and id
+      //  We add a patch field that allows us to specify what ws message changes should cause an update to this query
+      // @ts-expect-error - patch is not part of the query args
+      { projectName: projectName, patch: ['id', 'name', 'label'] },
       { skip: !projectName || isLoading },
     )
 


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
Optimises the kanban page WS real time updates:

- Only patches tasks that are actually on your board
- Only patches certain attributes
- Uses new `value` field in summary to skip additional requests.
- `projectFolders` query now uses `value` field when possible and for details panel use skips certain values.

