### PR TITLE
Projects page: Reordering columns breaks the view

### DIFF
--- a/shared/src/containers/ListTable/ListTable.tsx
+++ b/shared/src/containers/ListTable/ListTable.tsx
@@ -130,7 +130,15 @@ export function ListTable<TData extends RowData>({
       // @ts-ignore
       const colId = col.id || col.accessorKey
       if (colId) {
-        resolved[colId] = checkColumnVisibility(columnVisibility, colId, defaultColumnVisibility)
+        const isVisible = checkColumnVisibility(columnVisibility, colId, defaultColumnVisibility)
+        // if col has an explicit visible property, use it as a fallback
+        // @ts-ignore
+        const explicitVisible = col.visible
+        if (explicitVisible !== undefined && columnVisibility[colId] === undefined) {
+          resolved[colId] = explicitVisible
+        } else {
+          resolved[colId] = isVisible
+        }
       }
     })
     return resolved

--- a/shared/src/containers/ProjectTreeTable/ProjectTreeTable.tsx
+++ b/shared/src/containers/ProjectTreeTable/ProjectTreeTable.tsx
@@ -421,8 +421,14 @@ export const ProjectTreeTable = ({
   const resolvedColumnVisibility = useMemo(() => {
     const merged = { ...columnVisibility }
     columns.forEach((col) => {
+      // @ts-ignore
+      const explicitVisible = col.visible
       if (col.id && merged[col.id] === undefined) {
-        merged[col.id] = checkColumnVisibility({}, col.id, defaultColumnVisibility)
+        if (explicitVisible !== undefined) {
+          merged[col.id] = explicitVisible
+        } else {
+          merged[col.id] = checkColumnVisibility({}, col.id, defaultColumnVisibility)
+        }
       }
     })
     return merged

--- a/shared/src/containers/ProjectTreeTable/utils/checkColumnVisibility.ts
+++ b/shared/src/containers/ProjectTreeTable/utils/checkColumnVisibility.ts
@@ -44,18 +44,6 @@ export const checkColumnVisibility = (
     }
   }
 
-  // 5. Hardcoded core defaults (always show if not explicitly hidden)
-  const CORE_DEFAULTS: Record<string, boolean> = {
-    thumbnail: true,
-    name: true,
-    status: true,
-    subType: true,
-  }
-
-  if (CORE_DEFAULTS[fieldName] !== undefined) {
-    return CORE_DEFAULTS[fieldName]
-  }
-
-  // 6. Fallback to false (new behavior: opt-in)
+  // 5. Fallback to false (new behavior: opt-in)
   return false
 }

--- a/src/pages/ProjectsPage/constants.ts
+++ b/src/pages/ProjectsPage/constants.ts
@@ -1,25 +1,38 @@
 export const GROUP_BY_FOLDER_KEY = 'projectFolder'
 
 export const DEFAULT_COLUMNS_FOLDER = {
+  thumbnail: true,
+  name: true,
+  status: true,
   attrib_priority: true,
   attrib_description: true,
 }
 export const DEFAULT_COLUMNS_TASK = {
+  thumbnail: true,
+  name: true,
+  status: true,
+  assignees: true,
   attrib_priority: true,
   attrib_description: true,
-  assignees: true,
 }
 export const DEFAULT_COLUMNS_VERSION = {
+  thumbnail: true,
+  name: true,
+  status: true,
   author: true,
   folder: true,
   version: true,
 }
 
 export const DEFAULT_COLUMNS_PRODUCT = {
+  thumbnail: true,
+  name: true,
+  status: true,
   productType: true,
 }
 
 export const DEFAULT_COLUMNS_PROJECT = {
+  thumbnail: true,
   label: true,
   name: false,
   code: true,

--- a/src/pages/ProjectsPage/hooks/useProjectColumnConfig.ts
+++ b/src/pages/ProjectsPage/hooks/useProjectColumnConfig.ts
@@ -44,6 +44,19 @@ export const useProjectColumnConfig = ({ columns }: Props) => {
   columnVisibilityRef.current = columnVisibility
   columnSizingRef.current = columnSizing
 
+  const getFinalVisibility = useCallback(
+    (overrides: VisibilityState) => {
+      const final: VisibilityState = {}
+      columns.forEach((col) => {
+        if (col.id) {
+          final[col.id] = overrides[col.id] ?? col.visible ?? false
+        }
+      })
+      return final
+    },
+    [columns],
+  )
+
   const allColumnIds = useMemo(() => columns.map((c) => c.id as string), [columns])
 
   const handleColumnOrderChange = useCallback(
@@ -51,7 +64,7 @@ export const useProjectColumnConfig = ({ columns }: Props) => {
       const columnConfig = convertTanstackStatesToColumnConfig(
         {
           columnOrder: newOrder,
-          columnVisibility: columnVisibilityRef.current,
+          columnVisibility: getFinalVisibility(columnVisibilityRef.current),
           columnPinning: {},
           columnSizing: columnSizingRef.current,
         },
@@ -59,7 +72,7 @@ export const useProjectColumnConfig = ({ columns }: Props) => {
       )
       await updateViewSettings({ columns: columnConfig.columns }, setLocalColumnOrder, newOrder, {})
     },
-    [allColumnIds, updateViewSettings],
+    [allColumnIds, updateViewSettings, getFinalVisibility],
   )
 
   const handleColumnVisibilityChange = useCallback(
@@ -67,7 +80,7 @@ export const useProjectColumnConfig = ({ columns }: Props) => {
       const columnConfig = convertTanstackStatesToColumnConfig(
         {
           columnOrder: columnOrderRef.current,
-          columnVisibility: newVisibility,
+          columnVisibility: getFinalVisibility(newVisibility),
           columnPinning: {},
           columnSizing: columnSizingRef.current,
         },
@@ -80,7 +93,7 @@ export const useProjectColumnConfig = ({ columns }: Props) => {
         {},
       )
     },
-    [allColumnIds, updateViewSettings],
+    [allColumnIds, updateViewSettings, getFinalVisibility],
   )
 
   const handleColumnSizingChange = useCallback(
@@ -88,7 +101,7 @@ export const useProjectColumnConfig = ({ columns }: Props) => {
       const columnConfig = convertTanstackStatesToColumnConfig(
         {
           columnOrder: columnOrderRef.current,
-          columnVisibility: columnVisibilityRef.current,
+          columnVisibility: getFinalVisibility(columnVisibilityRef.current),
           columnPinning: {},
           columnSizing: newSizing,
         },
@@ -101,7 +114,7 @@ export const useProjectColumnConfig = ({ columns }: Props) => {
         {},
       )
     },
-    [allColumnIds, updateViewSettings],
+    [allColumnIds, updateViewSettings, getFinalVisibility],
   )
 
   /**
@@ -114,7 +127,7 @@ export const useProjectColumnConfig = ({ columns }: Props) => {
       const columnConfig = convertTanstackStatesToColumnConfig(
         {
           columnOrder: newOrder,
-          columnVisibility: newVisibility,
+          columnVisibility: getFinalVisibility(newVisibility),
           columnPinning: {},
           columnSizing: columnSizingRef.current,
         },
@@ -132,7 +145,7 @@ export const useProjectColumnConfig = ({ columns }: Props) => {
         {},
       )
     },
-    [allColumnIds, updateViewSettings],
+    [allColumnIds, updateViewSettings, getFinalVisibility],
   )
 
   return {

--- a/src/pages/ProjectsPage/hooks/useProjectColumns.tsx
+++ b/src/pages/ProjectsPage/hooks/useProjectColumns.tsx
@@ -11,13 +11,16 @@ import ProjectHeartbeat from '../components/ProjectDetailsPanel/components/Proje
 import type { ProjectFolderModel } from '@shared/api'
 import { isEmptyFolderPlaceholderRow, ProjectTableRow } from './useProjectTableRows'
 import { useGlobalContext } from '@shared/context'
+import { DEFAULT_COLUMNS_PROJECT } from '../constants'
 
 const columnHelper = createColumnHelper<ProjectTableRow>()
 
 export type ProjectTableColumnAttributeData = Record<string, AttributeData>
 type FolderMap = Map<string, ProjectFolderModel>
 
-// Padding constants matching ListTable cell indent calculation:
+export type ProjectColumn = ColumnDef<ProjectTableRow, any> & {
+  visible?: boolean
+}
 // TDInner left = var(--padding-m) + depth * 16 = 8 + depth * 16
 // TDInner internal padding = 8px each side
 // Minimum column size for thumbnail: 8 + maxDepth * 16 + 8 + THUMBNAIL_WIDTH + 8 = 24 + maxDepth * 16 + THUMBNAIL_WIDTH
@@ -83,8 +86,6 @@ const STATIC_COLUMNS_AFTER_HEARTBEAT: ColumnDef<ProjectTableRow, any>[] = [
 ]
 
 const isProjectScopedAttribute = (attribute: AttributeModel) => attribute.scope?.includes('project')
-
-export type ProjectColumn = ColumnDef<ProjectTableRow, any>
 
 export const useProjectColumns = (
   foldersMap: FolderMap = new Map(),
@@ -231,29 +232,36 @@ export const useProjectColumns = (
   }, [maxGroupDepth])
 
   const columns = useMemo(
-    () => [
-      thumbnailColumn,
-      ...STATIC_COLUMNS_AFTER_THUMBNAIL,
-      heartbeatColumn,
-      ...STATIC_COLUMNS_AFTER_HEARTBEAT.map((column) =>
-        column.id === 'projectFolder'
-          ? {
-              ...column,
-              sortingFn: (
-                rowA: { original: ProjectTableRow },
-                rowB: { original: ProjectTableRow },
-              ) => {
-                const labelA =
-                  foldersMap.get(rowA.original.projectFolder ?? '')?.label ?? 'No folder'
-                const labelB =
-                  foldersMap.get(rowB.original.projectFolder ?? '')?.label ?? 'No folder'
-                return labelA.localeCompare(labelB, undefined, { sensitivity: 'base' })
-              },
-            }
-          : column,
-      ),
-      ...attribColumns,
-    ],
+    () =>
+      (
+        [
+          thumbnailColumn,
+          ...STATIC_COLUMNS_AFTER_THUMBNAIL,
+          heartbeatColumn,
+          ...STATIC_COLUMNS_AFTER_HEARTBEAT.map((column) =>
+            column.id === 'projectFolder'
+              ? {
+                  ...column,
+                  sortingFn: (
+                    rowA: { original: ProjectTableRow },
+                    rowB: { original: ProjectTableRow },
+                  ) => {
+                    const labelA =
+                      foldersMap.get(rowA.original.projectFolder ?? '')?.label ?? 'No folder'
+                    const labelB =
+                      foldersMap.get(rowB.original.projectFolder ?? '')?.label ?? 'No folder'
+                    return labelA.localeCompare(labelB, undefined, { sensitivity: 'base' })
+                  },
+                }
+              : column,
+          ),
+          ...attribColumns,
+        ] as ProjectColumn[]
+      ).map((col) => ({
+        ...col,
+        visible:
+          col.visible ?? (DEFAULT_COLUMNS_PROJECT as Record<string, boolean>)[col.id!] ?? false,
+      })),
     [attribColumns, foldersMap, heartbeatColumn, thumbnailColumn],
   )
 


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
When making an initial change to the columns they would all disappear because undefined is now treated as hidden.

Now we ensure the default columns are included as `visible: true` on first columns patch.

