### PR TITLE
Views: Fix issue where a view could sometimes disapear

### DIFF
--- a/shared/src/api/queries/views/updateViews.ts
+++ b/shared/src/api/queries/views/updateViews.ts
@@ -202,9 +202,13 @@ const updateViewsApi = getViewsApi.enhanceEndpoints({
       },
       transformErrorResponse: (error: any) => error.data?.detail,
       invalidatesTags: (_r, _e, { viewType, projectName, viewId, payload }) => {
-        const tags: any[] = [{ type: 'view', id: viewId }]
+        const tags: any[] = []
 
-        // Only invalidate the full list if metadata fields (like label) have changed
+        // Only invalidate when metadata fields (label, owner, etc.) change.
+        // For settings-only updates the optimistic cache patches are sufficient —
+        // emitting the view ID tag here would trigger a background refetch that races
+        // with any other in-flight rapid mutations and temporarily reverts the cache
+        // to a stale server response, causing a visible "previous view" flicker.
         const metadataFields = [
           'label',
           'owner',
@@ -217,6 +221,7 @@ const updateViewsApi = getViewsApi.enhanceEndpoints({
         const hasMetadataChanges = Object.keys(payload).some((key) => metadataFields.includes(key))
 
         if (hasMetadataChanges) {
+          tags.push({ type: 'view', id: viewId })
           tags.push(getScopeTag(viewType, projectName))
         }
 

--- a/shared/src/containers/Views/context/ViewsContext.tsx
+++ b/shared/src/containers/Views/context/ViewsContext.tsx
@@ -155,7 +155,7 @@ export const ViewsProvider: FC<ViewsProviderProps> = ({
   })
 
   // Fetch views data and filter out base views
-  const { currentData: viewsListRaw = [], isFetching: isLoadingViewsList } = useListViewsQuery(
+  const { currentData: viewsListRaw = [], isLoading: isLoadingViewsList } = useListViewsQuery(
     { projectName: projectName, viewType: viewType as string },
     { skip: !viewType },
   )
@@ -179,22 +179,24 @@ export const ViewsProvider: FC<ViewsProviderProps> = ({
   })
 
   //   always get your working view
-  const { currentData: workingView, isFetching: isLoadingWorkingView } = useGetWorkingViewQuery(
+  const { currentData: workingView, isLoading: isLoadingWorkingView } = useGetWorkingViewQuery(
     { projectName: projectName, viewType: viewType as string },
     { skip: !viewType },
   )
 
   // Fetch both project and studio base views
-  const { currentData: projectBaseView, isFetching: isLoadingProjectBaseView } =
-    useGetBaseViewQuery(
-      { projectName: projectName, viewType: viewType as string },
-      { skip: !viewType },
-    )
-  const { currentData: studioBaseView, isFetching: isLoadingStudioBaseView } = useGetBaseViewQuery(
+  const { currentData: projectBaseView, isLoading: isLoadingProjectBaseView } = useGetBaseViewQuery(
+    { projectName: projectName, viewType: viewType as string },
+    { skip: !viewType },
+  )
+  const { currentData: studioBaseView, isLoading: isLoadingStudioBaseView } = useGetBaseViewQuery(
     { projectName: undefined, viewType: viewType as string },
     { skip: !viewType },
   )
 
+  // isLoadingViews is true ONLY on the very first fetch (no cached data yet).
+  // It does NOT flip back to true during background re-fetches (e.g. after a save),
+  // which prevents UI flickering in consumers like ProjectOverviewContext.
   const isLoadingViews =
     isLoadingViewsList ||
     isLoadingDefaultView ||

--- a/shared/src/containers/Views/context/ViewsContext.tsx
+++ b/shared/src/containers/Views/context/ViewsContext.tsx
@@ -144,17 +144,18 @@ export const ViewsProvider: FC<ViewsProviderProps> = ({
   )
 
   // setting of default views
-  const [selectedView, setSelectedView, previousSelectedViewId] = useSelectedView({
-    viewType: viewType as string,
-    projectName: projectName,
-  })
+  const [selectedView, setSelectedView, previousSelectedViewId, isLoadingDefaultView] =
+    useSelectedView({
+      viewType: viewType as string,
+      projectName: projectName,
+    })
 
   const [viewSettingsChanged, setViewSettingsChanged] = useViewSettingsChanged({
     viewType: viewType as ViewType,
   })
 
   // Fetch views data and filter out base views
-  const { currentData: viewsListRaw = [], isLoading: isLoadingViews } = useListViewsQuery(
+  const { currentData: viewsListRaw = [], isFetching: isLoadingViewsList } = useListViewsQuery(
     { projectName: projectName, viewType: viewType as string },
     { skip: !viewType },
   )
@@ -178,20 +179,28 @@ export const ViewsProvider: FC<ViewsProviderProps> = ({
   })
 
   //   always get your working view
-  const { currentData: workingView } = useGetWorkingViewQuery(
+  const { currentData: workingView, isFetching: isLoadingWorkingView } = useGetWorkingViewQuery(
     { projectName: projectName, viewType: viewType as string },
     { skip: !viewType },
   )
 
   // Fetch both project and studio base views
-  const { currentData: projectBaseView } = useGetBaseViewQuery(
-    { projectName: projectName, viewType: viewType as string },
-    { skip: !viewType },
-  )
-  const { currentData: studioBaseView } = useGetBaseViewQuery(
+  const { currentData: projectBaseView, isFetching: isLoadingProjectBaseView } =
+    useGetBaseViewQuery(
+      { projectName: projectName, viewType: viewType as string },
+      { skip: !viewType },
+    )
+  const { currentData: studioBaseView, isFetching: isLoadingStudioBaseView } = useGetBaseViewQuery(
     { projectName: undefined, viewType: viewType as string },
     { skip: !viewType },
   )
+
+  const isLoadingViews =
+    isLoadingViewsList ||
+    isLoadingDefaultView ||
+    isLoadingWorkingView ||
+    isLoadingProjectBaseView ||
+    isLoadingStudioBaseView
 
   const workingSettings = workingView?.settings
 

--- a/shared/src/containers/Views/hooks/pages/useListsViewSettings.ts
+++ b/shared/src/containers/Views/hooks/pages/useListsViewSettings.ts
@@ -50,11 +50,19 @@ export const useListsViewSettings = (): ListsViewSettings => {
     [JSON.stringify(viewSettings)],
   )
 
-  // Sync local state with server when viewSettings change
+  // Sync local state with server when the relevant setting fields change.
+  // Use per-field deps (not JSON.stringify(viewSettings)) so a change to one
+  // field does not clear in-flight local state for unrelated fields, which
+  // would cause a visible flicker during rapid sequential updates.
   useEffect(() => {
     setLocalFilters(null)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [JSON.stringify((viewSettings as OverviewSettings)?.filter)])
+
+  useEffect(() => {
     setLocalColumns(null)
-  }, [JSON.stringify(viewSettings)])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [JSON.stringify((viewSettings as OverviewSettings)?.columns)])
 
   // Use local state if available, otherwise use server state
   const filters = localFilters !== null ? localFilters : serverFilters

--- a/shared/src/containers/Views/hooks/pages/useOverviewViewSettings.ts
+++ b/shared/src/containers/Views/hooks/pages/useOverviewViewSettings.ts
@@ -63,12 +63,27 @@ export const useOverviewViewSettings = ({ viewSettings, updateViewSettings }: Pr
     [JSON.stringify(viewSettings)],
   )
 
-  // Sync local state with server when viewSettings change
+  // Sync local state with server when the relevant setting fields change.
+  // Use per-field deps (not JSON.stringify(viewSettings)) so a change to one
+  // field does not clear in-flight local state for unrelated fields, which
+  // would cause a visible flicker during rapid sequential updates.
   useEffect(() => {
     setLocalFilters(null)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [JSON.stringify((viewSettings as OverviewSettings)?.filter)])
+
+  useEffect(() => {
     setLocalHierarchy(null)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    (viewSettings as OverviewSettings)?.showHierarchy,
+    (viewSettings as OverviewSettings)?.groupBy,
+  ])
+
+  useEffect(() => {
     setLocalColumns(null)
-  }, [JSON.stringify(viewSettings)])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [JSON.stringify((viewSettings as OverviewSettings)?.columns)])
 
   // Use local state if available, otherwise use server state
   const filters = localFilters !== null ? localFilters : serverFilters
@@ -178,9 +193,7 @@ export const useOverviewViewSettings = ({ viewSettings, updateViewSettings }: Pr
 
       // Combined setter lets updateViewSettings manage optimism/reset for both
       // local states atomically (so error paths don't leave one stale).
-      const combinedSetter = (
-        value: { showHierarchy: boolean; columns: ColumnsConfig } | null,
-      ) => {
+      const combinedSetter = (value: { showHierarchy: boolean; columns: ColumnsConfig } | null) => {
         if (value === null) {
           setLocalHierarchy(null)
           setLocalColumns(null)

--- a/shared/src/containers/Views/hooks/pages/useTaskProgressViewSettings.ts
+++ b/shared/src/containers/Views/hooks/pages/useTaskProgressViewSettings.ts
@@ -46,11 +46,19 @@ export const useTaskProgressViewSettings = (): Return => {
   const serverColumns = (taskProgressSettings?.columns as ColumnItemModel[]) ?? []
   const serverSliceType = taskProgressSettings?.sliceType
 
-  // Sync local state with server when viewSettings change
+  // Sync local state with server when the relevant setting fields change.
+  // Use per-field deps (not JSON.stringify(viewSettings)) so a change to one
+  // field does not clear in-flight local state for unrelated fields, which
+  // would cause a visible flicker during rapid sequential updates.
   useEffect(() => {
     setLocalFilters(null)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [JSON.stringify((viewSettings as TaskProgressSettings)?.filter)])
+
+  useEffect(() => {
     setLocalColumns(null)
-  }, [JSON.stringify(viewSettings)])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [JSON.stringify((viewSettings as TaskProgressSettings)?.columns)])
 
   // Use local state if available, otherwise use server state
   const filters = localFilters !== null ? localFilters : serverFilters

--- a/shared/src/containers/Views/hooks/useSelectedView.tsx
+++ b/shared/src/containers/Views/hooks/useSelectedView.tsx
@@ -21,7 +21,7 @@ type Return = [
 ]
 
 export const useSelectedView = ({ viewType, projectName }: Props): Return => {
-  const { currentData: defaultView, isFetching: isLoading } = useGetDefaultViewQuery(
+  const { currentData: defaultView, isLoading } = useGetDefaultViewQuery(
     { viewType, projectName },
     { skip: !viewType },
   )

--- a/shared/src/containers/Views/hooks/useSelectedView.tsx
+++ b/shared/src/containers/Views/hooks/useSelectedView.tsx
@@ -17,10 +17,11 @@ type Return = [
   selectedView: GetDefaultViewApiResponse | undefined,
   setSelectedView: (viewId: string) => void,
   previousSelectedViewId: string | undefined,
+  isLoading: boolean,
 ]
 
 export const useSelectedView = ({ viewType, projectName }: Props): Return => {
-  const { currentData: defaultView } = useGetDefaultViewQuery(
+  const { currentData: defaultView, isFetching: isLoading } = useGetDefaultViewQuery(
     { viewType, projectName },
     { skip: !viewType },
   )
@@ -53,5 +54,5 @@ export const useSelectedView = ({ viewType, projectName }: Props): Return => {
     }
   }
 
-  return [defaultView, setSelectedView, previousSelectedViewId]
+  return [defaultView, setSelectedView, previousSelectedViewId, isLoading]
 }

--- a/shared/src/containers/Views/utils/viewUpdateHelper.ts
+++ b/shared/src/containers/Views/utils/viewUpdateHelper.ts
@@ -21,7 +21,7 @@ import { generateWorkingView } from './generateWorkingView'
 import { toast } from 'react-toastify'
 import { useCallback } from 'react'
 import { useStore } from 'react-redux'
-import { useViewsContext, ViewsContextValue, ViewSettings } from '../context/ViewsContext'
+import { useViewsContext, ViewsContextValue } from '../context/ViewsContext'
 
 interface UpdateOptions {
   successMessage?: string
@@ -50,6 +50,11 @@ export type UpdateViewSettingsFn = (
   options: UpdateOptions,
 ) => Promise<void>
 
+export interface LatestSettingsResult {
+  settings?: any
+  workingViewId?: string
+}
+
 export const updateViewSettings = async (
   updatedSettings: any,
   localStateSetter: (value: any) => void,
@@ -59,7 +64,7 @@ export const updateViewSettings = async (
   onApplyViewChanges: (arg: any, viewId?: string) => Promise<EntityIdResponse | void>,
   // Reads latest effective settings from RTK Query cache at call time. Required to
   // prevent stale-closure races when two updates fire in the same tick.
-  getLatestSettings: () => ViewSettings | undefined,
+  getLatest: () => LatestSettingsResult,
   // Invoked synchronously right after the mutation is dispatched. The caller
   // uses this to flip a "cache is fresh this tick" flag so subsequent sync
   // calls in the same tick read the just-updated cache instead of stale state.
@@ -73,6 +78,7 @@ export const updateViewSettings = async (
     setSelectedView,
     workingView,
     onSettingsChanged,
+    isLoadingViews,
   } = viewContext
 
   if (!viewType) throw new Error('No view type provided for updating view settings')
@@ -86,9 +92,11 @@ export const updateViewSettings = async (
 
     // Read latest settings from RTK cache (includes prior same-tick optimistic writes).
     // Fallback to closure-captured value if cache has nothing (first render, etc.).
-    const latestSettings = getLatestSettings() ?? viewSettings
+    const { settings: latestSettingsFromCache, workingViewId: latestWorkingViewIdFromCache } =
+      getLatest()
+    const latestSettings = latestSettingsFromCache ?? viewSettings
 
-    if (!latestSettings && viewContext.isLoadingViews) {
+    if (!latestSettings && isLoadingViews) {
       toast.warn('Views are still loading. Please wait a moment and try again.')
       console.warn(
         'updateViewSettings called while views are still loading. Aborting to prevent data loss.',
@@ -103,7 +111,7 @@ export const updateViewSettings = async (
     const newWorkingView = generateWorkingView(newSettings)
 
     // Ensure the payload uses the consistent ID if we already have a working view
-    const viewId = workingView?.id
+    const viewId = latestWorkingViewIdFromCache ?? workingView?.id
     if (viewId) {
       newWorkingView.id = viewId
     }
@@ -128,7 +136,8 @@ export const updateViewSettings = async (
     markCacheDirty()
 
     // if not already on the working view: set that the settings have been changed to show the little blue save button and switch to the working view
-    if (!wasWorking) {
+    // Note: selectedView?.id is always a real UUID from the server, never the WORKING_VIEW_ID sentinel.
+    if (!wasWorking || selectedView?.id !== viewId) {
       if (selectedView) {
         onSettingsChanged(true)
       }
@@ -199,35 +208,69 @@ export const useViewUpdateHelper = () => {
   // cache. Otherwise returns undefined and the caller falls back to the
   // closure-captured viewSettings (correct baseline for the first write in a
   // tick, including the named-view → working-view fork).
-  const getLatestSettings = useCallback((): ViewSettings | undefined => {
-    if (!cacheDirtyThisTick) return undefined
-    const { viewType, projectName } = viewContext
-    if (!viewType) return undefined
-    // RTK selector state is typed against the full RootState; we don't have that
-    // type in @shared and the store is project-specific. Cast is safe: the
-    // selector only touches the api slice, which exists in every consumer app.
-    const entry = viewsQueries.endpoints.getWorkingView.select({ viewType, projectName })(
-      store.getState() as any,
-    )
-    return entry?.data?.settings
+  const getLatest = useCallback((): LatestSettingsResult => {
+    const { viewType, projectName, selectedView, workingView } = viewContext
+    if (!viewType) return {}
+
+    const state = store.getState() as any
+
+    // 1. Get the working view from the store — most authoritative after optimistic writes.
+    const workingViewEntry = viewsQueries.endpoints.getWorkingView.select({
+      viewType,
+      projectName,
+    })(state)
+    const storeWorkingViewId = workingViewEntry?.data?.id
+    // Prefer the store's working view ID over the potentially stale context closure value.
+    const resolvedWorkingViewId = storeWorkingViewId || workingView?.id
+
+    // 2. Determine the currently targeted view ID.
+    // Use the store's getDefaultView cache (updated optimistically by setSelectedView) so that
+    // an in-flight selection change is visible before React re-renders the context.
+    const defaultViewEntry = viewsQueries.endpoints.getDefaultView.select({
+      viewType,
+      projectName,
+    })(state)
+    const targetViewId = defaultViewEntry?.data?.id || selectedView?.id
+
+    // 3. Determine if the working view is active.
+    // IMPORTANT: use !!resolvedWorkingViewId to avoid the undefined === undefined false-positive
+    // that would occur on a new project before any working view exists.
+    // Note: WORKING_VIEW_ID ('_working_') is a UI-only sentinel; it never appears in
+    // server-side cache IDs, so there is no point checking for it here.
+    const isWorkingViewActive =
+      (!!resolvedWorkingViewId && targetViewId === resolvedWorkingViewId) || cacheDirtyThisTick
+
+    // 4. If the working view is active, use its cache as the baseline to prevent stale merges.
+    if (isWorkingViewActive && workingViewEntry?.data?.settings) {
+      return {
+        settings: workingViewEntry.data.settings,
+        workingViewId: resolvedWorkingViewId,
+      }
+    }
+
+    // 5. For named views: use the defaultView cache settings as the baseline.
+    // This is populated by the initial useGetDefaultViewQuery fetch and is more reliable
+    // than the getView endpoint cache (which is only fetched on-demand when editing).
+    if (defaultViewEntry?.data?.settings) {
+      return {
+        settings: defaultViewEntry.data.settings,
+        workingViewId: resolvedWorkingViewId,
+      }
+    }
+
+    return { workingViewId: resolvedWorkingViewId }
   }, [store, viewContext])
 
   const updateViewSettingsHandler = useCallback<UpdateViewSettingsFn>(
     async (...args) =>
-      await updateViewSettings(
-        ...args,
-        viewContext,
-        onApplyViewChanges,
-        getLatestSettings,
-        markCacheDirty,
-      ),
-    [viewContext, onApplyViewChanges, getLatestSettings],
+      await updateViewSettings(...args, viewContext, onApplyViewChanges, getLatest, markCacheDirty),
+    [viewContext, onApplyViewChanges, getLatest],
   )
 
   return {
     updateViewSettings: updateViewSettingsHandler,
     onCreateView: onApplyViewChanges,
-    getLatestSettings,
+    getLatestSettings: getLatest,
     markCacheDirty,
   }
 }

--- a/shared/src/containers/Views/utils/viewUpdateHelper.ts
+++ b/shared/src/containers/Views/utils/viewUpdateHelper.ts
@@ -88,6 +88,14 @@ export const updateViewSettings = async (
     // Fallback to closure-captured value if cache has nothing (first render, etc.).
     const latestSettings = getLatestSettings() ?? viewSettings
 
+    if (!latestSettings && viewContext.isLoadingViews) {
+      toast.warn('Views are still loading. Please wait a moment and try again.')
+      console.warn(
+        'updateViewSettings called while views are still loading. Aborting to prevent data loss.',
+      )
+      return
+    }
+
     // Create settings with updates
     const newSettings = { ...latestSettings, ...updatedSettings }
 

--- a/shared/src/containers/Views/utils/viewUpdateHelper.ts
+++ b/shared/src/containers/Views/utils/viewUpdateHelper.ts
@@ -78,7 +78,6 @@ export const updateViewSettings = async (
     setSelectedView,
     workingView,
     onSettingsChanged,
-    isLoadingViews,
   } = viewContext
 
   if (!viewType) throw new Error('No view type provided for updating view settings')
@@ -96,10 +95,13 @@ export const updateViewSettings = async (
       getLatest()
     const latestSettings = latestSettingsFromCache ?? viewSettings
 
-    if (!latestSettings && isLoadingViews) {
-      toast.warn('Views are still loading. Please wait a moment and try again.')
+    // If we have no settings baseline at all (neither from cache nor from context),
+    // abort to prevent writing a partial payload that would overwrite saved settings.
+    // This is a defence-in-depth guard; in normal flow isLoadingViews prevents callers
+    // from triggering updates before data is available.
+    if (latestSettings === undefined) {
       console.warn(
-        'updateViewSettings called while views are still loading. Aborting to prevent data loss.',
+        'updateViewSettings: no settings baseline available, aborting to prevent data loss.',
       )
       return
     }

--- a/src/pages/ProjectsPage/constants.ts
+++ b/src/pages/ProjectsPage/constants.ts
@@ -15,6 +15,8 @@ export const DEFAULT_COLUMNS_FOLDER = {
 }
 export const DEFAULT_COLUMNS_TASK = {
   ...CORE_DEFAULT_COLUMNS,
+  assignees: true,
+  folder: true,
   attrib_priority: true,
   attrib_description: true,
 }


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
There was a race condition in views that meant you could potentially try to update a view before it was loaded. This would cause you to overwrite your view completely. This sometimes happened when there was a automatic sync hook like the slicer type that would update the view on a page before the view had loaded, but sometimes it had loaded in time.


## Technical details
<!-- Please state any technical details such as limitations -->
- Do not invalidate views when updating settings. Drastically improves stability and removes flickering


## Additional context
<!-- Add any other context or screenshots here. -->

