### PR TITLE
Slicer: persist selection per project, page and slice type

### DIFF
--- a/shared/src/containers/Slicer/components/Slicer.tsx
+++ b/shared/src/containers/Slicer/components/Slicer.tsx
@@ -59,6 +59,15 @@ export const Slicer: FC<SlicerProps> = ({
     onRowSelectionChange?.(s, sliceMap)
   }
 
+  // selection ids are persisted, selection data is not — rebuild it once slice rows are loaded
+  // keyed on sliceMap so it only fires when loaded rows actually match the current slice type
+  useEffect(() => {
+    if (isViewSyncPending || isLoadingSliceTableData) return
+    if (!Object.keys(rowSelection).some((id) => rowSelection[id])) return
+    onRowSelectionChange?.(rowSelection, sliceMap)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sliceMap, isViewSyncPending, isLoadingSliceTableData])
+
   // on first mount, check that current sliceType is in sliceFields, if not, change to first option
   // Skip if view sync is pending — the view will set the correct type once loaded
   useEffect(() => {

--- a/shared/src/containers/Slicer/context/SlicerContext.tsx
+++ b/shared/src/containers/Slicer/context/SlicerContext.tsx
@@ -94,24 +94,25 @@ export const SlicerProvider = ({
   onSliceTypeChange: onSliceTypeChangeProp,
   scope = 'project',
 }: SlicerProviderProps) => {
-  const [internalRowSelection, setInternalRowSelection] = useLocalStorage<RowSelectionState>(
-    `${scope}-slicer-rowSelection`,
-    {},
-  )
-  const [internalExpanded, setInternalExpanded] = useLocalStorage<ExpandedState>(
-    `${scope}-slicer-expanded`,
-    {},
-  )
   const [internalSliceType, setInternalSliceType] = useLocalStorage<SliceType>(
     `${scope}-slicer-sliceType`,
     'hierarchy',
+  )
+  const sliceType = sliceTypeProp ?? internalSliceType
+
+  const [internalRowSelection, setInternalRowSelection] = useLocalStorage<RowSelectionState>(
+    `${scope}-slicer-rowSelection-${sliceType}`,
+    {},
+  )
+  const [internalExpanded, setInternalExpanded] = useLocalStorage<ExpandedState>(
+    `${scope}-slicer-expanded-${sliceType}`,
+    {},
   )
 
   const rowSelection = rowSelectionProp ?? internalRowSelection
   const setRowSelection = setRowSelectionProp ?? setInternalRowSelection
   const expanded = expandedProp ?? internalExpanded
   const setExpanded = setExpandedProp ?? setInternalExpanded
-  const sliceType = sliceTypeProp ?? internalSliceType
 
   const [isViewSyncPending, setIsViewSyncPending] = useState(false)
   const [rowSelectionData, setRowSelectionData] = useState<SelectionData>({})
@@ -189,31 +190,21 @@ export const SlicerProvider = ({
     leavePersistentSlice,
     returnToPersistentSlice,
   ) => {
-    // reset selection
-    setRowSelection({})
-    // set slice type
+    // set slice type — selection is NOT reset, each slice type loads from its own storage key
     if (onSliceTypeChangeProp) {
       onSliceTypeChangeProp(newSliceType, leavePersistentSlice, returnToPersistentSlice)
     } else {
       setInternalSliceType(newSliceType)
     }
-    // reset selection data
+    // clear stale in-memory data, Slicer rebuilds it from the restored selection once rows load
     setRowSelectionData({})
     // set persistent selection data
     if (leavePersistentSlice) setPersistentRowSelectionData(rowSelectionData)
     // we returned to the persisted slice type
-
     if (returnToPersistentSlice) {
-      // clear the persisted selection data
+      // clear the persisted selection data and restore data instantly while rows load
       setPersistentRowSelectionData({})
-      // restore the selection data and selection
       setRowSelectionData(persistentRowSelectionData)
-      setRowSelection(
-        Object.keys(persistentRowSelectionData).reduce((acc, id) => {
-          acc[id] = true
-          return acc
-        }, {} as RowSelectionState),
-      )
     }
   }
 

--- a/shared/src/containers/Slicer/context/SlicerContext.tsx
+++ b/shared/src/containers/Slicer/context/SlicerContext.tsx
@@ -2,6 +2,7 @@ import {
   createContext,
   useContext,
   useState,
+  useEffect,
   ReactNode,
   ForwardRefExoticComponent,
   RefAttributes,
@@ -118,6 +119,12 @@ export const SlicerProvider = ({
   const [rowSelectionData, setRowSelectionData] = useState<SelectionData>({})
   // if there is a need to leavePersistentSlice row selection data between slice changes (like the hierarchy)
   const [persistentRowSelectionData, setPersistentRowSelectionData] = useState<SelectionData>({})
+
+  // in-memory selection data must not survive scope (project/page) changes
+  useEffect(() => {
+    setRowSelectionData({})
+    setPersistentRowSelectionData({})
+  }, [scope])
   const config: SlicerConfig = {
     progress: {
       fields: [

--- a/shared/src/containers/Slicer/hooks/useSlicerViewSync.ts
+++ b/shared/src/containers/Slicer/hooks/useSlicerViewSync.ts
@@ -14,13 +14,7 @@ export const useSlicerViewSync = (
   onUpdateSliceType: (sliceType: string) => void,
   isLoadingViews?: boolean,
 ) => {
-  const {
-    sliceType,
-    setSliceType,
-    setIsViewSyncPending,
-    setRowSelection,
-    setRowSelectionData,
-  } = useSlicerContext()
+  const { sliceType, setSliceType, setIsViewSyncPending } = useSlicerContext()
   const initializedRef = useRef(false)
   const isRestoringTypeRef = useRef(false)
 
@@ -48,11 +42,10 @@ export const useSlicerViewSync = (
     setIsViewSyncPending(false)
 
     // Restore saved slice type if present.
+    // Selection is keyed per slice type in storage, so no reset is needed here.
     if (viewSliceType && viewSliceType !== sliceType) {
       isRestoringTypeRef.current = true
       setSliceType(viewSliceType as SliceType)
-      setRowSelection({})
-      setRowSelectionData({})
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isLoadingViews])

--- a/src/pages/ProjectPage/ProjectPage.tsx
+++ b/src/pages/ProjectPage/ProjectPage.tsx
@@ -411,7 +411,7 @@ const ProjectPageInner = () => {
         onVersionCreated={handleNewVersionUploaded}
       >
         <EntityListsProvider projectName={projectName}>
-          <SlicerProvider scope={`${projectName}-${module}`}>
+          <SlicerProvider scope={`${projectName}-${addonName ?? module}`}>
             <WithViews viewType={page.viewType} projectName={projectName}>
               {page.component}
             </WithViews>

--- a/src/pages/ProjectPage/ProjectPage.tsx
+++ b/src/pages/ProjectPage/ProjectPage.tsx
@@ -411,7 +411,7 @@ const ProjectPageInner = () => {
         onVersionCreated={handleNewVersionUploaded}
       >
         <EntityListsProvider projectName={projectName}>
-          <SlicerProvider>
+          <SlicerProvider scope={`${projectName}-${module}`}>
             <WithViews viewType={page.viewType} projectName={projectName}>
               {page.component}
             </WithViews>


### PR DESCRIPTION
Slicer: persist selection per project, page and slice type

<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Fixes slicer selection leaking between projects. Selection is now saved per project, page and slice type, and switching slice types keeps each type's selection.

## Technical details
<!-- Please state any technical details such as limitations -->

- `SlicerProvider` gets `scope={projectName}-{module}`, localStorage keys become `{project}-{page}-slicer-*` keyed by slice type
- slice type change no longer resets selection  the new storage key loads it
- new effect in `Slicer.tsx` rebuilds `rowSelectionData` once rows load, so restored selection actually filters (before it only highlighted)

## Additional context
<!-- Add any other context or screenshots here. -->

