### PR TITLE
Overview: do not include slicer folder in table

### DIFF
--- a/shared/src/containers/ProjectTreeTable/context/ProjectTableProvider.tsx
+++ b/shared/src/containers/ProjectTreeTable/context/ProjectTableProvider.tsx
@@ -77,6 +77,7 @@ export interface ProjectTableProviderProps {
   entitiesMap: EntitiesMap
   tasksByFolderMap: TasksByFolderMap
   tableRows?: TableRow[] // any extra rows that we want to add to the table
+  selectedFolders?: string[]
 
   // grouping
   groups: EntityGroup[]
@@ -156,6 +157,7 @@ export const ProjectTableProvider = ({
   tasksMap,
   entitiesMap,
   tasksByFolderMap,
+  selectedFolders,
   expanded,
   showHierarchy,
   loadingTasks,
@@ -210,6 +212,7 @@ export const ProjectTableProvider = ({
     showEmptyFolders: showEmptyGroups,
     loadingTasks,
     isLoadingMore,
+    selectedFolders,
   })
 
   // overrideGroupBy (from view dropdown) takes priority over Customize panel's groupBy.

--- a/shared/src/containers/ProjectTreeTable/hooks/useBuildProjectDataTable.ts
+++ b/shared/src/containers/ProjectTreeTable/hooks/useBuildProjectDataTable.ts
@@ -27,6 +27,7 @@ type Params = {
   loadingTasks?: LoadingTasks
   isLoadingMore?: boolean
   groupBy?: TableGroupBy
+  selectedFolders?: string[]
 }
 
 export default function useBuildProjectDataTable({
@@ -40,6 +41,7 @@ export default function useBuildProjectDataTable({
   showEmptyFolders = false,
   loadingTasks = {},
   isLoadingMore = false,
+  selectedFolders = [],
 }: Params): TableRow[] {
   const project = useProjectContext()
   const getEntityTypeData = useGetEntityTypeData({ projectInfo: project })
@@ -156,6 +158,19 @@ export default function useBuildProjectDataTable({
       }
     }
 
+    const createRootTaskRows = (): TableRow[] => {
+      const rootTaskRows: TableRow[] = []
+      for (const folderId of selectedFolders) {
+        if (foldersMap.has(folderId)) continue
+        const folderTaskIds = tasksByFolderMap.get(folderId) || []
+        for (const taskId of folderTaskIds) {
+          const task = tasksMap.get(taskId)
+          if (task) rootTaskRows.push(createTaskRow(task))
+        }
+      }
+      return rootTaskRows
+    }
+
     // Flat folder view: all folders at root level, each expandable to show tasks
     if (isFlatFolderView) {
       const flatFolderRows: TableRow[] = []
@@ -219,6 +234,8 @@ export default function useBuildProjectDataTable({
 
         flatFolderRows.push(row)
       }
+
+      flatFolderRows.push(...createRootTaskRows())
 
       return flatFolderRows
     }
@@ -347,6 +364,8 @@ export default function useBuildProjectDataTable({
       parentRow.subRows?.push(childRow)
     }
 
+    rootRows.push(...createRootTaskRows())
+
     // Add any extra rows to the root rows
     for (const row of rows || []) {
       rootRows.push(row)
@@ -356,6 +375,7 @@ export default function useBuildProjectDataTable({
   }, [
     foldersMap,
     tasksMap,
+    tasksByFolderMap,
     rows,
     visibleFolders,
     childToParentMap,
@@ -365,5 +385,6 @@ export default function useBuildProjectDataTable({
     showEmptyFolders,
     loadingTasks,
     isLoadingMore,
+    selectedFolders,
   ])
 }

--- a/shared/src/containers/ProjectTreeTable/hooks/useFetchOverviewData.ts
+++ b/shared/src/containers/ProjectTreeTable/hooks/useFetchOverviewData.ts
@@ -40,6 +40,7 @@ type useFetchOverviewDataData = {
 type Params = {
   projectName: string
   selectedFolders: string[] // folders selected in the slicer (hierarchy)
+  excludeSelectedFolders?: boolean
   taskIds?: string[] // specific task IDs to filter by (from entity list slicer)
   taskFilters: QueryFilterParams // filters for tasks
   folderFilters: QueryFilterParams // filters for folders
@@ -58,6 +59,7 @@ type Params = {
 export const useFetchOverviewData = ({
   projectName,
   selectedFolders, // comes from the slicer
+  excludeSelectedFolders = false,
   taskIds, // specific task IDs from entity list slicer
   taskFilters,
   folderFilters,
@@ -86,6 +88,10 @@ export const useFetchOverviewData = ({
     .filter(([id]) => !isGroupId(id)) // filter out the root folder
     .map(([id]) => id)
 
+  const taskParentIds = excludeSelectedFolders
+    ? Array.from(new Set([...expandedParentIds, ...selectedFolders]))
+    : expandedParentIds
+
   const {
     data: expandedFoldersTasks = [],
     isFetching: isFetchingExpandedFoldersTasks,
@@ -94,12 +100,12 @@ export const useFetchOverviewData = ({
   } = useGetOverviewTasksByFoldersQuery(
     {
       projectName,
-      parentIds: expandedParentIds,
+      parentIds: taskParentIds,
       filter: taskFilters.filterString,
       folderFilter: folderFilters.filterString,
       search: taskFilters.search,
     },
-    { skip: !expandedParentIds.length || (!showHierarchy && !isFlatFolderView) },
+    { skip: !taskParentIds.length || (!showHierarchy && !isFlatFolderView) },
   )
 
   const skipFoldersByTaskFilter =
@@ -146,15 +152,24 @@ export const useFetchOverviewData = ({
 
       // Check if parent is expanded
       const parentId = folder.parentId as string
-      const isSelectedInSlicer = selectedFolders.includes(folder.id as string)
+      const isRootFromSlicer = excludeSelectedFolders
+        ? selectedFolders.includes(parentId)
+        : selectedFolders.includes(folder.id as string)
       const expandedMap = expanded as Record<string, boolean>
-      if (expandedMap[parentId] === true || isSelectedInSlicer) {
+      if (expandedMap[parentId] === true || isRootFromSlicer) {
         visibleSet.add(folder.id)
       }
     })
 
     return visibleSet
-  }, [folders, foldersByTaskFilter, skipFoldersByTaskFilter, expanded, selectedFolders])
+  }, [
+    folders,
+    foldersByTaskFilter,
+    skipFoldersByTaskFilter,
+    expanded,
+    selectedFolders,
+    excludeSelectedFolders,
+  ])
 
   // get all links for visible folders
   const {
@@ -247,24 +262,14 @@ export const useFetchOverviewData = ({
       map.forEach((folder, folderId) => {
         const folderPath = folder.path as string
 
-        // Include if it's a parent or the folder itself
-        const folderPathParts = folderPath.split('/')
-        let isParentOrSelf = false
-
-        for (let i = 0; i < folderPathParts.length; i++) {
-          const partialPath = folderPathParts.slice(0, i + 1).join('/')
-          if (selectedPaths.some((p) => p === partialPath)) {
-            isParentOrSelf = true
-            break
-          }
-        }
+        const isSelected = selectedPaths.includes(folderPath)
 
         // Include if it's a child of any selected folder
         const isChild = selectedPaths.some((selectedPath) =>
           folderPath.startsWith(selectedPath + '/'),
         )
 
-        if (isParentOrSelf || isChild) {
+        if (isChild || (isSelected && !excludeSelectedFolders)) {
           filteredMap.set(folderId, addExtraDataToFolder(folder))
         }
       })
@@ -278,6 +283,7 @@ export const useFetchOverviewData = ({
     foldersByTaskFilter,
     isUninitialized,
     selectedFolders,
+    excludeSelectedFolders,
     foldersLinks,
     isFlatFolderView,
   ])
@@ -305,7 +311,11 @@ export const useFetchOverviewData = ({
   // if task list and sorting by name, sort by path instead
   const sortByPath = singleSort?.id === 'name' && !showHierarchy
   const sortId = sortByPath ? 'path' : singleSort?.id === 'subType' ? 'taskType' : singleSort?.id
-  const tasksFolderIdsParams = selectedFolders.length ? Array.from(foldersMap.keys()) : undefined
+  const tasksFolderIdsParams = selectedFolders.length
+    ? Array.from(
+        new Set([...foldersMap.keys(), ...(excludeSelectedFolders ? selectedFolders : [])]),
+      )
+    : undefined
 
   // Use the new infinite query hook for tasks list with correct name
   const {

--- a/src/components/NewEntity/NewEntity.tsx
+++ b/src/components/NewEntity/NewEntity.tsx
@@ -111,60 +111,88 @@ const NewEntity: React.FC<NewEntityProps> = ({ disabled, onNewEntities }) => {
   const [createMore, setCreateMore] = useState(false)
   const { selectedCells } = useSelectionCellsContext()
   const {
-    rowSelection: slicerSelection,
     rowSelectionData: slicerSelectionData,
+    persistentRowSelectionData,
     sliceType,
   } = useSlicerContext()
   const { getEntityById } = useProjectTableContext()
 
-  const [selectedFolderIds, selectedEntitiesLabels] = React.useMemo(() => {
-    const selectedRowIds = Array.from(
-      new Set(
-        Array.from(selectedCells)
-          .map((cellId) => parseCellId(cellId))
-          .filter((cell) => cell && cell?.colId === 'name')
-          .map((cell) => cell?.rowId) as string[],
-      ),
-    )
+  const [allSelectedFolderIds, _allSelectedEntitiesLabels, parentTargetOptions] =
+    React.useMemo(() => {
+      const selectedRowIds = Array.from(
+        new Set(
+          Array.from(selectedCells)
+            .map((cellId) => parseCellId(cellId))
+            .filter((cell) => cell && cell?.colId === 'name')
+            .map((cell) => cell?.rowId) as string[],
+        ),
+      )
 
-    const selectedEntities = selectedRowIds.map((id) => getEntityById(id))
+      let ids: string[] = []
+      let labels: string[] = []
 
-    const selectedFolders = selectedEntities
-      .filter((entity) => entity?.entityType === 'folder')
-      .filter(Boolean) as MatchingFolder[]
-    const selectedTasks = selectedEntities
-      .filter((entity) => entity?.entityType === 'task')
-      .filter(Boolean) as EditorTaskNode[]
+      if (selectedRowIds.length > 0) {
+        const selectedEntities = selectedRowIds.map((id) => getEntityById(id))
 
-    // Extract folder IDs from selected folders and tasks
-    const folderIdsFromFolders = selectedFolders.map((folder) => folder.id)
-    // get parent folder ids from tasks
-    const folderIdsFromTasks = selectedTasks.map((task) => task.folderId)
+        const selectedFolders = selectedEntities
+          .filter((entity) => entity?.entityType === 'folder')
+          .filter(Boolean) as MatchingFolder[]
+        const selectedTasks = selectedEntities
+          .filter((entity) => entity?.entityType === 'task')
+          .filter(Boolean) as EditorTaskNode[]
 
-    // Combine and remove duplicate folder IDs
-    // These are the folders to create the new entity in
-    const selectedFolderIds = Array.from(new Set([...folderIdsFromFolders, ...folderIdsFromTasks]))
+        // Extract folder IDs from selected folders and tasks
+        const folderIdsFromFolders = selectedFolders.map((folder) => folder.id)
+        // get parent folder ids from tasks
+        const folderIdsFromTasks = selectedTasks.map((task) => task.folderId)
 
-    // if no folders or tasks are selected, try to get the selected folder from the slicer
-    if (!selectedFolderIds.length && sliceType === 'hierarchy') {
-      // add the selected folder ids from the slicer
-      const selectedFolderIdsFromSlicer = Object.keys(slicerSelection)
-      const selectedEntitiesLabels = Object.entries(slicerSelectionData)
-        .filter(([id]) => selectedFolderIdsFromSlicer.includes(id))
-        .map(([, data]) => data.label || data.name)
-        .filter(Boolean)
-      return [selectedFolderIdsFromSlicer, selectedEntitiesLabels]
-    } else {
-      const selectedEntitiesLabels = selectedEntities
-        .map((e) => e?.label || e?.name)
-        .filter(Boolean)
-      return [selectedFolderIds, selectedEntitiesLabels]
-    }
-  }, [selectedCells, slicerSelection, sliceType, entityType, getEntityById])
+        // Combine and remove duplicate folder IDs
+        ids = Array.from(new Set([...folderIdsFromFolders, ...folderIdsFromTasks]))
+
+        labels = ids
+          .map((id) => {
+            const entity = getEntityById(id)
+            return (entity?.label || entity?.name) as string
+          })
+          .filter(Boolean)
+      } else {
+        // no table selection, use slicer selection
+        const activeSlicerData =
+          sliceType === 'hierarchy' ? slicerSelectionData : persistentRowSelectionData
+        ids = Object.keys(activeSlicerData)
+        labels = Object.entries(activeSlicerData)
+          .map(([, data]) => data.label || data.name)
+          .filter(Boolean) as string[]
+      }
+
+      const options: { value: string; label: string }[] = []
+      ids.forEach((id, index) => {
+        options.push({ value: id, label: labels[index] || id })
+      })
+
+      return [ids, labels, options]
+    }, [selectedCells, slicerSelectionData, persistentRowSelectionData, sliceType, getEntityById])
+
+  const [manuallySelectedParents, setManuallySelectedParents] = useState<string[] | null>(null)
+
+  let selectedFolderIds =
+    manuallySelectedParents !== null ? manuallySelectedParents : allSelectedFolderIds
+
+  // ensure we don't accidentally create things with invalid parents (e.g. selection changed)
+  selectedFolderIds = selectedFolderIds.filter((id) => allSelectedFolderIds.includes(id))
+
+  // if the filtering removed everything (e.g. selection completely changed or user deselected all), revert to full selection
+  if (selectedFolderIds.length === 0 && allSelectedFolderIds.length > 0) {
+    selectedFolderIds = allSelectedFolderIds
+  }
+
+  const selectedEntitiesLabels = selectedFolderIds
+    .map((id) => parentTargetOptions.find((o) => o.value === id)?.label || '')
+    .filter(Boolean)
 
   const parentLabel = selectedEntitiesLabels[0] || ''
 
-  const isRoot = isEmpty(selectedFolderIds)
+  const isRoot = isEmpty(allSelectedFolderIds)
 
   const [nameFocused, setNameFocused] = useState<boolean>(false)
   const [nameManuallyEdited, setNameManuallyEdited] = useState<boolean>(false)
@@ -441,49 +469,70 @@ const NewEntity: React.FC<NewEntityProps> = ({ disabled, onNewEntities }) => {
             target.tagName !== 'INPUT' && setNameFocused(false)
           }}
         >
-          {sequenceForm.active ? (
-            // @ts-ignore
-            <FolderSequence
-              base={entityForm.label}
-              type={entityForm.subType}
-              increment={sequenceForm.increment}
-              length={sequenceForm.length}
-              prefix={sequenceForm.prefix}
-              prefixDepth={sequenceForm.prefixDepth}
-              parentLabel={parentLabel}
-              entityType="folder"
-              nesting={false}
-              onChange={handleSeqChange}
-              isRoot={isRoot}
-              typeSelectRef={typeSelectRef}
-              // @ts-ignore
-              onLastInputKeydown={(e) => handleKeyDown(e, true)}
-              folders={projectInfo?.folderTypes || []}
-            />
-          ) : (
-            <ContentStyled>
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 'var(--base-gap-large)',
+            }}
+          >
+            {!isRoot && (
               <InputsContainer>
-                <InputLabel>Type</InputLabel>
-                <TypeEditor
-                  value={[entityForm.subType]}
-                  onChange={(v: string) => handleChange(v, 'subType')}
-                  options={typeOptions}
-                  style={{ width: 160 }}
-                  ref={typeSelectRef}
-                  onFocus={handleTypeSelectFocus}
-                  onClick={() => setNameFocused(false)}
+                <InputLabel>Parent folder</InputLabel>
+                <Dropdown
+                  value={selectedFolderIds}
+                  options={parentTargetOptions}
+                  onChange={(v) => setManuallySelectedParents(v)}
+                  disabled={parentTargetOptions.length <= 1}
+                  multiSelect={true}
+                  style={{ width: '100%', minHeight: 32 }}
                 />
               </InputsContainer>
-              <NewEntityForm
-                handleChange={handleChange}
-                entityForm={entityForm}
-                labelRef={labelRef}
-                setNameFocused={setNameFocused}
-                handleKeyDown={handleKeyDown}
-                nameInfo={`Names are auto generated from the label using the Entity Naming setting on the project anatomy. Capitalization: ${config.capitalization}. Separator: "${config.separator}"`}
+            )}
+            {sequenceForm.active ? (
+              // @ts-ignore
+              <FolderSequence
+                base={entityForm.label}
+                type={entityForm.subType}
+                increment={sequenceForm.increment}
+                length={sequenceForm.length}
+                prefix={sequenceForm.prefix}
+                prefixDepth={sequenceForm.prefixDepth}
+                parentLabel={parentLabel}
+                entityType="folder"
+                nesting={false}
+                onChange={handleSeqChange}
+                isRoot={isRoot}
+                typeSelectRef={typeSelectRef}
+                // @ts-ignore
+                onLastInputKeydown={(e) => handleKeyDown(e, true)}
+                folders={projectInfo?.folderTypes || []}
               />
-            </ContentStyled>
-          )}
+            ) : (
+              <ContentStyled>
+                <InputsContainer>
+                  <InputLabel>Type</InputLabel>
+                  <TypeEditor
+                    value={[entityForm.subType]}
+                    onChange={(v: string) => handleChange(v, 'subType')}
+                    options={typeOptions}
+                    style={{ width: 160 }}
+                    ref={typeSelectRef}
+                    onFocus={handleTypeSelectFocus}
+                    onClick={() => setNameFocused(false)}
+                  />
+                </InputsContainer>
+                <NewEntityForm
+                  handleChange={handleChange}
+                  entityForm={entityForm}
+                  labelRef={labelRef}
+                  setNameFocused={setNameFocused}
+                  handleKeyDown={handleKeyDown}
+                  nameInfo={`Names are auto generated from the label using the Entity Naming setting on the project anatomy. Capitalization: ${config.capitalization}. Separator: "${config.separator}"`}
+                />
+              </ContentStyled>
+            )}
+          </div>
         </StyledDialog>
       )}
     </>

--- a/src/components/NewEntity/NewEntity.tsx
+++ b/src/components/NewEntity/NewEntity.tsx
@@ -289,6 +289,7 @@ const NewEntity: React.FC<NewEntityProps> = ({ disabled, onNewEntities }) => {
     setEntityForm(initData)
     setSequenceForm((prev) => ({ ...prev, active: false }))
     setNameManuallyEdited(false)
+    setManuallySelectedParents(null)
   }
 
   // open dropdown - delay to wait for dialog opening

--- a/src/components/NewEntity/NewEntityForm.tsx
+++ b/src/components/NewEntity/NewEntityForm.tsx
@@ -57,7 +57,6 @@ export const InputsContainer = styled.div`
   flex-direction: column;
   align-items: flex-start;
   gap: var(--base-gap-small);
-  margin-bottom: calc(var(--base-gap-large) - 16px);
 
   label {
     white-space: nowrap;
@@ -169,7 +168,7 @@ const NewEntityForm: React.FC<NewEntityFormProps> = ({
   }
 
   return (
-    <InputsContainer>
+    <InputsContainer style={{ flex: 1 }}>
       <InputLabel>Label</InputLabel>
       <InputText
         value={entityForm.label}
@@ -177,7 +176,7 @@ const NewEntityForm: React.FC<NewEntityFormProps> = ({
         ref={labelRef}
         onFocus={() => setNameFocused(true)}
         onKeyDown={handleLabelKeydown}
-        style={{ flex: 1 }}
+        style={{ flex: 1, width: '100%' }}
       />
       <NameRow onKeyDown={handleNameKeydown}>
         <InputLabel>Name</InputLabel>

--- a/src/components/NewEntity/TypeEditor.tsx
+++ b/src/components/NewEntity/TypeEditor.tsx
@@ -43,7 +43,6 @@ const TypeEditor = forwardRef<DropdownRef, TypeEditorProps>(
         disabled={disabled}
         isChanged={isChanged}
         placeholder={placeholder}
-        valueIcon={options[value]?.icon}
         widthExpand
         search
         searchFields={['name']}

--- a/src/pages/ProjectOverviewPage/containers/ProjectOverviewTable.tsx
+++ b/src/pages/ProjectOverviewPage/containers/ProjectOverviewTable.tsx
@@ -46,6 +46,11 @@ const ProjectOverviewTable = ({}: Props) => {
     () => (!statsTaskIds && selectedFolders.length ? Array.from(foldersMap.keys()) : undefined),
     [statsTaskIds, selectedFolders, foldersMap],
   )
+  const taskStatsFolderIds = useMemo(
+    () =>
+      statsFolderIds ? Array.from(new Set([...statsFolderIds, ...selectedFolders])) : undefined,
+    [statsFolderIds, selectedFolders],
+  )
 
   const { onOpenNew } = useNewEntityContext()
 
@@ -76,7 +81,7 @@ const ProjectOverviewTable = ({}: Props) => {
       filter: taskFilters?.filterString || undefined,
       folderFilter: folderFilters?.filterString || undefined,
       search: taskFilters?.search || undefined,
-      folderIds: statsFolderIds,
+      folderIds: taskStatsFolderIds,
       taskIds: statsTaskIds,
       targets: taskTargets,
     },

--- a/src/pages/ProjectOverviewPage/context/ProjectOverviewContext.tsx
+++ b/src/pages/ProjectOverviewPage/context/ProjectOverviewContext.tsx
@@ -267,6 +267,7 @@ export const ProjectOverviewProvider = ({ children, modules }: ProjectOverviewPr
   } = useFetchOverviewData({
     projectName,
     selectedFolders,
+    excludeSelectedFolders: sliceType !== 'entityList',
     taskIds: rawEntityIds.taskIds,
     taskFilters: {
       filter: combinedTaskFilter.filter,


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Selecting folders in the slicer now shows only their contents in the table, the selected folder row itself is excluded, so folder counts reflect what is inside the folder.

## Technical details
<!-- Please state any technical details such as limitations -->

- `useFetchOverviewData` gains an `excludeSelectedFolders` flag: `foldersMap` keeps only strict descendants of the selected paths, which promotes their children to root rows; the selected folders' direct tasks are fetched eagerly (there is no row left to expand) and their ids are re-included in the flat-list/grouped task query `folderIds`.
- `useBuildProjectDataTable` renders tasks of excluded selected folders as root rows (`createRootTaskRows`) — covers selecting a leaf folder that only contains tasks, in both hierarchy and flat-folder views.
- `ProjectTableProvider` threads an optional `selectedFolders` prop into the table build; entity-list slices keep showing the listed folders themselves (`sliceType !== 'entityList'` gate in `ProjectOverviewContext`, plus a `foldersMap.has` guard).
- Footer summaries (`ProjectOverviewTable`): folder stats use descendants only, task stats union in the selected folder ids so their direct tasks stay counted.

## Additional context
<!-- Add any other context or screenshots here. -->

Closes #2050
