### PR TITLE
Review: Clicking on details thumbnail not opening the viewer

### DIFF
--- a/src/pages/ProjectListsPage/ProjectListsPage.tsx
+++ b/src/pages/ProjectListsPage/ProjectListsPage.tsx
@@ -45,7 +45,7 @@ import { Actions } from '@shared/containers/Actions/Actions'
 import { ListsModuleProvider } from './context/ListsModulesContext.tsx'
 import OpenReviewSessionButton from '@pages/ReviewPage/OpenReviewSessionButton.tsx'
 import { useNavigate, useParams, useLocation, useSearchParams } from 'react-router-dom'
-import { useAppSelector } from '@state/store.ts'
+import { useAppDispatch, useAppSelector } from '@state/store.ts'
 import { UniqueIdentifier } from '@dnd-kit/core'
 import useTableOpenViewer from '@pages/ProjectOverviewPage/hooks/useTableOpenViewer'
 import ListsShortcuts from './components/ListsShortcuts.tsx'
@@ -244,6 +244,7 @@ const ProjectLists: FC<ProjectListsProps> = ({
   isStoryboards,
   dndActiveId, // Destructure new prop
 }) => {
+  const dispatch = useAppDispatch()
   const user = useAppSelector((state) => state.user?.attrib)
   const isDeveloperMode = user?.developerMode ?? false
   const navigate = useNavigate()
@@ -453,6 +454,7 @@ const ProjectLists: FC<ProjectListsProps> = ({
                         isReview={!!isReview}
                         isStoryboards={!!isStoryboards}
                         displayStyle={pageDisplayStyle}
+                        dispatch={dispatch}
                       />
                     </SplitterPanel>
                   </DetailsPanelSplitter>

--- a/src/pages/ProjectListsPage/components/ProjectListsDetailsPanels/ProjectListsDetailsPanels.tsx
+++ b/src/pages/ProjectListsPage/components/ProjectListsDetailsPanels/ProjectListsDetailsPanels.tsx
@@ -1,6 +1,6 @@
-import { useListsContext } from "@pages/ProjectListsPage/context"
-import { useListItemsDataContext } from "@pages/ProjectListsPage/context/ListItemsDataContext"
-import ProjectOverviewDetailsPanel from "@pages/ProjectOverviewPage/containers/ProjectOverviewDetailsPanel"
+import { useListsContext } from '@pages/ProjectListsPage/context'
+import { useListItemsDataContext } from '@pages/ProjectListsPage/context/ListItemsDataContext'
+import ProjectOverviewDetailsPanel from '@pages/ProjectOverviewPage/containers/ProjectOverviewDetailsPanel'
 import {
   getCellId,
   isEntityRestricted,
@@ -9,21 +9,27 @@ import {
   useProjectTableContext,
   useSelectedRowsContext,
   useSelectionCellsContext,
-} from "@shared/containers"
-import { useProjectContext } from "@shared/context"
-import { useEffect, useMemo, useState } from "react"
-import ListDetailsPanel from "../ListDetailsPanel/ListDetailsPanel"
-import useReviewSessionCardsModules from "@pages/ProjectListsPage/hooks/useReviewSessionCardsModules"
-import useStoryboardsCardsModules from "@pages/ProjectListsPage/hooks/useStoryboardsCardsModules"
-import { ReviewsSettings } from "@shared/api"
+} from '@shared/containers'
+import { useProjectContext } from '@shared/context'
+import { useEffect, useMemo, useState } from 'react'
+import ListDetailsPanel from '../ListDetailsPanel/ListDetailsPanel'
+import useReviewSessionCardsModules from '@pages/ProjectListsPage/hooks/useReviewSessionCardsModules'
+import useStoryboardsCardsModules from '@pages/ProjectListsPage/hooks/useStoryboardsCardsModules'
+import { ReviewsSettings } from '@shared/api'
 
 type Props = {
   isReview: boolean
   isStoryboards: boolean
   displayStyle: ReviewsSettings['displayStyle']
+  dispatch: any // if we need to provide explicit dispatch context (for review)
 }
 
-export default function ProjectListsDetailsPanels({ isReview, isStoryboards, displayStyle }: Props) {
+export default function ProjectListsDetailsPanels({
+  isReview,
+  isStoryboards,
+  displayStyle,
+  dispatch,
+}: Props) {
   const { projectName, ...projectInfo } = useProjectContext()
   const { getEntityById } = useProjectTableContext()
   const { selectedList, listDetailsOpen } = useListsContext()
@@ -90,21 +96,16 @@ export default function ProjectListsDetailsPanels({ isReview, isStoryboards, dis
     (selectedRows.length > 0 || selectedEntity !== null) && hasNonRestrictedSelectedRows
   const shouldShowListDetailsPanel = listDetailsOpen && !!selectedList
 
+  const useModules = isStoryboards ? useStoryboardsCardsModules : useReviewSessionCardsModules
 
-  const useModules = isStoryboards
-    ? useStoryboardsCardsModules
-    : useReviewSessionCardsModules
-
-  const {
-    useReviewSessionCards
-  } = useModules({ skip: !isReview })
+  const { useReviewSessionCards } = useModules({ skip: !isReview })
 
   const { clearHighlighted } = useReviewSessionCards()
 
   // For review session lists, closing the details panel
   // should also clear the state in the addon component.
   const onClose = useMemo(() => {
-    if (!clearHighlighted || displayStyle !== "cards") return
+    if (!clearHighlighted || displayStyle !== 'cards') return
 
     return () => {
       clearHighlighted()
@@ -119,12 +120,11 @@ export default function ProjectListsDetailsPanels({ isReview, isStoryboards, dis
         isOpen={shouldShowEntityDetailsPanel}
         onUriOpen={(entity) => setUriEntityId(entity.id)}
         onClose={onClose}
+        dispatch={dispatch}
       />
-      {selectedList &&
-        !shouldShowEntityDetailsPanel &&
-        shouldShowListDetailsPanel && (
-          <ListDetailsPanel listId={selectedList.id} projectName={projectName} />
-        )}
+      {selectedList && !shouldShowEntityDetailsPanel && shouldShowListDetailsPanel && (
+        <ListDetailsPanel listId={selectedList.id} projectName={projectName} />
+      )}
     </>
   )
 }

--- a/src/pages/ProjectOverviewPage/containers/ProjectOverviewDetailsPanel.tsx
+++ b/src/pages/ProjectOverviewPage/containers/ProjectOverviewDetailsPanel.tsx
@@ -20,6 +20,7 @@ type ProjectOverviewDetailsPanelProps = {
   isOpen?: boolean
   onUriOpen?: (entity: DetailsPanelEntityData, source: 'uri' | 'url') => void
   onClose?: () => void
+  dispatch: any // if we need to provide explicit dispatch context (for review)
 }
 
 type EntitySelection = {
@@ -34,8 +35,9 @@ const ProjectOverviewDetailsPanel = ({
   isOpen,
   onUriOpen,
   onClose,
+  dispatch: dispatchProp,
 }: ProjectOverviewDetailsPanelProps) => {
-  const dispatch = useAppDispatch()
+  const dispatch = dispatchProp || useAppDispatch()
   const handleOpenViewer = (args: any) => dispatch(openViewer(args))
 
   const { getEntityById } = useProjectTableContext()


### PR DESCRIPTION
<img width="1418" height="955" alt="image" src="https://github.com/user-attachments/assets/69ed2872-d7bd-43c3-b4b5-2e27c4e2461b" />

Turns that although we were using the details panel from ayon-frontend  butit was wrapped with <ReviewSessionCardsProvider> which seems to have it's own redux provider. So the dispatch inside the details panel was using the redux context from review not ayon. Opening the viewer requires the dispatch.

Now we are just passing down the dispatch from ayon-frontend 