### PR TITLE
Summaries: fix Ungrouped group visibility and table layout

### DIFF
--- a/shared/src/containers/ProjectTreeTable/hooks/useBuildGroupByTableData.ts
+++ b/shared/src/containers/ProjectTreeTable/hooks/useBuildGroupByTableData.ts
@@ -181,10 +181,10 @@ const useBuildGroupByTableData = ({
       })
     }
 
-    const ungroupedId = GROUP_BY_ID + '.' + UNGROUPED_VALUE // unique id for ungrouped group
+    const ungroupedId = buildGroupId(UNGROUPED_VALUE)
     // gets the "Ungrouped" group, creating it if it doesn't exist
     const getUnGroupedGroup = () => {
-      let ungroupedGroup = groupsMap.get(ungroupedId)
+      let ungroupedGroup = groupsMap.get(UNGROUPED_VALUE)
       if (!ungroupedGroup) {
         ungroupedGroup = {
           id: ungroupedId,
@@ -192,14 +192,18 @@ const useBuildGroupByTableData = ({
           entityType: 'group',
           subRows: [],
           label: 'Ungrouped',
-          group: { value: ungroupedId, label: 'Ungrouped' },
+          group: { value: UNGROUPED_VALUE, label: 'Ungrouped' },
           links: {},
         }
         // create ungrouped group if it doesn't exist
-        groupsMap.set(ungroupedId, ungroupedGroup)
+        groupsMap.set(UNGROUPED_VALUE, ungroupedGroup)
       }
       return ungroupedGroup
     }
+
+    const canHaveUngrouped =
+      groupBy.id === 'tags' || groupBy.id === 'assignees' || groupBy.id.startsWith('attrib.')
+    if (canHaveUngrouped) getUnGroupedGroup()
 
     for (const [id, entity] of entities) {
       // if the entity is not of the specified type, skip it
@@ -267,8 +271,8 @@ const useBuildGroupByTableData = ({
     // if the group is an attribute with enum values, sort by the enum values
     const sortDirection = groupBy.desc ? -1 : 1
     groupsList.sort((a, b) => {
-      if (a.group?.value === ungroupedId) return 1 // "Ungrouped" should always be last
-      if (b.group?.value === ungroupedId) return -1 // "Ungrouped" should always be last
+      if (a.group?.value === UNGROUPED_VALUE) return 1 // "Ungrouped" should always be last
+      if (b.group?.value === UNGROUPED_VALUE) return -1 // "Ungrouped" should always be last
       if (attribSortingIds.length) {
         // sort by index of the enum value
         const indexA = attribSortingIds.indexOf(a.group?.value || '')
@@ -286,8 +290,13 @@ const useBuildGroupByTableData = ({
       }
     })
 
-    // filter out empty groups
-    const nonEmptyGroups = groupsList.filter((group) => group.group?.count && group.group.count > 0)
+    // filter out empty groups — Ungrouped has no server count, keep it reachable
+    const nonEmptyGroups = groupsList.filter(
+      (group) =>
+        (group.group?.count ?? 0) > 0 ||
+        (group.subRows?.length ?? 0) > 0 ||
+        group.group?.value === UNGROUPED_VALUE,
+    )
 
     return showEmpty ? groupsList : nonEmptyGroups
   }

--- a/src/pages/ProjectListsPage/ProjectListsPage.tsx
+++ b/src/pages/ProjectListsPage/ProjectListsPage.tsx
@@ -82,6 +82,7 @@ const ProviderFill = styled.div`
   flex-direction: column;
   flex: 1;
   min-height: 0;
+  gap: var(--base-gap-large);
   width: 100%;
 
   & > *:only-child {
@@ -326,179 +327,185 @@ const ProjectLists: FC<ProjectListsProps> = ({
         <SplitterPanel size={88}>
           <Section wrap direction="column" style={{ height: '100%' }}>
             <ProviderFill>
-            <ReviewSessionCardsProvider
-              projectName={projectName}
-              router={{
-                useParams,
-                useNavigate,
-                useLocation,
-                useSearchParams,
-              }}
-              api={api}
-              toast={toast}
-              gridSize={gridHeight}
-              playlistView={pageDisplayStyle === 'playlist'}
-              onSelectionChange={(versionIds) => {
-                if (versionIds.length === 0) return clearSelection()
+              <ReviewSessionCardsProvider
+                projectName={projectName}
+                router={{
+                  useParams,
+                  useNavigate,
+                  useLocation,
+                  useSearchParams,
+                }}
+                api={api}
+                toast={toast}
+                gridSize={gridHeight}
+                playlistView={pageDisplayStyle === 'playlist'}
+                onSelectionChange={(versionIds) => {
+                  if (versionIds.length === 0) return clearSelection()
 
-                const areRowsSelected = Array.from(selectedCells).some(
-                  (cellId) => parseCellId(cellId)?.colId === ROW_SELECTION_COLUMN_ID,
-                )
+                  const areRowsSelected = Array.from(selectedCells).some(
+                    (cellId) => parseCellId(cellId)?.colId === ROW_SELECTION_COLUMN_ID,
+                  )
 
-                const columnToSelect = areRowsSelected ? ROW_SELECTION_COLUMN_ID : 'name'
+                  const columnToSelect = areRowsSelected ? ROW_SELECTION_COLUMN_ID : 'name'
 
-                const cellIds = versionIds
-                  .map((versionId) => getCellIdForColumn(listItemsData, versionId, columnToSelect))
-                  .filter((id) => id !== null)
+                  const cellIds = versionIds
+                    .map((versionId) =>
+                      getCellIdForColumn(listItemsData, versionId, columnToSelect),
+                    )
+                    .filter((id) => id !== null)
 
-                setSelectedCells(new Set(cellIds))
-              }}
-              onOpenDetails={(versionId) => {
-                const cellId = getCellIdForColumn(listItemsData, versionId, ROW_SELECTION_COLUMN_ID)
-                if (!cellId) return
+                  setSelectedCells(new Set(cellIds))
+                }}
+                onOpenDetails={(versionId) => {
+                  const cellId = getCellIdForColumn(
+                    listItemsData,
+                    versionId,
+                    ROW_SELECTION_COLUMN_ID,
+                  )
+                  if (!cellId) return
 
-                const position = parseCellId(cellId)
-                setSelectedCells(new Set([cellId]))
-                setFocusedCellId(cellId)
-                setAnchorCell(position)
-              }}
-              onOpenInViewer={(state) => {
-                handleOpenPlayer(state, { quickView: true })
-              }}
-              onItemsChanged={() => {
-                refetchListItems()
-                refetchLists()
-              }}
-            >
-              {selectedList && (
-                <Toolbar>
-                  {isStoryboards ? (
-                    <OpenStoryboardButton projectName={projectName} />
-                  ) : (
-                    <OpenReviewSessionButton
-                      projectName={projectName}
-                      disabled={listItemsData.length === 0}
-                    />
-                  )}
-                  {reviewModulesLoaded && pageDisplayStyle !== 'table' && (
-                    <ReviewSessionCardsControlsLeft />
-                  )}
-                  {pageDisplayStyle === 'table' && (
-                    <>
-                      <OverviewActions items={['undo', 'redo', deleteListItemAction]} />
-                      <ListItemsFilter
-                        entityType={selectedList.entityType}
-                        projectName={projectName}
-                      />
-                    </>
-                  )}
-                  {isReview && reviewModulesLoaded && (
-                    <>
-                      <Spacer />
-                      <ReviewSessionCardsControlsRight
-                        groupingDisabled={pageDisplayStyle === 'table'}
-                      />
-                    </>
-                  )}
-                  <ImportDialogButton
-                    importContext="entity_list_item"
-                    projectName={projectName}
-                    folderId={selectedList?.id}
-                  />
-                  <Actions
-                    entities={[
-                      {
-                        id: selectedList.id,
-                        projectName,
-                        entitySubType: `${selectedList.entityType}:${selectedList.entityListType}`,
-                      },
-                    ]}
-                    entityType={'list'}
-                    isLoadingEntity={false}
-                    entitySubTypes={[`${selectedList.entityType}:${selectedList.entityListType}`]}
-                    onNavigate={navigate}
-                    onSetSearchParams={setSearchParams}
-                    searchParams={searchParams}
-                    featuredCount={0}
-                    isDeveloperMode={isDeveloperMode}
-                    align="right"
-                  />
-                  {!reviewSessionCardsOutdated && isReview && !isStoryboards && (
-                    <TableGridPlaylistSwitch
-                      value={pageDisplayStyle}
-                      onChange={(style) => {
-                        onUpdateDisplayStyle(style)
-                        onUpdateDisplayStyleWithPersistence(style)
-                      }}
-                    />
-                  )}
-                  <CustomizeButton />
-                </Toolbar>
-              )}
-              <Splitter
-                layout="horizontal"
-                stateKey="overview-splitter-settings"
-                stateStorage="local"
-                style={{ width: '100%', flex: 1, minHeight: 0, overflow: 'hidden' }}
-                gutterSize={isPanelOpen && selectedList ? 4 : 0}
+                  const position = parseCellId(cellId)
+                  setSelectedCells(new Set([cellId]))
+                  setFocusedCellId(cellId)
+                  setAnchorCell(position)
+                }}
+                onOpenInViewer={(state) => {
+                  handleOpenPlayer(state, { quickView: true })
+                }}
+                onItemsChanged={() => {
+                  refetchListItems()
+                  refetchLists()
+                }}
               >
-                <SplitterPanel size={82}>
-                  <DetailsPanelSplitter
-                    layout="horizontal"
-                    stateKey="overview-splitter-details"
-                    stateStorage="local"
-                    style={{ width: '100%', height: '100%' }}
-                  >
-                    <SplitterPanel size={70}>
-                      {selectedList && isReview && pageDisplayStyle !== 'table' ? (
-                        reviewModulesLoaded && <ReviewSessionCards />
-                      ) : (
-                        <ListItemsTable
-                          extraColumns={extraColumns}
-                          isReview={isReview && !reviewSessionCardsOutdated}
-                          dndActiveId={dndActiveId} // Pass prop
-                          viewOnly={(selectedList?.accessLevel || 0) < 20}
+                {selectedList && (
+                  <Toolbar>
+                    {isStoryboards ? (
+                      <OpenStoryboardButton projectName={projectName} />
+                    ) : (
+                      <OpenReviewSessionButton
+                        projectName={projectName}
+                        disabled={listItemsData.length === 0}
+                      />
+                    )}
+                    {reviewModulesLoaded && pageDisplayStyle !== 'table' && (
+                      <ReviewSessionCardsControlsLeft />
+                    )}
+                    {pageDisplayStyle === 'table' && (
+                      <>
+                        <OverviewActions items={['undo', 'redo', deleteListItemAction]} />
+                        <ListItemsFilter
+                          entityType={selectedList.entityType}
+                          projectName={projectName}
                         />
+                      </>
+                    )}
+                    {isReview && reviewModulesLoaded && (
+                      <>
+                        <Spacer />
+                        <ReviewSessionCardsControlsRight
+                          groupingDisabled={pageDisplayStyle === 'table'}
+                        />
+                      </>
+                    )}
+                    <ImportDialogButton
+                      importContext="entity_list_item"
+                      projectName={projectName}
+                      folderId={selectedList?.id}
+                    />
+                    <Actions
+                      entities={[
+                        {
+                          id: selectedList.id,
+                          projectName,
+                          entitySubType: `${selectedList.entityType}:${selectedList.entityListType}`,
+                        },
+                      ]}
+                      entityType={'list'}
+                      isLoadingEntity={false}
+                      entitySubTypes={[`${selectedList.entityType}:${selectedList.entityListType}`]}
+                      onNavigate={navigate}
+                      onSetSearchParams={setSearchParams}
+                      searchParams={searchParams}
+                      featuredCount={0}
+                      isDeveloperMode={isDeveloperMode}
+                      align="right"
+                    />
+                    {!reviewSessionCardsOutdated && isReview && !isStoryboards && (
+                      <TableGridPlaylistSwitch
+                        value={pageDisplayStyle}
+                        onChange={(style) => {
+                          onUpdateDisplayStyle(style)
+                          onUpdateDisplayStyleWithPersistence(style)
+                        }}
+                      />
+                    )}
+                    <CustomizeButton />
+                  </Toolbar>
+                )}
+                <Splitter
+                  layout="horizontal"
+                  stateKey="overview-splitter-settings"
+                  stateStorage="local"
+                  style={{ width: '100%', flex: 1, minHeight: 0, overflow: 'hidden' }}
+                  gutterSize={isPanelOpen && selectedList ? 4 : 0}
+                >
+                  <SplitterPanel size={82}>
+                    <DetailsPanelSplitter
+                      layout="horizontal"
+                      stateKey="overview-splitter-details"
+                      stateStorage="local"
+                      style={{ width: '100%', height: '100%' }}
+                    >
+                      <SplitterPanel size={70}>
+                        {selectedList && isReview && pageDisplayStyle !== 'table' ? (
+                          reviewModulesLoaded && <ReviewSessionCards />
+                        ) : (
+                          <ListItemsTable
+                            extraColumns={extraColumns}
+                            isReview={isReview && !reviewSessionCardsOutdated}
+                            dndActiveId={dndActiveId} // Pass prop
+                            viewOnly={(selectedList?.accessLevel || 0) < 20}
+                          />
+                        )}
+                      </SplitterPanel>
+                      <SplitterPanel
+                        size={30}
+                        style={{
+                          zIndex: 300,
+                          minWidth: 300,
+                        }}
+                        className="details"
+                      >
+                        <ProjectListsDetailsPanels
+                          isReview={!!isReview}
+                          isStoryboards={!!isStoryboards}
+                          displayStyle={pageDisplayStyle}
+                        />
+                      </SplitterPanel>
+                    </DetailsPanelSplitter>
+                  </SplitterPanel>
+                  {isPanelOpen && selectedList ? (
+                    <SplitterPanel
+                      size={18}
+                      style={{
+                        zIndex: 500,
+                      }}
+                    >
+                      {pageDisplayStyle === 'table' ? (
+                        <ListsTableSettings
+                          extraColumns={extraColumnsSettings}
+                          highlightedSetting={highlightedSetting}
+                          onGoTo={handleGoToCustomAttrib}
+                        />
+                      ) : (
+                        <ReviewCardsSettings pageDisplayStyle={pageDisplayStyle} />
                       )}
                     </SplitterPanel>
-                    <SplitterPanel
-                      size={30}
-                      style={{
-                        zIndex: 300,
-                        minWidth: 300,
-                      }}
-                      className="details"
-                    >
-                      <ProjectListsDetailsPanels
-                        isReview={!!isReview}
-                        isStoryboards={!!isStoryboards}
-                        displayStyle={pageDisplayStyle}
-                      />
-                    </SplitterPanel>
-                  </DetailsPanelSplitter>
-                </SplitterPanel>
-                {isPanelOpen && selectedList ? (
-                  <SplitterPanel
-                    size={18}
-                    style={{
-                      zIndex: 500,
-                    }}
-                  >
-                    {pageDisplayStyle === 'table' ? (
-                      <ListsTableSettings
-                        extraColumns={extraColumnsSettings}
-                        highlightedSetting={highlightedSetting}
-                        onGoTo={handleGoToCustomAttrib}
-                      />
-                    ) : (
-                      <ReviewCardsSettings pageDisplayStyle={pageDisplayStyle} />
-                    )}
-                  </SplitterPanel>
-                ) : (
-                  <SplitterPanel style={{ maxWidth: 0 }}></SplitterPanel>
-                )}
-              </Splitter>
-            </ReviewSessionCardsProvider>
+                  ) : (
+                    <SplitterPanel style={{ maxWidth: 0 }}></SplitterPanel>
+                  )}
+                </Splitter>
+              </ReviewSessionCardsProvider>
             </ProviderFill>
           </Section>
         </SplitterPanel>

--- a/src/pages/ProjectListsPage/ProjectListsPage.tsx
+++ b/src/pages/ProjectListsPage/ProjectListsPage.tsx
@@ -8,6 +8,7 @@ import { FC, useEffect, useMemo } from 'react'
 import { ListsProvider, useListsContext } from './context'
 import { Splitter, SplitterPanel } from 'primereact/splitter'
 import { Section, Spacer, Toolbar } from '@ynput/ayon-react-components'
+import styled from 'styled-components'
 import { ListsDataProvider, useListsDataContext } from './context/ListsDataContext'
 import ListsTable from './components/ListsTable/ListsTable'
 import ListsFiltersDialog from './components/ListsFiltersDialog/ListsFiltersDialog'
@@ -73,6 +74,24 @@ type ProjectListsPageProps = {
   isReview?: boolean
   isStoryboards?: boolean
 }
+
+// The review-addon provider renders a wrapper that doesn't fill the flex column,
+// collapsing the table and hiding its scrollbar. Force its root to fill the height.
+const ProviderFill = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  width: 100%;
+
+  & > *:only-child {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+    width: 100%;
+  }
+`
 
 const ProjectListsWithOuterProviders: FC<ProjectListsPageProps> = ({
   projectName,
@@ -306,6 +325,7 @@ const ProjectLists: FC<ProjectListsProps> = ({
         </SplitterPanel>
         <SplitterPanel size={88}>
           <Section wrap direction="column" style={{ height: '100%' }}>
+            <ProviderFill>
             <ReviewSessionCardsProvider
               projectName={projectName}
               router={{
@@ -419,7 +439,7 @@ const ProjectLists: FC<ProjectListsProps> = ({
                 layout="horizontal"
                 stateKey="overview-splitter-settings"
                 stateStorage="local"
-                style={{ width: '100%', height: '100%', overflow: 'hidden' }}
+                style={{ width: '100%', flex: 1, minHeight: 0, overflow: 'hidden' }}
                 gutterSize={isPanelOpen && selectedList ? 4 : 0}
               >
                 <SplitterPanel size={82}>
@@ -479,6 +499,7 @@ const ProjectLists: FC<ProjectListsProps> = ({
                 )}
               </Splitter>
             </ReviewSessionCardsProvider>
+            </ProviderFill>
           </Section>
         </SplitterPanel>
       </Splitter>


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Fixes the "Ungrouped" group not showing when grouping by tags, assignees, or attributes. Also fixes the lists table collapsing (and hiding its scrollbar) when the review addon wraps the page.

## Technical details
<!-- Please state any technical details such as limitations -->

- `useBuildGroupByTableData`: ungrouped group is now keyed consistently by `UNGROUPED_VALUE` in `groupsMap` (was mixing the full `__group__.` id and the raw value, so lookups never matched), and is pre-created for tags/assignees/`attrib.*` groupings.

## Additional context
<!-- Add any other context or screenshots here. -->
