### PR TITLE
Summaries: Use inherited_attributes for tasks

### DIFF
--- a/shared/src/api/queries/columnStats/columnStats.ts
+++ b/shared/src/api/queries/columnStats/columnStats.ts
@@ -41,6 +41,9 @@ export const canonicalColumnId = (name: string): string => {
   if (name.startsWith('project_attributes_')) {
     return 'attrib_' + name.slice('project_attributes_'.length)
   }
+  if (name.startsWith('inherited_attributes_')) {
+    return 'attrib_' + name.slice('inherited_attributes_'.length)
+  }
   if (name.startsWith('attrib_')) return name
   return snakeToCamel(name)
 }
@@ -78,34 +81,11 @@ const normalizeDistribution = (raw: unknown): FieldStats['distribution'] => {
   return undefined
 }
 
-// Normalize a raw fieldStats response (apply in transformResponse).
-export const normalizeFieldStats = (stats: FieldStats[]): FieldStats[] =>
-  stats.map((s) => ({ ...s, distribution: normalizeDistribution(s.distribution) }))
-
-// Merge stats lists by canonical column id, field-wise: overlay's non-null values
-// win, base fills the gaps. A single list also dedupes its own repeated columns.
-export const mergeFieldStats = (
-  overlay: FieldStats[] = [],
-  base: FieldStats[] = [],
-): FieldStats[] => {
-  const byId = new Map<string, FieldStats>()
-  for (const s of base) byId.set(canonicalColumnId(s.columnName), { ...s })
-  for (const s of overlay) {
-    const id = canonicalColumnId(s.columnName)
-    const merged: FieldStats = { ...(byId.get(id) || { columnName: s.columnName }) }
-    for (const [k, v] of Object.entries(s)) {
-      if (v !== null && v !== undefined) (merged as any)[k] = v
-    }
-    byId.set(id, merged)
-  }
-  return [...byId.values()]
-}
-
 const sumN = (a?: number | null, b?: number | null): number | undefined =>
   a == null && b == null ? undefined : (a ?? 0) + (b ?? 0)
-const lowest = <T,>(a?: T | null, b?: T | null): T | undefined =>
+const lowest = <T>(a?: T | null, b?: T | null): T | undefined =>
   a == null ? b ?? undefined : b == null ? a : a < b ? a : b
-const highest = <T,>(a?: T | null, b?: T | null): T | undefined =>
+const highest = <T>(a?: T | null, b?: T | null): T | undefined =>
   a == null ? b ?? undefined : b == null ? a : a > b ? a : b
 const pct = (part?: number, rest?: number): number | undefined =>
   part != null && rest != null && part + rest > 0
@@ -162,6 +142,33 @@ const combineTwo = (a: FieldStats, b: FieldStats): FieldStats => {
     primaryCount: a.primaryCount ?? b.primaryCount,
     secondaryCount: a.secondaryCount ?? b.secondaryCount,
   }
+}
+
+// Normalize a raw fieldStats response (apply in transformResponse).
+export const normalizeFieldStats = (stats: FieldStats[]): FieldStats[] =>
+  stats.map((s) => ({
+    ...s,
+    columnName: canonicalColumnId(s.columnName),
+    distribution: normalizeDistribution(s.distribution),
+  }))
+
+// Merge stats lists by canonical column id, field-wise: overlay's non-null values
+// win, base fills the gaps. A single list also dedupes its own repeated columns.
+export const mergeFieldStats = (
+  overlay: FieldStats[] = [],
+  base: FieldStats[] = [],
+): FieldStats[] => {
+  const byId = new Map<string, FieldStats>()
+  for (const s of base) byId.set(canonicalColumnId(s.columnName), { ...s })
+  for (const s of overlay) {
+    const id = canonicalColumnId(s.columnName)
+    const merged: FieldStats = { ...(byId.get(id) || { columnName: s.columnName }) }
+    for (const [k, v] of Object.entries(s)) {
+      if (v !== null && v !== undefined) (merged as any)[k] = v
+    }
+    byId.set(id, merged)
+  }
+  return [...byId.values()]
 }
 
 // Total row count for an entity set = max(filled + not-filled) across its

--- a/shared/src/api/queries/columnStats/metricTargets.ts
+++ b/shared/src/api/queries/columnStats/metricTargets.ts
@@ -106,7 +106,10 @@ export const buildMetricTargets = ({
     if (attrib.scope && !attrib.scope.includes(entity)) continue
     if (!isVisible(`attrib_${attrib.name}`)) continue
 
-    const field = `inherited_attributes.${attrib.name}`
+    let field = `attrib.${attrib.name}`
+    if (['folder', 'task'].includes(entity)) {
+      field = `inherited_attributes.${attrib.name}`
+    }
     const type = attrib.data?.type
     if (type === 'integer' || type === 'float') {
       targets.push({ field, aggregations: NUMERIC })

--- a/shared/src/api/queries/columnStats/metricTargets.ts
+++ b/shared/src/api/queries/columnStats/metricTargets.ts
@@ -106,7 +106,7 @@ export const buildMetricTargets = ({
     if (attrib.scope && !attrib.scope.includes(entity)) continue
     if (!isVisible(`attrib_${attrib.name}`)) continue
 
-    const field = `attrib.${attrib.name}`
+    const field = `inherited_attributes.${attrib.name}`
     const type = attrib.data?.type
     if (type === 'integer' || type === 'float') {
       targets.push({ field, aggregations: NUMERIC })

--- a/shared/src/api/queries/entityLists/listItemsColumnStats.ts
+++ b/shared/src/api/queries/entityLists/listItemsColumnStats.ts
@@ -1,20 +1,21 @@
 import { gqlApi } from '@shared/api/generated'
 import type { GetListItemsColumnStatsQuery } from '@shared/api/generated'
-import {
-  DefinitionsFromApi,
-  OverrideResultType,
-  TagTypesFromApi,
-} from '@reduxjs/toolkit/query'
+import { DefinitionsFromApi, OverrideResultType, TagTypesFromApi } from '@reduxjs/toolkit/query'
 import type { FieldStats, MetricTarget } from '../columnStats'
 import { normalizeFieldStats, mergeFieldStats, hasNewTargetFields } from '../columnStats'
 
 // The list items query aliases entity columns `_entity_{col}` and merges
 // entity+item attribs into `_all_attrib`, so canonical target fields must be
 // translated out and stat column names translated back (ayon-backend#943).
-const toBackendField = (field: string): string =>
-  field.startsWith('attrib.')
-    ? `_all_attrib.${field.slice('attrib.'.length)}`
-    : `_entity_${field}`
+const toBackendField = (field: string): string => {
+  if (field.startsWith('attrib.')) {
+    return `_all_attrib.${field.slice('attrib.'.length)}`
+  }
+  if (field.startsWith('inherited_attributes.')) {
+    return `_all_attrib.${field.slice('inherited_attributes.'.length)}`
+  }
+  return `_entity_${field}`
+}
 
 const toCanonicalColumn = (name: string): string => {
   if (name.startsWith('_all_attrib_')) return `attrib_${name.slice('_all_attrib_'.length)}`
@@ -28,10 +29,7 @@ export const toListItemsStatsTargets = (targets: MetricTarget[]): MetricTarget[]
 type Definitions = DefinitionsFromApi<typeof gqlApi>
 type TagTypes = TagTypesFromApi<typeof gqlApi>
 type UpdatedDefinitions = Definitions & {
-  GetListItemsColumnStats: OverrideResultType<
-    Definitions['GetListItemsColumnStats'],
-    FieldStats[]
-  >
+  GetListItemsColumnStats: OverrideResultType<Definitions['GetListItemsColumnStats'], FieldStats[]>
 }
 
 const listItemsColumnStatsApi = gqlApi.enhanceEndpoints<TagTypes, UpdatedDefinitions>({


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
Uses `inherited_attributes.{attrib}` so that the summaries include inherited task attrib data.

<img width="1640" height="873" alt="image" src="https://github.com/user-attachments/assets/ab5b1717-68e7-4b15-ab89-75f9c684479c" />

Requires https://github.com/ynput/ayon-backend/pull/973
