### PR TITLE
Views: Removed strongly typed View Settings

### DIFF
--- a/shared/src/api/generated/views.ts
+++ b/shared/src/api/generated/views.ts
@@ -13,7 +13,7 @@ const injectedRtkApi = api.injectEndpoints({
       query: (queryArg) => ({
         url: `/api/views/${queryArg.viewType}`,
         method: 'POST',
-        body: queryArg.payload,
+        body: queryArg.genericViewPostModel,
         params: {
           project_name: queryArg.projectName,
         },
@@ -74,7 +74,7 @@ const injectedRtkApi = api.injectEndpoints({
       query: (queryArg) => ({
         url: `/api/views/${queryArg.viewType}/${queryArg.viewId}`,
         method: 'PATCH',
-        body: queryArg.payload,
+        body: queryArg.genericViewPatchModel,
         params: {
           project_name: queryArg.projectName,
         },
@@ -93,43 +93,19 @@ export type CreateViewApiResponse = /** status 200 Successful Response */ Entity
 export type CreateViewApiArg = {
   viewType: string
   projectName?: string
-  payload:
-    | OverviewViewPostModel
-    | TaskProgressViewPostModel
-    | ListsViewPostModel
-    | ReviewsViewPostModel
-    | VersionsViewPostModel
-    | GenericViewPostModel
+  genericViewPostModel: GenericViewPostModel
 }
-export type GetWorkingViewApiResponse = /** status 200 Successful Response */
-  | OverviewViewModel
-  | TaskProgressViewModel
-  | ListsViewModel
-  | ReviewsViewModel
-  | VersionsViewModel
-  | GenericViewModel
+export type GetWorkingViewApiResponse = /** status 200 Successful Response */ GenericViewModel
 export type GetWorkingViewApiArg = {
   viewType: string
   projectName?: string
 }
-export type GetBaseViewApiResponse = /** status 200 Successful Response */
-  | OverviewViewModel
-  | TaskProgressViewModel
-  | ListsViewModel
-  | ReviewsViewModel
-  | VersionsViewModel
-  | GenericViewModel
+export type GetBaseViewApiResponse = /** status 200 Successful Response */ GenericViewModel
 export type GetBaseViewApiArg = {
   viewType: string
   projectName?: string
 }
-export type GetDefaultViewApiResponse = /** status 200 Successful Response */
-  | OverviewViewModel
-  | TaskProgressViewModel
-  | ListsViewModel
-  | ReviewsViewModel
-  | VersionsViewModel
-  | GenericViewModel
+export type GetDefaultViewApiResponse = /** status 200 Successful Response */ GenericViewModel
 export type GetDefaultViewApiArg = {
   viewType: string
   projectName?: string
@@ -140,13 +116,7 @@ export type SetDefaultViewApiArg = {
   projectName?: string
   setDefaultViewRequestModel: SetDefaultViewRequestModel
 }
-export type GetViewApiResponse = /** status 200 Successful Response */
-  | OverviewViewModel
-  | TaskProgressViewModel
-  | ListsViewModel
-  | ReviewsViewModel
-  | VersionsViewModel
-  | GenericViewModel
+export type GetViewApiResponse = /** status 200 Successful Response */ GenericViewModel
 export type GetViewApiArg = {
   viewType: string
   viewId: string
@@ -163,13 +133,7 @@ export type UpdateViewApiArg = {
   viewType: string
   viewId: string
   projectName?: string
-  payload:
-    | OverviewViewPatchModel
-    | TaskProgressViewPatchModel
-    | ListsViewPatchModel
-    | ReviewsViewPatchModel
-    | VersionsViewPatchModel
-    | GenericViewPatchModel
+  genericViewPatchModel: GenericViewPatchModel
 }
 export type ViewListItemModel = {
   /** Unique identifier for the view within the given scope. */
@@ -202,142 +166,6 @@ export type EntityIdResponse = {
   /** Entity ID */
   id: string
 }
-export type QueryCondition = {
-  /** Path to the key separated by slashes */
-  key: string
-  /** Value to compare against */
-  value?: string | number | number | boolean | string[] | number[] | number[]
-  /** Comparison operator */
-  operator?:
-    | 'eq'
-    | 'like'
-    | 'lt'
-    | 'gt'
-    | 'lte'
-    | 'gte'
-    | 'ne'
-    | 'isnull'
-    | 'notnull'
-    | 'in'
-    | 'notin'
-    | 'includes'
-    | 'excludes'
-    | 'includesall'
-    | 'excludesall'
-    | 'includesany'
-    | 'excludesany'
-}
-export type QueryFilter = {
-  /** List of conditions to be evaluated */
-  conditions?: (QueryCondition | QueryFilter)[]
-  /** Operator to use when joining conditions */
-  operator?: 'and' | 'or'
-}
-export type ColumnItemModel = {
-  name: string
-  visible?: boolean
-  pinned?: boolean
-  width?: number
-}
-export type OverviewSettings = {
-  showHierarchy?: boolean
-  rowHeight?: number
-  groupBy?: string
-  groupSortByDesc?: boolean
-  showEmptyGroups?: boolean
-  sortBy?: string
-  sortDesc?: boolean
-  filter?: QueryFilter
-  folderFilter?: QueryFilter
-  sliceType?: string
-  columns?: ColumnItemModel[]
-}
-export type OverviewViewPostModel = {
-  /** Unique identifier for the view within the given scope. */
-  id?: string
-  /** Human-readable name of the view. */
-  label: string
-  /** Working view is a special type of the view that automatically stores the current view settings without explicitly saving them. Working views are always private and scoped to the project  */
-  working?: boolean
-  settings: OverviewSettings
-  viewType?: 'overview'
-}
-export type TaskProgressSettings = {
-  filter?: QueryFilter
-  sliceType?: string
-  columns?: ColumnItemModel[]
-}
-export type TaskProgressViewPostModel = {
-  /** Unique identifier for the view within the given scope. */
-  id?: string
-  /** Human-readable name of the view. */
-  label: string
-  /** Working view is a special type of the view that automatically stores the current view settings without explicitly saving them. Working views are always private and scoped to the project  */
-  working?: boolean
-  settings: TaskProgressSettings
-  viewType?: 'taskProgress'
-}
-export type ListsSettings = {
-  rowHeight?: number
-  sortBy?: string
-  sortDesc?: boolean
-  filter?: QueryFilter
-  columns?: ColumnItemModel[]
-}
-export type ListsViewPostModel = {
-  /** Unique identifier for the view within the given scope. */
-  id?: string
-  /** Human-readable name of the view. */
-  label: string
-  /** Working view is a special type of the view that automatically stores the current view settings without explicitly saving them. Working views are always private and scoped to the project  */
-  working?: boolean
-  settings: ListsSettings
-  viewType?: 'lists'
-}
-export type ReviewsSettings = {
-  rowHeight?: number
-  sortBy?: string
-  sortDesc?: boolean
-  filter?: QueryFilter
-  columns?: ColumnItemModel[]
-  gridHeight?: number
-  displayStyle?: 'cards' | 'table' | 'playlist'
-}
-export type ReviewsViewPostModel = {
-  /** Unique identifier for the view within the given scope. */
-  id?: string
-  /** Human-readable name of the view. */
-  label: string
-  /** Working view is a special type of the view that automatically stores the current view settings without explicitly saving them. Working views are always private and scoped to the project  */
-  working?: boolean
-  settings: ReviewsSettings
-  viewType?: 'reviews'
-}
-export type VersionsSettings = {
-  showProducts?: boolean
-  rowHeight?: number
-  showGrid?: boolean
-  gridHeight?: number
-  featuredVersionOrder?: string[]
-  slicerType?: string
-  groupBy?: string
-  groupSortByDesc?: boolean
-  showEmptyGroups?: boolean
-  sortBy?: string
-  sortDesc?: boolean
-  filter?: QueryFilter
-  columns?: ColumnItemModel[]
-}
-export type VersionsViewPostModel = {
-  /** Unique identifier for the view within the given scope. */
-  id?: string
-  /** Human-readable name of the view. */
-  label: string
-  /** Working view is a special type of the view that automatically stores the current view settings without explicitly saving them. Working views are always private and scoped to the project  */
-  working?: boolean
-  settings: VersionsSettings
-  viewType?: 'versions'
-}
 export type GenericViewPostModel = {
   /** Unique identifier for the view within the given scope. */
   id?: string
@@ -345,103 +173,8 @@ export type GenericViewPostModel = {
   label: string
   /** Working view is a special type of the view that automatically stores the current view settings without explicitly saving them. Working views are always private and scoped to the project  */
   working?: boolean
+  viewType?: string
   settings: object
-  viewType: string
-}
-export type OverviewViewModel = {
-  /** Unique identifier for the view within the given scope. */
-  id?: string
-  /** Human-readable name of the view. */
-  label: string
-  /** Determines whether the view is only available for the given project or for all projects (studio). */
-  scope: 'project' | 'studio'
-  /** Name of the user who created the view. Owners have full control over the view,  */
-  owner: string
-  /** Visibility of the view. Public views are visible to all users, private views are only visible to the owner. */
-  visibility: 'public' | 'private'
-  /** Working view is a special type of the view that automatically stores the current view settings without explicitly saving them. Working views are always private and scoped to the project  */
-  working: boolean
-  position: number
-  accessLevel: number
-  settings: OverviewSettings
-  access: object
-  viewType?: 'overview'
-}
-export type TaskProgressViewModel = {
-  /** Unique identifier for the view within the given scope. */
-  id?: string
-  /** Human-readable name of the view. */
-  label: string
-  /** Determines whether the view is only available for the given project or for all projects (studio). */
-  scope: 'project' | 'studio'
-  /** Name of the user who created the view. Owners have full control over the view,  */
-  owner: string
-  /** Visibility of the view. Public views are visible to all users, private views are only visible to the owner. */
-  visibility: 'public' | 'private'
-  /** Working view is a special type of the view that automatically stores the current view settings without explicitly saving them. Working views are always private and scoped to the project  */
-  working: boolean
-  position: number
-  accessLevel: number
-  settings: TaskProgressSettings
-  access: object
-  viewType?: 'taskProgress'
-}
-export type ListsViewModel = {
-  /** Unique identifier for the view within the given scope. */
-  id?: string
-  /** Human-readable name of the view. */
-  label: string
-  /** Determines whether the view is only available for the given project or for all projects (studio). */
-  scope: 'project' | 'studio'
-  /** Name of the user who created the view. Owners have full control over the view,  */
-  owner: string
-  /** Visibility of the view. Public views are visible to all users, private views are only visible to the owner. */
-  visibility: 'public' | 'private'
-  /** Working view is a special type of the view that automatically stores the current view settings without explicitly saving them. Working views are always private and scoped to the project  */
-  working: boolean
-  position: number
-  accessLevel: number
-  settings: ListsSettings
-  access: object
-  viewType?: 'lists'
-}
-export type ReviewsViewModel = {
-  /** Unique identifier for the view within the given scope. */
-  id?: string
-  /** Human-readable name of the view. */
-  label: string
-  /** Determines whether the view is only available for the given project or for all projects (studio). */
-  scope: 'project' | 'studio'
-  /** Name of the user who created the view. Owners have full control over the view,  */
-  owner: string
-  /** Visibility of the view. Public views are visible to all users, private views are only visible to the owner. */
-  visibility: 'public' | 'private'
-  /** Working view is a special type of the view that automatically stores the current view settings without explicitly saving them. Working views are always private and scoped to the project  */
-  working: boolean
-  position: number
-  accessLevel: number
-  settings: ReviewsSettings
-  access: object
-  viewType?: 'reviews'
-}
-export type VersionsViewModel = {
-  /** Unique identifier for the view within the given scope. */
-  id?: string
-  /** Human-readable name of the view. */
-  label: string
-  /** Determines whether the view is only available for the given project or for all projects (studio). */
-  scope: 'project' | 'studio'
-  /** Name of the user who created the view. Owners have full control over the view,  */
-  owner: string
-  /** Visibility of the view. Public views are visible to all users, private views are only visible to the owner. */
-  visibility: 'public' | 'private'
-  /** Working view is a special type of the view that automatically stores the current view settings without explicitly saving them. Working views are always private and scoped to the project  */
-  working: boolean
-  position: number
-  accessLevel: number
-  settings: VersionsSettings
-  access: object
-  viewType?: 'versions'
 }
 export type GenericViewModel = {
   /** Unique identifier for the view within the given scope. */
@@ -458,46 +191,16 @@ export type GenericViewModel = {
   working: boolean
   position: number
   accessLevel: number
+  viewType: string
   settings: object
   access: object
-  viewType: string
 }
 export type SetDefaultViewRequestModel = {
   viewId: string
 }
-export type OverviewViewPatchModel = {
-  label?: string
-  owner?: string
-  settings?: OverviewSettings
-  viewType?: 'overview'
-}
-export type TaskProgressViewPatchModel = {
-  label?: string
-  owner?: string
-  settings?: TaskProgressSettings
-  viewType?: 'taskProgress'
-}
-export type ListsViewPatchModel = {
-  label?: string
-  owner?: string
-  settings?: ListsSettings
-  viewType?: 'lists'
-}
-export type ReviewsViewPatchModel = {
-  label?: string
-  owner?: string
-  settings?: ReviewsSettings
-  viewType?: 'reviews'
-}
-export type VersionsViewPatchModel = {
-  label?: string
-  owner?: string
-  settings?: VersionsSettings
-  viewType?: 'versions'
-}
 export type GenericViewPatchModel = {
   label?: string
   owner?: string
+  viewType?: string
   settings?: object
-  viewType: string
 }

--- a/shared/src/api/queries/views/updateViews.ts
+++ b/shared/src/api/queries/views/updateViews.ts
@@ -178,7 +178,7 @@ const updateViewsApi = getViewsApi.enhanceEndpoints<TagTypes, UpdatedDefinitions
     },
     updateView: {
       // See createView note — keep the FE on `payload` despite codegen renaming the arg.
-      query: ({ viewType, projectName, viewId, payload }: any) => ({
+      query: ({ viewType, projectName, viewId, payload }: UpdateViewArg) => ({
         url: `/api/views/${viewType}/${viewId}`,
         method: 'PATCH',
         body: payload,

--- a/shared/src/api/queries/views/updateViews.ts
+++ b/shared/src/api/queries/views/updateViews.ts
@@ -44,7 +44,7 @@ const updateViewsApi = getViewsApi.enhanceEndpoints<TagTypes, UpdatedDefinitions
       // Codegen names the request body arg after its model (genericViewPostModel).
       // Override the query so the whole FE keeps passing `payload`, regardless of
       // how codegen names the arg on the next regen.
-      query: ({ viewType, projectName, payload }: any) => ({
+      query: ({ viewType, projectName, payload }: CreateViewArg) => ({
         url: `/api/views/${viewType}`,
         method: 'POST',
         body: payload,

--- a/shared/src/api/queries/views/updateViews.ts
+++ b/shared/src/api/queries/views/updateViews.ts
@@ -1,10 +1,55 @@
-import { ViewListItemModel } from '@shared/api/generated'
+import { GenericViewPostModel, GenericViewPatchModel, ViewListItemModel } from '@shared/api/generated'
+import type {
+  DefinitionsFromApi,
+  MutationDefinition,
+  TagTypesFromApi,
+} from '@reduxjs/toolkit/query'
 import { getScopeTag, getViewsApi } from './getViews'
 import { v4 as uuidv4 } from 'uuid'
 
-const updateViewsApi = getViewsApi.enhanceEndpoints({
+type Definitions = DefinitionsFromApi<typeof getViewsApi>
+type TagTypes = TagTypesFromApi<typeof getViewsApi>
+
+// Codegen names the create/update body arg after its request model
+// (genericViewPostModel / genericViewPatchModel). We keep the whole FE on
+// `payload` via the query overrides below, and re-type the mutation args here
+// so callers stay decoupled from whatever codegen names the field next time.
+type OverrideMutationArg<D, NewArg> = D extends MutationDefinition<
+  any,
+  infer BaseQuery,
+  infer Tag,
+  infer Result,
+  infer ReducerPath,
+  infer RawResult
+>
+  ? MutationDefinition<NewArg, BaseQuery, Tag, Result, ReducerPath, RawResult>
+  : never
+
+type CreateViewArg = { viewType: string; projectName?: string; payload: GenericViewPostModel }
+type UpdateViewArg = {
+  viewType: string
+  projectName?: string
+  viewId: string
+  payload: GenericViewPatchModel
+}
+
+type UpdatedDefinitions = Omit<Definitions, 'createView' | 'updateView'> & {
+  createView: OverrideMutationArg<Definitions['createView'], CreateViewArg>
+  updateView: OverrideMutationArg<Definitions['updateView'], UpdateViewArg>
+}
+
+const updateViewsApi = getViewsApi.enhanceEndpoints<TagTypes, UpdatedDefinitions>({
   endpoints: {
     createView: {
+      // Codegen names the request body arg after its model (genericViewPostModel).
+      // Override the query so the whole FE keeps passing `payload`, regardless of
+      // how codegen names the arg on the next regen.
+      query: ({ viewType, projectName, payload }: any) => ({
+        url: `/api/views/${viewType}`,
+        method: 'POST',
+        body: payload,
+        params: { project_name: projectName },
+      }),
       onQueryStarted: async (arg, { dispatch, queryFulfilled, getState }) => {
         const { payload } = arg
         const state = getState()
@@ -132,6 +177,13 @@ const updateViewsApi = getViewsApi.enhanceEndpoints({
       ],
     },
     updateView: {
+      // See createView note — keep the FE on `payload` despite codegen renaming the arg.
+      query: ({ viewType, projectName, viewId, payload }: any) => ({
+        url: `/api/views/${viewType}/${viewId}`,
+        method: 'PATCH',
+        body: payload,
+        params: { project_name: projectName },
+      }),
       onQueryStarted: async (arg, { dispatch, queryFulfilled }) => {
         const { viewId, payload, viewType, projectName } = arg
 

--- a/shared/src/api/viewSettings.ts
+++ b/shared/src/api/viewSettings.ts
@@ -1,0 +1,74 @@
+// Frontend-owned view settings types.
+//
+// The backend stores view `settings` as an untyped dict and no longer ships
+// per-page settings schemas, so these shapes live here instead of in the
+// generated REST types. Adding a view setting is now a frontend-only change.
+
+import type { QueryFilter } from './generated/folders'
+
+export type DisplayStyle = 'cards' | 'table' | 'playlist'
+
+// Backend stores view columns as an untyped dict, so this shape lives here too.
+export type ColumnItemModel = {
+  name: string
+  visible?: boolean
+  pinned?: boolean
+  width?: number
+}
+
+export type OverviewSettings = {
+  showHierarchy?: boolean
+  rowHeight?: number
+  groupBy?: string
+  groupSortByDesc?: boolean
+  showEmptyGroups?: boolean
+  sortBy?: string
+  sortDesc?: boolean
+  filter?: QueryFilter
+  folderFilter?: QueryFilter
+  sliceType?: string
+  columns?: ColumnItemModel[]
+}
+
+export type TaskProgressSettings = {
+  filter?: QueryFilter
+  sliceType?: string
+  columns?: ColumnItemModel[]
+}
+
+export type ListsSettings = {
+  rowHeight?: number
+  sortBy?: string
+  sortDesc?: boolean
+  filter?: QueryFilter
+  columns?: ColumnItemModel[]
+}
+
+export type ReviewsSettings = ListsSettings & {
+  gridHeight?: number
+  displayStyle?: DisplayStyle
+}
+
+export type VersionsSettings = {
+  showProducts?: boolean
+  rowHeight?: number
+  showGrid?: boolean
+  gridHeight?: number
+  featuredVersionOrder?: string[]
+  slicerType?: string
+  groupBy?: string
+  groupSortByDesc?: boolean
+  showEmptyGroups?: boolean
+  sortBy?: string
+  sortDesc?: boolean
+  filter?: QueryFilter
+  columns?: ColumnItemModel[]
+}
+
+export type ViewSettings =
+  | OverviewSettings
+  | TaskProgressSettings
+  | ListsSettings
+  | ReviewsSettings
+  | VersionsSettings
+  | Record<string, unknown>

--- a/shared/src/containers/Views/context/ViewsContext.tsx
+++ b/shared/src/containers/Views/context/ViewsContext.tsx
@@ -21,9 +21,10 @@ import { useBaseViewMutations } from '../hooks/useBaseViewMutations'
 import { useSaveViewFromCurrent } from '../hooks/useSaveViewFromCurrent'
 import { useViewSettingsChanged } from '../hooks/useViewSettingsChanged'
 import { useLocalStorage } from '@shared/hooks'
+import type { ViewSettings } from '@shared/api/viewSettings'
 
 export type ViewData = GetDefaultViewApiResponse
-export type ViewSettings = GetDefaultViewApiResponse['settings']
+export type { ViewSettings }
 export type SelectedViewState = ViewData | undefined // id of view otherwise null with use working
 export type EditingViewState = string | true | null // id of view being edited otherwise null
 

--- a/shared/src/containers/Views/hooks/pages/useListsViewSettings.ts
+++ b/shared/src/containers/Views/hooks/pages/useListsViewSettings.ts
@@ -9,7 +9,7 @@
  */
 
 import { useViewsContext } from '../../context/ViewsContext'
-import { OverviewSettings } from '@shared/api'
+import { OverviewSettings } from '@shared/api/viewSettings'
 import { ColumnsConfig } from '@shared/containers/ProjectTreeTable'
 import {
   convertColumnConfigToTanstackStates,

--- a/shared/src/containers/Views/hooks/pages/useOverviewViewSettings.ts
+++ b/shared/src/containers/Views/hooks/pages/useOverviewViewSettings.ts
@@ -10,7 +10,7 @@
  */
 
 import { useViewsContext } from '../../context/ViewsContext'
-import { OverviewSettings } from '@shared/api'
+import { OverviewSettings } from '@shared/api/viewSettings'
 import { ColumnsConfig } from '@shared/containers/ProjectTreeTable'
 import {
   convertColumnConfigToTanstackStates,

--- a/shared/src/containers/Views/hooks/pages/useTaskProgressViewSettings.ts
+++ b/shared/src/containers/Views/hooks/pages/useTaskProgressViewSettings.ts
@@ -9,7 +9,7 @@
  */
 
 import { useViewsContext } from '../../context/ViewsContext'
-import { TaskProgressSettings, ColumnItemModel } from '@shared/api'
+import { ColumnItemModel, TaskProgressSettings } from '@shared/api/viewSettings'
 import { useViewUpdateHelper } from '../../utils/viewUpdateHelper'
 import { useState, useEffect, useCallback } from 'react'
 

--- a/shared/src/containers/Views/hooks/useViewsMutations.ts
+++ b/shared/src/containers/Views/hooks/useViewsMutations.ts
@@ -1,5 +1,5 @@
 import {
-  CreateViewApiArg,
+  GenericViewPostModel,
   useCreateViewMutation,
   useDeleteViewMutation,
   useUpdateViewMutation,
@@ -24,7 +24,7 @@ type Props = {
 }
 
 export type UseViewMutations = {
-  onCreateView: (payload: CreateViewApiArg['payload'], isStudioScope: boolean) => Promise<void>
+  onCreateView: (payload: GenericViewPostModel, isStudioScope: boolean) => Promise<void>
   onDeleteView: (viewId: string, isStudioScope: boolean) => Promise<void>
   onUpdateView: (
     viewId: string,

--- a/shared/src/containers/Views/utils/generateWorkingView.ts
+++ b/shared/src/containers/Views/utils/generateWorkingView.ts
@@ -1,11 +1,11 @@
-import { CreateViewApiArg } from '@shared/api'
+import { GenericViewPostModel } from '@shared/api'
 import { v4 as uuidv4 } from 'uuid'
 
 export const generateViewId = (): string => uuidv4().replace(/-/g, '')
 
 export const generateWorkingView = (
-  settings: CreateViewApiArg['payload']['settings'] = {},
-): CreateViewApiArg['payload'] => ({
+  settings: GenericViewPostModel['settings'] = {},
+): GenericViewPostModel => ({
   id: generateViewId(),
   label: 'Working',
   working: true,

--- a/shared/src/util/columnConfigConverter.ts
+++ b/shared/src/util/columnConfigConverter.ts
@@ -5,7 +5,7 @@ import {
   ColumnSizingState,
   SortingState,
 } from '@tanstack/react-table'
-import { ColumnItemModel, OverviewSettings } from '@shared/api/generated/views'
+import { ColumnItemModel, OverviewSettings } from '@shared/api/viewSettings'
 import { ColumnsConfig, TableGroupBy } from '@shared/containers'
 import { GroupByConfig } from '@shared/containers/ProjectTreeTable/components/GroupSettingsFallback'
 import {

--- a/src/pages/ProjectListsPage/components/ProjectListsDetailsPanels/ProjectListsDetailsPanels.tsx
+++ b/src/pages/ProjectListsPage/components/ProjectListsDetailsPanels/ProjectListsDetailsPanels.tsx
@@ -15,7 +15,7 @@ import { useEffect, useMemo, useState } from 'react'
 import ListDetailsPanel from '../ListDetailsPanel/ListDetailsPanel'
 import useReviewSessionCardsModules from '@pages/ProjectListsPage/hooks/useReviewSessionCardsModules'
 import useStoryboardsCardsModules from '@pages/ProjectListsPage/hooks/useStoryboardsCardsModules'
-import { ReviewsSettings } from '@shared/api'
+import { ReviewsSettings } from '@shared/api/viewSettings'
 
 type Props = {
   isReview: boolean

--- a/src/pages/ProjectListsPage/components/TableGridPlaylistSwitch/TableGridPlaylistSwitch.tsx
+++ b/src/pages/ProjectListsPage/components/TableGridPlaylistSwitch/TableGridPlaylistSwitch.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, useEffect } from 'react'
 import * as Styled from './TableGridPlaylistSwitch.styled'
-import { ReviewsSettings } from '@shared/api'
+import { ReviewsSettings } from '@shared/api/viewSettings'
 
 interface TableGridPlaylistSwitchProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange'> {
   value: ReviewsSettings['displayStyle']

--- a/src/pages/ProjectListsPage/context/ReviewCardsSettingsContext.tsx
+++ b/src/pages/ProjectListsPage/context/ReviewCardsSettingsContext.tsx
@@ -1,4 +1,4 @@
-import { ReviewsSettings } from '@shared/api'
+import { ReviewsSettings } from '@shared/api/viewSettings'
 import { useViewsContext } from '@shared/containers'
 import { useViewUpdateHelper } from '@shared/containers/Views/utils/viewUpdateHelper'
 import {

--- a/src/pages/ProjectOverviewPage/context/ProjectOverviewContext.tsx
+++ b/src/pages/ProjectOverviewPage/context/ProjectOverviewContext.tsx
@@ -3,7 +3,7 @@ import { createContext, useCallback, useContext, useMemo, useState } from 'react
 
 // Third-party libraries
 import { ExpandedState } from '@tanstack/react-table'
-import { OverviewSettings } from '@shared/api'
+import { OverviewSettings } from '@shared/api/viewSettings'
 
 // Shared components and hooks
 import { useLocalStorage, useGetEntityGroups } from '@shared/hooks'

--- a/src/pages/ProjectsPage/hooks/useProjectColumnConfig.ts
+++ b/src/pages/ProjectsPage/hooks/useProjectColumnConfig.ts
@@ -4,7 +4,7 @@ import {
   convertColumnConfigToTanstackStates,
   convertTanstackStatesToColumnConfig,
 } from '@shared/util'
-import type { OverviewSettings } from '@shared/api/generated/views'
+import type { OverviewSettings } from '@shared/api/viewSettings'
 import { ColumnOrderState, ColumnSizingState, VisibilityState } from '@tanstack/react-table'
 import { useCallback, useMemo, useRef, useState } from 'react'
 import { ProjectColumn } from './useProjectColumns'

--- a/src/pages/ProjectsPage/hooks/useProjectFilters.ts
+++ b/src/pages/ProjectsPage/hooks/useProjectFilters.ts
@@ -1,6 +1,6 @@
 import { useViewsContext } from '@shared/containers'
 import { useViewUpdateHelper } from '@shared/containers/Views/utils/viewUpdateHelper'
-import type { OverviewSettings } from '@shared/api/generated/views'
+import type { OverviewSettings } from '@shared/api/viewSettings'
 import { QueryFilter } from '@shared/containers/ProjectTreeTable/types/operations'
 import { useCallback, useMemo, useState } from 'react'
 

--- a/src/pages/ProjectsPage/hooks/useProjectGrouping.ts
+++ b/src/pages/ProjectsPage/hooks/useProjectGrouping.ts
@@ -1,6 +1,6 @@
 import { useViewsContext } from '@shared/containers'
 import { useViewUpdateHelper } from '@shared/containers/Views/utils/viewUpdateHelper'
-import type { OverviewSettings } from '@shared/api/generated/views'
+import type { OverviewSettings } from '@shared/api/viewSettings'
 import { useCallback, useMemo, useState } from 'react'
 import { AttributeModel } from '@shared/api'
 import { useGlobalContext } from '@shared/context'

--- a/src/pages/ProjectsPage/hooks/useProjectSorting.ts
+++ b/src/pages/ProjectsPage/hooks/useProjectSorting.ts
@@ -1,7 +1,7 @@
 import { useViewsContext } from '@shared/containers'
 import { useViewUpdateHelper } from '@shared/containers/Views/utils/viewUpdateHelper'
 import { convertColumnConfigToTanstackStates } from '@shared/util'
-import type { OverviewSettings } from '@shared/api/generated/views'
+import type { OverviewSettings } from '@shared/api/viewSettings'
 import { SortingState } from '@tanstack/react-table'
 import { useCallback, useMemo, useState } from 'react'
 

--- a/src/pages/VersionsProductsPage/context/VPViewsContext.tsx
+++ b/src/pages/VersionsProductsPage/context/VPViewsContext.tsx
@@ -1,4 +1,5 @@
-import { QueryFilter, VersionsSettings } from '@shared/api'
+import { QueryFilter } from '@shared/api'
+import { VersionsSettings } from '@shared/api/viewSettings'
 import { ColumnsConfig, useViewsContext } from '@shared/containers'
 import { useViewUpdateHelper } from '@shared/containers/Views/utils/viewUpdateHelper'
 import {


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Frontend now owns its view settings types instead of generating them from the REST schema, so adding a view setting no longer needs a backend change. Pairs with backend #974.

## Technical details
<!-- Please state any technical details such as limitations -->

- Settings types moved to `shared/src/api/viewSettings.ts`; all consumers repointed there.
- `views.ts` regenerated against ynput/ayon-backend#974 -> `GenericView*`.
- Codegen renamed the create/update body arg, so `updateViews.ts` pins a stable `payload` contract to keep saves working.

## Additional context
<!-- Add any other context or screenshots here. -->

Pairs with ynput/ayon-backend#974
