### PR TITLE
Versions: Add linked task

### DIFF
--- a/shared/src/api/generated/graphql.ts
+++ b/shared/src/api/generated/graphql.ts
@@ -1773,7 +1773,7 @@ export type GetDetailsPanelRepresentationQueryVariables = Exact<{
 }>;
 
 
-export type GetDetailsPanelRepresentationQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', representation?: { __typename?: 'RepresentationNode', id: string, versionId: string, name: string, status: string, tags: Array<string>, updatedAt: any, createdAt: any, allAttrib: string, context?: string | null, parents: Array<string>, version: { __typename?: 'VersionNode', id: string, thumbnailId?: string | null, name: string, updatedAt: any, createdAt: any, productId: string, version: number, author?: string | null, task?: { __typename?: 'TaskNode', id: string, name: string, label?: string | null, assignees: Array<string>, taskType: string, subtasks: Array<{ __typename?: 'SubTaskNode', id: string, name: string, label: string, assignees: Array<string>, description?: string | null, startDate?: any | null, endDate?: any | null, isDone: boolean }> } | null, product: { __typename?: 'ProductNode', id: string, name: string, productType: string, folder: { __typename?: 'FolderNode', id: string, name: string, label?: string | null, path?: string | null, folderType: string }, latestVersion?: { __typename?: 'VersionNode', version: number } | null } } } | null } };
+export type GetDetailsPanelRepresentationQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', representation?: { __typename?: 'RepresentationNode', id: string, versionId: string, name: string, status: string, tags: Array<string>, updatedAt: any, createdAt: any, allAttrib: string, context?: string | null, parents: Array<string>, version: { __typename?: 'VersionNode', id: string, thumbnailId?: string | null, name: string, updatedAt: any, createdAt: any, productId: string, version: number, author?: string | null, task?: { __typename?: 'TaskNode', id: string, name: string, label?: string | null, assignees: Array<string>, taskType: string } | null, product: { __typename?: 'ProductNode', id: string, name: string, productType: string, folder: { __typename?: 'FolderNode', id: string, name: string, label?: string | null, path?: string | null, folderType: string }, latestVersion?: { __typename?: 'VersionNode', version: number } | null } } } | null } };
 
 export type GetDetailsPanelTaskQueryVariables = Exact<{
   projectName: Scalars['String']['input'];
@@ -1789,7 +1789,7 @@ export type GetDetailsPanelVersionQueryVariables = Exact<{
 }>;
 
 
-export type GetDetailsPanelVersionQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', projectName: string, code: string, version?: { __typename?: 'VersionNode', id: string, version: number, name: string, author?: string | null, status: string, tags: Array<string>, updatedAt: any, createdAt: any, thumbnailHash: string, thumbnailId?: string | null, hasReviewables: boolean, parents: Array<string>, allAttrib: string, product: { __typename?: 'ProductNode', id: string, name: string, productType: string, folder: { __typename?: 'FolderNode', id: string, name: string, label?: string | null, path?: string | null, folderType: string }, latestVersion?: { __typename?: 'VersionNode', version: number } | null }, task?: { __typename?: 'TaskNode', id: string, name: string, label?: string | null, assignees: Array<string>, taskType: string, subtasks: Array<{ __typename?: 'SubTaskNode', id: string, name: string, label: string, assignees: Array<string>, description?: string | null, startDate?: any | null, endDate?: any | null, isDone: boolean }> } | null, representations: { __typename?: 'RepresentationsConnection', edges: Array<{ __typename?: 'RepresentationEdge', node: { __typename?: 'RepresentationNode', id: string, name: string, fileCount: number } }> } } | null } };
+export type GetDetailsPanelVersionQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', projectName: string, code: string, version?: { __typename?: 'VersionNode', id: string, version: number, name: string, author?: string | null, status: string, tags: Array<string>, updatedAt: any, createdAt: any, thumbnailHash: string, thumbnailId?: string | null, hasReviewables: boolean, parents: Array<string>, allAttrib: string, product: { __typename?: 'ProductNode', id: string, name: string, productType: string, folder: { __typename?: 'FolderNode', id: string, name: string, label?: string | null, path?: string | null, folderType: string }, latestVersion?: { __typename?: 'VersionNode', version: number } | null }, task?: { __typename?: 'TaskNode', id: string, name: string, label?: string | null, assignees: Array<string>, taskType: string } | null, representations: { __typename?: 'RepresentationsConnection', edges: Array<{ __typename?: 'RepresentationEdge', node: { __typename?: 'RepresentationNode', id: string, name: string, fileCount: number } }> } } | null } };
 
 export type GetProductVersionsQueryVariables = Exact<{
   projectName: Scalars['String']['input'];
@@ -1805,7 +1805,7 @@ export type DetailsPanelProductFragmentFragment = { __typename?: 'ProductNode', 
 
 export type DetailsPanelRepresentationFragmentFragment = { __typename?: 'RepresentationNode', id: string, name: string, fileCount: number };
 
-export type DetailsPanelTaskFragmentFragment = { __typename?: 'TaskNode', id: string, name: string, label?: string | null, assignees: Array<string>, taskType: string, subtasks: Array<{ __typename?: 'SubTaskNode', id: string, name: string, label: string, assignees: Array<string>, description?: string | null, startDate?: any | null, endDate?: any | null, isDone: boolean }> };
+export type DetailsPanelTaskFragmentFragment = { __typename?: 'TaskNode', id: string, name: string, label?: string | null, assignees: Array<string>, taskType: string };
 
 export type DetailsPanelVersionFragmentFragment = { __typename?: 'VersionNode', id: string, thumbnailId?: string | null, name: string, updatedAt: any, createdAt: any, productId: string, version: number, author?: string | null };
 
@@ -2253,18 +2253,6 @@ export const DetailsPanelRepresentationFragmentFragmentDoc = new TypedDocumentSt
   fileCount
 }
     `, {"fragmentName":"DetailsPanelRepresentationFragment"});
-export const SubTaskFragmentFragmentDoc = new TypedDocumentString(`
-    fragment SubTaskFragment on SubTaskNode {
-  id
-  name
-  label
-  assignees
-  description
-  startDate
-  endDate
-  isDone
-}
-    `, {"fragmentName":"SubTaskFragment"});
 export const DetailsPanelTaskFragmentFragmentDoc = new TypedDocumentString(`
     fragment DetailsPanelTaskFragment on TaskNode {
   id
@@ -2272,20 +2260,8 @@ export const DetailsPanelTaskFragmentFragmentDoc = new TypedDocumentString(`
   label
   assignees
   taskType
-  subtasks {
-    ...SubTaskFragment
-  }
 }
-    fragment SubTaskFragment on SubTaskNode {
-  id
-  name
-  label
-  assignees
-  description
-  startDate
-  endDate
-  isDone
-}`, {"fragmentName":"DetailsPanelTaskFragment"});
+    `, {"fragmentName":"DetailsPanelTaskFragment"});
 export const DetailsPanelVersionFragmentFragmentDoc = new TypedDocumentString(`
     fragment DetailsPanelVersionFragment on VersionNode {
   id
@@ -2298,6 +2274,18 @@ export const DetailsPanelVersionFragmentFragmentDoc = new TypedDocumentString(`
   author
 }
     `, {"fragmentName":"DetailsPanelVersionFragment"});
+export const SubTaskFragmentFragmentDoc = new TypedDocumentString(`
+    fragment SubTaskFragment on SubTaskNode {
+  id
+  name
+  label
+  assignees
+  description
+  startDate
+  endDate
+  isDone
+}
+    `, {"fragmentName":"SubTaskFragment"});
 export const ListItemFragmentFragmentDoc = new TypedDocumentString(`
     fragment ListItemFragment on BaseNode {
   active
@@ -2919,9 +2907,6 @@ fragment DetailsPanelTaskFragment on TaskNode {
   label
   assignees
   taskType
-  subtasks {
-    ...SubTaskFragment
-  }
 }
 fragment DetailsPanelVersionFragment on VersionNode {
   id
@@ -2932,16 +2917,6 @@ fragment DetailsPanelVersionFragment on VersionNode {
   productId
   version
   author
-}
-fragment SubTaskFragment on SubTaskNode {
-  id
-  name
-  label
-  assignees
-  description
-  startDate
-  endDate
-  isDone
 }`);
 export const GetDetailsPanelTaskDocument = new TypedDocumentString(`
     query GetDetailsPanelTask($projectName: String!, $entityId: String!) {
@@ -3071,19 +3046,6 @@ fragment DetailsPanelTaskFragment on TaskNode {
   label
   assignees
   taskType
-  subtasks {
-    ...SubTaskFragment
-  }
-}
-fragment SubTaskFragment on SubTaskNode {
-  id
-  name
-  label
-  assignees
-  description
-  startDate
-  endDate
-  isDone
 }`);
 export const GetProductVersionsDocument = new TypedDocumentString(`
     query GetProductVersions($projectName: String!, $productId: String!) {

--- a/shared/src/api/queries/entities/gql/fragments/DetailsPanelTaskFragment.graphql
+++ b/shared/src/api/queries/entities/gql/fragments/DetailsPanelTaskFragment.graphql
@@ -4,7 +4,4 @@ fragment DetailsPanelTaskFragment on TaskNode {
   label
   assignees
   taskType
-  subtasks {
-    ...SubTaskFragment
-  }
 }

--- a/shared/src/api/queries/entities/transformDetailsPanelData.ts
+++ b/shared/src/api/queries/entities/transformDetailsPanelData.ts
@@ -49,7 +49,8 @@ export type DetailsPanelEntityData = {
   entitySubType?: string
   projectName: string
   // type specific
-  task?: DetailsPanelTaskFragmentFragment
+  // subtasks aren't on the shared fragment (version/rep don't need them); the task entity adds them from its own query
+  task?: DetailsPanelTaskFragmentFragment & { subtasks?: DetailsPanelTask['subtasks'] }
   folder?: DetailsPanelFolderFragmentFragment
   product?: DetailsPanelProductFragmentFragment
   version?: DetailsPanelVersionFragmentFragment

--- a/shared/src/containers/DetailsPanel/DetailsPanel.tsx
+++ b/shared/src/containers/DetailsPanel/DetailsPanel.tsx
@@ -30,6 +30,7 @@ import getAllProjectStatuses from './helpers/getAllProjectsStatuses'
 import FeedWrapper from './containers/FeedWrapper'
 import FeedContextWrapper from './containers/FeedContextWrapper'
 import mergeProjectInfo from './helpers/mergeProjectInfo'
+import buildEntityTypeIcons from './helpers/buildEntityTypeIcons'
 import DetailsPanelSubtasks from './containers/DetailsPanelSubtasks'
 
 export const entitiesWithoutFeed = ['product', 'representation']
@@ -160,30 +161,8 @@ DetailsPanelProps) => {
     [projectsInfo, activeProjectNames],
   )
 
-  // build icons for entity types
-  const entityTypeIcons = useMemo(
-    () => ({
-      task: projectInfo.taskTypes
-        .filter((task) => !!task.icon)
-        .reduce((acc, task) => ({ ...acc, [task.name]: task.icon }), {}),
-      folder: projectInfo.folderTypes
-        .filter((folder) => !!folder.icon)
-        .reduce((acc, folder) => ({ ...acc, [folder.name]: folder.icon }), {}),
-      product: projectInfo.productTypes
-        .filter((product) => !!product.icon)
-        .reduce((acc, product) => ({ ...acc, [product.name]: product.icon }), {}),
-    }),
-    [projectInfo],
-  )
-
-  // task type colors, threaded alongside the icons (keeps the panel decoupled from ProjectContext)
-  const taskTypeColors = useMemo(
-    () =>
-      projectInfo.taskTypes
-        .filter((task) => !!task.color)
-        .reduce((acc, task) => ({ ...acc, [task.name]: task.color }), {}),
-    [projectInfo],
-  )
+  // build icons for entity types (used by the entity path breadcrumb)
+  const entityTypeIcons = useMemo(() => buildEntityTypeIcons(projectInfo), [projectInfo])
 
   // for example when switching from version to task, task doesn't have reps tab
   // if reps tab was selected, set default to feed
@@ -469,8 +448,7 @@ DetailsPanelProps) => {
           isCompact={isCompact}
           currentTab={currentTab}
           onTabChange={setTab}
-          entityTypeIcons={entityTypeIcons}
-          taskTypeColors={taskTypeColors}
+          projectInfo={projectInfo}
           onOpenViewer={(args) => onOpenViewer?.(args)}
           onEntityFocus={onEntityFocus}
           thumbnailInputRef={thumbnailInputRef}

--- a/shared/src/containers/DetailsPanel/DetailsPanel.tsx
+++ b/shared/src/containers/DetailsPanel/DetailsPanel.tsx
@@ -176,6 +176,15 @@ DetailsPanelProps) => {
     [projectInfo],
   )
 
+  // task type colors, threaded alongside the icons (keeps the panel decoupled from ProjectContext)
+  const taskTypeColors = useMemo(
+    () =>
+      projectInfo.taskTypes
+        .filter((task) => !!task.color)
+        .reduce((acc, task) => ({ ...acc, [task.name]: task.color }), {}),
+    [projectInfo],
+  )
+
   // for example when switching from version to task, task doesn't have reps tab
   // if reps tab was selected, set default to feed
   useEffect(() => {
@@ -461,6 +470,7 @@ DetailsPanelProps) => {
           currentTab={currentTab}
           onTabChange={setTab}
           entityTypeIcons={entityTypeIcons}
+          taskTypeColors={taskTypeColors}
           onOpenViewer={(args) => onOpenViewer?.(args)}
           onEntityFocus={onEntityFocus}
           thumbnailInputRef={thumbnailInputRef}

--- a/shared/src/containers/DetailsPanel/components/DetailsPanelHeader/DetailsPanelHeader.styled.ts
+++ b/shared/src/containers/DetailsPanel/components/DetailsPanelHeader/DetailsPanelHeader.styled.ts
@@ -55,7 +55,7 @@ export const CloseButton = styled(Button)`
 
 export const Header = styled.header`
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   gap: var(--base-gap-large);
   z-index: 50;
 

--- a/shared/src/containers/DetailsPanel/components/DetailsPanelHeader/DetailsPanelHeader.tsx
+++ b/shared/src/containers/DetailsPanel/components/DetailsPanelHeader/DetailsPanelHeader.tsx
@@ -13,6 +13,7 @@ import { useScopedStatuses, useEntityUpdate } from '@shared/hooks'
 import { DetailsPanelTab, useDetailsPanelContext } from '@shared/context'
 
 import DetailsPanelTabs from '../DetailsPanelTabs/DetailsPanelTabs'
+import LinkedTaskRow from './LinkedTaskRow'
 import * as Styled from './DetailsPanelHeader.styled'
 import getThumbnails from '../../helpers/getThumbnails'
 import { buildDetailsPanelTitles } from '../../helpers/buildDetailsPanelTitles'
@@ -39,6 +40,7 @@ type DetailsPanelHeaderProps = {
   onOpenViewer: (args: any) => void
   onEntityFocus: DetailsPanelProps['onEntityFocus']
   entityTypeIcons: EntityTypeIcons
+  taskTypeColors: Record<string, string>
   thumbnailInputRef: RefObject<HTMLInputElement>
   versionsInputRef: RefObject<HTMLInputElement>
 }
@@ -56,6 +58,7 @@ const DetailsPanelHeader = ({
   currentTab,
   onTabChange,
   entityTypeIcons,
+  taskTypeColors,
   onOpenViewer,
   onEntityFocus,
   thumbnailInputRef,
@@ -203,7 +206,7 @@ const DetailsPanelHeader = ({
           <Styled.Header
             className={clsx('titles', { isCompact, loading: isLoading }, 'no-shimmer')}
           >
-            <div style={{ position: 'relative' }}>
+            <div style={{ position: 'relative', alignSelf: 'stretch' }}>
               <StackedThumbnails
                 isLoading={isLoading}
                 shimmer={isLoading}
@@ -234,6 +237,15 @@ const DetailsPanelHeader = ({
                 <span className="entity-type">{upperFirst(entityType)} - </span>
                 <h3>{subTitle}</h3>
               </div>
+              {entityType === 'version' && !isMultiple && !isLoading && firstEntity && (
+                <LinkedTaskRow
+                  key={firstEntity.id}
+                  entity={firstEntity}
+                  taskTypeIcons={entityTypeIcons.task}
+                  taskTypeColors={taskTypeColors}
+                  onLinkTask={(taskId) => handleUpdate('taskId', taskId)}
+                />
+              )}
             </Styled.Content>
           </Styled.Header>
           <Styled.StatusSelect

--- a/shared/src/containers/DetailsPanel/components/DetailsPanelHeader/DetailsPanelHeader.tsx
+++ b/shared/src/containers/DetailsPanel/components/DetailsPanelHeader/DetailsPanelHeader.tsx
@@ -16,6 +16,8 @@ import DetailsPanelTabs from '../DetailsPanelTabs/DetailsPanelTabs'
 import LinkedTaskRow from './LinkedTaskRow'
 import * as Styled from './DetailsPanelHeader.styled'
 import getThumbnails from '../../helpers/getThumbnails'
+import buildEntityTypeIcons from '../../helpers/buildEntityTypeIcons'
+import type { ProjectInfo } from '../../helpers/mergeProjectInfo'
 import { buildDetailsPanelTitles } from '../../helpers/buildDetailsPanelTitles'
 import { PlayableIcon } from '@shared/components/PlayableIcon/PlayableIcon'
 
@@ -39,8 +41,7 @@ type DetailsPanelHeaderProps = {
   onTabChange: (tab: DetailsPanelTab) => void
   onOpenViewer: (args: any) => void
   onEntityFocus: DetailsPanelProps['onEntityFocus']
-  entityTypeIcons: EntityTypeIcons
-  taskTypeColors: Record<string, string>
+  projectInfo: ProjectInfo
   thumbnailInputRef: RefObject<HTMLInputElement>
   versionsInputRef: RefObject<HTMLInputElement>
 }
@@ -57,8 +58,7 @@ const DetailsPanelHeader = ({
   isCompact = false,
   currentTab,
   onTabChange,
-  entityTypeIcons,
-  taskTypeColors,
+  projectInfo,
   onOpenViewer,
   onEntityFocus,
   thumbnailInputRef,
@@ -68,6 +68,8 @@ const DetailsPanelHeader = ({
   const navigate = useNavigate()
   const [searchParams, setSearchParams] = useSearchParams()
   const tagsSelectRef = useRef<DropdownRef>(null)
+
+  const entityTypeIcons = useMemo(() => buildEntityTypeIcons(projectInfo), [projectInfo])
 
   const statuses = useScopedStatuses(
     entities.map((entity) => entity.projectName),
@@ -241,9 +243,7 @@ const DetailsPanelHeader = ({
                 <LinkedTaskRow
                   key={firstEntity.id}
                   entity={firstEntity}
-                  taskTypeIcons={entityTypeIcons.task}
-                  taskTypeColors={taskTypeColors}
-                  onLinkTask={(taskId) => handleUpdate('taskId', taskId)}
+                  taskTypes={projectInfo.taskTypes}
                 />
               )}
             </Styled.Content>

--- a/shared/src/containers/DetailsPanel/components/DetailsPanelHeader/DetailsPanelHeader.tsx
+++ b/shared/src/containers/DetailsPanel/components/DetailsPanelHeader/DetailsPanelHeader.tsx
@@ -208,7 +208,7 @@ const DetailsPanelHeader = ({
           <Styled.Header
             className={clsx('titles', { isCompact, loading: isLoading }, 'no-shimmer')}
           >
-            <div style={{ position: 'relative', alignSelf: 'stretch' }}>
+            <div style={{ position: 'relative' }}>
               <StackedThumbnails
                 isLoading={isLoading}
                 shimmer={isLoading}

--- a/shared/src/containers/DetailsPanel/components/DetailsPanelHeader/LinkedTaskRow.styled.ts
+++ b/shared/src/containers/DetailsPanel/components/DetailsPanelHeader/LinkedTaskRow.styled.ts
@@ -31,10 +31,3 @@ export const TaskLink = styled.button`
     white-space: nowrap;
   }
 `
-
-export const Skeleton = styled.span`
-  display: inline-block;
-  width: 96px;
-  height: 18px;
-  border-radius: var(--border-radius-m);
-`

--- a/shared/src/containers/DetailsPanel/components/DetailsPanelHeader/LinkedTaskRow.styled.ts
+++ b/shared/src/containers/DetailsPanel/components/DetailsPanelHeader/LinkedTaskRow.styled.ts
@@ -4,7 +4,6 @@ export const Row = styled.div`
   display: flex;
   align-items: center;
   gap: var(--base-gap-small);
-  min-height: 28px;
   overflow: hidden;
 `
 

--- a/shared/src/containers/DetailsPanel/components/DetailsPanelHeader/LinkedTaskRow.styled.ts
+++ b/shared/src/containers/DetailsPanel/components/DetailsPanelHeader/LinkedTaskRow.styled.ts
@@ -1,0 +1,40 @@
+import styled from 'styled-components'
+
+export const Row = styled.div`
+  display: flex;
+  align-items: center;
+  gap: var(--base-gap-small);
+  min-height: 28px;
+  overflow: hidden;
+`
+
+export const TaskLink = styled.button`
+  display: inline-flex;
+  align-items: center;
+  gap: var(--base-gap-small);
+  max-width: 100%;
+  margin: 0;
+  padding: 2px 6px;
+  border: none;
+  border-radius: var(--border-radius-m);
+  background: none;
+  color: var(--md-sys-color-on-surface);
+  cursor: pointer;
+
+  &:hover {
+    background: var(--md-sys-color-surface-container-hover);
+  }
+
+  .label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+`
+
+export const Skeleton = styled.span`
+  display: inline-block;
+  width: 96px;
+  height: 18px;
+  border-radius: var(--border-radius-m);
+`

--- a/shared/src/containers/DetailsPanel/components/DetailsPanelHeader/LinkedTaskRow.tsx
+++ b/shared/src/containers/DetailsPanel/components/DetailsPanelHeader/LinkedTaskRow.tsx
@@ -1,85 +1,34 @@
-import { useState } from 'react'
-import { Button, Icon } from '@ynput/ayon-react-components'
+import { Icon } from '@ynput/ayon-react-components'
 
-import { useGetTaskQuery } from '@shared/api'
-import type { DetailsPanelEntityData } from '@shared/api'
-import { useDetailsPanelContext, ProjectFoldersContextProvider } from '@shared/context'
-import { EntityPickerDialog } from '@shared/containers'
+import type { DetailsPanelEntityData, TaskType } from '@shared/api'
+import { useDetailsPanelContext } from '@shared/context'
 
 import * as Styled from './LinkedTaskRow.styled'
 
 interface LinkedTaskRowProps {
   entity: DetailsPanelEntityData
-  taskTypeIcons: Record<string, string>
-  taskTypeColors: Record<string, string>
-  onLinkTask: (taskId: string) => void | Promise<void>
+  taskTypes: TaskType[]
 }
 
-const LinkedTaskRow = ({
-  entity,
-  taskTypeIcons,
-  taskTypeColors,
-  onLinkTask,
-}: LinkedTaskRowProps) => {
+const LinkedTaskRow = ({ entity, taskTypes }: LinkedTaskRowProps) => {
   const { openSlideOut } = useDetailsPanelContext()
-  const [pickerOpen, setPickerOpen] = useState(false)
-  const [linkedTaskId, setLinkedTaskId] = useState<string>()
+  const { projectName } = entity
 
-  const { folder, projectName } = entity
-  const taskId = linkedTaskId || entity.task?.id
-  // the optimistic version update leaves an empty task object; ignore it until it has real data
-  const panelTask = entity.task?.name ? entity.task : undefined
-  const needsFetch = !!linkedTaskId || (!!taskId && !panelTask)
+  // the optimistic version update can leave an empty task object; ignore it until it has real data
+  const task = entity.task?.name ? entity.task : undefined
+  if (!task?.id) return null
 
-  const { data: fetchedTask } = useGetTaskQuery(
-    { projectName, taskId: taskId as string },
-    { skip: !taskId || !needsFetch },
-  )
-
-  const task = fetchedTask ?? panelTask
-  const showSkeleton = !!taskId && !task
-
-  const handleSubmit = (selection: string[]) => {
-    setPickerOpen(false)
-    const newTaskId = selection[0]
-    if (!newTaskId) return
-    setLinkedTaskId(newTaskId)
-    onLinkTask(newTaskId)
-  }
+  const taskType = taskTypes.find((type) => type.name === task.taskType)
 
   return (
     <Styled.Row className="linked-task">
       <span>Task</span>
-      {task && task.id ? (
-        <Styled.TaskLink
-          onClick={() =>
-            openSlideOut({ entityId: task.id as string, entityType: 'task', projectName })
-          }
-        >
-          <Icon
-            icon={taskTypeIcons[task.taskType] || 'task_alt'}
-            style={{ color: taskTypeColors[task.taskType] }}
-          />
-          <span className="label">{task.label || task.name}</span>
-        </Styled.TaskLink>
-      ) : showSkeleton ? (
-        <Styled.Skeleton className="loading" />
-      ) : (
-        <Button variant="text" icon="add_link" onClick={() => setPickerOpen(true)}>
-          Link task
-        </Button>
-      )}
-      {pickerOpen && (
-        <ProjectFoldersContextProvider projectName={projectName}>
-          <EntityPickerDialog
-            onClose={() => setPickerOpen(false)}
-            projectName={projectName}
-            entityType="task"
-            initialSelection={folder?.id ? { folder: { [folder.id]: true } } : undefined}
-            onSubmit={handleSubmit}
-          />
-        </ProjectFoldersContextProvider>
-      )}
+      <Styled.TaskLink
+        onClick={() => openSlideOut({ entityId: task.id as string, entityType: 'task', projectName })}
+      >
+        <Icon icon={taskType?.icon || 'task_alt'} style={{ color: taskType?.color || undefined }} />
+        <span className="label">{task.label || task.name}</span>
+      </Styled.TaskLink>
     </Styled.Row>
   )
 }

--- a/shared/src/containers/DetailsPanel/components/DetailsPanelHeader/LinkedTaskRow.tsx
+++ b/shared/src/containers/DetailsPanel/components/DetailsPanelHeader/LinkedTaskRow.tsx
@@ -1,0 +1,87 @@
+import { useState } from 'react'
+import { Button, Icon } from '@ynput/ayon-react-components'
+
+import { useGetTaskQuery } from '@shared/api'
+import type { DetailsPanelEntityData } from '@shared/api'
+import { useDetailsPanelContext, ProjectFoldersContextProvider } from '@shared/context'
+import { EntityPickerDialog } from '@shared/containers'
+
+import * as Styled from './LinkedTaskRow.styled'
+
+interface LinkedTaskRowProps {
+  entity: DetailsPanelEntityData
+  taskTypeIcons: Record<string, string>
+  taskTypeColors: Record<string, string>
+  onLinkTask: (taskId: string) => void | Promise<void>
+}
+
+const LinkedTaskRow = ({
+  entity,
+  taskTypeIcons,
+  taskTypeColors,
+  onLinkTask,
+}: LinkedTaskRowProps) => {
+  const { openSlideOut } = useDetailsPanelContext()
+  const [pickerOpen, setPickerOpen] = useState(false)
+  const [linkedTaskId, setLinkedTaskId] = useState<string>()
+
+  const { folder, projectName } = entity
+  const taskId = linkedTaskId || entity.task?.id
+  // the optimistic version update leaves an empty task object; ignore it until it has real data
+  const panelTask = entity.task?.name ? entity.task : undefined
+  const needsFetch = !!linkedTaskId || (!!taskId && !panelTask)
+
+  const { data: fetchedTask } = useGetTaskQuery(
+    { projectName, taskId: taskId as string },
+    { skip: !taskId || !needsFetch },
+  )
+
+  const task = fetchedTask ?? panelTask
+  const showSkeleton = !!taskId && !task
+
+  const handleSubmit = (selection: string[]) => {
+    setPickerOpen(false)
+    const newTaskId = selection[0]
+    if (!newTaskId) return
+    setLinkedTaskId(newTaskId)
+    onLinkTask(newTaskId)
+  }
+
+  return (
+    <Styled.Row className="linked-task">
+      <span>Task</span>
+      {task && task.id ? (
+        <Styled.TaskLink
+          onClick={() =>
+            openSlideOut({ entityId: task.id as string, entityType: 'task', projectName })
+          }
+        >
+          <Icon
+            icon={taskTypeIcons[task.taskType] || 'task_alt'}
+            style={{ color: taskTypeColors[task.taskType] }}
+          />
+          <span className="label">{task.label || task.name}</span>
+        </Styled.TaskLink>
+      ) : showSkeleton ? (
+        <Styled.Skeleton className="loading" />
+      ) : (
+        <Button variant="text" icon="add_link" onClick={() => setPickerOpen(true)}>
+          Link task
+        </Button>
+      )}
+      {pickerOpen && (
+        <ProjectFoldersContextProvider projectName={projectName}>
+          <EntityPickerDialog
+            onClose={() => setPickerOpen(false)}
+            projectName={projectName}
+            entityType="task"
+            initialSelection={folder?.id ? { folder: { [folder.id]: true } } : undefined}
+            onSubmit={handleSubmit}
+          />
+        </ProjectFoldersContextProvider>
+      )}
+    </Styled.Row>
+  )
+}
+
+export default LinkedTaskRow

--- a/shared/src/containers/DetailsPanel/helpers/buildEntityTypeIcons.ts
+++ b/shared/src/containers/DetailsPanel/helpers/buildEntityTypeIcons.ts
@@ -1,0 +1,15 @@
+import type { EntityTypeIcons } from '@shared/containers'
+import type { ProjectInfo } from './mergeProjectInfo'
+
+const toIconMap = (types: { name: string; icon?: string | null }[]): Record<string, string> =>
+  types
+    .filter((type) => !!type.icon)
+    .reduce((acc, type) => ({ ...acc, [type.name]: type.icon as string }), {})
+
+const buildEntityTypeIcons = (projectInfo: ProjectInfo): EntityTypeIcons => ({
+  task: toIconMap(projectInfo.taskTypes),
+  folder: toIconMap(projectInfo.folderTypes),
+  product: toIconMap(projectInfo.productTypes),
+})
+
+export default buildEntityTypeIcons

--- a/shared/src/containers/DetailsPanel/helpers/getEntityPathData.ts
+++ b/shared/src/containers/DetailsPanel/helpers/getEntityPathData.ts
@@ -51,7 +51,7 @@ const getEntityPathData = (entity: DetailsPanelEntityData, folders: FoldersMap) 
   }
   if (entity.entityType === 'task') {
     // add task
-    segments.push({ type: 'task', label: entity.name, id: entity.id })
+    segments.push({ type: 'task', label: entity.label || entity.name, id: entity.id })
   }
 
   return segments

--- a/shared/src/containers/DetailsPanel/helpers/getEntityPathData.ts
+++ b/shared/src/containers/DetailsPanel/helpers/getEntityPathData.ts
@@ -37,14 +37,6 @@ const getEntityPathData = (entity: DetailsPanelEntityData, folders: FoldersMap) 
   })
 
   if (entity.entityType === 'version') {
-    // linked task sits between the folder hierarchy and the product/version
-    if (entity.task?.id) {
-      segments.push({
-        type: 'task',
-        label: entity.task.label || entity.task.name,
-        id: entity.task.id,
-      })
-    }
     const productVersion = `${entity.product?.name} - ${entity.name}`
     // add product - version
     segments.push({ type: 'version', label: productVersion, id: entity.id })

--- a/shared/src/containers/DetailsPanel/helpers/getEntityPathData.ts
+++ b/shared/src/containers/DetailsPanel/helpers/getEntityPathData.ts
@@ -37,6 +37,14 @@ const getEntityPathData = (entity: DetailsPanelEntityData, folders: FoldersMap) 
   })
 
   if (entity.entityType === 'version') {
+    // linked task sits between the folder hierarchy and the product/version
+    if (entity.task?.id) {
+      segments.push({
+        type: 'task',
+        label: entity.task.label || entity.task.name,
+        id: entity.task.id,
+      })
+    }
     const productVersion = `${entity.product?.name} - ${entity.name}`
     // add product - version
     segments.push({ type: 'version', label: productVersion, id: entity.id })

--- a/shared/src/containers/DetailsPanel/helpers/mergeProjectInfo.ts
+++ b/shared/src/containers/DetailsPanel/helpers/mergeProjectInfo.ts
@@ -1,7 +1,7 @@
 import type { FolderType, TaskType, Status, Tag, LinkTypeModel, ProductType } from '@shared/api'
 import { ProjectModelWithProducts } from '@shared/context'
 
-type ProjectInfo = {
+export type ProjectInfo = {
   folderTypes: FolderType[]
   taskTypes: TaskType[]
   statuses: Status[]

--- a/src/features/viewer.ts
+++ b/src/features/viewer.ts
@@ -47,19 +47,33 @@ const viewerSlice = createSlice({
   name: 'viewer',
   initialState,
   reducers: {
-    openViewer: (state: ViewerState, { payload }: PayloadAction<Partial<ViewerState>>) => {
-      state.projectName = payload.projectName || state.projectName
-      state.quickView = !!payload.quickView
+    openViewer: {
+      reducer: (state: ViewerState, { payload }: PayloadAction<Partial<ViewerState>>) => {
+        state.projectName = payload.projectName || state.projectName
+        state.quickView = !!payload.quickView
 
-      if (payload.productId) state.productId = payload.productId
-      if (payload.selectedProductId) state.selectedProductId = payload.selectedProductId
-      if (payload.taskId) state.taskId = payload.taskId
-      if (payload.folderId) state.folderId = payload.folderId
+        state.productId = payload.productId ?? null
+        state.selectedProductId = payload.selectedProductId ?? null
+        state.taskId = payload.taskId ?? null
+        state.folderId = payload.folderId ?? null
+        state.versionIds = payload.versionIds ?? []
+        state.reviewableIds = payload.reviewableIds ?? []
 
-      if (payload.productId || payload.taskId || payload.folderId) state.isOpen = true
-
-      if (payload.versionIds) state.versionIds = payload.versionIds
-      if (payload.reviewableIds) state.reviewableIds = payload.reviewableIds || []
+        if (state.productId || state.taskId || state.folderId) state.isOpen = true
+      },
+      // a new target replaces the previous one — default every id so a stale
+      // product/task/folder can't leak through (e.g. opening from the slide-out)
+      prepare: (payload: Partial<ViewerState>) => ({
+        payload: {
+          productId: null,
+          selectedProductId: null,
+          taskId: null,
+          folderId: null,
+          versionIds: [],
+          reviewableIds: [],
+          ...payload,
+        },
+      }),
     },
     updateProduct: (
       state: ViewerState,


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Opening a reviewable from a task or folder slide-out now switches the viewer instead of staying on the previous item. Versions also show their linked task in the details panel, with a button to link one when missing.

## Technical details
<!-- Please state any technical details such as limitations -->

- `openViewer` resets stale target ids so a leftover product/task/folder can't pin the viewer (`viewer.ts`).
- New `LinkedTaskRow` on the version details header: task-type icon + label, click opens the task slide-out.
- No task → "Link task" button opens `EntityPickerDialog` with the version's folder preselected, patches the version `taskId`.
- Row owns its own `getTask` query with a local skeleton — no panel refetch, so no flicker. Task-type colors threaded through the existing icon prop.

## Additional context
<!-- Add any other context or screenshots here. -->
<img width="972" height="792" alt="Screenshot 2026-06-18 at 11 03 45" src="https://github.com/user-attachments/assets/00fe5e11-d667-45b9-8b17-3f9e0956fc45" />
<img width="2218" height="920" alt="Screenshot 2026-06-18 at 11 05 37" src="https://github.com/user-attachments/assets/294b7454-f82c-424f-91d1-58d156dacf33" />

