### PR TITLE
Search filter products query optimisations

### DIFF
--- a/shared/src/api/queries/grouping/getGrouping.ts
+++ b/shared/src/api/queries/grouping/getGrouping.ts
@@ -3,26 +3,7 @@ import { PubSub } from '@shared/util'
 
 const enhancedGroupingApi = groupingApi.enhanceEndpoints({
   endpoints: {
-    getEntityGroups: {
-      // Subscribe to entity changes to refresh group counts
-      onCacheEntryAdded: async (arg, { cacheDataLoaded, cacheEntryRemoved, dispatch }) => {
-        await cacheDataLoaded
-
-        // Map entityType to PubSub topic (handle plural forms)
-        const entityType = arg.entityType.replace(/s$/, '') // 'versions' -> 'version'
-        const topic = `entity.${entityType}`
-
-        const token = PubSub.subscribe(topic, () => {
-          // Refetch groups when any entity of this type changes
-          dispatch(
-            enhancedGroupingApi.endpoints.getEntityGroups.initiate(arg, { forceRefetch: true }),
-          )
-        })
-
-        await cacheEntryRemoved
-        PubSub.unsubscribe(token)
-      },
-    },
+    getEntityGroups: {},
   },
 })
 

--- a/shared/src/api/queries/products/createProduct.ts
+++ b/shared/src/api/queries/products/createProduct.ts
@@ -1,4 +1,4 @@
-import { productsApi } from '@shared/api/generated'
+import { enhancedProductsApi as productsApi } from './getProduct'
 
 const enhancedProductsApi = productsApi.enhanceEndpoints({
   endpoints: {

--- a/shared/src/api/queries/products/getProduct.ts
+++ b/shared/src/api/queries/products/getProduct.ts
@@ -1,0 +1,11 @@
+import { productsApi } from '@shared/api/generated'
+
+export const enhancedProductsApi = productsApi.enhanceEndpoints({
+  endpoints: {
+    getProductTypes: {
+      providesTags: (_result, _error, _args) => [{ type: 'productType', id: 'LIST' }],
+    },
+  },
+})
+
+export const { useGetProductTypesQuery } = enhancedProductsApi

--- a/shared/src/components/SearchFilter/useBuildFilterOptions.tsx
+++ b/shared/src/components/SearchFilter/useBuildFilterOptions.tsx
@@ -1,10 +1,5 @@
 import { getAttributeIcon, getEntityTypeIcon } from '@shared/util'
-import {
-  ProductType,
-  useGetEntityGroupsQuery,
-  useGetKanbanProjectUsersQuery,
-  useGetProjectsInfoQuery,
-} from '@shared/api'
+import { ProductType, useGetKanbanProjectUsersQuery, useGetProjectsInfoQuery } from '@shared/api'
 import type {
   GetProjectsInfoResponse,
   FolderType,
@@ -14,7 +9,6 @@ import type {
   AttributeModel,
   EnumItem,
   AttributeData,
-  EntityGroup,
 } from '@shared/api'
 import { ColumnOrderState } from '@tanstack/react-table'
 import { Icon, Option, Filter, SEARCH_FILTER_ID } from '@ynput/ayon-react-components'
@@ -79,7 +73,7 @@ export type BuildFilterOptions = {
     assignees?: string[]
     productTypes?: ProductType[]
     productNames?: string[]
-    productBaseTypes?: string[]
+    productBaseTypes?: ProductType[]
   }
   columnOrder?: ColumnOrderState
   config?: FilterConfig
@@ -96,6 +90,8 @@ export const useBuildFilterOptions = ({
   columnOrder = [],
   power,
 }: BuildFilterOptions): Option[] => {
+  const productTypes = data.productTypes || []
+  const productBaseTypes = data.productBaseTypes || []
   let options: Option[] = []
 
   // Determine which scopes to use
@@ -124,32 +120,6 @@ export const useBuildFilterOptions = ({
     ['assignees', 'users', 'author'].some((type) =>
       s.filterTypes.includes(type as FilterFieldType),
     ),
-  )
-  // find if any search field is in any of the scopesWithTypes
-  const fieldInScopes = (field: FilterFieldType): boolean => {
-    return scopesWithTypes.some((s) => s.filterTypes.includes(field))
-  }
-
-  // get grouping options for productTypes
-  // NOTE: We should revisit this to be used for all attribs and fields
-  const { data: { groups: productTypes = [] } = {} } = useGetEntityGroupsQuery(
-    {
-      entityType: 'product',
-      groupingKey: 'productType',
-      projectName: projectNames[0],
-      empty: true,
-    },
-    { skip: !projectNames?.length || !fieldInScopes('productType') },
-  )
-
-  const { data: { groups: productBaseTypes = [] } = {} } = useGetEntityGroupsQuery(
-    {
-      entityType: 'product',
-      groupingKey: 'productBaseType',
-      projectName: projectNames[0],
-      empty: true,
-    },
-    { skip: !projectNames?.length || !fieldInScopes('productBaseType') },
   )
 
   const { data: projectsInfo = {} } = useGetProjectsInfoQuery(
@@ -260,20 +230,21 @@ export const useBuildFilterOptions = ({
         scopeLabel,
       )
       if (productBaseTypeOption) {
-        productBaseTypes.forEach(({ icon, label, value }) => {
-          if (!productBaseTypeOption.values?.some((v) => v.id === value)) {
-            productBaseTypeOption.values?.push({
-              id: value,
-              label: label || value,
-              icon: icon || getEntityTypeIcon('product'),
-            })
-          }
-        })
-        data.productBaseTypes?.forEach((name) => {
+        productBaseTypes.forEach(({ icon, name }) => {
           if (!productBaseTypeOption.values?.some((v) => v.id === name)) {
             productBaseTypeOption.values?.push({
               id: name,
               label: name,
+              icon: icon || getEntityTypeIcon('product'),
+            })
+          }
+        })
+        data.productBaseTypes?.forEach(({ icon, name }) => {
+          if (!productBaseTypeOption.values?.some((v) => v.id === name)) {
+            productBaseTypeOption.values?.push({
+              id: name,
+              label: name,
+              icon: icon || getEntityTypeIcon('product'),
             })
           }
         })
@@ -629,16 +600,16 @@ const getSubTypes = (
   {
     projectsInfo,
     productTypes,
-  }: { projectsInfo: GetProjectsInfoResponse; productTypes: EntityGroup[] },
+  }: { projectsInfo: GetProjectsInfoResponse; productTypes: ProductType[] },
   type: ScopeType,
 ): Option[] => {
   const options: Option[] = []
   if (type === 'product') {
-    productTypes.forEach(({ icon, label, value }) => {
+    productTypes.forEach(({ icon, name }) => {
       options.push({
-        id: value,
+        id: name,
         type: 'string',
-        label: label || value,
+        label: name,
         icon: icon || getEntityTypeIcon('product'),
         inverted: false,
         values: [],
@@ -1010,7 +981,7 @@ const getAttributeOptions = (
         type: type,
         label: enumItem.label,
         values: [],
-        icon: enumItem.icon,
+        icon: enumItem.icon as string,
         color: enumItem.color,
         pt: {
           style: { color: 'inherit' },

--- a/shared/src/context/ProjectContext.tsx
+++ b/shared/src/context/ProjectContext.tsx
@@ -2,7 +2,16 @@ import { createContext, useContext, useCallback } from 'react'
 import { useGetProjectQuery, useGetProjectAnatomyQuery } from '@shared/api'
 import { getEntityTypeIcon } from '@shared/util'
 
-import type { FolderType, TaskType, ProductTypeListItem, ProjectModel, Anatomy } from '@shared/api'
+import type {
+  FolderType,
+  TaskType,
+  ProductTypeListItem,
+  ProjectModel,
+  Anatomy,
+  ProductType,
+  ProductTypesList,
+} from '@shared/api'
+import { useGetProductTypesQuery } from '@shared/api/queries/products/getProduct'
 
 export type ProjectModelWithProducts = ProjectModel & {
   // Extend project with product types
@@ -28,6 +37,31 @@ const emptyProject: ProjectModelWithProducts = {
   ownAttrib: [],
 }
 
+function getProductTypesData(sourceData: ProductTypesList | undefined) {
+  if (!sourceData) {
+    return { productTypes: [], productBaseTypes: [] }
+  }
+  const productTypes = sourceData.productTypes || []
+
+  // Create unique base types by mapping and filtering duplicates
+  const baseTypesMap = new Map<string, ProductType>()
+
+  productTypes.forEach((item: any) => {
+    if (!baseTypesMap.has(item.baseType)) {
+      baseTypesMap.set(item.baseType, {
+        name: item.baseType,
+        icon: item.icon,
+        color: item.color,
+      })
+    }
+  })
+
+  return {
+    productTypes,
+    productBaseTypes: Array.from(baseTypesMap.values()),
+  }
+}
+
 export interface ProjectContextValue extends ProjectModelWithProducts {
   projectName: string
   isLoading: boolean
@@ -35,6 +69,8 @@ export interface ProjectContextValue extends ProjectModelWithProducts {
   isUninitialized: boolean
   error: any
   anatomy: Anatomy
+  productBaseTypes: ProductType[]
+
   refetch: () => void
   getProductType: (productType: string) => {
     icon: string
@@ -80,19 +116,21 @@ export const ProjectContextProvider: React.FC<ProjectProviderProps> = ({
   // (we're referencing nested objects. no need to use useMemo for these)
 
   const defaultProductType = anatomy.product_base_types?.['default']
-  const productTypes: ProductTypeListItem[] = (anatomy.product_base_types?.definitions || []).map(
-    (t) => ({
-      name: t.name || '',
-      icon: t.icon,
-      color: t.color,
-    }),
+
+  const { data: productTypesAll } = useGetProductTypesQuery(
+    { projectName: projectName },
+    {
+      skip: !projectName,
+    },
   )
+
+  const { productTypes, productBaseTypes } = getProductTypesData(productTypesAll)
+
   //
   // Magic functions
   //
 
   // Folder types
-
   const getFolderType = useCallback(
     (name: string): FolderType | undefined => {
       return project?.folderTypes?.find((type: FolderType) => type.name === name)
@@ -101,7 +139,6 @@ export const ProjectContextProvider: React.FC<ProjectProviderProps> = ({
   )
 
   // Task types
-
   const getTaskType = useCallback(
     (name: string): TaskType | undefined => {
       return project?.taskTypes?.find((type: TaskType) => type.name === name)
@@ -110,7 +147,6 @@ export const ProjectContextProvider: React.FC<ProjectProviderProps> = ({
   )
 
   // Product types
-
   const getProductType = useCallback(
     (productType: string) => {
       const type = productTypes.find((t) => t.name === productType)
@@ -160,7 +196,8 @@ export const ProjectContextProvider: React.FC<ProjectProviderProps> = ({
         ...emptyProject,
         ...project,
         projectName,
-        productTypes: productTypes,
+        productTypes,
+        productBaseTypes,
         anatomy,
         isLoading: isLoading || isFetching,
         isSuccess: isSuccess,

--- a/src/pages/ProjectListsPage/components/ListItemsFilter/ListItemsFilter.tsx
+++ b/src/pages/ProjectListsPage/components/ListItemsFilter/ListItemsFilter.tsx
@@ -28,6 +28,7 @@ const ListItemsFilter: FC<ListItemsFilterProps> = ({ entityType, projectName }) 
       projectNames={[projectName]}
       projectInfo={projectInfo}
       enableGlobalSearch={false}
+      data={entityType === 'version' ? { productTypes: projectInfo.productTypes } : {}}
       config={{
         prefixes: {
           assignees: 'entity_',

--- a/src/pages/VersionsProductsPage/components/VPToolbar/VPSearchFilter.tsx
+++ b/src/pages/VersionsProductsPage/components/VPToolbar/VPSearchFilter.tsx
@@ -1,9 +1,8 @@
-import { FC, useMemo } from 'react'
+import { FC } from 'react'
 import SearchFilterWrapper from '@pages/ProjectOverviewPage/containers/SearchFilterWrapper'
 import { useProjectContext } from '@shared/context'
 import { buildScopes } from '@shared/components'
 import { useVPViewsContext } from '@pages/VersionsProductsPage/context/VPViewsContext'
-import { useVersionsDataContext } from '@pages/VersionsProductsPage/context/VPDataContext'
 
 // folderType/taskType are only whitelisted on the flat versions resolver — the
 // products resolver (hierarchy mode) and task filters reject them server-side
@@ -15,30 +14,8 @@ const SCOPES = buildScopes(['version', 'product', 'task'], {
 interface VPSearchFilterProps {}
 
 const VPSearchFilter: FC<VPSearchFilterProps> = ({}) => {
-  const { projectName, ...projectInfo } = useProjectContext()
+  const { projectName, productBaseTypes, ...projectInfo } = useProjectContext()
   const { filters, onUpdateFilters } = useVPViewsContext()
-  const { productsMap, versionsMap } = useVersionsDataContext()
-
-  const data = useMemo(
-    () => ({
-      productNames: [
-        ...new Set(
-          productsMap.size
-            ? Array.from(productsMap.values()).map((product) => product.name)
-            : Array.from(versionsMap.values()).map((version) => version.product.name),
-        ),
-      ],
-      productBaseTypes: [
-        ...new Set(
-          (productsMap.size
-            ? Array.from(productsMap.values()).map((product) => product.productBaseType)
-            : Array.from(versionsMap.values()).map((version) => version.product.productBaseType)
-          ).filter((v): v is string => !!v),
-        ),
-      ],
-    }),
-    [productsMap, versionsMap],
-  )
 
   return (
     <SearchFilterWrapper
@@ -48,7 +25,7 @@ const VPSearchFilter: FC<VPSearchFilterProps> = ({}) => {
       scopes={SCOPES}
       projectNames={[projectName]}
       projectInfo={projectInfo}
-      data={data}
+      data={{ productTypes: projectInfo.productTypes, productBaseTypes }}
       config={{
         keys: { productName: 'name' },
       }}


### PR DESCRIPTION
## Problem

The search filter was using the inefficient `grouping` query **twice** to get product types data.

To make matters worse the `grouping` query was listening for all websocket messages for that entity type and refreshing the query on any message.

This created a situation, particularly on the products page where just opening the page would call the `grouping` endpoint and then we any change to a version occurred across the instance, every single user on the products page would call `grouping` twice.

On a busy server the changes to versions are happening every second. So every second, for every user on the products page this double query is called.

If **only** 20 users were on the page that would result in **2,400** additional requests for per minute.

## Changes

- Remove websocket subscription for `grouping` as it's not required to be realtime.
- Remove `grouping` queries in the search filter.
- Call `productTypes` endpoint in ProjectContext
- Use product types data from ProjectContext for filter options.


