### PR TITLE
Products: New and updated versions realtime events optimisations

### DIFF
--- a/gen/graphql.schema.json
+++ b/gen/graphql.schema.json
@@ -8089,18 +8089,6 @@
                 "deprecationReason": null
               },
               {
-                "name": "filter",
-                "description": "Filter activities using QueryFilter",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                },
-                "defaultValue": "null",
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
                 "name": "first",
                 "description": "Pagination: first",
                 "type": {

--- a/shared/src/api/generated/graphql.ts
+++ b/shared/src/api/generated/graphql.ts
@@ -1798,38 +1798,38 @@ export type GetProductVersionsQueryVariables = Exact<{
 }>;
 
 
-export type GetProductVersionsQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', product?: { __typename?: 'ProductNode', versionList: Array<{ __typename?: 'VersionListItem', id: string, name: string, version: number }> } | null } };
+export type GetProductVersionsQuery = { project: { product: { versionList: Array<{ id: string, name: string, version: number }> } | null } };
 
-export type DetailsPanelFolderFragmentFragment = { __typename?: 'FolderNode', id: string, name: string, label?: string | null, path?: string | null, folderType: string };
+export type DetailsPanelFolderFragmentFragment = { id: string, name: string, label: string | null, path: string | null, folderType: string };
 
-export type DetailsPanelProductFragmentFragment = { __typename?: 'ProductNode', id: string, name: string, productType: string, latestVersion?: { __typename?: 'VersionNode', version: number } | null };
+export type DetailsPanelProductFragmentFragment = { id: string, name: string, productType: string, latestVersion: { version: number } | null };
 
-export type DetailsPanelRepresentationFragmentFragment = { __typename?: 'RepresentationNode', id: string, name: string, fileCount: number };
+export type DetailsPanelRepresentationFragmentFragment = { id: string, name: string, fileCount: number };
 
-export type DetailsPanelTaskFragmentFragment = { __typename?: 'TaskNode', id: string, name: string, label?: string | null, assignees: Array<string>, taskType: string, subtasks: Array<{ __typename?: 'SubTaskNode', id: string, name: string, label: string, assignees: Array<string>, description?: string | null, startDate?: any | null, endDate?: any | null, isDone: boolean }> };
+export type DetailsPanelTaskFragmentFragment = { id: string, name: string, label: string | null, assignees: Array<string>, taskType: string, subtasks: Array<{ id: string, name: string, label: string, assignees: Array<string>, description: string | null, startDate: unknown, endDate: unknown, isDone: boolean }> };
 
-export type DetailsPanelVersionFragmentFragment = { __typename?: 'VersionNode', id: string, thumbnailId?: string | null, name: string, updatedAt: any, createdAt: any, productId: string, version: number, author?: string | null };
+export type DetailsPanelVersionFragmentFragment = { id: string, thumbnailId: string | null, name: string, updatedAt: unknown, createdAt: unknown, productId: string, version: number, author: string | null };
 
 export type GetListItemsQueryVariables = Exact<{
-  projectName: Scalars['String']['input'];
-  listId: Scalars['String']['input'];
-  first?: InputMaybe<Scalars['Int']['input']>;
-  after?: InputMaybe<Scalars['String']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
-  sortBy?: InputMaybe<Scalars['String']['input']>;
-  filter?: InputMaybe<Scalars['String']['input']>;
-  showComments?: Scalars['Boolean']['input'];
+  projectName: string;
+  listId: string;
+  first?: number | null | undefined;
+  after?: string | null | undefined;
+  before?: string | null | undefined;
+  last?: number | null | undefined;
+  sortBy?: string | null | undefined;
+  filter?: string | null | undefined;
+  showComments?: boolean;
 }>;
 
 
-export type GetListItemsQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', entityLists: { __typename?: 'EntityListsConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, edges: Array<{ __typename?: 'EntityListEdge', node: { __typename?: 'EntityListNode', id: string, active: boolean, items: { __typename?: 'EntityListItemsConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, edges: Array<{ __typename?: 'EntityListItemEdge', id: string, entityId: string, entityType: string, allAttrib: string, position: number, ownItemAttrib: Array<string>, node?:
-                | { __typename?: 'FolderNode', label?: string | null, status: string, tags: Array<string>, folderType: string, path?: string | null, ownAttrib: Array<string>, hasReviewables: boolean, thumbnailHash: string, active: boolean, name: string, updatedAt: any, createdAt: any, parents: Array<string>, folderId: string, latestComments?: Array<{ __typename?: 'EntityComment', activityId: string, body: string, author?: string | null, createdAt: string }> | null }
-                | { __typename?: 'ProductNode', status: string, tags: Array<string>, productType: string, folderId: string, active: boolean, name: string, updatedAt: any, createdAt: any, parents: Array<string>, folder: { __typename?: 'FolderNode', name: string, label?: string | null, path?: string | null, folderType: string } }
-                | { __typename?: 'RepresentationNode', active: boolean, name: string, updatedAt: any, createdAt: any, parents: Array<string> }
-                | { __typename?: 'TaskNode', label?: string | null, status: string, tags: Array<string>, taskType: string, assignees: Array<string>, ownAttrib: Array<string>, hasReviewables: boolean, folderId: string, thumbnailHash: string, active: boolean, name: string, updatedAt: any, createdAt: any, parents: Array<string>, folder: { __typename?: 'FolderNode', name: string, label?: string | null, path?: string | null, folderType: string }, subtasks: Array<{ __typename?: 'SubTaskNode', id: string, name: string, label: string, assignees: Array<string>, description?: string | null, startDate?: any | null, endDate?: any | null, isDone: boolean }>, latestComments?: Array<{ __typename?: 'EntityComment', activityId: string, body: string, author?: string | null, createdAt: string }> | null }
-                | { __typename?: 'VersionNode', status: string, tags: Array<string>, hasReviewables: boolean, author?: string | null, version: number, thumbnailHash: string, active: boolean, name: string, updatedAt: any, createdAt: any, parents: Array<string>, product: { __typename?: 'ProductNode', id: string, name: string, productType: string, productBaseType?: string | null, folderId: string, folder: { __typename?: 'FolderNode', id: string, name: string, label?: string | null, path?: string | null, folderType: string } }, task?: { __typename?: 'TaskNode', name: string, label?: string | null, taskType: string } | null, latestComments?: Array<{ __typename?: 'EntityComment', activityId: string, body: string, author?: string | null, createdAt: string }> | null }
-                | { __typename?: 'WorkfileNode', active: boolean, name: string, updatedAt: any, createdAt: any, parents: Array<string> }
+export type GetListItemsQuery = { project: { entityLists: { pageInfo: { hasNextPage: boolean, endCursor: string | null }, edges: Array<{ node: { id: string, active: boolean, items: { pageInfo: { hasNextPage: boolean, endCursor: string | null }, edges: Array<{ id: string, entityId: string, entityType: string, allAttrib: string, position: number, ownItemAttrib: Array<string>, node:
+                | { label: string | null, status: string, tags: Array<string>, folderType: string, path: string | null, ownAttrib: Array<string>, hasReviewables: boolean, thumbnailHash: string, active: boolean, name: string, updatedAt: unknown, createdAt: unknown, parents: Array<string>, folderId: string, latestComments?: Array<{ activityId: string, body: string, author: string | null, createdAt: string }> | null }
+                | { status: string, tags: Array<string>, productType: string, folderId: string, active: boolean, name: string, updatedAt: unknown, createdAt: unknown, parents: Array<string>, folder: { name: string, label: string | null, path: string | null, folderType: string } }
+                | { active: boolean, name: string, updatedAt: unknown, createdAt: unknown, parents: Array<string> }
+                | { label: string | null, status: string, tags: Array<string>, taskType: string, assignees: Array<string>, ownAttrib: Array<string>, hasReviewables: boolean, folderId: string, thumbnailHash: string, active: boolean, name: string, updatedAt: unknown, createdAt: unknown, parents: Array<string>, folder: { name: string, label: string | null, path: string | null, folderType: string }, subtasks: Array<{ id: string, name: string, label: string, assignees: Array<string>, description: string | null, startDate: unknown, endDate: unknown, isDone: boolean }>, latestComments?: Array<{ activityId: string, body: string, author: string | null, createdAt: string }> | null }
+                | { status: string, tags: Array<string>, hasReviewables: boolean, author: string | null, version: number, thumbnailHash: string, active: boolean, name: string, updatedAt: unknown, createdAt: unknown, parents: Array<string>, product: { id: string, name: string, productType: string, productBaseType: string | null, folderId: string, folder: { id: string, name: string, label: string | null, path: string | null, folderType: string } }, task: { name: string, label: string | null, taskType: string } | null, latestComments?: Array<{ activityId: string, body: string, author: string | null, createdAt: string }> | null }
+                | { active: boolean, name: string, updatedAt: unknown, createdAt: unknown, parents: Array<string> }
                | null }> } } }> } } };
 
 export type GetListItemsColumnStatsQueryVariables = Exact<{
@@ -1843,36 +1843,36 @@ export type GetListItemsColumnStatsQueryVariables = Exact<{
 export type GetListItemsColumnStatsQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', name: string, entityLists: { __typename?: 'EntityListsConnection', edges: Array<{ __typename?: 'EntityListEdge', node: { __typename?: 'EntityListNode', id: string, items: { __typename?: 'EntityListItemsConnection', fieldStats: Array<{ __typename?: 'ColumnStats', columnName: string, min?: number | null, max?: number | null, avg?: number | null, sum?: number | null, count?: number | null, valueFilledCount?: number | null, percentageFilled?: number | null, valueNotFilledCount?: number | null, percentageNotFilled?: number | null, checkedCount?: number | null, checkedPercentage?: number | null, notCheckedCount?: number | null, notCheckedPercentage?: number | null, distribution?: any | null }> } } }> } } };
 
 export type GetListsQueryVariables = Exact<{
-  projectName: Scalars['String']['input'];
-  first: Scalars['Int']['input'];
-  after?: InputMaybe<Scalars['String']['input']>;
-  filter?: InputMaybe<Scalars['String']['input']>;
+  projectName: string;
+  first: number;
+  after?: string | null | undefined;
+  filter?: string | null | undefined;
 }>;
 
 
-export type GetListsQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', entityLists: { __typename?: 'EntityListsConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, edges: Array<{ __typename?: 'EntityListEdge', node: { __typename?: 'EntityListNode', id: string, label: string, entityListType: string, entityListFolderId?: string | null, tags: Array<string>, data: string, allAttrib: string, entityType: string, active: boolean, createdAt: any, updatedAt: any, updatedBy?: string | null, projectName: string, owner?: string | null, accessLevel: number, access: string, count: number } }> } } };
+export type GetListsQuery = { project: { entityLists: { pageInfo: { hasNextPage: boolean, endCursor: string | null }, edges: Array<{ node: { id: string, label: string, entityListType: string, entityListFolderId: string | null, tags: Array<string>, data: string, allAttrib: string, entityType: string, active: boolean, createdAt: unknown, updatedAt: unknown, updatedBy: string | null, projectName: string, owner: string | null, accessLevel: number, access: string, count: number } }> } } };
 
 export type GetListsItemsForReviewSessionQueryVariables = Exact<{
-  projectName: Scalars['String']['input'];
-  first?: InputMaybe<Scalars['Int']['input']>;
-  after?: InputMaybe<Scalars['String']['input']>;
-  ids?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
+  projectName: string;
+  first?: number | null | undefined;
+  after?: string | null | undefined;
+  ids?: Array<string> | string | null | undefined;
 }>;
 
 
-export type GetListsItemsForReviewSessionQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', entityLists: { __typename?: 'EntityListsConnection', pageInfo: { __typename?: 'PageInfo', hasNextPage: boolean, endCursor?: string | null }, edges: Array<{ __typename?: 'EntityListEdge', node: { __typename?: 'EntityListNode', id: string, label: string, active: boolean, entityType: string, updatedAt: any, count: number, accessLevel: number } }> } } };
+export type GetListsItemsForReviewSessionQuery = { project: { entityLists: { pageInfo: { hasNextPage: boolean, endCursor: string | null }, edges: Array<{ node: { id: string, label: string, active: boolean, entityType: string, updatedAt: unknown, count: number, accessLevel: number } }> } } };
 
-type ListItemFragment_FolderNode_Fragment = { __typename?: 'FolderNode', label?: string | null, status: string, tags: Array<string>, folderType: string, path?: string | null, ownAttrib: Array<string>, hasReviewables: boolean, thumbnailHash: string, active: boolean, name: string, updatedAt: any, createdAt: any, parents: Array<string>, folderId: string, latestComments?: Array<{ __typename?: 'EntityComment', activityId: string, body: string, author?: string | null, createdAt: string }> | null };
+type ListItemFragment_FolderNode_Fragment = { label: string | null, status: string, tags: Array<string>, folderType: string, path: string | null, ownAttrib: Array<string>, hasReviewables: boolean, thumbnailHash: string, active: boolean, name: string, updatedAt: unknown, createdAt: unknown, parents: Array<string>, folderId: string, latestComments?: Array<{ activityId: string, body: string, author: string | null, createdAt: string }> | null };
 
-type ListItemFragment_ProductNode_Fragment = { __typename?: 'ProductNode', status: string, tags: Array<string>, productType: string, folderId: string, active: boolean, name: string, updatedAt: any, createdAt: any, parents: Array<string>, folder: { __typename?: 'FolderNode', name: string, label?: string | null, path?: string | null, folderType: string } };
+type ListItemFragment_ProductNode_Fragment = { status: string, tags: Array<string>, productType: string, folderId: string, active: boolean, name: string, updatedAt: unknown, createdAt: unknown, parents: Array<string>, folder: { name: string, label: string | null, path: string | null, folderType: string } };
 
-type ListItemFragment_RepresentationNode_Fragment = { __typename?: 'RepresentationNode', active: boolean, name: string, updatedAt: any, createdAt: any, parents: Array<string> };
+type ListItemFragment_RepresentationNode_Fragment = { active: boolean, name: string, updatedAt: unknown, createdAt: unknown, parents: Array<string> };
 
-type ListItemFragment_TaskNode_Fragment = { __typename?: 'TaskNode', label?: string | null, status: string, tags: Array<string>, taskType: string, assignees: Array<string>, ownAttrib: Array<string>, hasReviewables: boolean, folderId: string, thumbnailHash: string, active: boolean, name: string, updatedAt: any, createdAt: any, parents: Array<string>, folder: { __typename?: 'FolderNode', name: string, label?: string | null, path?: string | null, folderType: string }, subtasks: Array<{ __typename?: 'SubTaskNode', id: string, name: string, label: string, assignees: Array<string>, description?: string | null, startDate?: any | null, endDate?: any | null, isDone: boolean }>, latestComments?: Array<{ __typename?: 'EntityComment', activityId: string, body: string, author?: string | null, createdAt: string }> | null };
+type ListItemFragment_TaskNode_Fragment = { label: string | null, status: string, tags: Array<string>, taskType: string, assignees: Array<string>, ownAttrib: Array<string>, hasReviewables: boolean, folderId: string, thumbnailHash: string, active: boolean, name: string, updatedAt: unknown, createdAt: unknown, parents: Array<string>, folder: { name: string, label: string | null, path: string | null, folderType: string }, subtasks: Array<{ id: string, name: string, label: string, assignees: Array<string>, description: string | null, startDate: unknown, endDate: unknown, isDone: boolean }>, latestComments?: Array<{ activityId: string, body: string, author: string | null, createdAt: string }> | null };
 
-type ListItemFragment_VersionNode_Fragment = { __typename?: 'VersionNode', status: string, tags: Array<string>, hasReviewables: boolean, author?: string | null, version: number, thumbnailHash: string, active: boolean, name: string, updatedAt: any, createdAt: any, parents: Array<string>, product: { __typename?: 'ProductNode', id: string, name: string, productType: string, productBaseType?: string | null, folderId: string, folder: { __typename?: 'FolderNode', id: string, name: string, label?: string | null, path?: string | null, folderType: string } }, task?: { __typename?: 'TaskNode', name: string, label?: string | null, taskType: string } | null, latestComments?: Array<{ __typename?: 'EntityComment', activityId: string, body: string, author?: string | null, createdAt: string }> | null };
+type ListItemFragment_VersionNode_Fragment = { status: string, tags: Array<string>, hasReviewables: boolean, author: string | null, version: number, thumbnailHash: string, active: boolean, name: string, updatedAt: unknown, createdAt: unknown, parents: Array<string>, product: { id: string, name: string, productType: string, productBaseType: string | null, folderId: string, folder: { id: string, name: string, label: string | null, path: string | null, folderType: string } }, task: { name: string, label: string | null, taskType: string } | null, latestComments?: Array<{ activityId: string, body: string, author: string | null, createdAt: string }> | null };
 
-type ListItemFragment_WorkfileNode_Fragment = { __typename?: 'WorkfileNode', active: boolean, name: string, updatedAt: any, createdAt: any, parents: Array<string> };
+type ListItemFragment_WorkfileNode_Fragment = { active: boolean, name: string, updatedAt: unknown, createdAt: unknown, parents: Array<string> };
 
 export type ListItemFragmentFragment =
   | ListItemFragment_FolderNode_Fragment
@@ -1883,305 +1883,313 @@ export type ListItemFragmentFragment =
   | ListItemFragment_WorkfileNode_Fragment
 ;
 
-export type ColumnStatsFragmentFragment = { __typename?: 'ColumnStats', columnName: string, min?: number | null, max?: number | null, avg?: number | null, sum?: number | null, count?: number | null, valueFilledCount?: number | null, percentageFilled?: number | null, valueNotFilledCount?: number | null, percentageNotFilled?: number | null, checkedCount?: number | null, checkedPercentage?: number | null, notCheckedCount?: number | null, notCheckedPercentage?: number | null, distribution?: any | null };
+export type ColumnStatsFragmentFragment = { columnName: string, min: number | null, max: number | null, avg: number | null, sum: number | null, count: number | null, valueFilledCount: number | null, percentageFilled: number | null, valueNotFilledCount: number | null, percentageNotFilled: number | null, checkedCount: number | null, checkedPercentage: number | null, notCheckedCount: number | null, notCheckedPercentage: number | null, distribution: unknown };
 
 export type GetFolderColumnStatsQueryVariables = Exact<{
-  projectName: Scalars['String']['input'];
-  filter?: InputMaybe<Scalars['String']['input']>;
-  search?: InputMaybe<Scalars['String']['input']>;
-  folderIds?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
-  targets?: InputMaybe<Array<MetricTargetInput> | MetricTargetInput>;
+  projectName: string;
+  filter?: string | null | undefined;
+  search?: string | null | undefined;
+  folderIds?: Array<string> | string | null | undefined;
+  targets?: Array<MetricTargetInput> | MetricTargetInput | null | undefined;
 }>;
 
 
-export type GetFolderColumnStatsQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', name: string, folders: { __typename?: 'FoldersConnection', fieldStats: Array<{ __typename?: 'ColumnStats', columnName: string, min?: number | null, max?: number | null, avg?: number | null, sum?: number | null, count?: number | null, valueFilledCount?: number | null, percentageFilled?: number | null, valueNotFilledCount?: number | null, percentageNotFilled?: number | null, checkedCount?: number | null, checkedPercentage?: number | null, notCheckedCount?: number | null, notCheckedPercentage?: number | null, distribution?: any | null }> } } };
+export type GetFolderColumnStatsQuery = { project: { name: string, folders: { fieldStats: Array<{ columnName: string, min: number | null, max: number | null, avg: number | null, sum: number | null, count: number | null, valueFilledCount: number | null, percentageFilled: number | null, valueNotFilledCount: number | null, percentageNotFilled: number | null, checkedCount: number | null, checkedPercentage: number | null, notCheckedCount: number | null, notCheckedPercentage: number | null, distribution: unknown }> } } };
 
 export type GetFolderDeleteInfoQueryVariables = Exact<{
-  projectName: Scalars['String']['input'];
-  folderIds: Array<Scalars['String']['input']> | Scalars['String']['input'];
+  projectName: string;
+  folderIds: Array<string> | string;
 }>;
 
 
-export type GetFolderDeleteInfoQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', folders: { __typename?: 'FoldersConnection', edges: Array<{ __typename?: 'FolderEdge', node: { __typename?: 'FolderNode', id: string, name: string, label?: string | null, totalFolderCount: number, totalTaskCount: number, totalProductCount: number, totalVersionCount: number } }> } } };
+export type GetFolderDeleteInfoQuery = { project: { folders: { edges: Array<{ node: { id: string, name: string, label: string | null, totalFolderCount: number, totalTaskCount: number, totalProductCount: number, totalVersionCount: number } }> } } };
 
 export type GetTaskColumnStatsQueryVariables = Exact<{
-  projectName: Scalars['String']['input'];
-  filter?: InputMaybe<Scalars['String']['input']>;
-  folderFilter?: InputMaybe<Scalars['String']['input']>;
-  search?: InputMaybe<Scalars['String']['input']>;
-  folderIds?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
-  taskIds?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
-  targets?: InputMaybe<Array<MetricTargetInput> | MetricTargetInput>;
+  projectName: string;
+  filter?: string | null | undefined;
+  folderFilter?: string | null | undefined;
+  search?: string | null | undefined;
+  folderIds?: Array<string> | string | null | undefined;
+  taskIds?: Array<string> | string | null | undefined;
+  targets?: Array<MetricTargetInput> | MetricTargetInput | null | undefined;
 }>;
 
 
-export type GetTaskColumnStatsQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', name: string, tasks: { __typename?: 'TasksConnection', fieldStats: Array<{ __typename?: 'ColumnStats', columnName: string, min?: number | null, max?: number | null, avg?: number | null, sum?: number | null, count?: number | null, valueFilledCount?: number | null, percentageFilled?: number | null, valueNotFilledCount?: number | null, percentageNotFilled?: number | null, checkedCount?: number | null, checkedPercentage?: number | null, notCheckedCount?: number | null, notCheckedPercentage?: number | null, distribution?: any | null }> } } };
+export type GetTaskColumnStatsQuery = { project: { name: string, tasks: { fieldStats: Array<{ columnName: string, min: number | null, max: number | null, avg: number | null, sum: number | null, count: number | null, valueFilledCount: number | null, percentageFilled: number | null, valueNotFilledCount: number | null, percentageNotFilled: number | null, checkedCount: number | null, checkedPercentage: number | null, notCheckedCount: number | null, notCheckedPercentage: number | null, distribution: unknown }> } } };
 
 export type GetTasksByParentQueryVariables = Exact<{
-  projectName: Scalars['String']['input'];
-  parentIds: Array<Scalars['String']['input']> | Scalars['String']['input'];
-  filter?: InputMaybe<Scalars['String']['input']>;
-  folderFilter?: InputMaybe<Scalars['String']['input']>;
-  search?: InputMaybe<Scalars['String']['input']>;
-  showComments?: Scalars['Boolean']['input'];
+  projectName: string;
+  parentIds: Array<string> | string;
+  filter?: string | null | undefined;
+  folderFilter?: string | null | undefined;
+  search?: string | null | undefined;
+  showComments?: boolean;
 }>;
 
 
-export type GetTasksByParentQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', name: string, tasks: { __typename?: 'TasksConnection', edges: Array<{ __typename?: 'TaskEdge', node: { __typename?: 'TaskNode', id: string, folderId: string, label?: string | null, name: string, ownAttrib: Array<string>, status: string, tags: Array<string>, taskType: string, updatedAt: any, createdAt: any, thumbnailHash: string, active: boolean, assignees: Array<string>, allAttrib: string, hasReviewables: boolean, parents: Array<string>, subtasks: Array<{ __typename?: 'SubTaskNode', id: string, name: string, label: string, assignees: Array<string>, description?: string | null, startDate?: any | null, endDate?: any | null, isDone: boolean }>, latestComments?: Array<{ __typename?: 'EntityComment', activityId: string, body: string, author?: string | null, createdAt: string }> | null, folder: { __typename?: 'FolderNode', folderType: string } } }> } } };
+export type GetTasksByParentQuery = { project: { name: string, tasks: { edges: Array<{ node: { id: string, folderId: string, label: string | null, name: string, ownAttrib: Array<string>, status: string, tags: Array<string>, taskType: string, updatedAt: unknown, createdAt: unknown, thumbnailHash: string, active: boolean, assignees: Array<string>, allAttrib: string, hasReviewables: boolean, parents: Array<string>, subtasks: Array<{ id: string, name: string, label: string, assignees: Array<string>, description: string | null, startDate: unknown, endDate: unknown, isDone: boolean }>, latestComments?: Array<{ activityId: string, body: string, author: string | null, createdAt: string }> | null, folder: { folderType: string } } }> } } };
 
 export type GetTasksListQueryVariables = Exact<{
-  projectName: Scalars['String']['input'];
-  folderIds?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
-  taskIds?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
-  filter?: InputMaybe<Scalars['String']['input']>;
-  folderFilter?: InputMaybe<Scalars['String']['input']>;
-  search?: InputMaybe<Scalars['String']['input']>;
-  after?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
-  sortBy?: InputMaybe<Scalars['String']['input']>;
-  showComments?: Scalars['Boolean']['input'];
+  projectName: string;
+  folderIds?: Array<string> | string | null | undefined;
+  taskIds?: Array<string> | string | null | undefined;
+  filter?: string | null | undefined;
+  folderFilter?: string | null | undefined;
+  search?: string | null | undefined;
+  after?: string | null | undefined;
+  first?: number | null | undefined;
+  before?: string | null | undefined;
+  last?: number | null | undefined;
+  sortBy?: string | null | undefined;
+  showComments?: boolean;
 }>;
 
 
-export type GetTasksListQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', name: string, tasks: { __typename?: 'TasksConnection', pageInfo: { __typename?: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean }, edges: Array<{ __typename?: 'TaskEdge', cursor?: string | null, node: { __typename?: 'TaskNode', id: string, folderId: string, label?: string | null, name: string, ownAttrib: Array<string>, status: string, tags: Array<string>, taskType: string, updatedAt: any, createdAt: any, thumbnailHash: string, active: boolean, assignees: Array<string>, allAttrib: string, hasReviewables: boolean, parents: Array<string>, subtasks: Array<{ __typename?: 'SubTaskNode', id: string, name: string, label: string, assignees: Array<string>, description?: string | null, startDate?: any | null, endDate?: any | null, isDone: boolean }>, latestComments?: Array<{ __typename?: 'EntityComment', activityId: string, body: string, author?: string | null, createdAt: string }> | null, folder: { __typename?: 'FolderNode', folderType: string } } }> } } };
+export type GetTasksListQuery = { project: { name: string, tasks: { pageInfo: { startCursor: string | null, endCursor: string | null, hasNextPage: boolean, hasPreviousPage: boolean }, edges: Array<{ cursor: string | null, node: { id: string, folderId: string, label: string | null, name: string, ownAttrib: Array<string>, status: string, tags: Array<string>, taskType: string, updatedAt: unknown, createdAt: unknown, thumbnailHash: string, active: boolean, assignees: Array<string>, allAttrib: string, hasReviewables: boolean, parents: Array<string>, subtasks: Array<{ id: string, name: string, label: string, assignees: Array<string>, description: string | null, startDate: unknown, endDate: unknown, isDone: boolean }>, latestComments?: Array<{ activityId: string, body: string, author: string | null, createdAt: string }> | null, folder: { folderType: string } } }> } } };
 
-export type SubTaskFragmentFragment = { __typename?: 'SubTaskNode', id: string, name: string, label: string, assignees: Array<string>, description?: string | null, startDate?: any | null, endDate?: any | null, isDone: boolean };
+export type SubTaskFragmentFragment = { id: string, name: string, label: string, assignees: Array<string>, description: string | null, startDate: unknown, endDate: unknown, isDone: boolean };
 
-export type TaskPropsFragmentFragment = { __typename?: 'TaskNode', id: string, folderId: string, label?: string | null, name: string, ownAttrib: Array<string>, status: string, tags: Array<string>, taskType: string, updatedAt: any, createdAt: any, thumbnailHash: string, active: boolean, assignees: Array<string>, allAttrib: string, hasReviewables: boolean, parents: Array<string>, subtasks: Array<{ __typename?: 'SubTaskNode', id: string, name: string, label: string, assignees: Array<string>, description?: string | null, startDate?: any | null, endDate?: any | null, isDone: boolean }>, latestComments?: Array<{ __typename?: 'EntityComment', activityId: string, body: string, author?: string | null, createdAt: string }> | null, folder: { __typename?: 'FolderNode', folderType: string } };
+export type TaskPropsFragmentFragment = { id: string, folderId: string, label: string | null, name: string, ownAttrib: Array<string>, status: string, tags: Array<string>, taskType: string, updatedAt: unknown, createdAt: unknown, thumbnailHash: string, active: boolean, assignees: Array<string>, allAttrib: string, hasReviewables: boolean, parents: Array<string>, subtasks: Array<{ id: string, name: string, label: string, assignees: Array<string>, description: string | null, startDate: unknown, endDate: unknown, isDone: boolean }>, latestComments?: Array<{ activityId: string, body: string, author: string | null, createdAt: string }> | null, folder: { folderType: string } };
 
 export type GetFolderProductsQueryVariables = Exact<{
-  projectName: Scalars['String']['input'];
-  folderId: Scalars['String']['input'];
+  projectName: string;
+  folderId: string;
 }>;
 
 
-export type GetFolderProductsQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', products: { __typename?: 'ProductsConnection', edges: Array<{ __typename?: 'ProductEdge', node: { __typename?: 'ProductNode', id: string, name: string, productType: string, latestVersion?: { __typename?: 'VersionNode', id: string, version: number, task?: { __typename?: 'TaskNode', id: string, name: string, label?: string | null, taskType: string } | null } | null } }> } } };
+export type GetFolderProductsQuery = { project: { products: { edges: Array<{ node: { id: string, name: string, productType: string, latestVersion: { id: string, version: number, task: { id: string, name: string, label: string | null, taskType: string } | null } | null } }> } } };
 
 export type GetProjectLatestQueryVariables = Exact<{
-  projectName: Scalars['String']['input'];
+  projectName: string;
 }>;
 
 
-export type GetProjectLatestQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', name: string } };
+export type GetProjectLatestQuery = { project: { name: string } };
 
 export type GetProjectsQueryVariables = Exact<{
-  last?: InputMaybe<Scalars['Int']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
+  last?: number | null | undefined;
+  before?: string | null | undefined;
 }>;
 
 
-export type GetProjectsQuery = { __typename?: 'Query', projects: { __typename?: 'ProjectsConnection', edges: Array<{ __typename?: 'ProjectEdge', cursor?: string | null, node: { __typename?: 'ProjectNode', allAttrib: string, active: boolean, code: string, color?: string | null, createdAt: any, updatedAt: any, label?: string | null, library: boolean, name: string, projectFolder?: string | null, projectName: string, skeleton: boolean } }>, pageInfo: { __typename?: 'PageInfo', endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null } } };
+export type GetProjectsQuery = { projects: { edges: Array<{ cursor: string | null, node: { allAttrib: string, active: boolean, code: string, color: string | null, createdAt: unknown, updatedAt: unknown, label: string | null, library: boolean, name: string, projectFolder: string | null, projectName: string, skeleton: boolean } }>, pageInfo: { endCursor: string | null, hasNextPage: boolean, hasPreviousPage: boolean, startCursor: string | null } } };
 
-export type ProjectFragmentFragment = { __typename?: 'ProjectNode', allAttrib: string, active: boolean, code: string, color?: string | null, createdAt: any, updatedAt: any, label?: string | null, library: boolean, name: string, projectFolder?: string | null, projectName: string, skeleton: boolean };
+export type ProjectFragmentFragment = { allAttrib: string, active: boolean, code: string, color: string | null, createdAt: unknown, updatedAt: unknown, label: string | null, library: boolean, name: string, projectFolder: string | null, projectName: string, skeleton: boolean };
 
 export type GetKanbanQueryVariables = Exact<{
-  projects?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
-  assignees?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
+  projects?: Array<string> | string | null | undefined;
+  assignees?: Array<string> | string | null | undefined;
 }>;
 
 
-export type GetKanbanQuery = { __typename?: 'Query', kanban: { __typename?: 'KanbanConnection', edges: Array<{ __typename?: 'KanbanEdge', node: { __typename?: 'KanbanNode', id: string, projectName: string, projectCode: string, name: string, label?: string | null, status: string, tags: Array<string>, taskType: string, assignees: Array<string>, updatedAt: any, createdAt: any, thumbnailHash: string, dueDate?: any | null, thumbnailId?: string | null, folderId: string, folderLabel?: string | null, folderName: string, folderPath: string, hasReviewables: boolean, priority?: string | null } }> } };
+export type GetKanbanQuery = { kanban: { edges: Array<{ node: { id: string, projectName: string, projectCode: string, name: string, label: string | null, status: string, tags: Array<string>, taskType: string, assignees: Array<string>, updatedAt: unknown, createdAt: unknown, thumbnailHash: string, dueDate: unknown, thumbnailId: string | null, folderId: string, folderLabel: string | null, folderName: string, folderPath: string, hasReviewables: boolean, priority: string | null } }> } };
 
 export type GetKanbanProjectUsersQueryVariables = Exact<{
-  projects?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
+  projects?: Array<string> | string | null | undefined;
 }>;
 
 
-export type GetKanbanProjectUsersQuery = { __typename?: 'Query', users: { __typename?: 'UsersConnection', edges: Array<{ __typename?: 'UserEdge', node: { __typename?: 'UserNode', name: string, accessGroups: string, isManager: boolean, isAdmin: boolean, attrib: { __typename?: 'UserAttribType', fullName?: string | null } } }> } };
+export type GetKanbanProjectUsersQuery = { users: { edges: Array<{ node: { name: string, accessGroups: string, isManager: boolean, isAdmin: boolean, attrib: { fullName: string | null } } }> } };
 
 export type GetKanbanTasksQueryVariables = Exact<{
-  projects?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
-  taskIds?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
+  projects?: Array<string> | string | null | undefined;
+  taskIds?: Array<string> | string | null | undefined;
+  last?: number | null | undefined;
 }>;
 
 
-export type GetKanbanTasksQuery = { __typename?: 'Query', kanban: { __typename?: 'KanbanConnection', edges: Array<{ __typename?: 'KanbanEdge', node: { __typename?: 'KanbanNode', id: string, projectName: string, projectCode: string, name: string, label?: string | null, status: string, tags: Array<string>, taskType: string, assignees: Array<string>, updatedAt: any, createdAt: any, thumbnailHash: string, dueDate?: any | null, thumbnailId?: string | null, folderId: string, folderLabel?: string | null, folderName: string, folderPath: string, hasReviewables: boolean, priority?: string | null } }> } };
+export type GetKanbanTasksQuery = { kanban: { edges: Array<{ node: { id: string, projectName: string, projectCode: string, name: string, label: string | null, status: string, tags: Array<string>, taskType: string, assignees: Array<string>, updatedAt: unknown, createdAt: unknown, thumbnailHash: string, dueDate: unknown, thumbnailId: string | null, folderId: string, folderLabel: string | null, folderName: string, folderPath: string, hasReviewables: boolean, priority: string | null } }> } };
 
-export type KanbanFragmentFragment = { __typename?: 'KanbanNode', id: string, projectName: string, projectCode: string, name: string, label?: string | null, status: string, tags: Array<string>, taskType: string, assignees: Array<string>, updatedAt: any, createdAt: any, thumbnailHash: string, dueDate?: any | null, thumbnailId?: string | null, folderId: string, folderLabel?: string | null, folderName: string, folderPath: string, hasReviewables: boolean, priority?: string | null };
+export type KanbanFragmentFragment = { id: string, projectName: string, projectCode: string, name: string, label: string | null, status: string, tags: Array<string>, taskType: string, assignees: Array<string>, updatedAt: unknown, createdAt: unknown, thumbnailHash: string, dueDate: unknown, thumbnailId: string | null, folderId: string, folderLabel: string | null, folderName: string, folderPath: string, hasReviewables: boolean, priority: string | null };
 
 export type GetActiveUsersCountQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetActiveUsersCountQuery = { __typename?: 'Query', users: { __typename?: 'UsersConnection', edges: Array<{ __typename?: 'UserEdge', node: { __typename?: 'UserNode', active: boolean, isGuest: boolean } }> } };
+export type GetActiveUsersCountQuery = { users: { edges: Array<{ node: { active: boolean, isGuest: boolean } }> } };
 
 export type GetAllAssigneesQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetAllAssigneesQuery = { __typename?: 'Query', users: { __typename?: 'UsersConnection', edges: Array<{ __typename?: 'UserEdge', node: { __typename?: 'UserNode', name: string, updatedAt: any, attrib: { __typename?: 'UserAttribType', fullName?: string | null } } }> } };
+export type GetAllAssigneesQuery = { users: { edges: Array<{ node: { name: string, updatedAt: unknown, attrib: { fullName: string | null } } }> } };
 
 export type GetAllProjectUsersAsAssigneeQueryVariables = Exact<{
-  projectName?: InputMaybe<Scalars['String']['input']>;
+  projectName?: string | null | undefined;
 }>;
 
 
-export type GetAllProjectUsersAsAssigneeQuery = { __typename?: 'Query', users: { __typename?: 'UsersConnection', edges: Array<{ __typename?: 'UserEdge', node: { __typename?: 'UserNode', name: string, updatedAt: any, attrib: { __typename?: 'UserAttribType', fullName?: string | null } } }> } };
+export type GetAllProjectUsersAsAssigneeQuery = { users: { edges: Array<{ node: { name: string, updatedAt: unknown, attrib: { fullName: string | null } } }> } };
 
-export type VpFolderFragment = { __typename?: 'FolderNode', id: string, name: string, label?: string | null, folderType: string, allAttrib: string };
+export type VpFolderFragment = { id: string, name: string, label: string | null, folderType: string, allAttrib: string };
 
 export type GetLatestProductVersionQueryVariables = Exact<{
-  projectName: Scalars['String']['input'];
-  productId: Scalars['String']['input'];
+  projectName: string;
+  productId: string;
 }>;
 
 
-export type GetLatestProductVersionQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', versions: { __typename?: 'VersionsConnection', edges: Array<{ __typename?: 'VersionEdge', node: { __typename?: 'VersionNode', id: string, name: string, version: number, productId: string, createdAt: any, updatedAt: any, status: string, active: boolean } }> } } };
+export type GetLatestProductVersionQuery = { project: { versions: { edges: Array<{ node: { id: string, name: string, version: number, productId: string, createdAt: unknown, updatedAt: unknown, status: string, active: boolean } }> } } };
 
 export type GetProductsQueryVariables = Exact<{
-  projectName: Scalars['String']['input'];
-  productIds?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
-  productFilter?: InputMaybe<Scalars['String']['input']>;
-  versionFilter?: InputMaybe<Scalars['String']['input']>;
-  taskFilter?: InputMaybe<Scalars['String']['input']>;
-  featuredVersionOrder?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
-  search?: InputMaybe<Scalars['String']['input']>;
-  folderIds?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
-  after?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
-  sortBy?: InputMaybe<Scalars['String']['input']>;
-  showComments?: Scalars['Boolean']['input'];
+  projectName: string;
+  productIds?: Array<string> | string | null | undefined;
+  productFilter?: string | null | undefined;
+  versionFilter?: string | null | undefined;
+  taskFilter?: string | null | undefined;
+  featuredVersionOrder?: Array<string> | string | null | undefined;
+  search?: string | null | undefined;
+  folderIds?: Array<string> | string | null | undefined;
+  after?: string | null | undefined;
+  first?: number | null | undefined;
+  before?: string | null | undefined;
+  last?: number | null | undefined;
+  sortBy?: string | null | undefined;
+  showComments?: boolean;
 }>;
 
 
-export type GetProductsQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', products: { __typename?: 'ProductsConnection', pageInfo: { __typename?: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean }, edges: Array<{ __typename?: 'ProductEdge', cursor?: string | null, node: { __typename?: 'ProductNode', id: string, name: string, folderId: string, active: boolean, status: string, tags: Array<string>, type: string, productType: string, productBaseType?: string | null, allAttrib: string, parents: Array<string>, createdAt: any, updatedAt: any, featuredVersion?: { __typename?: 'VersionNode', name: string, id: string, hasReviewables: boolean, parents: Array<string>, path?: string | null, active: boolean, allAttrib: string, author?: string | null, createdAt: any, status: string, tags: Array<string>, updatedAt: any, thumbnailHash: string, version: number, featuredVersionType?: string | null, heroVersionId?: string | null, latestComments?: Array<{ __typename?: 'EntityComment', activityId: string, body: string, author?: string | null, createdAt: string }> | null } | null, versions: Array<{ __typename?: 'VersionListItem', id: string, name: string, version: number }>, folder: { __typename?: 'FolderNode', id: string, name: string, label?: string | null, folderType: string, allAttrib: string } } }> } } };
+export type GetProductsQuery = { project: { products: { pageInfo: { startCursor: string | null, endCursor: string | null, hasNextPage: boolean, hasPreviousPage: boolean }, edges: Array<{ cursor: string | null, node: { id: string, name: string, folderId: string, active: boolean, status: string, tags: Array<string>, type: string, productType: string, productBaseType: string | null, allAttrib: string, parents: Array<string>, createdAt: unknown, updatedAt: unknown, featuredVersion: { name: string, id: string, hasReviewables: boolean, parents: Array<string>, path: string | null, active: boolean, allAttrib: string, author: string | null, createdAt: unknown, status: string, tags: Array<string>, updatedAt: unknown, thumbnailHash: string, version: number, featuredVersionType: string | null, heroVersionId: string | null, latestComments?: Array<{ activityId: string, body: string, author: string | null, createdAt: string }> | null } | null, versions: Array<{ id: string, name: string, version: number }>, folder: { id: string, name: string, label: string | null, folderType: string, allAttrib: string } } }> } } };
 
 export type GetProductsColumnStatsQueryVariables = Exact<{
-  projectName: Scalars['String']['input'];
-  productFilter?: InputMaybe<Scalars['String']['input']>;
-  versionFilter?: InputMaybe<Scalars['String']['input']>;
-  taskFilter?: InputMaybe<Scalars['String']['input']>;
-  folderIds?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
-  productIds?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
-  targets?: InputMaybe<Array<MetricTargetInput> | MetricTargetInput>;
+  projectName: string;
+  productFilter?: string | null | undefined;
+  versionFilter?: string | null | undefined;
+  taskFilter?: string | null | undefined;
+  folderIds?: Array<string> | string | null | undefined;
+  productIds?: Array<string> | string | null | undefined;
+  targets?: Array<MetricTargetInput> | MetricTargetInput | null | undefined;
 }>;
 
 
-export type GetProductsColumnStatsQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', products: { __typename?: 'ProductsConnection', fieldStats: Array<{ __typename?: 'ColumnStats', columnName: string, min?: number | null, max?: number | null, avg?: number | null, sum?: number | null, count?: number | null, valueFilledCount?: number | null, percentageFilled?: number | null, valueNotFilledCount?: number | null, percentageNotFilled?: number | null, checkedCount?: number | null, checkedPercentage?: number | null, notCheckedCount?: number | null, notCheckedPercentage?: number | null, distribution?: any | null }> } } };
+export type GetProductsColumnStatsQuery = { project: { products: { fieldStats: Array<{ columnName: string, min: number | null, max: number | null, avg: number | null, sum: number | null, count: number | null, valueFilledCount: number | null, percentageFilled: number | null, valueNotFilledCount: number | null, percentageNotFilled: number | null, checkedCount: number | null, checkedPercentage: number | null, notCheckedCount: number | null, notCheckedPercentage: number | null, distribution: unknown }> } } };
 
 export type GetVersionsQueryVariables = Exact<{
-  projectName: Scalars['String']['input'];
-  productIds?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
-  versionIds?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
-  versionFilter?: InputMaybe<Scalars['String']['input']>;
-  productFilter?: InputMaybe<Scalars['String']['input']>;
-  taskFilter?: InputMaybe<Scalars['String']['input']>;
-  featuredOnly?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
-  hasReviewables?: InputMaybe<Scalars['Boolean']['input']>;
-  folderIds?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
-  search?: InputMaybe<Scalars['String']['input']>;
-  after?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
-  sortBy?: InputMaybe<Scalars['String']['input']>;
-  showComments?: Scalars['Boolean']['input'];
+  projectName: string;
+  productIds?: Array<string> | string | null | undefined;
+  versionIds?: Array<string> | string | null | undefined;
+  versionFilter?: string | null | undefined;
+  productFilter?: string | null | undefined;
+  taskFilter?: string | null | undefined;
+  featuredOnly?: Array<string> | string | null | undefined;
+  hasReviewables?: boolean | null | undefined;
+  folderIds?: Array<string> | string | null | undefined;
+  search?: string | null | undefined;
+  after?: string | null | undefined;
+  first?: number | null | undefined;
+  before?: string | null | undefined;
+  last?: number | null | undefined;
+  sortBy?: string | null | undefined;
+  showComments?: boolean;
 }>;
 
 
-export type GetVersionsQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', versions: { __typename?: 'VersionsConnection', pageInfo: { __typename?: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean }, edges: Array<{ __typename?: 'VersionEdge', cursor?: string | null, node: { __typename?: 'VersionNode', name: string, id: string, hasReviewables: boolean, parents: Array<string>, path?: string | null, active: boolean, allAttrib: string, author?: string | null, createdAt: any, status: string, tags: Array<string>, updatedAt: any, thumbnailHash: string, version: number, featuredVersionType?: string | null, heroVersionId?: string | null, task?: { __typename?: 'TaskNode', id: string, taskType: string, label?: string | null, name: string } | null, product: { __typename?: 'ProductNode', id: string, name: string, productType: string, productBaseType?: string | null, allAttrib: string, folder: { __typename?: 'FolderNode', id: string, name: string, label?: string | null, folderType: string, allAttrib: string } }, latestComments?: Array<{ __typename?: 'EntityComment', activityId: string, body: string, author?: string | null, createdAt: string }> | null } }> } } };
+export type GetVersionsQuery = { project: { versions: { pageInfo: { startCursor: string | null, endCursor: string | null, hasNextPage: boolean, hasPreviousPage: boolean }, edges: Array<{ cursor: string | null, node: { name: string, id: string, hasReviewables: boolean, parents: Array<string>, path: string | null, active: boolean, allAttrib: string, author: string | null, createdAt: unknown, status: string, tags: Array<string>, updatedAt: unknown, thumbnailHash: string, version: number, featuredVersionType: string | null, heroVersionId: string | null, task: { id: string, taskType: string, label: string | null, name: string } | null, product: { id: string, name: string, productType: string, productBaseType: string | null, allAttrib: string, folder: { id: string, name: string, label: string | null, folderType: string, allAttrib: string } }, latestComments?: Array<{ activityId: string, body: string, author: string | null, createdAt: string }> | null } }> } } };
+
+export type GetVersionsAttribsQueryVariables = Exact<{
+  projectName: string;
+  versionIds: Array<string> | string;
+}>;
+
+
+export type GetVersionsAttribsQuery = { project: { versions: { edges: Array<{ node: { id: string, allAttrib: string } }> } } };
 
 export type GetVersionsByProductIdQueryVariables = Exact<{
-  projectName: Scalars['String']['input'];
-  productIds: Array<Scalars['String']['input']> | Scalars['String']['input'];
-  versionFilter?: InputMaybe<Scalars['String']['input']>;
-  taskFilter?: InputMaybe<Scalars['String']['input']>;
-  featuredOnly?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
-  hasReviewables?: InputMaybe<Scalars['Boolean']['input']>;
-  sortBy?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
-  after?: InputMaybe<Scalars['String']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  showComments?: Scalars['Boolean']['input'];
+  projectName: string;
+  productIds: Array<string> | string;
+  versionFilter?: string | null | undefined;
+  taskFilter?: string | null | undefined;
+  featuredOnly?: Array<string> | string | null | undefined;
+  hasReviewables?: boolean | null | undefined;
+  sortBy?: string | null | undefined;
+  first?: number | null | undefined;
+  last?: number | null | undefined;
+  after?: string | null | undefined;
+  before?: string | null | undefined;
+  showComments?: boolean;
 }>;
 
 
-export type GetVersionsByProductIdQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', versions: { __typename?: 'VersionsConnection', pageInfo: { __typename?: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean }, edges: Array<{ __typename?: 'VersionEdge', cursor?: string | null, node: { __typename?: 'VersionNode', name: string, id: string, hasReviewables: boolean, parents: Array<string>, path?: string | null, active: boolean, allAttrib: string, author?: string | null, createdAt: any, status: string, tags: Array<string>, updatedAt: any, thumbnailHash: string, version: number, featuredVersionType?: string | null, heroVersionId?: string | null, task?: { __typename?: 'TaskNode', id: string, taskType: string, label?: string | null, name: string } | null, product: { __typename?: 'ProductNode', id: string, name: string, productType: string, productBaseType?: string | null, allAttrib: string, folder: { __typename?: 'FolderNode', id: string, name: string, label?: string | null, folderType: string, allAttrib: string } }, latestComments?: Array<{ __typename?: 'EntityComment', activityId: string, body: string, author?: string | null, createdAt: string }> | null } }> } } };
+export type GetVersionsByProductIdQuery = { project: { versions: { pageInfo: { startCursor: string | null, endCursor: string | null, hasNextPage: boolean, hasPreviousPage: boolean }, edges: Array<{ cursor: string | null, node: { name: string, id: string, hasReviewables: boolean, parents: Array<string>, path: string | null, active: boolean, allAttrib: string, author: string | null, createdAt: unknown, status: string, tags: Array<string>, updatedAt: unknown, thumbnailHash: string, version: number, featuredVersionType: string | null, heroVersionId: string | null, task: { id: string, taskType: string, label: string | null, name: string } | null, product: { id: string, name: string, productType: string, productBaseType: string | null, allAttrib: string, folder: { id: string, name: string, label: string | null, folderType: string, allAttrib: string } }, latestComments?: Array<{ activityId: string, body: string, author: string | null, createdAt: string }> | null } }> } } };
 
 export type GetVersionsColumnStatsQueryVariables = Exact<{
-  projectName: Scalars['String']['input'];
-  versionFilter?: InputMaybe<Scalars['String']['input']>;
-  productFilter?: InputMaybe<Scalars['String']['input']>;
-  taskFilter?: InputMaybe<Scalars['String']['input']>;
-  folderIds?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
-  versionIds?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
-  productIds?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
-  targets?: InputMaybe<Array<MetricTargetInput> | MetricTargetInput>;
+  projectName: string;
+  versionFilter?: string | null | undefined;
+  productFilter?: string | null | undefined;
+  taskFilter?: string | null | undefined;
+  folderIds?: Array<string> | string | null | undefined;
+  versionIds?: Array<string> | string | null | undefined;
+  productIds?: Array<string> | string | null | undefined;
+  targets?: Array<MetricTargetInput> | MetricTargetInput | null | undefined;
 }>;
 
 
-export type GetVersionsColumnStatsQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', versions: { __typename?: 'VersionsConnection', fieldStats: Array<{ __typename?: 'ColumnStats', columnName: string, min?: number | null, max?: number | null, avg?: number | null, sum?: number | null, count?: number | null, valueFilledCount?: number | null, percentageFilled?: number | null, valueNotFilledCount?: number | null, percentageNotFilled?: number | null, checkedCount?: number | null, checkedPercentage?: number | null, notCheckedCount?: number | null, notCheckedPercentage?: number | null, distribution?: any | null }> } } };
+export type GetVersionsColumnStatsQuery = { project: { versions: { fieldStats: Array<{ columnName: string, min: number | null, max: number | null, avg: number | null, sum: number | null, count: number | null, valueFilledCount: number | null, percentageFilled: number | null, valueNotFilledCount: number | null, percentageNotFilled: number | null, checkedCount: number | null, checkedPercentage: number | null, notCheckedCount: number | null, notCheckedPercentage: number | null, distribution: unknown }> } } };
 
-export type PageInfoFragment = { __typename?: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean };
+export type PageInfoFragment = { startCursor: string | null, endCursor: string | null, hasNextPage: boolean, hasPreviousPage: boolean };
 
-export type VersionBaseFragment = { __typename?: 'VersionNode', name: string, id: string, hasReviewables: boolean, parents: Array<string>, path?: string | null, active: boolean, allAttrib: string, author?: string | null, createdAt: any, status: string, tags: Array<string>, updatedAt: any, thumbnailHash: string, version: number, featuredVersionType?: string | null, heroVersionId?: string | null, latestComments?: Array<{ __typename?: 'EntityComment', activityId: string, body: string, author?: string | null, createdAt: string }> | null };
+export type VersionBaseFragment = { name: string, id: string, hasReviewables: boolean, parents: Array<string>, path: string | null, active: boolean, allAttrib: string, author: string | null, createdAt: unknown, status: string, tags: Array<string>, updatedAt: unknown, thumbnailHash: string, version: number, featuredVersionType: string | null, heroVersionId: string | null, latestComments?: Array<{ activityId: string, body: string, author: string | null, createdAt: string }> | null };
 
-export type VersionExtendedFragment = { __typename?: 'VersionNode', name: string, id: string, hasReviewables: boolean, parents: Array<string>, path?: string | null, active: boolean, allAttrib: string, author?: string | null, createdAt: any, status: string, tags: Array<string>, updatedAt: any, thumbnailHash: string, version: number, featuredVersionType?: string | null, heroVersionId?: string | null, task?: { __typename?: 'TaskNode', id: string, taskType: string, label?: string | null, name: string } | null, product: { __typename?: 'ProductNode', id: string, name: string, productType: string, productBaseType?: string | null, allAttrib: string, folder: { __typename?: 'FolderNode', id: string, name: string, label?: string | null, folderType: string, allAttrib: string } }, latestComments?: Array<{ __typename?: 'EntityComment', activityId: string, body: string, author?: string | null, createdAt: string }> | null };
+export type VersionExtendedFragment = { name: string, id: string, hasReviewables: boolean, parents: Array<string>, path: string | null, active: boolean, allAttrib: string, author: string | null, createdAt: unknown, status: string, tags: Array<string>, updatedAt: unknown, thumbnailHash: string, version: number, featuredVersionType: string | null, heroVersionId: string | null, task: { id: string, taskType: string, label: string | null, name: string } | null, product: { id: string, name: string, productType: string, productBaseType: string | null, allAttrib: string, folder: { id: string, name: string, label: string | null, folderType: string, allAttrib: string } }, latestComments?: Array<{ activityId: string, body: string, author: string | null, createdAt: string }> | null };
 
 export type GetInboxHasUnreadQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetInboxHasUnreadQuery = { __typename?: 'Query', inbox: { __typename?: 'ActivitiesConnection', edges: Array<{ __typename?: 'ActivityEdge', node: { __typename?: 'ActivityNode', referenceId: string, read: boolean } }> } };
+export type GetInboxHasUnreadQuery = { inbox: { edges: Array<{ node: { referenceId: string, read: boolean } }> } };
 
 export type GetInboxMessagesQueryVariables = Exact<{
-  last?: InputMaybe<Scalars['Int']['input']>;
-  active?: InputMaybe<Scalars['Boolean']['input']>;
-  important?: InputMaybe<Scalars['Boolean']['input']>;
-  cursor?: InputMaybe<Scalars['String']['input']>;
+  last?: number | null | undefined;
+  active?: boolean | null | undefined;
+  important?: boolean | null | undefined;
+  cursor?: string | null | undefined;
 }>;
 
 
-export type GetInboxMessagesQuery = { __typename?: 'Query', inbox: { __typename?: 'ActivitiesConnection', pageInfo: { __typename?: 'PageInfo', hasPreviousPage: boolean, startCursor?: string | null, endCursor?: string | null }, edges: Array<{ __typename?: 'ActivityEdge', cursor?: string | null, node: { __typename?: 'ActivityNode', projectName: string, activityId: string, activityType: string, activityData: string, referenceType: string, referenceId: string, body: string, createdAt: any, updatedAt: any, active: boolean, read: boolean, author?: { __typename?: 'UserNode', name: string, attrib: { __typename?: 'UserAttribType', fullName?: string | null } } | null, origin?: { __typename?: 'ActivityOriginNode', id: string, name: string, label?: string | null, type: string, subtype?: string | null } | null, parents: Array<{ __typename?: 'ActivityOriginNode', type: string, name: string, label?: string | null }> } }> } };
+export type GetInboxMessagesQuery = { inbox: { pageInfo: { hasPreviousPage: boolean, startCursor: string | null, endCursor: string | null }, edges: Array<{ cursor: string | null, node: { projectName: string, activityId: string, activityType: string, activityData: string, referenceType: string, referenceId: string, body: string, createdAt: unknown, updatedAt: unknown, active: boolean, read: boolean, author: { name: string, attrib: { fullName: string | null } } | null, origin: { id: string, name: string, label: string | null, type: string, subtype: string | null } | null, parents: Array<{ type: string, name: string, label: string | null }> } }> } };
 
-export type MessageFragmentFragment = { __typename?: 'ActivityNode', projectName: string, activityId: string, activityType: string, activityData: string, referenceType: string, referenceId: string, body: string, createdAt: any, updatedAt: any, active: boolean, read: boolean, author?: { __typename?: 'UserNode', name: string, attrib: { __typename?: 'UserAttribType', fullName?: string | null } } | null, origin?: { __typename?: 'ActivityOriginNode', id: string, name: string, label?: string | null, type: string, subtype?: string | null } | null, parents: Array<{ __typename?: 'ActivityOriginNode', type: string, name: string, label?: string | null }> };
+export type MessageFragmentFragment = { projectName: string, activityId: string, activityType: string, activityData: string, referenceType: string, referenceId: string, body: string, createdAt: unknown, updatedAt: unknown, active: boolean, read: boolean, author: { name: string, attrib: { fullName: string | null } } | null, origin: { id: string, name: string, label: string | null, type: string, subtype: string | null } | null, parents: Array<{ type: string, name: string, label: string | null }> };
 
 export type GetInboxUnreadCountQueryVariables = Exact<{
-  important?: InputMaybe<Scalars['Boolean']['input']>;
+  important?: boolean | null | undefined;
 }>;
 
 
-export type GetInboxUnreadCountQuery = { __typename?: 'Query', inbox: { __typename?: 'ActivitiesConnection', edges: Array<{ __typename?: 'ActivityEdge', node: { __typename?: 'ActivityNode', referenceId: string, read: boolean } }> } };
+export type GetInboxUnreadCountQuery = { inbox: { edges: Array<{ node: { referenceId: string, read: boolean } }> } };
 
 export type GetMarketInstallEventsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetMarketInstallEventsQuery = { __typename?: 'Query', events: { __typename?: 'EventsConnection', edges: Array<{ __typename?: 'EventEdge', node: { __typename?: 'EventNode', id: string, status: string, description: string, summary: string } }> } };
+export type GetMarketInstallEventsQuery = { events: { edges: Array<{ node: { id: string, status: string, description: string, summary: string } }> } };
 
 export type GetInstallEventsQueryVariables = Exact<{
-  ids: Array<Scalars['String']['input']> | Scalars['String']['input'];
+  ids: Array<string> | string;
 }>;
 
 
-export type GetInstallEventsQuery = { __typename?: 'Query', events: { __typename?: 'EventsConnection', edges: Array<{ __typename?: 'EventEdge', node: { __typename?: 'EventNode', id: string, status: string, description: string } }> } };
+export type GetInstallEventsQuery = { events: { edges: Array<{ node: { id: string, status: string, description: string } }> } };
 
 export type GetProgressTaskQueryVariables = Exact<{
-  projectName: Scalars['String']['input'];
-  taskId: Scalars['String']['input'];
+  projectName: string;
+  taskId: string;
 }>;
 
 
-export type GetProgressTaskQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', name: string, task?: { __typename?: 'TaskNode', projectName: string, id: string, name: string, label?: string | null, taskType: string, status: string, assignees: Array<string>, updatedAt: any, thumbnailHash: string, active: boolean, hasReviewables: boolean, tags: Array<string>, attrib: { __typename?: 'TaskAttribType', priority?: string | null, endDate?: any | null, resolutionHeight?: number | null, resolutionWidth?: number | null, fps?: number | null }, folder: { __typename?: 'FolderNode', id: string, name: string, label?: string | null, folderType: string, parents: Array<string>, status: string, updatedAt: any, thumbnailHash: string, parent?: { __typename?: 'FolderNode', id: string, name: string, label?: string | null, parents: Array<string> } | null } } | null } };
+export type GetProgressTaskQuery = { project: { name: string, task: { projectName: string, id: string, name: string, label: string | null, taskType: string, status: string, assignees: Array<string>, updatedAt: unknown, thumbnailHash: string, active: boolean, hasReviewables: boolean, tags: Array<string>, attrib: { priority: string | null, endDate: unknown, resolutionHeight: number | null, resolutionWidth: number | null, fps: number | null }, folder: { id: string, name: string, label: string | null, folderType: string, parents: Array<string>, status: string, updatedAt: unknown, thumbnailHash: string, parent: { id: string, name: string, label: string | null, parents: Array<string> } | null } } | null } };
 
 export type GetTasksProgressQueryVariables = Exact<{
-  projectName: Scalars['String']['input'];
-  folderIds?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
-  assignees?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
-  assigneesAny?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
-  tags?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
-  tagsAny?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
-  statuses?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
-  taskTypes?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
-  attributes?: InputMaybe<Array<AttributeFilterInput> | AttributeFilterInput>;
+  projectName: string;
+  folderIds?: Array<string> | string | null | undefined;
+  assignees?: Array<string> | string | null | undefined;
+  assigneesAny?: Array<string> | string | null | undefined;
+  tags?: Array<string> | string | null | undefined;
+  tagsAny?: Array<string> | string | null | undefined;
+  statuses?: Array<string> | string | null | undefined;
+  taskTypes?: Array<string> | string | null | undefined;
+  attributes?: Array<AttributeFilterInput> | AttributeFilterInput | null | undefined;
 }>;
 
 
-export type GetTasksProgressQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', name: string, tasks: { __typename?: 'TasksConnection', edges: Array<{ __typename?: 'TaskEdge', node: { __typename?: 'TaskNode', projectName: string, id: string, name: string, label?: string | null, taskType: string, status: string, assignees: Array<string>, updatedAt: any, thumbnailHash: string, active: boolean, hasReviewables: boolean, tags: Array<string>, attrib: { __typename?: 'TaskAttribType', priority?: string | null, endDate?: any | null, resolutionHeight?: number | null, resolutionWidth?: number | null, fps?: number | null }, folder: { __typename?: 'FolderNode', id: string, name: string, label?: string | null, folderType: string, parents: Array<string>, status: string, updatedAt: any, thumbnailHash: string, parent?: { __typename?: 'FolderNode', id: string, name: string, label?: string | null, parents: Array<string> } | null } } }> } } };
+export type GetTasksProgressQuery = { project: { name: string, tasks: { edges: Array<{ node: { projectName: string, id: string, name: string, label: string | null, taskType: string, status: string, assignees: Array<string>, updatedAt: unknown, thumbnailHash: string, active: boolean, hasReviewables: boolean, tags: Array<string>, attrib: { priority: string | null, endDate: unknown, resolutionHeight: number | null, resolutionWidth: number | null, fps: number | null }, folder: { id: string, name: string, label: string | null, folderType: string, parents: Array<string>, status: string, updatedAt: unknown, thumbnailHash: string, parent: { id: string, name: string, label: string | null, parents: Array<string> } | null } } }> } } };
 
-export type ProgressTaskFragmentFragment = { __typename?: 'TaskNode', projectName: string, id: string, name: string, label?: string | null, taskType: string, status: string, assignees: Array<string>, updatedAt: any, thumbnailHash: string, active: boolean, hasReviewables: boolean, tags: Array<string>, attrib: { __typename?: 'TaskAttribType', priority?: string | null, endDate?: any | null, resolutionHeight?: number | null, resolutionWidth?: number | null, fps?: number | null }, folder: { __typename?: 'FolderNode', id: string, name: string, label?: string | null, folderType: string, parents: Array<string>, status: string, updatedAt: any, thumbnailHash: string, parent?: { __typename?: 'FolderNode', id: string, name: string, label?: string | null, parents: Array<string> } | null } };
+export type ProgressTaskFragmentFragment = { projectName: string, id: string, name: string, label: string | null, taskType: string, status: string, assignees: Array<string>, updatedAt: unknown, thumbnailHash: string, active: boolean, hasReviewables: boolean, tags: Array<string>, attrib: { priority: string | null, endDate: unknown, resolutionHeight: number | null, resolutionWidth: number | null, fps: number | null }, folder: { id: string, name: string, label: string | null, folderType: string, parents: Array<string>, status: string, updatedAt: unknown, thumbnailHash: string, parent: { id: string, name: string, label: string | null, parents: Array<string> } | null } };
 
 export const ActivityFragmentFragmentDoc = new TypedDocumentString(`
     fragment ActivityFragment on ActivityNode {
@@ -3979,6 +3987,20 @@ fragment VersionExtended on VersionNode {
     }
   }
 }`);
+export const GetVersionsAttribsDocument = new TypedDocumentString(`
+    query GetVersionsAttribs($projectName: String!, $versionIds: [String!]!) {
+  project(name: $projectName) {
+    versions(ids: $versionIds) {
+      edges {
+        node {
+          id
+          allAttrib
+        }
+      }
+    }
+  }
+}
+    `);
 export const GetVersionsByProductIdDocument = new TypedDocumentString(`
     query GetVersionsByProductId($projectName: String!, $productIds: [String!]!, $versionFilter: String, $taskFilter: String, $featuredOnly: [String!], $hasReviewables: Boolean, $sortBy: String, $first: Int, $last: Int, $after: String, $before: String, $showComments: Boolean! = false) {
   project(name: $projectName) {
@@ -4323,124 +4345,127 @@ export const GetTasksProgressDocument = new TypedDocumentString(`
 const injectedRtkApi = api.injectEndpoints({
   endpoints: (build) => ({
     GetActivitiesById: build.query<GetActivitiesByIdQuery, GetActivitiesByIdQueryVariables>({
-      query: (variables) => ({ document: GetActivitiesByIdDocument, variables })
+      query: (variables) => ({ document: GetActivitiesByIdDocument as unknown as string, variables })
     }),
     GetActivityUsers: build.query<GetActivityUsersQuery, GetActivityUsersQueryVariables | void>({
-      query: (variables) => ({ document: GetActivityUsersDocument, variables })
+      query: (variables) => ({ document: GetActivityUsersDocument as unknown as string, variables })
     }),
     GetActivities: build.query<GetActivitiesQuery, GetActivitiesQueryVariables>({
-      query: (variables) => ({ document: GetActivitiesDocument, variables })
+      query: (variables) => ({ document: GetActivitiesDocument as unknown as string, variables })
     }),
     GetEntitiesChecklists: build.query<GetEntitiesChecklistsQuery, GetEntitiesChecklistsQueryVariables>({
-      query: (variables) => ({ document: GetEntitiesChecklistsDocument, variables })
+      query: (variables) => ({ document: GetEntitiesChecklistsDocument as unknown as string, variables })
     }),
     GetDetailsPanelFolder: build.query<GetDetailsPanelFolderQuery, GetDetailsPanelFolderQueryVariables>({
-      query: (variables) => ({ document: GetDetailsPanelFolderDocument, variables })
+      query: (variables) => ({ document: GetDetailsPanelFolderDocument as unknown as string, variables })
     }),
     GetDetailsPanelRepresentation: build.query<GetDetailsPanelRepresentationQuery, GetDetailsPanelRepresentationQueryVariables>({
-      query: (variables) => ({ document: GetDetailsPanelRepresentationDocument, variables })
+      query: (variables) => ({ document: GetDetailsPanelRepresentationDocument as unknown as string, variables })
     }),
     GetDetailsPanelTask: build.query<GetDetailsPanelTaskQuery, GetDetailsPanelTaskQueryVariables>({
-      query: (variables) => ({ document: GetDetailsPanelTaskDocument, variables })
+      query: (variables) => ({ document: GetDetailsPanelTaskDocument as unknown as string, variables })
     }),
     GetDetailsPanelVersion: build.query<GetDetailsPanelVersionQuery, GetDetailsPanelVersionQueryVariables>({
-      query: (variables) => ({ document: GetDetailsPanelVersionDocument, variables })
+      query: (variables) => ({ document: GetDetailsPanelVersionDocument as unknown as string, variables })
     }),
     GetProductVersions: build.query<GetProductVersionsQuery, GetProductVersionsQueryVariables>({
-      query: (variables) => ({ document: GetProductVersionsDocument, variables })
+      query: (variables) => ({ document: GetProductVersionsDocument as unknown as string, variables })
     }),
     GetListItems: build.query<GetListItemsQuery, GetListItemsQueryVariables>({
-      query: (variables) => ({ document: GetListItemsDocument, variables })
+      query: (variables) => ({ document: GetListItemsDocument as unknown as string, variables })
     }),
     GetListItemsColumnStats: build.query<GetListItemsColumnStatsQuery, GetListItemsColumnStatsQueryVariables>({
-      query: (variables) => ({ document: GetListItemsColumnStatsDocument, variables })
+      query: (variables) => ({ document: GetListItemsColumnStatsDocument as unknown as string, variables })
     }),
     GetLists: build.query<GetListsQuery, GetListsQueryVariables>({
-      query: (variables) => ({ document: GetListsDocument, variables })
+      query: (variables) => ({ document: GetListsDocument as unknown as string, variables })
     }),
     GetListsItemsForReviewSession: build.query<GetListsItemsForReviewSessionQuery, GetListsItemsForReviewSessionQueryVariables>({
-      query: (variables) => ({ document: GetListsItemsForReviewSessionDocument, variables })
+      query: (variables) => ({ document: GetListsItemsForReviewSessionDocument as unknown as string, variables })
     }),
     GetFolderColumnStats: build.query<GetFolderColumnStatsQuery, GetFolderColumnStatsQueryVariables>({
-      query: (variables) => ({ document: GetFolderColumnStatsDocument, variables })
+      query: (variables) => ({ document: GetFolderColumnStatsDocument as unknown as string, variables })
     }),
     GetFolderDeleteInfo: build.query<GetFolderDeleteInfoQuery, GetFolderDeleteInfoQueryVariables>({
-      query: (variables) => ({ document: GetFolderDeleteInfoDocument, variables })
+      query: (variables) => ({ document: GetFolderDeleteInfoDocument as unknown as string, variables })
     }),
     GetTaskColumnStats: build.query<GetTaskColumnStatsQuery, GetTaskColumnStatsQueryVariables>({
-      query: (variables) => ({ document: GetTaskColumnStatsDocument, variables })
+      query: (variables) => ({ document: GetTaskColumnStatsDocument as unknown as string, variables })
     }),
     GetTasksByParent: build.query<GetTasksByParentQuery, GetTasksByParentQueryVariables>({
-      query: (variables) => ({ document: GetTasksByParentDocument, variables })
+      query: (variables) => ({ document: GetTasksByParentDocument as unknown as string, variables })
     }),
     GetTasksList: build.query<GetTasksListQuery, GetTasksListQueryVariables>({
-      query: (variables) => ({ document: GetTasksListDocument, variables })
+      query: (variables) => ({ document: GetTasksListDocument as unknown as string, variables })
     }),
     GetFolderProducts: build.query<GetFolderProductsQuery, GetFolderProductsQueryVariables>({
-      query: (variables) => ({ document: GetFolderProductsDocument, variables })
+      query: (variables) => ({ document: GetFolderProductsDocument as unknown as string, variables })
     }),
     GetProjectLatest: build.query<GetProjectLatestQuery, GetProjectLatestQueryVariables>({
-      query: (variables) => ({ document: GetProjectLatestDocument, variables })
+      query: (variables) => ({ document: GetProjectLatestDocument as unknown as string, variables })
     }),
     GetProjects: build.query<GetProjectsQuery, GetProjectsQueryVariables | void>({
-      query: (variables) => ({ document: GetProjectsDocument, variables })
+      query: (variables) => ({ document: GetProjectsDocument as unknown as string, variables })
     }),
     GetKanban: build.query<GetKanbanQuery, GetKanbanQueryVariables | void>({
-      query: (variables) => ({ document: GetKanbanDocument, variables })
+      query: (variables) => ({ document: GetKanbanDocument as unknown as string, variables })
     }),
     GetKanbanProjectUsers: build.query<GetKanbanProjectUsersQuery, GetKanbanProjectUsersQueryVariables | void>({
-      query: (variables) => ({ document: GetKanbanProjectUsersDocument, variables })
+      query: (variables) => ({ document: GetKanbanProjectUsersDocument as unknown as string, variables })
     }),
     GetKanbanTasks: build.query<GetKanbanTasksQuery, GetKanbanTasksQueryVariables | void>({
-      query: (variables) => ({ document: GetKanbanTasksDocument, variables })
+      query: (variables) => ({ document: GetKanbanTasksDocument as unknown as string, variables })
     }),
     GetActiveUsersCount: build.query<GetActiveUsersCountQuery, GetActiveUsersCountQueryVariables | void>({
-      query: (variables) => ({ document: GetActiveUsersCountDocument, variables })
+      query: (variables) => ({ document: GetActiveUsersCountDocument as unknown as string, variables })
     }),
     GetAllAssignees: build.query<GetAllAssigneesQuery, GetAllAssigneesQueryVariables | void>({
-      query: (variables) => ({ document: GetAllAssigneesDocument, variables })
+      query: (variables) => ({ document: GetAllAssigneesDocument as unknown as string, variables })
     }),
     GetAllProjectUsersAsAssignee: build.query<GetAllProjectUsersAsAssigneeQuery, GetAllProjectUsersAsAssigneeQueryVariables | void>({
-      query: (variables) => ({ document: GetAllProjectUsersAsAssigneeDocument, variables })
+      query: (variables) => ({ document: GetAllProjectUsersAsAssigneeDocument as unknown as string, variables })
     }),
     GetLatestProductVersion: build.query<GetLatestProductVersionQuery, GetLatestProductVersionQueryVariables>({
-      query: (variables) => ({ document: GetLatestProductVersionDocument, variables })
+      query: (variables) => ({ document: GetLatestProductVersionDocument as unknown as string, variables })
     }),
     GetProducts: build.query<GetProductsQuery, GetProductsQueryVariables>({
-      query: (variables) => ({ document: GetProductsDocument, variables })
+      query: (variables) => ({ document: GetProductsDocument as unknown as string, variables })
     }),
     GetProductsColumnStats: build.query<GetProductsColumnStatsQuery, GetProductsColumnStatsQueryVariables>({
-      query: (variables) => ({ document: GetProductsColumnStatsDocument, variables })
+      query: (variables) => ({ document: GetProductsColumnStatsDocument as unknown as string, variables })
     }),
     GetVersions: build.query<GetVersionsQuery, GetVersionsQueryVariables>({
-      query: (variables) => ({ document: GetVersionsDocument, variables })
+      query: (variables) => ({ document: GetVersionsDocument as unknown as string, variables })
+    }),
+    GetVersionsAttribs: build.query<GetVersionsAttribsQuery, GetVersionsAttribsQueryVariables>({
+      query: (variables) => ({ document: GetVersionsAttribsDocument as unknown as string, variables })
     }),
     GetVersionsByProductId: build.query<GetVersionsByProductIdQuery, GetVersionsByProductIdQueryVariables>({
-      query: (variables) => ({ document: GetVersionsByProductIdDocument, variables })
+      query: (variables) => ({ document: GetVersionsByProductIdDocument as unknown as string, variables })
     }),
     GetVersionsColumnStats: build.query<GetVersionsColumnStatsQuery, GetVersionsColumnStatsQueryVariables>({
-      query: (variables) => ({ document: GetVersionsColumnStatsDocument, variables })
+      query: (variables) => ({ document: GetVersionsColumnStatsDocument as unknown as string, variables })
     }),
     GetInboxHasUnread: build.query<GetInboxHasUnreadQuery, GetInboxHasUnreadQueryVariables | void>({
-      query: (variables) => ({ document: GetInboxHasUnreadDocument, variables })
+      query: (variables) => ({ document: GetInboxHasUnreadDocument as unknown as string, variables })
     }),
     GetInboxMessages: build.query<GetInboxMessagesQuery, GetInboxMessagesQueryVariables | void>({
-      query: (variables) => ({ document: GetInboxMessagesDocument, variables })
+      query: (variables) => ({ document: GetInboxMessagesDocument as unknown as string, variables })
     }),
     GetInboxUnreadCount: build.query<GetInboxUnreadCountQuery, GetInboxUnreadCountQueryVariables | void>({
-      query: (variables) => ({ document: GetInboxUnreadCountDocument, variables })
+      query: (variables) => ({ document: GetInboxUnreadCountDocument as unknown as string, variables })
     }),
     GetMarketInstallEvents: build.query<GetMarketInstallEventsQuery, GetMarketInstallEventsQueryVariables | void>({
-      query: (variables) => ({ document: GetMarketInstallEventsDocument, variables })
+      query: (variables) => ({ document: GetMarketInstallEventsDocument as unknown as string, variables })
     }),
     GetInstallEvents: build.query<GetInstallEventsQuery, GetInstallEventsQueryVariables>({
-      query: (variables) => ({ document: GetInstallEventsDocument, variables })
+      query: (variables) => ({ document: GetInstallEventsDocument as unknown as string, variables })
     }),
     GetProgressTask: build.query<GetProgressTaskQuery, GetProgressTaskQueryVariables>({
-      query: (variables) => ({ document: GetProgressTaskDocument, variables })
+      query: (variables) => ({ document: GetProgressTaskDocument as unknown as string, variables })
     }),
     GetTasksProgress: build.query<GetTasksProgressQuery, GetTasksProgressQueryVariables>({
-      query: (variables) => ({ document: GetTasksProgressDocument, variables })
+      query: (variables) => ({ document: GetTasksProgressDocument as unknown as string, variables })
     }),
   }),
 });

--- a/shared/src/api/generated/graphqlLinks.ts
+++ b/shared/src/api/generated/graphqlLinks.ts
@@ -11,1259 +11,1222 @@
 // @ts-nocheck
 export class TypedDocumentString<TResult, TVariables> extends String {
   constructor(private value: string, public __meta__?: Record<string, any>) {
-    super(value);
+    super(value)
   }
   toString(): string | any {
-    return this.value;
+    return this.value
   }
 }
 
-import { api } from '@shared/api/base';
-export type Maybe<T> = T | null;
-export type InputMaybe<T> = Maybe<T>;
-export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
-export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
-export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
-export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = { [_ in K]?: never };
-export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] }
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never }
+import { DocumentTypeDecoration } from '@graphql-typed-document-node/core'
+import { api } from '@shared/api/base'
+export type Maybe<T> = T | null
+export type InputMaybe<T> = Maybe<T>
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: { input: string; output: string; }
-  String: { input: string; output: string; }
-  Boolean: { input: boolean; output: boolean; }
-  Int: { input: number; output: number; }
-  Float: { input: number; output: number; }
-  DateTime: { input: any; output: any; }
-  JSON: { input: any; output: any; }
-};
+  ID: { input: string; output: string }
+  String: { input: string; output: string }
+  Boolean: { input: boolean; output: boolean }
+  Int: { input: number; output: number }
+  Float: { input: number; output: number }
+  DateTime: { input: unknown; output: unknown }
+  JSON: { input: unknown; output: unknown }
+}
 
 export type ActivitiesConnection = {
-  __typename?: 'ActivitiesConnection';
-  edges: Array<ActivityEdge>;
-  fieldStats: Array<ColumnStats>;
+  __typename?: 'ActivitiesConnection'
+  edges: Array<ActivityEdge>
+  fieldStats: Array<ColumnStats>
   /** Pagination information */
-  pageInfo: PageInfo;
-};
+  pageInfo: PageInfo
+}
 
 export type ActivityCategory = {
-  __typename?: 'ActivityCategory';
-  color: Scalars['String']['output'];
-  name: Scalars['String']['output'];
-};
+  __typename?: 'ActivityCategory'
+  color: Scalars['String']['output']
+  name: Scalars['String']['output']
+}
 
 export type ActivityEdge = {
-  __typename?: 'ActivityEdge';
-  cursor?: Maybe<Scalars['String']['output']>;
-  node: ActivityNode;
-};
+  __typename?: 'ActivityEdge'
+  cursor?: Maybe<Scalars['String']['output']>
+  node: ActivityNode
+}
 
 export type ActivityFileNode = {
-  __typename?: 'ActivityFileNode';
-  author?: Maybe<Scalars['String']['output']>;
-  createdAt: Scalars['DateTime']['output'];
-  id: Scalars['String']['output'];
-  mime?: Maybe<Scalars['String']['output']>;
-  name?: Maybe<Scalars['String']['output']>;
-  size: Scalars['String']['output'];
-  updatedAt: Scalars['DateTime']['output'];
-};
+  __typename?: 'ActivityFileNode'
+  author?: Maybe<Scalars['String']['output']>
+  createdAt: Scalars['DateTime']['output']
+  id: Scalars['String']['output']
+  mime?: Maybe<Scalars['String']['output']>
+  name?: Maybe<Scalars['String']['output']>
+  size: Scalars['String']['output']
+  updatedAt: Scalars['DateTime']['output']
+}
 
 export type ActivityNode = {
-  __typename?: 'ActivityNode';
-  active: Scalars['Boolean']['output'];
-  activityData: Scalars['String']['output'];
-  activityId: Scalars['String']['output'];
-  activityType: Scalars['String']['output'];
-  assignee?: Maybe<UserNode>;
-  author?: Maybe<UserNode>;
-  body: Scalars['String']['output'];
-  category?: Maybe<ActivityCategory>;
-  createdAt: Scalars['DateTime']['output'];
-  creationOrder: Scalars['Int']['output'];
-  entityId?: Maybe<Scalars['String']['output']>;
-  entityName?: Maybe<Scalars['String']['output']>;
-  entityPath?: Maybe<Scalars['String']['output']>;
-  entityType: Scalars['String']['output'];
-  files: Array<ActivityFileNode>;
-  origin?: Maybe<ActivityOriginNode>;
-  parents: Array<ActivityOriginNode>;
-  projectName: Scalars['String']['output'];
-  reactions: Array<ActivityReactionNode>;
-  read: Scalars['Boolean']['output'];
-  referenceData: Scalars['String']['output'];
-  referenceId: Scalars['String']['output'];
-  referenceType: Scalars['String']['output'];
-  tags: Array<Scalars['String']['output']>;
-  updatedAt: Scalars['DateTime']['output'];
-  version?: Maybe<VersionNode>;
-};
+  __typename?: 'ActivityNode'
+  active: Scalars['Boolean']['output']
+  activityData: Scalars['String']['output']
+  activityId: Scalars['String']['output']
+  activityType: Scalars['String']['output']
+  assignee?: Maybe<UserNode>
+  author?: Maybe<UserNode>
+  body: Scalars['String']['output']
+  category?: Maybe<ActivityCategory>
+  createdAt: Scalars['DateTime']['output']
+  creationOrder: Scalars['Int']['output']
+  entityId?: Maybe<Scalars['String']['output']>
+  entityName?: Maybe<Scalars['String']['output']>
+  entityPath?: Maybe<Scalars['String']['output']>
+  entityType: Scalars['String']['output']
+  files: Array<ActivityFileNode>
+  origin?: Maybe<ActivityOriginNode>
+  parents: Array<ActivityOriginNode>
+  projectName: Scalars['String']['output']
+  reactions: Array<ActivityReactionNode>
+  read: Scalars['Boolean']['output']
+  referenceData: Scalars['String']['output']
+  referenceId: Scalars['String']['output']
+  referenceType: Scalars['String']['output']
+  tags: Array<Scalars['String']['output']>
+  updatedAt: Scalars['DateTime']['output']
+  version?: Maybe<VersionNode>
+}
 
 export type ActivityOriginNode = {
-  __typename?: 'ActivityOriginNode';
-  id: Scalars['String']['output'];
-  label?: Maybe<Scalars['String']['output']>;
-  link: Scalars['String']['output'];
-  name: Scalars['String']['output'];
-  subtype?: Maybe<Scalars['String']['output']>;
-  type: Scalars['String']['output'];
-};
+  __typename?: 'ActivityOriginNode'
+  id: Scalars['String']['output']
+  label?: Maybe<Scalars['String']['output']>
+  link: Scalars['String']['output']
+  name: Scalars['String']['output']
+  subtype?: Maybe<Scalars['String']['output']>
+  type: Scalars['String']['output']
+}
 
 export type ActivityReactionNode = {
-  __typename?: 'ActivityReactionNode';
-  fullName?: Maybe<Scalars['String']['output']>;
-  reaction: Scalars['String']['output'];
-  timestamp: Scalars['DateTime']['output'];
-  userName: Scalars['String']['output'];
-};
+  __typename?: 'ActivityReactionNode'
+  fullName?: Maybe<Scalars['String']['output']>
+  reaction: Scalars['String']['output']
+  timestamp: Scalars['DateTime']['output']
+  userName: Scalars['String']['output']
+}
 
 export type AttributeFilterInput = {
-  name: Scalars['String']['input'];
-  values: Array<Scalars['String']['input']>;
-};
+  name: Scalars['String']['input']
+  values: Array<Scalars['String']['input']>
+}
 
 export type BaseNode = {
-  active: Scalars['Boolean']['output'];
-  activities: ActivitiesConnection;
-  allAttrib: Scalars['String']['output'];
-  createdAt: Scalars['DateTime']['output'];
-  createdBy?: Maybe<Scalars['String']['output']>;
-  id: Scalars['String']['output'];
-  links: LinksConnection;
-  name: Scalars['String']['output'];
-  parents: Array<Scalars['String']['output']>;
-  projectName: Scalars['String']['output'];
-  updatedAt: Scalars['DateTime']['output'];
-  updatedBy?: Maybe<Scalars['String']['output']>;
-};
-
+  active: Scalars['Boolean']['output']
+  activities: ActivitiesConnection
+  allAttrib: Scalars['String']['output']
+  createdAt: Scalars['DateTime']['output']
+  createdBy?: Maybe<Scalars['String']['output']>
+  id: Scalars['String']['output']
+  links: LinksConnection
+  name: Scalars['String']['output']
+  parents: Array<Scalars['String']['output']>
+  projectName: Scalars['String']['output']
+  updatedAt: Scalars['DateTime']['output']
+  updatedBy?: Maybe<Scalars['String']['output']>
+}
 
 export type BaseNodeActivitiesArgs = {
-  activityTypes?: InputMaybe<Array<Scalars['String']['input']>>;
-  after?: InputMaybe<Scalars['String']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
-  referenceTypes?: InputMaybe<Array<Scalars['String']['input']>>;
-};
-
+  activityTypes?: InputMaybe<Array<Scalars['String']['input']>>
+  after?: InputMaybe<Scalars['String']['input']>
+  before?: InputMaybe<Scalars['String']['input']>
+  first?: InputMaybe<Scalars['Int']['input']>
+  last?: InputMaybe<Scalars['Int']['input']>
+  referenceTypes?: InputMaybe<Array<Scalars['String']['input']>>
+}
 
 export type BaseNodeLinksArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  direction?: InputMaybe<Scalars['String']['input']>;
-  first?: Scalars['Int']['input'];
-  linkTypes?: InputMaybe<Array<Scalars['String']['input']>>;
-  nameEx?: InputMaybe<Scalars['String']['input']>;
-  names?: InputMaybe<Array<Scalars['String']['input']>>;
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  direction?: InputMaybe<Scalars['String']['input']>
+  first?: Scalars['Int']['input']
+  linkTypes?: InputMaybe<Array<Scalars['String']['input']>>
+  nameEx?: InputMaybe<Scalars['String']['input']>
+  names?: InputMaybe<Array<Scalars['String']['input']>>
+}
 
 export type ColumnStats = {
-  __typename?: 'ColumnStats';
-  avg?: Maybe<Scalars['Float']['output']>;
-  checkedCount?: Maybe<Scalars['Int']['output']>;
-  checkedPercentage?: Maybe<Scalars['Float']['output']>;
-  columnName: Scalars['String']['output'];
-  count?: Maybe<Scalars['Float']['output']>;
-  distribution?: Maybe<Scalars['JSON']['output']>;
-  max?: Maybe<Scalars['Float']['output']>;
-  min?: Maybe<Scalars['Float']['output']>;
-  notCheckedCount?: Maybe<Scalars['Int']['output']>;
-  notCheckedPercentage?: Maybe<Scalars['Float']['output']>;
-  percentageFilled?: Maybe<Scalars['Float']['output']>;
-  percentageNotFilled?: Maybe<Scalars['Float']['output']>;
-  sum?: Maybe<Scalars['Float']['output']>;
-  valueFilledCount?: Maybe<Scalars['Int']['output']>;
-  valueNotFilledCount?: Maybe<Scalars['Int']['output']>;
-};
+  __typename?: 'ColumnStats'
+  avg?: Maybe<Scalars['Float']['output']>
+  checkedCount?: Maybe<Scalars['Int']['output']>
+  checkedPercentage?: Maybe<Scalars['Float']['output']>
+  columnName: Scalars['String']['output']
+  count?: Maybe<Scalars['Float']['output']>
+  distribution?: Maybe<Scalars['JSON']['output']>
+  max?: Maybe<Scalars['Float']['output']>
+  min?: Maybe<Scalars['Float']['output']>
+  notCheckedCount?: Maybe<Scalars['Int']['output']>
+  notCheckedPercentage?: Maybe<Scalars['Float']['output']>
+  percentageFilled?: Maybe<Scalars['Float']['output']>
+  percentageNotFilled?: Maybe<Scalars['Float']['output']>
+  sum?: Maybe<Scalars['Float']['output']>
+  valueFilledCount?: Maybe<Scalars['Int']['output']>
+  valueNotFilledCount?: Maybe<Scalars['Int']['output']>
+}
 
 export type EntityComment = {
-  __typename?: 'EntityComment';
-  activityId: Scalars['String']['output'];
-  author?: Maybe<Scalars['String']['output']>;
-  body: Scalars['String']['output'];
-  createdAt: Scalars['String']['output'];
-};
+  __typename?: 'EntityComment'
+  activityId: Scalars['String']['output']
+  author?: Maybe<Scalars['String']['output']>
+  body: Scalars['String']['output']
+  createdAt: Scalars['String']['output']
+}
 
 export type EntityListEdge = {
-  __typename?: 'EntityListEdge';
-  cursor?: Maybe<Scalars['String']['output']>;
-  node: EntityListNode;
-};
+  __typename?: 'EntityListEdge'
+  cursor?: Maybe<Scalars['String']['output']>
+  node: EntityListNode
+}
 
 export type EntityListItemEdge = {
-  __typename?: 'EntityListItemEdge';
-  Entity?: Maybe<BaseNode>;
-  Forbidden: Scalars['Boolean']['output'];
-  allAttrib: Scalars['String']['output'];
-  attrib: Scalars['String']['output'];
-  createdAt: Scalars['DateTime']['output'];
-  createdBy?: Maybe<Scalars['String']['output']>;
-  cursor?: Maybe<Scalars['String']['output']>;
-  data: Scalars['String']['output'];
-  entityId: Scalars['String']['output'];
-  entityType: Scalars['String']['output'];
-  folderPath: Scalars['String']['output'];
-  id: Scalars['String']['output'];
+  __typename?: 'EntityListItemEdge'
+  Entity?: Maybe<BaseNode>
+  Forbidden: Scalars['Boolean']['output']
+  allAttrib: Scalars['String']['output']
+  attrib: Scalars['String']['output']
+  createdAt: Scalars['DateTime']['output']
+  createdBy?: Maybe<Scalars['String']['output']>
+  cursor?: Maybe<Scalars['String']['output']>
+  data: Scalars['String']['output']
+  entityId: Scalars['String']['output']
+  entityType: Scalars['String']['output']
+  folderPath: Scalars['String']['output']
+  id: Scalars['String']['output']
   /** Item node */
-  node?: Maybe<BaseNode>;
-  ownAttrib: Array<Scalars['String']['output']>;
-  position: Scalars['Int']['output'];
-  projectName: Scalars['String']['output'];
-  tags: Array<Scalars['String']['output']>;
-  updatedAt: Scalars['DateTime']['output'];
-  updatedBy?: Maybe<Scalars['String']['output']>;
-};
+  node?: Maybe<BaseNode>
+  ownAttrib: Array<Scalars['String']['output']>
+  position: Scalars['Int']['output']
+  projectName: Scalars['String']['output']
+  tags: Array<Scalars['String']['output']>
+  updatedAt: Scalars['DateTime']['output']
+  updatedBy?: Maybe<Scalars['String']['output']>
+}
 
 export type EntityListItemsConnection = {
-  __typename?: 'EntityListItemsConnection';
-  edges: Array<EntityListItemEdge>;
-  fieldStats: Array<ColumnStats>;
+  __typename?: 'EntityListItemsConnection'
+  edges: Array<EntityListItemEdge>
+  fieldStats: Array<ColumnStats>
   /** Pagination information */
-  pageInfo: PageInfo;
-};
+  pageInfo: PageInfo
+}
 
 export type EntityListNode = {
-  __typename?: 'EntityListNode';
-  access: Scalars['String']['output'];
-  accessLevel: Scalars['Int']['output'];
-  active: Scalars['Boolean']['output'];
-  allAttrib: Scalars['String']['output'];
-  attributes: Scalars['String']['output'];
-  count: Scalars['Int']['output'];
-  createdAt: Scalars['DateTime']['output'];
-  createdBy?: Maybe<Scalars['String']['output']>;
-  data: Scalars['String']['output'];
-  entityListFolderId?: Maybe<Scalars['String']['output']>;
-  entityListType: Scalars['String']['output'];
-  entityType: Scalars['String']['output'];
-  id: Scalars['String']['output'];
-  items: EntityListItemsConnection;
-  label: Scalars['String']['output'];
-  owner?: Maybe<Scalars['String']['output']>;
-  projectName: Scalars['String']['output'];
-  tags: Array<Scalars['String']['output']>;
-  updatedAt: Scalars['DateTime']['output'];
-  updatedBy?: Maybe<Scalars['String']['output']>;
-};
-
+  __typename?: 'EntityListNode'
+  access: Scalars['String']['output']
+  accessLevel: Scalars['Int']['output']
+  active: Scalars['Boolean']['output']
+  allAttrib: Scalars['String']['output']
+  attributes: Scalars['String']['output']
+  count: Scalars['Int']['output']
+  createdAt: Scalars['DateTime']['output']
+  createdBy?: Maybe<Scalars['String']['output']>
+  data: Scalars['String']['output']
+  entityListFolderId?: Maybe<Scalars['String']['output']>
+  entityListType: Scalars['String']['output']
+  entityType: Scalars['String']['output']
+  id: Scalars['String']['output']
+  items: EntityListItemsConnection
+  label: Scalars['String']['output']
+  owner?: Maybe<Scalars['String']['output']>
+  projectName: Scalars['String']['output']
+  tags: Array<Scalars['String']['output']>
+  updatedAt: Scalars['DateTime']['output']
+  updatedBy?: Maybe<Scalars['String']['output']>
+}
 
 export type EntityListNodeItemsArgs = {
-  accessibleOnly?: Scalars['Boolean']['input'];
-  after?: InputMaybe<Scalars['String']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  calculateSpecificStatistics?: InputMaybe<Array<MetricTargetInput>>;
-  calculateStatistics?: Scalars['Boolean']['input'];
-  filter?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
-  sortBy?: InputMaybe<Scalars['String']['input']>;
-};
+  accessibleOnly?: Scalars['Boolean']['input']
+  after?: InputMaybe<Scalars['String']['input']>
+  before?: InputMaybe<Scalars['String']['input']>
+  calculateSpecificStatistics?: InputMaybe<Array<MetricTargetInput>>
+  calculateStatistics?: Scalars['Boolean']['input']
+  filter?: InputMaybe<Scalars['String']['input']>
+  first?: InputMaybe<Scalars['Int']['input']>
+  last?: InputMaybe<Scalars['Int']['input']>
+  sortBy?: InputMaybe<Scalars['String']['input']>
+}
 
 export type EntityListsConnection = {
-  __typename?: 'EntityListsConnection';
-  edges: Array<EntityListEdge>;
-  fieldStats: Array<ColumnStats>;
+  __typename?: 'EntityListsConnection'
+  edges: Array<EntityListEdge>
+  fieldStats: Array<ColumnStats>
   /** Pagination information */
-  pageInfo: PageInfo;
-};
+  pageInfo: PageInfo
+}
 
 export type EventEdge = {
-  __typename?: 'EventEdge';
-  cursor?: Maybe<Scalars['String']['output']>;
-  node: EventNode;
-};
+  __typename?: 'EventEdge'
+  cursor?: Maybe<Scalars['String']['output']>
+  node: EventNode
+}
 
 export type EventNode = {
-  __typename?: 'EventNode';
-  createdAt: Scalars['DateTime']['output'];
-  data?: Maybe<Scalars['String']['output']>;
-  dependsOn?: Maybe<Scalars['String']['output']>;
-  description: Scalars['String']['output'];
-  hash: Scalars['String']['output'];
-  id: Scalars['String']['output'];
-  payload?: Maybe<Scalars['String']['output']>;
-  project?: Maybe<Scalars['String']['output']>;
-  retries: Scalars['Int']['output'];
-  sender?: Maybe<Scalars['String']['output']>;
-  status: Scalars['String']['output'];
-  summary: Scalars['String']['output'];
-  topic: Scalars['String']['output'];
-  updatedAt: Scalars['DateTime']['output'];
-  user?: Maybe<Scalars['String']['output']>;
-};
+  __typename?: 'EventNode'
+  createdAt: Scalars['DateTime']['output']
+  data?: Maybe<Scalars['String']['output']>
+  dependsOn?: Maybe<Scalars['String']['output']>
+  description: Scalars['String']['output']
+  hash: Scalars['String']['output']
+  id: Scalars['String']['output']
+  payload?: Maybe<Scalars['String']['output']>
+  project?: Maybe<Scalars['String']['output']>
+  retries: Scalars['Int']['output']
+  sender?: Maybe<Scalars['String']['output']>
+  status: Scalars['String']['output']
+  summary: Scalars['String']['output']
+  topic: Scalars['String']['output']
+  updatedAt: Scalars['DateTime']['output']
+  user?: Maybe<Scalars['String']['output']>
+}
 
 export type EventsConnection = {
-  __typename?: 'EventsConnection';
-  edges: Array<EventEdge>;
-  fieldStats: Array<ColumnStats>;
+  __typename?: 'EventsConnection'
+  edges: Array<EventEdge>
+  fieldStats: Array<ColumnStats>
   /** Pagination information */
-  pageInfo: PageInfo;
-};
+  pageInfo: PageInfo
+}
 
 export type FileNode = {
-  __typename?: 'FileNode';
-  hash?: Maybe<Scalars['String']['output']>;
-  hashType: Scalars['String']['output'];
-  id: Scalars['String']['output'];
-  name: Scalars['String']['output'];
-  path: Scalars['String']['output'];
-  size: Scalars['String']['output'];
-};
+  __typename?: 'FileNode'
+  hash?: Maybe<Scalars['String']['output']>
+  hashType: Scalars['String']['output']
+  id: Scalars['String']['output']
+  name: Scalars['String']['output']
+  path: Scalars['String']['output']
+  size: Scalars['String']['output']
+}
 
 export type FolderAttribType = {
-  __typename?: 'FolderAttribType';
-  clipIn?: Maybe<Scalars['Int']['output']>;
-  clipOut?: Maybe<Scalars['Int']['output']>;
+  __typename?: 'FolderAttribType'
+  clipIn?: Maybe<Scalars['Int']['output']>
+  clipOut?: Maybe<Scalars['Int']['output']>
   /** Textual description of the entity */
-  description?: Maybe<Scalars['String']['output']>;
+  description?: Maybe<Scalars['String']['output']>
   /** Deadline date and time */
-  endDate?: Maybe<Scalars['DateTime']['output']>;
+  endDate?: Maybe<Scalars['DateTime']['output']>
   /** Frame rate */
-  fps?: Maybe<Scalars['Float']['output']>;
-  frameEnd?: Maybe<Scalars['Int']['output']>;
-  frameStart?: Maybe<Scalars['Int']['output']>;
-  handleEnd?: Maybe<Scalars['Int']['output']>;
-  handleStart?: Maybe<Scalars['Int']['output']>;
-  pixelAspect?: Maybe<Scalars['Float']['output']>;
-  priority?: Maybe<Scalars['String']['output']>;
+  fps?: Maybe<Scalars['Float']['output']>
+  frameEnd?: Maybe<Scalars['Int']['output']>
+  frameStart?: Maybe<Scalars['Int']['output']>
+  handleEnd?: Maybe<Scalars['Int']['output']>
+  handleStart?: Maybe<Scalars['Int']['output']>
+  pixelAspect?: Maybe<Scalars['Float']['output']>
+  priority?: Maybe<Scalars['String']['output']>
   /** Vertical resolution */
-  resolutionHeight?: Maybe<Scalars['Int']['output']>;
+  resolutionHeight?: Maybe<Scalars['Int']['output']>
   /** Horizontal resolution */
-  resolutionWidth?: Maybe<Scalars['Int']['output']>;
+  resolutionWidth?: Maybe<Scalars['Int']['output']>
   /** Date and time when the project or task or asset was started */
-  startDate?: Maybe<Scalars['DateTime']['output']>;
-};
+  startDate?: Maybe<Scalars['DateTime']['output']>
+}
 
 export type FolderEdge = {
-  __typename?: 'FolderEdge';
-  cursor?: Maybe<Scalars['String']['output']>;
-  node: FolderNode;
-};
+  __typename?: 'FolderEdge'
+  cursor?: Maybe<Scalars['String']['output']>
+  node: FolderNode
+}
 
 export type FolderNode = BaseNode & {
-  __typename?: 'FolderNode';
-  active: Scalars['Boolean']['output'];
-  activities: ActivitiesConnection;
-  allAttrib: Scalars['String']['output'];
-  attrib: FolderAttribType;
-  childCount: Scalars['Int']['output'];
-  createdAt: Scalars['DateTime']['output'];
-  createdBy?: Maybe<Scalars['String']['output']>;
-  data?: Maybe<Scalars['String']['output']>;
-  folderType: Scalars['String']['output'];
-  hasChildren: Scalars['Boolean']['output'];
-  hasProducts: Scalars['Boolean']['output'];
-  hasReviewables: Scalars['Boolean']['output'];
-  hasTasks: Scalars['Boolean']['output'];
-  hasVersions: Scalars['Boolean']['output'];
-  id: Scalars['String']['output'];
-  label?: Maybe<Scalars['String']['output']>;
-  latestComments?: Maybe<Array<EntityComment>>;
-  links: LinksConnection;
-  name: Scalars['String']['output'];
-  ownAttrib: Array<Scalars['String']['output']>;
-  parent?: Maybe<FolderNode>;
-  parentId?: Maybe<Scalars['String']['output']>;
-  parents: Array<Scalars['String']['output']>;
-  path?: Maybe<Scalars['String']['output']>;
-  productCount: Scalars['Int']['output'];
+  __typename?: 'FolderNode'
+  active: Scalars['Boolean']['output']
+  activities: ActivitiesConnection
+  allAttrib: Scalars['String']['output']
+  attrib: FolderAttribType
+  childCount: Scalars['Int']['output']
+  createdAt: Scalars['DateTime']['output']
+  createdBy?: Maybe<Scalars['String']['output']>
+  data?: Maybe<Scalars['String']['output']>
+  folderType: Scalars['String']['output']
+  hasChildren: Scalars['Boolean']['output']
+  hasProducts: Scalars['Boolean']['output']
+  hasReviewables: Scalars['Boolean']['output']
+  hasTasks: Scalars['Boolean']['output']
+  hasVersions: Scalars['Boolean']['output']
+  id: Scalars['String']['output']
+  label?: Maybe<Scalars['String']['output']>
+  latestComments?: Maybe<Array<EntityComment>>
+  links: LinksConnection
+  name: Scalars['String']['output']
+  ownAttrib: Array<Scalars['String']['output']>
+  parent?: Maybe<FolderNode>
+  parentId?: Maybe<Scalars['String']['output']>
+  parents: Array<Scalars['String']['output']>
+  path?: Maybe<Scalars['String']['output']>
+  productCount: Scalars['Int']['output']
   /** Return a list of products. */
-  products: ProductsConnection;
-  projectName: Scalars['String']['output'];
-  status: Scalars['String']['output'];
-  tags: Array<Scalars['String']['output']>;
-  taskCount: Scalars['Int']['output'];
+  products: ProductsConnection
+  projectName: Scalars['String']['output']
+  status: Scalars['String']['output']
+  tags: Array<Scalars['String']['output']>
+  taskCount: Scalars['Int']['output']
   /** Return a list of tasks. */
-  tasks: TasksConnection;
-  thumbnail?: Maybe<ThumbnailInfo>;
-  thumbnailHash: Scalars['String']['output'];
-  thumbnailId?: Maybe<Scalars['String']['output']>;
-  totalFolderCount: Scalars['Int']['output'];
-  totalProductCount: Scalars['Int']['output'];
-  totalTaskCount: Scalars['Int']['output'];
-  totalVersionCount: Scalars['Int']['output'];
-  type: Scalars['String']['output'];
-  updatedAt: Scalars['DateTime']['output'];
-  updatedBy?: Maybe<Scalars['String']['output']>;
-};
-
+  tasks: TasksConnection
+  thumbnail?: Maybe<ThumbnailInfo>
+  thumbnailHash: Scalars['String']['output']
+  thumbnailId?: Maybe<Scalars['String']['output']>
+  totalFolderCount: Scalars['Int']['output']
+  totalProductCount: Scalars['Int']['output']
+  totalTaskCount: Scalars['Int']['output']
+  totalVersionCount: Scalars['Int']['output']
+  type: Scalars['String']['output']
+  updatedAt: Scalars['DateTime']['output']
+  updatedBy?: Maybe<Scalars['String']['output']>
+}
 
 export type FolderNodeActivitiesArgs = {
-  activityTypes?: InputMaybe<Array<Scalars['String']['input']>>;
-  after?: InputMaybe<Scalars['String']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
-  referenceTypes?: InputMaybe<Array<Scalars['String']['input']>>;
-};
-
+  activityTypes?: InputMaybe<Array<Scalars['String']['input']>>
+  after?: InputMaybe<Scalars['String']['input']>
+  before?: InputMaybe<Scalars['String']['input']>
+  first?: InputMaybe<Scalars['Int']['input']>
+  last?: InputMaybe<Scalars['Int']['input']>
+  referenceTypes?: InputMaybe<Array<Scalars['String']['input']>>
+}
 
 export type FolderNodeLinksArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  direction?: InputMaybe<Scalars['String']['input']>;
-  first?: Scalars['Int']['input'];
-  linkTypes?: InputMaybe<Array<Scalars['String']['input']>>;
-  nameEx?: InputMaybe<Scalars['String']['input']>;
-  names?: InputMaybe<Array<Scalars['String']['input']>>;
-};
-
+  after?: InputMaybe<Scalars['String']['input']>
+  direction?: InputMaybe<Scalars['String']['input']>
+  first?: Scalars['Int']['input']
+  linkTypes?: InputMaybe<Array<Scalars['String']['input']>>
+  nameEx?: InputMaybe<Scalars['String']['input']>
+  names?: InputMaybe<Array<Scalars['String']['input']>>
+}
 
 export type FolderNodeProductsArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  calculateSpecificStatistics?: InputMaybe<Array<MetricTargetInput>>;
-  calculateStatistics?: Scalars['Boolean']['input'];
-  filter?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  folderIds?: InputMaybe<Array<Scalars['String']['input']>>;
-  hasLinks?: InputMaybe<HasLinksFilter>;
-  ids?: InputMaybe<Array<Scalars['String']['input']>>;
-  includeFolderChildren?: Scalars['Boolean']['input'];
-  last?: InputMaybe<Scalars['Int']['input']>;
-  nameEx?: InputMaybe<Scalars['String']['input']>;
-  names?: InputMaybe<Array<Scalars['String']['input']>>;
-  namesCi?: InputMaybe<Array<Scalars['String']['input']>>;
-  pathEx?: InputMaybe<Scalars['String']['input']>;
-  productBaseTypes?: InputMaybe<Array<Scalars['String']['input']>>;
-  productTypes?: InputMaybe<Array<Scalars['String']['input']>>;
-  search?: InputMaybe<Scalars['String']['input']>;
-  sortBy?: InputMaybe<Scalars['String']['input']>;
-  statuses?: InputMaybe<Array<Scalars['String']['input']>>;
-  tags?: InputMaybe<Array<Scalars['String']['input']>>;
-  taskFilter?: InputMaybe<Scalars['String']['input']>;
-  versionFilter?: InputMaybe<Scalars['String']['input']>;
-};
-
+  after?: InputMaybe<Scalars['String']['input']>
+  before?: InputMaybe<Scalars['String']['input']>
+  calculateSpecificStatistics?: InputMaybe<Array<MetricTargetInput>>
+  calculateStatistics?: Scalars['Boolean']['input']
+  filter?: InputMaybe<Scalars['String']['input']>
+  first?: InputMaybe<Scalars['Int']['input']>
+  folderIds?: InputMaybe<Array<Scalars['String']['input']>>
+  hasLinks?: InputMaybe<HasLinksFilter>
+  ids?: InputMaybe<Array<Scalars['String']['input']>>
+  includeFolderChildren?: Scalars['Boolean']['input']
+  last?: InputMaybe<Scalars['Int']['input']>
+  nameEx?: InputMaybe<Scalars['String']['input']>
+  names?: InputMaybe<Array<Scalars['String']['input']>>
+  namesCi?: InputMaybe<Array<Scalars['String']['input']>>
+  pathEx?: InputMaybe<Scalars['String']['input']>
+  productBaseTypes?: InputMaybe<Array<Scalars['String']['input']>>
+  productTypes?: InputMaybe<Array<Scalars['String']['input']>>
+  search?: InputMaybe<Scalars['String']['input']>
+  sortBy?: InputMaybe<Scalars['String']['input']>
+  statuses?: InputMaybe<Array<Scalars['String']['input']>>
+  tags?: InputMaybe<Array<Scalars['String']['input']>>
+  taskFilter?: InputMaybe<Scalars['String']['input']>
+  versionFilter?: InputMaybe<Scalars['String']['input']>
+}
 
 export type FolderNodeTasksArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  assignees?: InputMaybe<Array<Scalars['String']['input']>>;
-  assigneesAny?: InputMaybe<Array<Scalars['String']['input']>>;
-  attributes?: InputMaybe<Array<AttributeFilterInput>>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  calculateSpecificStatistics?: InputMaybe<Array<MetricTargetInput>>;
-  calculateStatistics?: Scalars['Boolean']['input'];
-  filter?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  folderFilter?: InputMaybe<Scalars['String']['input']>;
-  folderIds?: InputMaybe<Array<Scalars['String']['input']>>;
-  hasLinks?: InputMaybe<HasLinksFilter>;
-  ids?: InputMaybe<Array<Scalars['String']['input']>>;
-  includeFolderChildren?: Scalars['Boolean']['input'];
-  last?: InputMaybe<Scalars['Int']['input']>;
-  names?: InputMaybe<Array<Scalars['String']['input']>>;
-  search?: InputMaybe<Scalars['String']['input']>;
-  sortBy?: InputMaybe<Scalars['String']['input']>;
-  statuses?: InputMaybe<Array<Scalars['String']['input']>>;
-  tags?: InputMaybe<Array<Scalars['String']['input']>>;
-  tagsAny?: InputMaybe<Array<Scalars['String']['input']>>;
-  taskTypes?: InputMaybe<Array<Scalars['String']['input']>>;
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  assignees?: InputMaybe<Array<Scalars['String']['input']>>
+  assigneesAny?: InputMaybe<Array<Scalars['String']['input']>>
+  attributes?: InputMaybe<Array<AttributeFilterInput>>
+  before?: InputMaybe<Scalars['String']['input']>
+  calculateSpecificStatistics?: InputMaybe<Array<MetricTargetInput>>
+  calculateStatistics?: Scalars['Boolean']['input']
+  filter?: InputMaybe<Scalars['String']['input']>
+  first?: InputMaybe<Scalars['Int']['input']>
+  folderFilter?: InputMaybe<Scalars['String']['input']>
+  folderIds?: InputMaybe<Array<Scalars['String']['input']>>
+  hasLinks?: InputMaybe<HasLinksFilter>
+  ids?: InputMaybe<Array<Scalars['String']['input']>>
+  includeFolderChildren?: Scalars['Boolean']['input']
+  last?: InputMaybe<Scalars['Int']['input']>
+  names?: InputMaybe<Array<Scalars['String']['input']>>
+  search?: InputMaybe<Scalars['String']['input']>
+  sortBy?: InputMaybe<Scalars['String']['input']>
+  statuses?: InputMaybe<Array<Scalars['String']['input']>>
+  tags?: InputMaybe<Array<Scalars['String']['input']>>
+  tagsAny?: InputMaybe<Array<Scalars['String']['input']>>
+  taskTypes?: InputMaybe<Array<Scalars['String']['input']>>
+}
 
 export type FolderType = {
-  __typename?: 'FolderType';
-  color?: Maybe<Scalars['String']['output']>;
-  icon?: Maybe<Scalars['String']['output']>;
-  name: Scalars['String']['output'];
-  shortName?: Maybe<Scalars['String']['output']>;
-};
+  __typename?: 'FolderType'
+  color?: Maybe<Scalars['String']['output']>
+  icon?: Maybe<Scalars['String']['output']>
+  name: Scalars['String']['output']
+  shortName?: Maybe<Scalars['String']['output']>
+}
 
 export type FoldersConnection = {
-  __typename?: 'FoldersConnection';
-  edges: Array<FolderEdge>;
-  fieldStats: Array<ColumnStats>;
+  __typename?: 'FoldersConnection'
+  edges: Array<FolderEdge>
+  fieldStats: Array<ColumnStats>
   /** Pagination information */
-  pageInfo: PageInfo;
-};
+  pageInfo: PageInfo
+}
 
 export enum HasLinksFilter {
   Any = 'ANY',
   Both = 'BOTH',
   In = 'IN',
   None = 'NONE',
-  Out = 'OUT'
+  Out = 'OUT',
 }
 
 export type KanbanConnection = {
-  __typename?: 'KanbanConnection';
-  edges: Array<KanbanEdge>;
-  fieldStats: Array<ColumnStats>;
+  __typename?: 'KanbanConnection'
+  edges: Array<KanbanEdge>
+  fieldStats: Array<ColumnStats>
   /** Pagination information */
-  pageInfo: PageInfo;
-};
+  pageInfo: PageInfo
+}
 
 export type KanbanEdge = {
-  __typename?: 'KanbanEdge';
-  cursor?: Maybe<Scalars['String']['output']>;
-  node: KanbanNode;
-};
+  __typename?: 'KanbanEdge'
+  cursor?: Maybe<Scalars['String']['output']>
+  node: KanbanNode
+}
 
 export type KanbanNode = {
-  __typename?: 'KanbanNode';
-  assignees: Array<Scalars['String']['output']>;
-  createdAt: Scalars['DateTime']['output'];
-  dueDate?: Maybe<Scalars['DateTime']['output']>;
-  folderId: Scalars['String']['output'];
-  folderLabel?: Maybe<Scalars['String']['output']>;
-  folderName: Scalars['String']['output'];
-  folderPath: Scalars['String']['output'];
-  hasReviewables: Scalars['Boolean']['output'];
-  id: Scalars['String']['output'];
-  label?: Maybe<Scalars['String']['output']>;
-  lastVersionWithReviewableProductId?: Maybe<Scalars['String']['output']>;
-  lastVersionWithReviewableVersionId?: Maybe<Scalars['String']['output']>;
-  lastVersionWithThumbnailId?: Maybe<Scalars['String']['output']>;
-  name: Scalars['String']['output'];
-  priority?: Maybe<Scalars['String']['output']>;
-  projectCode: Scalars['String']['output'];
-  projectName: Scalars['String']['output'];
-  status: Scalars['String']['output'];
-  tags: Array<Scalars['String']['output']>;
-  taskType: Scalars['String']['output'];
-  thumbnail?: Maybe<ThumbnailInfo>;
-  thumbnailHash: Scalars['String']['output'];
-  thumbnailId?: Maybe<Scalars['String']['output']>;
-  updatedAt: Scalars['DateTime']['output'];
-};
+  __typename?: 'KanbanNode'
+  assignees: Array<Scalars['String']['output']>
+  createdAt: Scalars['DateTime']['output']
+  dueDate?: Maybe<Scalars['DateTime']['output']>
+  folderId: Scalars['String']['output']
+  folderLabel?: Maybe<Scalars['String']['output']>
+  folderName: Scalars['String']['output']
+  folderPath: Scalars['String']['output']
+  hasReviewables: Scalars['Boolean']['output']
+  id: Scalars['String']['output']
+  label?: Maybe<Scalars['String']['output']>
+  lastVersionWithReviewableProductId?: Maybe<Scalars['String']['output']>
+  lastVersionWithReviewableVersionId?: Maybe<Scalars['String']['output']>
+  lastVersionWithThumbnailId?: Maybe<Scalars['String']['output']>
+  name: Scalars['String']['output']
+  priority?: Maybe<Scalars['String']['output']>
+  projectCode: Scalars['String']['output']
+  projectName: Scalars['String']['output']
+  status: Scalars['String']['output']
+  tags: Array<Scalars['String']['output']>
+  taskType: Scalars['String']['output']
+  thumbnail?: Maybe<ThumbnailInfo>
+  thumbnailHash: Scalars['String']['output']
+  thumbnailId?: Maybe<Scalars['String']['output']>
+  updatedAt: Scalars['DateTime']['output']
+}
 
 export type LinkEdge = {
-  __typename?: 'LinkEdge';
-  author?: Maybe<Scalars['String']['output']>;
-  cursor?: Maybe<Scalars['String']['output']>;
-  data: Scalars['JSON']['output'];
-  description: Scalars['String']['output'];
-  direction: Scalars['String']['output'];
-  entityId: Scalars['String']['output'];
-  entityType: Scalars['String']['output'];
-  id: Scalars['String']['output'];
-  linkType: Scalars['String']['output'];
-  name?: Maybe<Scalars['String']['output']>;
+  __typename?: 'LinkEdge'
+  author?: Maybe<Scalars['String']['output']>
+  cursor?: Maybe<Scalars['String']['output']>
+  data: Scalars['JSON']['output']
+  description: Scalars['String']['output']
+  direction: Scalars['String']['output']
+  entityId: Scalars['String']['output']
+  entityType: Scalars['String']['output']
+  id: Scalars['String']['output']
+  linkType: Scalars['String']['output']
+  name?: Maybe<Scalars['String']['output']>
   /** Linked node */
-  node?: Maybe<BaseNode>;
-  projectName: Scalars['String']['output'];
-};
+  node?: Maybe<BaseNode>
+  projectName: Scalars['String']['output']
+}
 
 export type LinkType = {
-  __typename?: 'LinkType';
-  color?: Maybe<Scalars['String']['output']>;
-  inputType: Scalars['String']['output'];
-  linkType: Scalars['String']['output'];
-  name: Scalars['String']['output'];
-  outputType: Scalars['String']['output'];
-  style: Scalars['String']['output'];
-};
+  __typename?: 'LinkType'
+  color?: Maybe<Scalars['String']['output']>
+  inputType: Scalars['String']['output']
+  linkType: Scalars['String']['output']
+  name: Scalars['String']['output']
+  outputType: Scalars['String']['output']
+  style: Scalars['String']['output']
+}
 
 export type LinksConnection = {
-  __typename?: 'LinksConnection';
-  edges: Array<LinkEdge>;
+  __typename?: 'LinksConnection'
+  edges: Array<LinkEdge>
   /** Pagination information */
-  pageInfo: PageInfo;
-};
+  pageInfo: PageInfo
+}
 
 export type MetricTargetInput = {
   /** List of statistical calculations to run */
-  aggregations: Array<StatsOperation>;
+  aggregations: Array<StatsOperation>
   /** The attribute path, e.g., 'attrib.fps' */
-  field: Scalars['String']['input'];
-};
+  field: Scalars['String']['input']
+}
 
 export type PageInfo = {
-  __typename?: 'PageInfo';
-  columnMetadata?: Maybe<Array<ColumnStats>>;
-  endCursor?: Maybe<Scalars['String']['output']>;
-  hasNextPage: Scalars['Boolean']['output'];
-  hasPreviousPage: Scalars['Boolean']['output'];
-  startCursor?: Maybe<Scalars['String']['output']>;
-};
+  __typename?: 'PageInfo'
+  columnMetadata?: Maybe<Array<ColumnStats>>
+  endCursor?: Maybe<Scalars['String']['output']>
+  hasNextPage: Scalars['Boolean']['output']
+  hasPreviousPage: Scalars['Boolean']['output']
+  startCursor?: Maybe<Scalars['String']['output']>
+}
 
 export type ProductAttribType = {
-  __typename?: 'ProductAttribType';
+  __typename?: 'ProductAttribType'
   /** Textual description of the entity */
-  description?: Maybe<Scalars['String']['output']>;
-  productGroup?: Maybe<Scalars['String']['output']>;
-};
+  description?: Maybe<Scalars['String']['output']>
+  productGroup?: Maybe<Scalars['String']['output']>
+}
 
 export type ProductBaseType = {
-  __typename?: 'ProductBaseType';
-  color: Scalars['String']['output'];
-  icon: Scalars['String']['output'];
-  name: Scalars['String']['output'];
-};
+  __typename?: 'ProductBaseType'
+  color: Scalars['String']['output']
+  icon: Scalars['String']['output']
+  name: Scalars['String']['output']
+}
 
 export type ProductEdge = {
-  __typename?: 'ProductEdge';
-  cursor?: Maybe<Scalars['String']['output']>;
-  node: ProductNode;
-};
+  __typename?: 'ProductEdge'
+  cursor?: Maybe<Scalars['String']['output']>
+  node: ProductNode
+}
 
 export type ProductNode = BaseNode & {
-  __typename?: 'ProductNode';
-  Folder?: Maybe<FolderNode>;
-  active: Scalars['Boolean']['output'];
-  activities: ActivitiesConnection;
-  allAttrib: Scalars['String']['output'];
-  attrib: ProductAttribType;
-  createdAt: Scalars['DateTime']['output'];
-  createdBy?: Maybe<Scalars['String']['output']>;
-  data?: Maybe<Scalars['String']['output']>;
-  featuredVersion?: Maybe<VersionNode>;
+  __typename?: 'ProductNode'
+  Folder?: Maybe<FolderNode>
+  active: Scalars['Boolean']['output']
+  activities: ActivitiesConnection
+  allAttrib: Scalars['String']['output']
+  attrib: ProductAttribType
+  createdAt: Scalars['DateTime']['output']
+  createdBy?: Maybe<Scalars['String']['output']>
+  data?: Maybe<Scalars['String']['output']>
+  featuredVersion?: Maybe<VersionNode>
   /** Parent folder of the product */
-  folder: FolderNode;
-  folderId: Scalars['String']['output'];
-  id: Scalars['String']['output'];
+  folder: FolderNode
+  folderId: Scalars['String']['output']
+  id: Scalars['String']['output']
   /** Last version of the product */
-  latestVersion?: Maybe<VersionNode>;
-  links: LinksConnection;
-  name: Scalars['String']['output'];
-  parents: Array<Scalars['String']['output']>;
-  path?: Maybe<Scalars['String']['output']>;
-  productBaseType?: Maybe<Scalars['String']['output']>;
-  productType: Scalars['String']['output'];
-  projectName: Scalars['String']['output'];
-  status: Scalars['String']['output'];
-  tags: Array<Scalars['String']['output']>;
-  type: Scalars['String']['output'];
-  updatedAt: Scalars['DateTime']['output'];
-  updatedBy?: Maybe<Scalars['String']['output']>;
+  latestVersion?: Maybe<VersionNode>
+  links: LinksConnection
+  name: Scalars['String']['output']
+  parents: Array<Scalars['String']['output']>
+  path?: Maybe<Scalars['String']['output']>
+  productBaseType?: Maybe<Scalars['String']['output']>
+  productType: Scalars['String']['output']
+  projectName: Scalars['String']['output']
+  status: Scalars['String']['output']
+  tags: Array<Scalars['String']['output']>
+  type: Scalars['String']['output']
+  updatedAt: Scalars['DateTime']['output']
+  updatedBy?: Maybe<Scalars['String']['output']>
   /** Simple (id /version) list of versions in the product */
-  versionList: Array<VersionListItem>;
+  versionList: Array<VersionListItem>
   /** Return a list of versions. */
-  versions: VersionsConnection;
-};
-
+  versions: VersionsConnection
+}
 
 export type ProductNodeActivitiesArgs = {
-  activityTypes?: InputMaybe<Array<Scalars['String']['input']>>;
-  after?: InputMaybe<Scalars['String']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
-  referenceTypes?: InputMaybe<Array<Scalars['String']['input']>>;
-};
-
+  activityTypes?: InputMaybe<Array<Scalars['String']['input']>>
+  after?: InputMaybe<Scalars['String']['input']>
+  before?: InputMaybe<Scalars['String']['input']>
+  first?: InputMaybe<Scalars['Int']['input']>
+  last?: InputMaybe<Scalars['Int']['input']>
+  referenceTypes?: InputMaybe<Array<Scalars['String']['input']>>
+}
 
 export type ProductNodeFeaturedVersionArgs = {
-  order?: InputMaybe<Array<Scalars['String']['input']>>;
-};
-
+  order?: InputMaybe<Array<Scalars['String']['input']>>
+}
 
 export type ProductNodeLinksArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  direction?: InputMaybe<Scalars['String']['input']>;
-  first?: Scalars['Int']['input'];
-  linkTypes?: InputMaybe<Array<Scalars['String']['input']>>;
-  nameEx?: InputMaybe<Scalars['String']['input']>;
-  names?: InputMaybe<Array<Scalars['String']['input']>>;
-};
-
+  after?: InputMaybe<Scalars['String']['input']>
+  direction?: InputMaybe<Scalars['String']['input']>
+  first?: Scalars['Int']['input']
+  linkTypes?: InputMaybe<Array<Scalars['String']['input']>>
+  nameEx?: InputMaybe<Scalars['String']['input']>
+  names?: InputMaybe<Array<Scalars['String']['input']>>
+}
 
 export type ProductNodeVersionsArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  authors?: InputMaybe<Array<Scalars['String']['input']>>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  calculateSpecificStatistics?: InputMaybe<Array<MetricTargetInput>>;
-  calculateStatistics?: Scalars['Boolean']['input'];
-  featuredOnly?: InputMaybe<Array<Scalars['String']['input']>>;
-  filter?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  folderIds?: InputMaybe<Array<Scalars['String']['input']>>;
-  hasLinks?: InputMaybe<HasLinksFilter>;
-  hasReviewables?: InputMaybe<Scalars['Boolean']['input']>;
-  heroOnly?: Scalars['Boolean']['input'];
-  heroOrLatestOnly?: Scalars['Boolean']['input'];
-  ids?: InputMaybe<Array<Scalars['String']['input']>>;
-  includeFolderChildren?: Scalars['Boolean']['input'];
-  last?: InputMaybe<Scalars['Int']['input']>;
-  latestOnly?: Scalars['Boolean']['input'];
-  productFilter?: InputMaybe<Scalars['String']['input']>;
-  productIds?: InputMaybe<Array<Scalars['String']['input']>>;
-  search?: InputMaybe<Scalars['String']['input']>;
-  sortBy?: InputMaybe<Scalars['String']['input']>;
-  statuses?: InputMaybe<Array<Scalars['String']['input']>>;
-  tags?: InputMaybe<Array<Scalars['String']['input']>>;
-  taskFilter?: InputMaybe<Scalars['String']['input']>;
-  taskIds?: InputMaybe<Array<Scalars['String']['input']>>;
-  version?: InputMaybe<Scalars['Int']['input']>;
-  versions?: InputMaybe<Array<Scalars['Int']['input']>>;
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  authors?: InputMaybe<Array<Scalars['String']['input']>>
+  before?: InputMaybe<Scalars['String']['input']>
+  calculateSpecificStatistics?: InputMaybe<Array<MetricTargetInput>>
+  calculateStatistics?: Scalars['Boolean']['input']
+  featuredOnly?: InputMaybe<Array<Scalars['String']['input']>>
+  filter?: InputMaybe<Scalars['String']['input']>
+  first?: InputMaybe<Scalars['Int']['input']>
+  folderIds?: InputMaybe<Array<Scalars['String']['input']>>
+  hasLinks?: InputMaybe<HasLinksFilter>
+  hasReviewables?: InputMaybe<Scalars['Boolean']['input']>
+  heroOnly?: Scalars['Boolean']['input']
+  heroOrLatestOnly?: Scalars['Boolean']['input']
+  ids?: InputMaybe<Array<Scalars['String']['input']>>
+  includeFolderChildren?: Scalars['Boolean']['input']
+  last?: InputMaybe<Scalars['Int']['input']>
+  latestOnly?: Scalars['Boolean']['input']
+  productFilter?: InputMaybe<Scalars['String']['input']>
+  productIds?: InputMaybe<Array<Scalars['String']['input']>>
+  search?: InputMaybe<Scalars['String']['input']>
+  sortBy?: InputMaybe<Scalars['String']['input']>
+  statuses?: InputMaybe<Array<Scalars['String']['input']>>
+  tags?: InputMaybe<Array<Scalars['String']['input']>>
+  taskFilter?: InputMaybe<Scalars['String']['input']>
+  taskIds?: InputMaybe<Array<Scalars['String']['input']>>
+  version?: InputMaybe<Scalars['Int']['input']>
+  versions?: InputMaybe<Array<Scalars['Int']['input']>>
+}
 
 export type ProductType = {
-  __typename?: 'ProductType';
-  color?: Maybe<Scalars['String']['output']>;
-  icon?: Maybe<Scalars['String']['output']>;
-  name: Scalars['String']['output'];
-};
+  __typename?: 'ProductType'
+  color?: Maybe<Scalars['String']['output']>
+  icon?: Maybe<Scalars['String']['output']>
+  name: Scalars['String']['output']
+}
 
 export type ProductsConnection = {
-  __typename?: 'ProductsConnection';
-  edges: Array<ProductEdge>;
-  fieldStats: Array<ColumnStats>;
+  __typename?: 'ProductsConnection'
+  edges: Array<ProductEdge>
+  fieldStats: Array<ColumnStats>
   /** Pagination information */
-  pageInfo: PageInfo;
-};
+  pageInfo: PageInfo
+}
 
 export type ProjectAttribType = {
-  __typename?: 'ProjectAttribType';
-  clipIn?: Maybe<Scalars['Int']['output']>;
-  clipOut?: Maybe<Scalars['Int']['output']>;
+  __typename?: 'ProjectAttribType'
+  clipIn?: Maybe<Scalars['Int']['output']>
+  clipOut?: Maybe<Scalars['Int']['output']>
   /** Textual description of the entity */
-  description?: Maybe<Scalars['String']['output']>;
+  description?: Maybe<Scalars['String']['output']>
   /** Deadline date and time */
-  endDate?: Maybe<Scalars['DateTime']['output']>;
+  endDate?: Maybe<Scalars['DateTime']['output']>
   /** Frame rate */
-  fps?: Maybe<Scalars['Float']['output']>;
-  frameEnd?: Maybe<Scalars['Int']['output']>;
-  frameStart?: Maybe<Scalars['Int']['output']>;
-  handleEnd?: Maybe<Scalars['Int']['output']>;
-  handleStart?: Maybe<Scalars['Int']['output']>;
-  pixelAspect?: Maybe<Scalars['Float']['output']>;
-  priority?: Maybe<Scalars['String']['output']>;
+  fps?: Maybe<Scalars['Float']['output']>
+  frameEnd?: Maybe<Scalars['Int']['output']>
+  frameStart?: Maybe<Scalars['Int']['output']>
+  handleEnd?: Maybe<Scalars['Int']['output']>
+  handleStart?: Maybe<Scalars['Int']['output']>
+  pixelAspect?: Maybe<Scalars['Float']['output']>
+  priority?: Maybe<Scalars['String']['output']>
   /** Vertical resolution */
-  resolutionHeight?: Maybe<Scalars['Int']['output']>;
+  resolutionHeight?: Maybe<Scalars['Int']['output']>
   /** Horizontal resolution */
-  resolutionWidth?: Maybe<Scalars['Int']['output']>;
+  resolutionWidth?: Maybe<Scalars['Int']['output']>
   /** Date and time when the project or task or asset was started */
-  startDate?: Maybe<Scalars['DateTime']['output']>;
-};
+  startDate?: Maybe<Scalars['DateTime']['output']>
+}
 
 export type ProjectBundleType = {
-  __typename?: 'ProjectBundleType';
-  production?: Maybe<Scalars['String']['output']>;
-  staging?: Maybe<Scalars['String']['output']>;
-};
+  __typename?: 'ProjectBundleType'
+  production?: Maybe<Scalars['String']['output']>
+  staging?: Maybe<Scalars['String']['output']>
+}
 
 export type ProjectEdge = {
-  __typename?: 'ProjectEdge';
-  cursor?: Maybe<Scalars['String']['output']>;
-  node: ProjectNode;
-};
+  __typename?: 'ProjectEdge'
+  cursor?: Maybe<Scalars['String']['output']>
+  node: ProjectNode
+}
 
 export type ProjectLinkEdge = {
-  __typename?: 'ProjectLinkEdge';
-  author?: Maybe<Scalars['String']['output']>;
-  createdAt: Scalars['DateTime']['output'];
-  cursor?: Maybe<Scalars['String']['output']>;
-  data: Scalars['JSON']['output'];
-  id: Scalars['String']['output'];
-  inputId: Scalars['String']['output'];
+  __typename?: 'ProjectLinkEdge'
+  author?: Maybe<Scalars['String']['output']>
+  createdAt: Scalars['DateTime']['output']
+  cursor?: Maybe<Scalars['String']['output']>
+  data: Scalars['JSON']['output']
+  id: Scalars['String']['output']
+  inputId: Scalars['String']['output']
   /** Input node */
-  inputNode?: Maybe<BaseNode>;
-  inputType: Scalars['String']['output'];
-  linkType: Scalars['String']['output'];
-  name?: Maybe<Scalars['String']['output']>;
-  outputId: Scalars['String']['output'];
+  inputNode?: Maybe<BaseNode>
+  inputType: Scalars['String']['output']
+  linkType: Scalars['String']['output']
+  name?: Maybe<Scalars['String']['output']>
+  outputId: Scalars['String']['output']
   /** Output node */
-  outputNode?: Maybe<BaseNode>;
-  outputType: Scalars['String']['output'];
-  projectName: Scalars['String']['output'];
-};
+  outputNode?: Maybe<BaseNode>
+  outputType: Scalars['String']['output']
+  projectName: Scalars['String']['output']
+}
 
 export type ProjectLinksConnection = {
-  __typename?: 'ProjectLinksConnection';
-  edges: Array<ProjectLinkEdge>;
+  __typename?: 'ProjectLinksConnection'
+  edges: Array<ProjectLinkEdge>
   /** Pagination information */
-  pageInfo: PageInfo;
-};
+  pageInfo: PageInfo
+}
 
 export type ProjectNode = {
-  __typename?: 'ProjectNode';
-  active: Scalars['Boolean']['output'];
-  activities: ActivitiesConnection;
-  allAttrib: Scalars['String']['output'];
-  attrib: ProjectAttribType;
-  bundle: ProjectBundleType;
-  code: Scalars['String']['output'];
-  color?: Maybe<Scalars['String']['output']>;
-  config?: Maybe<Scalars['String']['output']>;
-  createdAt: Scalars['DateTime']['output'];
-  data?: Maybe<Scalars['String']['output']>;
+  __typename?: 'ProjectNode'
+  active: Scalars['Boolean']['output']
+  activities: ActivitiesConnection
+  allAttrib: Scalars['String']['output']
+  attrib: ProjectAttribType
+  bundle: ProjectBundleType
+  code: Scalars['String']['output']
+  color?: Maybe<Scalars['String']['output']>
+  config?: Maybe<Scalars['String']['output']>
+  createdAt: Scalars['DateTime']['output']
+  data?: Maybe<Scalars['String']['output']>
   /** Return a folder node based on its ID */
-  entityList: EntityListNode;
-  entityLists: EntityListsConnection;
+  entityList: EntityListNode
+  entityLists: EntityListsConnection
   /** Return a folder node based on its ID */
-  folder?: Maybe<FolderNode>;
+  folder?: Maybe<FolderNode>
   /** List of project's folder types */
-  folderTypes: Array<FolderType>;
+  folderTypes: Array<FolderType>
   /** Return a list of folders. */
-  folders: FoldersConnection;
-  label?: Maybe<Scalars['String']['output']>;
-  library: Scalars['Boolean']['output'];
+  folders: FoldersConnection
+  label?: Maybe<Scalars['String']['output']>
+  library: Scalars['Boolean']['output']
   /** List of project's link types */
-  linkTypes: Array<LinkType>;
+  linkTypes: Array<LinkType>
   /** List all links in the project, with optional filters. */
-  links: ProjectLinksConnection;
-  name: Scalars['String']['output'];
+  links: ProjectLinksConnection
+  name: Scalars['String']['output']
   /** Return a representation node based on its ID */
-  product?: Maybe<ProductNode>;
+  product?: Maybe<ProductNode>
   /** List of project's product base types */
-  productBaseTypes: Array<ProductBaseType>;
+  productBaseTypes: Array<ProductBaseType>
   /** List of project's product types */
-  productTypes: Array<ProductType>;
+  productTypes: Array<ProductType>
   /** Return a list of products. */
-  products: ProductsConnection;
-  projectFolder?: Maybe<Scalars['String']['output']>;
-  projectName: Scalars['String']['output'];
+  products: ProductsConnection
+  projectFolder?: Maybe<Scalars['String']['output']>
+  projectName: Scalars['String']['output']
   /** Return a representation node based on its ID */
-  representation?: Maybe<RepresentationNode>;
+  representation?: Maybe<RepresentationNode>
   /** Return a list of representations. */
-  representations: RepresentationsConnection;
-  skeleton: Scalars['Boolean']['output'];
+  representations: RepresentationsConnection
+  skeleton: Scalars['Boolean']['output']
   /** List of project's statuses */
-  statuses: Array<Status>;
+  statuses: Array<Status>
   /** List of tags in the project */
-  tags: Array<Tag>;
+  tags: Array<Tag>
   /** Return a task node based on its ID */
-  task?: Maybe<TaskNode>;
+  task?: Maybe<TaskNode>
   /** List of project's task types */
-  taskTypes: Array<TaskType>;
+  taskTypes: Array<TaskType>
   /** Return a list of tasks. */
-  tasks: TasksConnection;
-  thumbnail?: Maybe<ThumbnailInfo>;
-  updatedAt: Scalars['DateTime']['output'];
+  tasks: TasksConnection
+  thumbnail?: Maybe<ThumbnailInfo>
+  updatedAt: Scalars['DateTime']['output']
   /** List of tags used in the project */
-  usedTags: Array<Scalars['String']['output']>;
+  usedTags: Array<Scalars['String']['output']>
   /** Return a task node based on its ID */
-  version?: Maybe<VersionNode>;
+  version?: Maybe<VersionNode>
   /** Return a list of versions. */
-  versions: VersionsConnection;
+  versions: VersionsConnection
   /** Return a task node based on its ID */
-  workfile?: Maybe<WorkfileNode>;
+  workfile?: Maybe<WorkfileNode>
   /** Return a list of workfiles. */
-  workfiles: WorkfilesConnection;
-};
-
+  workfiles: WorkfilesConnection
+}
 
 export type ProjectNodeActivitiesArgs = {
-  activityIds?: InputMaybe<Array<Scalars['String']['input']>>;
-  activityTypes?: InputMaybe<Array<Scalars['String']['input']>>;
-  after?: InputMaybe<Scalars['String']['input']>;
-  authors?: InputMaybe<Array<Scalars['String']['input']>>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  categories?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
-  changedAfter?: InputMaybe<Scalars['String']['input']>;
-  changedBefore?: InputMaybe<Scalars['String']['input']>;
-  entityIds?: InputMaybe<Array<Scalars['String']['input']>>;
-  entityNames?: InputMaybe<Array<Scalars['String']['input']>>;
-  entityType?: InputMaybe<Scalars['String']['input']>;
-  filter?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
-  referenceTypes?: InputMaybe<Array<Scalars['String']['input']>>;
-  tags?: InputMaybe<Array<Scalars['String']['input']>>;
-};
-
+  activityIds?: InputMaybe<Array<Scalars['String']['input']>>
+  activityTypes?: InputMaybe<Array<Scalars['String']['input']>>
+  after?: InputMaybe<Scalars['String']['input']>
+  authors?: InputMaybe<Array<Scalars['String']['input']>>
+  before?: InputMaybe<Scalars['String']['input']>
+  categories?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>
+  changedAfter?: InputMaybe<Scalars['String']['input']>
+  changedBefore?: InputMaybe<Scalars['String']['input']>
+  entityIds?: InputMaybe<Array<Scalars['String']['input']>>
+  entityNames?: InputMaybe<Array<Scalars['String']['input']>>
+  entityType?: InputMaybe<Scalars['String']['input']>
+  filter?: InputMaybe<Scalars['String']['input']>
+  first?: InputMaybe<Scalars['Int']['input']>
+  last?: InputMaybe<Scalars['Int']['input']>
+  referenceTypes?: InputMaybe<Array<Scalars['String']['input']>>
+  tags?: InputMaybe<Array<Scalars['String']['input']>>
+}
 
 export type ProjectNodeEntityListArgs = {
-  id: Scalars['String']['input'];
-};
-
+  id: Scalars['String']['input']
+}
 
 export type ProjectNodeEntityListsArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  filter?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  ids?: InputMaybe<Array<Scalars['String']['input']>>;
-  last?: InputMaybe<Scalars['Int']['input']>;
-  sortBy?: InputMaybe<Scalars['String']['input']>;
-};
-
+  after?: InputMaybe<Scalars['String']['input']>
+  before?: InputMaybe<Scalars['String']['input']>
+  filter?: InputMaybe<Scalars['String']['input']>
+  first?: InputMaybe<Scalars['Int']['input']>
+  ids?: InputMaybe<Array<Scalars['String']['input']>>
+  last?: InputMaybe<Scalars['Int']['input']>
+  sortBy?: InputMaybe<Scalars['String']['input']>
+}
 
 export type ProjectNodeFolderArgs = {
-  id: Scalars['String']['input'];
-};
-
+  id: Scalars['String']['input']
+}
 
 export type ProjectNodeFolderTypesArgs = {
-  activeOnly?: Scalars['Boolean']['input'];
-};
-
+  activeOnly?: Scalars['Boolean']['input']
+}
 
 export type ProjectNodeFoldersArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  assignees?: InputMaybe<Array<Scalars['String']['input']>>;
-  attributes?: InputMaybe<Array<AttributeFilterInput>>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  calculateSpecificStatistics?: InputMaybe<Array<MetricTargetInput>>;
-  calculateStatistics?: Scalars['Boolean']['input'];
-  filter?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  folderTypes?: InputMaybe<Array<Scalars['String']['input']>>;
-  hasChildren?: InputMaybe<Scalars['Boolean']['input']>;
-  hasLinks?: InputMaybe<HasLinksFilter>;
-  hasProducts?: InputMaybe<Scalars['Boolean']['input']>;
-  hasTasks?: InputMaybe<Scalars['Boolean']['input']>;
-  ids?: InputMaybe<Array<Scalars['String']['input']>>;
-  last?: InputMaybe<Scalars['Int']['input']>;
-  name?: InputMaybe<Scalars['String']['input']>;
-  names?: InputMaybe<Array<Scalars['String']['input']>>;
-  parentId?: InputMaybe<Scalars['String']['input']>;
-  parentIds?: InputMaybe<Array<Scalars['String']['input']>>;
-  pathEx?: InputMaybe<Scalars['String']['input']>;
-  paths?: InputMaybe<Array<Scalars['String']['input']>>;
-  search?: InputMaybe<Scalars['String']['input']>;
-  sortBy?: InputMaybe<Scalars['String']['input']>;
-  statuses?: InputMaybe<Array<Scalars['String']['input']>>;
-  tags?: InputMaybe<Array<Scalars['String']['input']>>;
-  taskFilter?: InputMaybe<Scalars['String']['input']>;
-};
-
+  after?: InputMaybe<Scalars['String']['input']>
+  assignees?: InputMaybe<Array<Scalars['String']['input']>>
+  attributes?: InputMaybe<Array<AttributeFilterInput>>
+  before?: InputMaybe<Scalars['String']['input']>
+  calculateSpecificStatistics?: InputMaybe<Array<MetricTargetInput>>
+  calculateStatistics?: Scalars['Boolean']['input']
+  filter?: InputMaybe<Scalars['String']['input']>
+  first?: InputMaybe<Scalars['Int']['input']>
+  folderTypes?: InputMaybe<Array<Scalars['String']['input']>>
+  hasChildren?: InputMaybe<Scalars['Boolean']['input']>
+  hasLinks?: InputMaybe<HasLinksFilter>
+  hasProducts?: InputMaybe<Scalars['Boolean']['input']>
+  hasTasks?: InputMaybe<Scalars['Boolean']['input']>
+  ids?: InputMaybe<Array<Scalars['String']['input']>>
+  last?: InputMaybe<Scalars['Int']['input']>
+  name?: InputMaybe<Scalars['String']['input']>
+  names?: InputMaybe<Array<Scalars['String']['input']>>
+  parentId?: InputMaybe<Scalars['String']['input']>
+  parentIds?: InputMaybe<Array<Scalars['String']['input']>>
+  pathEx?: InputMaybe<Scalars['String']['input']>
+  paths?: InputMaybe<Array<Scalars['String']['input']>>
+  search?: InputMaybe<Scalars['String']['input']>
+  sortBy?: InputMaybe<Scalars['String']['input']>
+  statuses?: InputMaybe<Array<Scalars['String']['input']>>
+  tags?: InputMaybe<Array<Scalars['String']['input']>>
+  taskFilter?: InputMaybe<Scalars['String']['input']>
+}
 
 export type ProjectNodeLinkTypesArgs = {
-  activeOnly?: Scalars['Boolean']['input'];
-};
-
+  activeOnly?: Scalars['Boolean']['input']
+}
 
 export type ProjectNodeLinksArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  entityIds?: InputMaybe<Array<Scalars['String']['input']>>;
-  first?: Scalars['Int']['input'];
-  ids?: InputMaybe<Array<Scalars['String']['input']>>;
-  inputIds?: InputMaybe<Array<Scalars['String']['input']>>;
-  inputTypes?: InputMaybe<Array<Scalars['String']['input']>>;
-  linkTypes?: InputMaybe<Array<Scalars['String']['input']>>;
-  nameEx?: InputMaybe<Scalars['String']['input']>;
-  names?: InputMaybe<Array<Scalars['String']['input']>>;
-  outputIds?: InputMaybe<Array<Scalars['String']['input']>>;
-  outputTypes?: InputMaybe<Array<Scalars['String']['input']>>;
-};
-
+  after?: InputMaybe<Scalars['String']['input']>
+  entityIds?: InputMaybe<Array<Scalars['String']['input']>>
+  first?: Scalars['Int']['input']
+  ids?: InputMaybe<Array<Scalars['String']['input']>>
+  inputIds?: InputMaybe<Array<Scalars['String']['input']>>
+  inputTypes?: InputMaybe<Array<Scalars['String']['input']>>
+  linkTypes?: InputMaybe<Array<Scalars['String']['input']>>
+  nameEx?: InputMaybe<Scalars['String']['input']>
+  names?: InputMaybe<Array<Scalars['String']['input']>>
+  outputIds?: InputMaybe<Array<Scalars['String']['input']>>
+  outputTypes?: InputMaybe<Array<Scalars['String']['input']>>
+}
 
 export type ProjectNodeProductArgs = {
-  id: Scalars['String']['input'];
-};
-
+  id: Scalars['String']['input']
+}
 
 export type ProjectNodeProductsArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  calculateSpecificStatistics?: InputMaybe<Array<MetricTargetInput>>;
-  calculateStatistics?: Scalars['Boolean']['input'];
-  filter?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  folderIds?: InputMaybe<Array<Scalars['String']['input']>>;
-  hasLinks?: InputMaybe<HasLinksFilter>;
-  ids?: InputMaybe<Array<Scalars['String']['input']>>;
-  includeFolderChildren?: Scalars['Boolean']['input'];
-  last?: InputMaybe<Scalars['Int']['input']>;
-  nameEx?: InputMaybe<Scalars['String']['input']>;
-  names?: InputMaybe<Array<Scalars['String']['input']>>;
-  namesCi?: InputMaybe<Array<Scalars['String']['input']>>;
-  pathEx?: InputMaybe<Scalars['String']['input']>;
-  productBaseTypes?: InputMaybe<Array<Scalars['String']['input']>>;
-  productTypes?: InputMaybe<Array<Scalars['String']['input']>>;
-  search?: InputMaybe<Scalars['String']['input']>;
-  sortBy?: InputMaybe<Scalars['String']['input']>;
-  statuses?: InputMaybe<Array<Scalars['String']['input']>>;
-  tags?: InputMaybe<Array<Scalars['String']['input']>>;
-  taskFilter?: InputMaybe<Scalars['String']['input']>;
-  versionFilter?: InputMaybe<Scalars['String']['input']>;
-};
-
+  after?: InputMaybe<Scalars['String']['input']>
+  before?: InputMaybe<Scalars['String']['input']>
+  calculateSpecificStatistics?: InputMaybe<Array<MetricTargetInput>>
+  calculateStatistics?: Scalars['Boolean']['input']
+  filter?: InputMaybe<Scalars['String']['input']>
+  first?: InputMaybe<Scalars['Int']['input']>
+  folderIds?: InputMaybe<Array<Scalars['String']['input']>>
+  hasLinks?: InputMaybe<HasLinksFilter>
+  ids?: InputMaybe<Array<Scalars['String']['input']>>
+  includeFolderChildren?: Scalars['Boolean']['input']
+  last?: InputMaybe<Scalars['Int']['input']>
+  nameEx?: InputMaybe<Scalars['String']['input']>
+  names?: InputMaybe<Array<Scalars['String']['input']>>
+  namesCi?: InputMaybe<Array<Scalars['String']['input']>>
+  pathEx?: InputMaybe<Scalars['String']['input']>
+  productBaseTypes?: InputMaybe<Array<Scalars['String']['input']>>
+  productTypes?: InputMaybe<Array<Scalars['String']['input']>>
+  search?: InputMaybe<Scalars['String']['input']>
+  sortBy?: InputMaybe<Scalars['String']['input']>
+  statuses?: InputMaybe<Array<Scalars['String']['input']>>
+  tags?: InputMaybe<Array<Scalars['String']['input']>>
+  taskFilter?: InputMaybe<Scalars['String']['input']>
+  versionFilter?: InputMaybe<Scalars['String']['input']>
+}
 
 export type ProjectNodeRepresentationArgs = {
-  id: Scalars['String']['input'];
-};
-
+  id: Scalars['String']['input']
+}
 
 export type ProjectNodeRepresentationsArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  filter?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  hasLinks?: InputMaybe<HasLinksFilter>;
-  ids?: InputMaybe<Array<Scalars['String']['input']>>;
-  last?: InputMaybe<Scalars['Int']['input']>;
-  names?: InputMaybe<Array<Scalars['String']['input']>>;
-  search?: InputMaybe<Scalars['String']['input']>;
-  statuses?: InputMaybe<Array<Scalars['String']['input']>>;
-  tags?: InputMaybe<Array<Scalars['String']['input']>>;
-  versionIds?: InputMaybe<Array<Scalars['String']['input']>>;
-};
-
+  after?: InputMaybe<Scalars['String']['input']>
+  before?: InputMaybe<Scalars['String']['input']>
+  filter?: InputMaybe<Scalars['String']['input']>
+  first?: InputMaybe<Scalars['Int']['input']>
+  hasLinks?: InputMaybe<HasLinksFilter>
+  ids?: InputMaybe<Array<Scalars['String']['input']>>
+  last?: InputMaybe<Scalars['Int']['input']>
+  names?: InputMaybe<Array<Scalars['String']['input']>>
+  search?: InputMaybe<Scalars['String']['input']>
+  statuses?: InputMaybe<Array<Scalars['String']['input']>>
+  tags?: InputMaybe<Array<Scalars['String']['input']>>
+  versionIds?: InputMaybe<Array<Scalars['String']['input']>>
+}
 
 export type ProjectNodeTaskArgs = {
-  id: Scalars['String']['input'];
-};
-
+  id: Scalars['String']['input']
+}
 
 export type ProjectNodeTaskTypesArgs = {
-  activeOnly?: Scalars['Boolean']['input'];
-};
-
+  activeOnly?: Scalars['Boolean']['input']
+}
 
 export type ProjectNodeTasksArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  assignees?: InputMaybe<Array<Scalars['String']['input']>>;
-  assigneesAny?: InputMaybe<Array<Scalars['String']['input']>>;
-  attributes?: InputMaybe<Array<AttributeFilterInput>>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  calculateSpecificStatistics?: InputMaybe<Array<MetricTargetInput>>;
-  calculateStatistics?: Scalars['Boolean']['input'];
-  filter?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  folderFilter?: InputMaybe<Scalars['String']['input']>;
-  folderIds?: InputMaybe<Array<Scalars['String']['input']>>;
-  hasLinks?: InputMaybe<HasLinksFilter>;
-  ids?: InputMaybe<Array<Scalars['String']['input']>>;
-  includeFolderChildren?: Scalars['Boolean']['input'];
-  last?: InputMaybe<Scalars['Int']['input']>;
-  names?: InputMaybe<Array<Scalars['String']['input']>>;
-  search?: InputMaybe<Scalars['String']['input']>;
-  sortBy?: InputMaybe<Scalars['String']['input']>;
-  statuses?: InputMaybe<Array<Scalars['String']['input']>>;
-  tags?: InputMaybe<Array<Scalars['String']['input']>>;
-  tagsAny?: InputMaybe<Array<Scalars['String']['input']>>;
-  taskTypes?: InputMaybe<Array<Scalars['String']['input']>>;
-};
-
+  after?: InputMaybe<Scalars['String']['input']>
+  assignees?: InputMaybe<Array<Scalars['String']['input']>>
+  assigneesAny?: InputMaybe<Array<Scalars['String']['input']>>
+  attributes?: InputMaybe<Array<AttributeFilterInput>>
+  before?: InputMaybe<Scalars['String']['input']>
+  calculateSpecificStatistics?: InputMaybe<Array<MetricTargetInput>>
+  calculateStatistics?: Scalars['Boolean']['input']
+  filter?: InputMaybe<Scalars['String']['input']>
+  first?: InputMaybe<Scalars['Int']['input']>
+  folderFilter?: InputMaybe<Scalars['String']['input']>
+  folderIds?: InputMaybe<Array<Scalars['String']['input']>>
+  hasLinks?: InputMaybe<HasLinksFilter>
+  ids?: InputMaybe<Array<Scalars['String']['input']>>
+  includeFolderChildren?: Scalars['Boolean']['input']
+  last?: InputMaybe<Scalars['Int']['input']>
+  names?: InputMaybe<Array<Scalars['String']['input']>>
+  search?: InputMaybe<Scalars['String']['input']>
+  sortBy?: InputMaybe<Scalars['String']['input']>
+  statuses?: InputMaybe<Array<Scalars['String']['input']>>
+  tags?: InputMaybe<Array<Scalars['String']['input']>>
+  tagsAny?: InputMaybe<Array<Scalars['String']['input']>>
+  taskTypes?: InputMaybe<Array<Scalars['String']['input']>>
+}
 
 export type ProjectNodeVersionArgs = {
-  id: Scalars['String']['input'];
-};
-
+  id: Scalars['String']['input']
+}
 
 export type ProjectNodeVersionsArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  authors?: InputMaybe<Array<Scalars['String']['input']>>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  calculateSpecificStatistics?: InputMaybe<Array<MetricTargetInput>>;
-  calculateStatistics?: Scalars['Boolean']['input'];
-  featuredOnly?: InputMaybe<Array<Scalars['String']['input']>>;
-  filter?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  folderIds?: InputMaybe<Array<Scalars['String']['input']>>;
-  hasLinks?: InputMaybe<HasLinksFilter>;
-  hasReviewables?: InputMaybe<Scalars['Boolean']['input']>;
-  heroOnly?: Scalars['Boolean']['input'];
-  heroOrLatestOnly?: Scalars['Boolean']['input'];
-  ids?: InputMaybe<Array<Scalars['String']['input']>>;
-  includeFolderChildren?: Scalars['Boolean']['input'];
-  last?: InputMaybe<Scalars['Int']['input']>;
-  latestOnly?: Scalars['Boolean']['input'];
-  productFilter?: InputMaybe<Scalars['String']['input']>;
-  productIds?: InputMaybe<Array<Scalars['String']['input']>>;
-  search?: InputMaybe<Scalars['String']['input']>;
-  sortBy?: InputMaybe<Scalars['String']['input']>;
-  statuses?: InputMaybe<Array<Scalars['String']['input']>>;
-  tags?: InputMaybe<Array<Scalars['String']['input']>>;
-  taskFilter?: InputMaybe<Scalars['String']['input']>;
-  taskIds?: InputMaybe<Array<Scalars['String']['input']>>;
-  version?: InputMaybe<Scalars['Int']['input']>;
-  versions?: InputMaybe<Array<Scalars['Int']['input']>>;
-};
-
+  after?: InputMaybe<Scalars['String']['input']>
+  authors?: InputMaybe<Array<Scalars['String']['input']>>
+  before?: InputMaybe<Scalars['String']['input']>
+  calculateSpecificStatistics?: InputMaybe<Array<MetricTargetInput>>
+  calculateStatistics?: Scalars['Boolean']['input']
+  featuredOnly?: InputMaybe<Array<Scalars['String']['input']>>
+  filter?: InputMaybe<Scalars['String']['input']>
+  first?: InputMaybe<Scalars['Int']['input']>
+  folderIds?: InputMaybe<Array<Scalars['String']['input']>>
+  hasLinks?: InputMaybe<HasLinksFilter>
+  hasReviewables?: InputMaybe<Scalars['Boolean']['input']>
+  heroOnly?: Scalars['Boolean']['input']
+  heroOrLatestOnly?: Scalars['Boolean']['input']
+  ids?: InputMaybe<Array<Scalars['String']['input']>>
+  includeFolderChildren?: Scalars['Boolean']['input']
+  last?: InputMaybe<Scalars['Int']['input']>
+  latestOnly?: Scalars['Boolean']['input']
+  productFilter?: InputMaybe<Scalars['String']['input']>
+  productIds?: InputMaybe<Array<Scalars['String']['input']>>
+  search?: InputMaybe<Scalars['String']['input']>
+  sortBy?: InputMaybe<Scalars['String']['input']>
+  statuses?: InputMaybe<Array<Scalars['String']['input']>>
+  tags?: InputMaybe<Array<Scalars['String']['input']>>
+  taskFilter?: InputMaybe<Scalars['String']['input']>
+  taskIds?: InputMaybe<Array<Scalars['String']['input']>>
+  version?: InputMaybe<Scalars['Int']['input']>
+  versions?: InputMaybe<Array<Scalars['Int']['input']>>
+}
 
 export type ProjectNodeWorkfileArgs = {
-  id: Scalars['String']['input'];
-};
-
+  id: Scalars['String']['input']
+}
 
 export type ProjectNodeWorkfilesArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  hasLinks?: InputMaybe<HasLinksFilter>;
-  ids?: InputMaybe<Array<Scalars['String']['input']>>;
-  last?: InputMaybe<Scalars['Int']['input']>;
-  pathEx?: InputMaybe<Scalars['String']['input']>;
-  paths?: InputMaybe<Array<Scalars['String']['input']>>;
-  search?: InputMaybe<Scalars['String']['input']>;
-  sortBy?: InputMaybe<Scalars['String']['input']>;
-  statuses?: InputMaybe<Array<Scalars['String']['input']>>;
-  tags?: InputMaybe<Array<Scalars['String']['input']>>;
-  taskIds?: InputMaybe<Array<Scalars['String']['input']>>;
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  before?: InputMaybe<Scalars['String']['input']>
+  first?: InputMaybe<Scalars['Int']['input']>
+  hasLinks?: InputMaybe<HasLinksFilter>
+  ids?: InputMaybe<Array<Scalars['String']['input']>>
+  last?: InputMaybe<Scalars['Int']['input']>
+  pathEx?: InputMaybe<Scalars['String']['input']>
+  paths?: InputMaybe<Array<Scalars['String']['input']>>
+  search?: InputMaybe<Scalars['String']['input']>
+  sortBy?: InputMaybe<Scalars['String']['input']>
+  statuses?: InputMaybe<Array<Scalars['String']['input']>>
+  tags?: InputMaybe<Array<Scalars['String']['input']>>
+  taskIds?: InputMaybe<Array<Scalars['String']['input']>>
+}
 
 export type ProjectsConnection = {
-  __typename?: 'ProjectsConnection';
-  edges: Array<ProjectEdge>;
-  fieldStats: Array<ColumnStats>;
+  __typename?: 'ProjectsConnection'
+  edges: Array<ProjectEdge>
+  fieldStats: Array<ColumnStats>
   /** Pagination information */
-  pageInfo: PageInfo;
-};
+  pageInfo: PageInfo
+}
 
 export type Query = {
-  __typename?: 'Query';
+  __typename?: 'Query'
   /** Get a list of recorded events */
-  events: EventsConnection;
+  events: EventsConnection
   /** Get user inbox */
-  inbox: ActivitiesConnection;
+  inbox: ActivitiesConnection
   /** Get kanban board */
-  kanban: KanbanConnection;
+  kanban: KanbanConnection
   /** Current user */
-  me: UserNode;
+  me: UserNode
   /** Studio-wide product type configuration */
-  productTypes: Array<ProductType>;
+  productTypes: Array<ProductType>
   /** Get a project by name */
-  project: ProjectNode;
+  project: ProjectNode
   /** Get a list of projects */
-  projects: ProjectsConnection;
+  projects: ProjectsConnection
   /** Get a user by name */
-  user: UserNode;
+  user: UserNode
   /** Get a list of users */
-  users: UsersConnection;
-};
-
+  users: UsersConnection
+}
 
 export type QueryEventsArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  filter?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  hasChildren?: InputMaybe<Scalars['Boolean']['input']>;
-  ids?: InputMaybe<Array<Scalars['String']['input']>>;
-  includeLogs?: Scalars['Boolean']['input'];
-  last?: InputMaybe<Scalars['Int']['input']>;
-  newerThan?: InputMaybe<Scalars['String']['input']>;
-  olderThan?: InputMaybe<Scalars['String']['input']>;
-  projects?: InputMaybe<Array<Scalars['String']['input']>>;
-  states?: InputMaybe<Array<Scalars['String']['input']>>;
-  statuses?: InputMaybe<Array<Scalars['String']['input']>>;
-  topics?: InputMaybe<Array<Scalars['String']['input']>>;
-  users?: InputMaybe<Array<Scalars['String']['input']>>;
-};
-
+  after?: InputMaybe<Scalars['String']['input']>
+  before?: InputMaybe<Scalars['String']['input']>
+  filter?: InputMaybe<Scalars['String']['input']>
+  first?: InputMaybe<Scalars['Int']['input']>
+  hasChildren?: InputMaybe<Scalars['Boolean']['input']>
+  ids?: InputMaybe<Array<Scalars['String']['input']>>
+  includeLogs?: Scalars['Boolean']['input']
+  last?: InputMaybe<Scalars['Int']['input']>
+  newerThan?: InputMaybe<Scalars['String']['input']>
+  olderThan?: InputMaybe<Scalars['String']['input']>
+  projects?: InputMaybe<Array<Scalars['String']['input']>>
+  states?: InputMaybe<Array<Scalars['String']['input']>>
+  statuses?: InputMaybe<Array<Scalars['String']['input']>>
+  topics?: InputMaybe<Array<Scalars['String']['input']>>
+  users?: InputMaybe<Array<Scalars['String']['input']>>
+}
 
 export type QueryInboxArgs = {
-  before?: InputMaybe<Scalars['String']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
-  showActiveMessages?: InputMaybe<Scalars['Boolean']['input']>;
-  showActiveProjects?: InputMaybe<Scalars['Boolean']['input']>;
-  showImportantMessages?: InputMaybe<Scalars['Boolean']['input']>;
-  showUnreadMessages?: InputMaybe<Scalars['Boolean']['input']>;
-};
-
+  before?: InputMaybe<Scalars['String']['input']>
+  last?: InputMaybe<Scalars['Int']['input']>
+  showActiveMessages?: InputMaybe<Scalars['Boolean']['input']>
+  showActiveProjects?: InputMaybe<Scalars['Boolean']['input']>
+  showImportantMessages?: InputMaybe<Scalars['Boolean']['input']>
+  showUnreadMessages?: InputMaybe<Scalars['Boolean']['input']>
+}
 
 export type QueryKanbanArgs = {
-  assigneesAny?: InputMaybe<Array<Scalars['String']['input']>>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
-  projects?: InputMaybe<Array<Scalars['String']['input']>>;
-  taskIds?: InputMaybe<Array<Scalars['String']['input']>>;
-};
-
+  assigneesAny?: InputMaybe<Array<Scalars['String']['input']>>
+  before?: InputMaybe<Scalars['String']['input']>
+  last?: InputMaybe<Scalars['Int']['input']>
+  projects?: InputMaybe<Array<Scalars['String']['input']>>
+  taskIds?: InputMaybe<Array<Scalars['String']['input']>>
+}
 
 export type QueryProjectArgs = {
-  code?: InputMaybe<Scalars['String']['input']>;
-  name?: InputMaybe<Scalars['String']['input']>;
-};
-
+  code?: InputMaybe<Scalars['String']['input']>
+  name?: InputMaybe<Scalars['String']['input']>
+}
 
 export type QueryProjectsArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  code?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  includeSkeleton?: Scalars['Boolean']['input'];
-  last?: InputMaybe<Scalars['Int']['input']>;
-  name?: InputMaybe<Scalars['String']['input']>;
-};
-
+  after?: InputMaybe<Scalars['String']['input']>
+  before?: InputMaybe<Scalars['String']['input']>
+  code?: InputMaybe<Scalars['String']['input']>
+  first?: InputMaybe<Scalars['Int']['input']>
+  includeSkeleton?: Scalars['Boolean']['input']
+  last?: InputMaybe<Scalars['Int']['input']>
+  name?: InputMaybe<Scalars['String']['input']>
+}
 
 export type QueryUserArgs = {
-  name: Scalars['String']['input'];
-};
-
+  name: Scalars['String']['input']
+}
 
 export type QueryUsersArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  emails?: InputMaybe<Array<Scalars['String']['input']>>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  isSupport?: InputMaybe<Scalars['Boolean']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
-  name?: InputMaybe<Scalars['String']['input']>;
-  names?: InputMaybe<Array<Scalars['String']['input']>>;
-  projectName?: InputMaybe<Scalars['String']['input']>;
-  projects?: InputMaybe<Array<Scalars['String']['input']>>;
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  before?: InputMaybe<Scalars['String']['input']>
+  emails?: InputMaybe<Array<Scalars['String']['input']>>
+  first?: InputMaybe<Scalars['Int']['input']>
+  isSupport?: InputMaybe<Scalars['Boolean']['input']>
+  last?: InputMaybe<Scalars['Int']['input']>
+  name?: InputMaybe<Scalars['String']['input']>
+  names?: InputMaybe<Array<Scalars['String']['input']>>
+  projectName?: InputMaybe<Scalars['String']['input']>
+  projects?: InputMaybe<Array<Scalars['String']['input']>>
+}
 
 export type RepresentationAttribType = {
-  __typename?: 'RepresentationAttribType';
-  clipIn?: Maybe<Scalars['Int']['output']>;
-  clipOut?: Maybe<Scalars['Int']['output']>;
+  __typename?: 'RepresentationAttribType'
+  clipIn?: Maybe<Scalars['Int']['output']>
+  clipOut?: Maybe<Scalars['Int']['output']>
   /** Textual description of the entity */
-  description?: Maybe<Scalars['String']['output']>;
-  extension?: Maybe<Scalars['String']['output']>;
+  description?: Maybe<Scalars['String']['output']>
+  extension?: Maybe<Scalars['String']['output']>
   /** Frame rate */
-  fps?: Maybe<Scalars['Float']['output']>;
-  frameEnd?: Maybe<Scalars['Int']['output']>;
-  frameStart?: Maybe<Scalars['Int']['output']>;
-  handleEnd?: Maybe<Scalars['Int']['output']>;
-  handleStart?: Maybe<Scalars['Int']['output']>;
-  path?: Maybe<Scalars['String']['output']>;
-  pixelAspect?: Maybe<Scalars['Float']['output']>;
+  fps?: Maybe<Scalars['Float']['output']>
+  frameEnd?: Maybe<Scalars['Int']['output']>
+  frameStart?: Maybe<Scalars['Int']['output']>
+  handleEnd?: Maybe<Scalars['Int']['output']>
+  handleStart?: Maybe<Scalars['Int']['output']>
+  path?: Maybe<Scalars['String']['output']>
+  pixelAspect?: Maybe<Scalars['Float']['output']>
   /** Vertical resolution */
-  resolutionHeight?: Maybe<Scalars['Int']['output']>;
+  resolutionHeight?: Maybe<Scalars['Int']['output']>
   /** Horizontal resolution */
-  resolutionWidth?: Maybe<Scalars['Int']['output']>;
-  template?: Maybe<Scalars['String']['output']>;
-};
+  resolutionWidth?: Maybe<Scalars['Int']['output']>
+  template?: Maybe<Scalars['String']['output']>
+}
 
 export type RepresentationEdge = {
-  __typename?: 'RepresentationEdge';
-  cursor?: Maybe<Scalars['String']['output']>;
-  node: RepresentationNode;
-};
+  __typename?: 'RepresentationEdge'
+  cursor?: Maybe<Scalars['String']['output']>
+  node: RepresentationNode
+}
 
 export type RepresentationNode = BaseNode & {
-  __typename?: 'RepresentationNode';
-  active: Scalars['Boolean']['output'];
-  activities: ActivitiesConnection;
-  allAttrib: Scalars['String']['output'];
-  attrib: RepresentationAttribType;
+  __typename?: 'RepresentationNode'
+  active: Scalars['Boolean']['output']
+  activities: ActivitiesConnection
+  allAttrib: Scalars['String']['output']
+  attrib: RepresentationAttribType
   /** JSON serialized context data */
-  context?: Maybe<Scalars['String']['output']>;
-  createdAt: Scalars['DateTime']['output'];
-  createdBy?: Maybe<Scalars['String']['output']>;
-  data?: Maybe<Scalars['String']['output']>;
+  context?: Maybe<Scalars['String']['output']>
+  createdAt: Scalars['DateTime']['output']
+  createdBy?: Maybe<Scalars['String']['output']>
+  data?: Maybe<Scalars['String']['output']>
   /** Number of files of the representation */
-  fileCount: Scalars['Int']['output'];
+  fileCount: Scalars['Int']['output']
   /** Files in the representation */
-  files: Array<FileNode>;
-  id: Scalars['String']['output'];
-  links: LinksConnection;
-  name: Scalars['String']['output'];
-  parents: Array<Scalars['String']['output']>;
-  path?: Maybe<Scalars['String']['output']>;
-  projectName: Scalars['String']['output'];
-  status: Scalars['String']['output'];
-  tags: Array<Scalars['String']['output']>;
-  traits?: Maybe<Scalars['String']['output']>;
-  updatedAt: Scalars['DateTime']['output'];
-  updatedBy?: Maybe<Scalars['String']['output']>;
+  files: Array<FileNode>
+  id: Scalars['String']['output']
+  links: LinksConnection
+  name: Scalars['String']['output']
+  parents: Array<Scalars['String']['output']>
+  path?: Maybe<Scalars['String']['output']>
+  projectName: Scalars['String']['output']
+  status: Scalars['String']['output']
+  tags: Array<Scalars['String']['output']>
+  traits?: Maybe<Scalars['String']['output']>
+  updatedAt: Scalars['DateTime']['output']
+  updatedBy?: Maybe<Scalars['String']['output']>
   /** Parent version of the representation */
-  version: VersionNode;
-  versionId: Scalars['String']['output'];
-};
-
+  version: VersionNode
+  versionId: Scalars['String']['output']
+}
 
 export type RepresentationNodeActivitiesArgs = {
-  activityTypes?: InputMaybe<Array<Scalars['String']['input']>>;
-  after?: InputMaybe<Scalars['String']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
-  referenceTypes?: InputMaybe<Array<Scalars['String']['input']>>;
-};
-
+  activityTypes?: InputMaybe<Array<Scalars['String']['input']>>
+  after?: InputMaybe<Scalars['String']['input']>
+  before?: InputMaybe<Scalars['String']['input']>
+  first?: InputMaybe<Scalars['Int']['input']>
+  last?: InputMaybe<Scalars['Int']['input']>
+  referenceTypes?: InputMaybe<Array<Scalars['String']['input']>>
+}
 
 export type RepresentationNodeLinksArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  direction?: InputMaybe<Scalars['String']['input']>;
-  first?: Scalars['Int']['input'];
-  linkTypes?: InputMaybe<Array<Scalars['String']['input']>>;
-  nameEx?: InputMaybe<Scalars['String']['input']>;
-  names?: InputMaybe<Array<Scalars['String']['input']>>;
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  direction?: InputMaybe<Scalars['String']['input']>
+  first?: Scalars['Int']['input']
+  linkTypes?: InputMaybe<Array<Scalars['String']['input']>>
+  nameEx?: InputMaybe<Scalars['String']['input']>
+  names?: InputMaybe<Array<Scalars['String']['input']>>
+}
 
 export type RepresentationsConnection = {
-  __typename?: 'RepresentationsConnection';
-  edges: Array<RepresentationEdge>;
-  fieldStats: Array<ColumnStats>;
+  __typename?: 'RepresentationsConnection'
+  edges: Array<RepresentationEdge>
+  fieldStats: Array<ColumnStats>
   /** Pagination information */
-  pageInfo: PageInfo;
-};
+  pageInfo: PageInfo
+}
 
 export enum StatsOperation {
   Avg = 'AVG',
@@ -1279,680 +1242,1153 @@ export enum StatsOperation {
   PercentageFilled = 'PERCENTAGE_FILLED',
   PercentageNotChecked = 'PERCENTAGE_NOT_CHECKED',
   PercentageNotFilled = 'PERCENTAGE_NOT_FILLED',
-  Sum = 'SUM'
+  Sum = 'SUM',
 }
 
 export type Status = {
-  __typename?: 'Status';
-  color?: Maybe<Scalars['String']['output']>;
-  icon?: Maybe<Scalars['String']['output']>;
-  name: Scalars['String']['output'];
-  scope?: Maybe<Array<Scalars['String']['output']>>;
-  shortName?: Maybe<Scalars['String']['output']>;
-  state?: Maybe<Scalars['String']['output']>;
-};
+  __typename?: 'Status'
+  color?: Maybe<Scalars['String']['output']>
+  icon?: Maybe<Scalars['String']['output']>
+  name: Scalars['String']['output']
+  scope?: Maybe<Array<Scalars['String']['output']>>
+  shortName?: Maybe<Scalars['String']['output']>
+  state?: Maybe<Scalars['String']['output']>
+}
 
 export type SubTaskNode = {
-  __typename?: 'SubTaskNode';
-  assignees: Array<Scalars['String']['output']>;
-  description?: Maybe<Scalars['String']['output']>;
-  endDate?: Maybe<Scalars['DateTime']['output']>;
-  id: Scalars['String']['output'];
-  isDone: Scalars['Boolean']['output'];
-  label: Scalars['String']['output'];
-  name: Scalars['String']['output'];
-  startDate?: Maybe<Scalars['DateTime']['output']>;
-};
+  __typename?: 'SubTaskNode'
+  assignees: Array<Scalars['String']['output']>
+  description?: Maybe<Scalars['String']['output']>
+  endDate?: Maybe<Scalars['DateTime']['output']>
+  id: Scalars['String']['output']
+  isDone: Scalars['Boolean']['output']
+  label: Scalars['String']['output']
+  name: Scalars['String']['output']
+  startDate?: Maybe<Scalars['DateTime']['output']>
+}
 
 export type Tag = {
-  __typename?: 'Tag';
-  color?: Maybe<Scalars['String']['output']>;
-  name: Scalars['String']['output'];
-};
+  __typename?: 'Tag'
+  color?: Maybe<Scalars['String']['output']>
+  name: Scalars['String']['output']
+}
 
 export type TaskAttribType = {
-  __typename?: 'TaskAttribType';
-  clipIn?: Maybe<Scalars['Int']['output']>;
-  clipOut?: Maybe<Scalars['Int']['output']>;
+  __typename?: 'TaskAttribType'
+  clipIn?: Maybe<Scalars['Int']['output']>
+  clipOut?: Maybe<Scalars['Int']['output']>
   /** Textual description of the entity */
-  description?: Maybe<Scalars['String']['output']>;
+  description?: Maybe<Scalars['String']['output']>
   /** Deadline date and time */
-  endDate?: Maybe<Scalars['DateTime']['output']>;
+  endDate?: Maybe<Scalars['DateTime']['output']>
   /** Frame rate */
-  fps?: Maybe<Scalars['Float']['output']>;
-  frameEnd?: Maybe<Scalars['Int']['output']>;
-  frameStart?: Maybe<Scalars['Int']['output']>;
-  handleEnd?: Maybe<Scalars['Int']['output']>;
-  handleStart?: Maybe<Scalars['Int']['output']>;
-  pixelAspect?: Maybe<Scalars['Float']['output']>;
-  priority?: Maybe<Scalars['String']['output']>;
+  fps?: Maybe<Scalars['Float']['output']>
+  frameEnd?: Maybe<Scalars['Int']['output']>
+  frameStart?: Maybe<Scalars['Int']['output']>
+  handleEnd?: Maybe<Scalars['Int']['output']>
+  handleStart?: Maybe<Scalars['Int']['output']>
+  pixelAspect?: Maybe<Scalars['Float']['output']>
+  priority?: Maybe<Scalars['String']['output']>
   /** Vertical resolution */
-  resolutionHeight?: Maybe<Scalars['Int']['output']>;
+  resolutionHeight?: Maybe<Scalars['Int']['output']>
   /** Horizontal resolution */
-  resolutionWidth?: Maybe<Scalars['Int']['output']>;
+  resolutionWidth?: Maybe<Scalars['Int']['output']>
   /** Date and time when the project or task or asset was started */
-  startDate?: Maybe<Scalars['DateTime']['output']>;
-};
+  startDate?: Maybe<Scalars['DateTime']['output']>
+}
 
 export type TaskEdge = {
-  __typename?: 'TaskEdge';
-  cursor?: Maybe<Scalars['String']['output']>;
-  node: TaskNode;
-};
+  __typename?: 'TaskEdge'
+  cursor?: Maybe<Scalars['String']['output']>
+  node: TaskNode
+}
 
 export type TaskNode = BaseNode & {
-  __typename?: 'TaskNode';
-  Folder?: Maybe<FolderNode>;
-  active: Scalars['Boolean']['output'];
-  activities: ActivitiesConnection;
-  allAttrib: Scalars['String']['output'];
-  assignees: Array<Scalars['String']['output']>;
-  attrib: TaskAttribType;
-  createdAt: Scalars['DateTime']['output'];
-  createdBy?: Maybe<Scalars['String']['output']>;
-  data?: Maybe<Scalars['String']['output']>;
+  __typename?: 'TaskNode'
+  Folder?: Maybe<FolderNode>
+  active: Scalars['Boolean']['output']
+  activities: ActivitiesConnection
+  allAttrib: Scalars['String']['output']
+  assignees: Array<Scalars['String']['output']>
+  attrib: TaskAttribType
+  createdAt: Scalars['DateTime']['output']
+  createdBy?: Maybe<Scalars['String']['output']>
+  data?: Maybe<Scalars['String']['output']>
   /** Parent folder of the task */
-  folder: FolderNode;
-  folderId: Scalars['String']['output'];
-  hasReviewables: Scalars['Boolean']['output'];
-  id: Scalars['String']['output'];
-  label?: Maybe<Scalars['String']['output']>;
-  latestComments?: Maybe<Array<EntityComment>>;
-  links: LinksConnection;
-  name: Scalars['String']['output'];
-  ownAttrib: Array<Scalars['String']['output']>;
-  parents: Array<Scalars['String']['output']>;
-  path?: Maybe<Scalars['String']['output']>;
-  projectName: Scalars['String']['output'];
-  status: Scalars['String']['output'];
-  subtasks: Array<SubTaskNode>;
-  tags: Array<Scalars['String']['output']>;
-  taskType: Scalars['String']['output'];
-  thumbnail?: Maybe<ThumbnailInfo>;
-  thumbnailHash: Scalars['String']['output'];
-  thumbnailId?: Maybe<Scalars['String']['output']>;
-  type: Scalars['String']['output'];
-  updatedAt: Scalars['DateTime']['output'];
-  updatedBy?: Maybe<Scalars['String']['output']>;
+  folder: FolderNode
+  folderId: Scalars['String']['output']
+  hasReviewables: Scalars['Boolean']['output']
+  id: Scalars['String']['output']
+  label?: Maybe<Scalars['String']['output']>
+  latestComments?: Maybe<Array<EntityComment>>
+  links: LinksConnection
+  name: Scalars['String']['output']
+  ownAttrib: Array<Scalars['String']['output']>
+  parents: Array<Scalars['String']['output']>
+  path?: Maybe<Scalars['String']['output']>
+  projectName: Scalars['String']['output']
+  status: Scalars['String']['output']
+  subtasks: Array<SubTaskNode>
+  tags: Array<Scalars['String']['output']>
+  taskType: Scalars['String']['output']
+  thumbnail?: Maybe<ThumbnailInfo>
+  thumbnailHash: Scalars['String']['output']
+  thumbnailId?: Maybe<Scalars['String']['output']>
+  type: Scalars['String']['output']
+  updatedAt: Scalars['DateTime']['output']
+  updatedBy?: Maybe<Scalars['String']['output']>
   /** Return a list of versions. */
-  versions: VersionsConnection;
+  versions: VersionsConnection
   /** Return a list of workfiles. */
-  workfiles: WorkfilesConnection;
-};
-
+  workfiles: WorkfilesConnection
+}
 
 export type TaskNodeActivitiesArgs = {
-  activityTypes?: InputMaybe<Array<Scalars['String']['input']>>;
-  after?: InputMaybe<Scalars['String']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
-  referenceTypes?: InputMaybe<Array<Scalars['String']['input']>>;
-};
-
+  activityTypes?: InputMaybe<Array<Scalars['String']['input']>>
+  after?: InputMaybe<Scalars['String']['input']>
+  before?: InputMaybe<Scalars['String']['input']>
+  first?: InputMaybe<Scalars['Int']['input']>
+  last?: InputMaybe<Scalars['Int']['input']>
+  referenceTypes?: InputMaybe<Array<Scalars['String']['input']>>
+}
 
 export type TaskNodeLinksArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  direction?: InputMaybe<Scalars['String']['input']>;
-  first?: Scalars['Int']['input'];
-  linkTypes?: InputMaybe<Array<Scalars['String']['input']>>;
-  nameEx?: InputMaybe<Scalars['String']['input']>;
-  names?: InputMaybe<Array<Scalars['String']['input']>>;
-};
-
+  after?: InputMaybe<Scalars['String']['input']>
+  direction?: InputMaybe<Scalars['String']['input']>
+  first?: Scalars['Int']['input']
+  linkTypes?: InputMaybe<Array<Scalars['String']['input']>>
+  nameEx?: InputMaybe<Scalars['String']['input']>
+  names?: InputMaybe<Array<Scalars['String']['input']>>
+}
 
 export type TaskNodeVersionsArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  authors?: InputMaybe<Array<Scalars['String']['input']>>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  calculateSpecificStatistics?: InputMaybe<Array<MetricTargetInput>>;
-  calculateStatistics?: Scalars['Boolean']['input'];
-  featuredOnly?: InputMaybe<Array<Scalars['String']['input']>>;
-  filter?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  folderIds?: InputMaybe<Array<Scalars['String']['input']>>;
-  hasLinks?: InputMaybe<HasLinksFilter>;
-  hasReviewables?: InputMaybe<Scalars['Boolean']['input']>;
-  heroOnly?: Scalars['Boolean']['input'];
-  heroOrLatestOnly?: Scalars['Boolean']['input'];
-  ids?: InputMaybe<Array<Scalars['String']['input']>>;
-  includeFolderChildren?: Scalars['Boolean']['input'];
-  last?: InputMaybe<Scalars['Int']['input']>;
-  latestOnly?: Scalars['Boolean']['input'];
-  productFilter?: InputMaybe<Scalars['String']['input']>;
-  productIds?: InputMaybe<Array<Scalars['String']['input']>>;
-  search?: InputMaybe<Scalars['String']['input']>;
-  sortBy?: InputMaybe<Scalars['String']['input']>;
-  statuses?: InputMaybe<Array<Scalars['String']['input']>>;
-  tags?: InputMaybe<Array<Scalars['String']['input']>>;
-  taskFilter?: InputMaybe<Scalars['String']['input']>;
-  taskIds?: InputMaybe<Array<Scalars['String']['input']>>;
-  version?: InputMaybe<Scalars['Int']['input']>;
-  versions?: InputMaybe<Array<Scalars['Int']['input']>>;
-};
-
+  after?: InputMaybe<Scalars['String']['input']>
+  authors?: InputMaybe<Array<Scalars['String']['input']>>
+  before?: InputMaybe<Scalars['String']['input']>
+  calculateSpecificStatistics?: InputMaybe<Array<MetricTargetInput>>
+  calculateStatistics?: Scalars['Boolean']['input']
+  featuredOnly?: InputMaybe<Array<Scalars['String']['input']>>
+  filter?: InputMaybe<Scalars['String']['input']>
+  first?: InputMaybe<Scalars['Int']['input']>
+  folderIds?: InputMaybe<Array<Scalars['String']['input']>>
+  hasLinks?: InputMaybe<HasLinksFilter>
+  hasReviewables?: InputMaybe<Scalars['Boolean']['input']>
+  heroOnly?: Scalars['Boolean']['input']
+  heroOrLatestOnly?: Scalars['Boolean']['input']
+  ids?: InputMaybe<Array<Scalars['String']['input']>>
+  includeFolderChildren?: Scalars['Boolean']['input']
+  last?: InputMaybe<Scalars['Int']['input']>
+  latestOnly?: Scalars['Boolean']['input']
+  productFilter?: InputMaybe<Scalars['String']['input']>
+  productIds?: InputMaybe<Array<Scalars['String']['input']>>
+  search?: InputMaybe<Scalars['String']['input']>
+  sortBy?: InputMaybe<Scalars['String']['input']>
+  statuses?: InputMaybe<Array<Scalars['String']['input']>>
+  tags?: InputMaybe<Array<Scalars['String']['input']>>
+  taskFilter?: InputMaybe<Scalars['String']['input']>
+  taskIds?: InputMaybe<Array<Scalars['String']['input']>>
+  version?: InputMaybe<Scalars['Int']['input']>
+  versions?: InputMaybe<Array<Scalars['Int']['input']>>
+}
 
 export type TaskNodeWorkfilesArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  hasLinks?: InputMaybe<HasLinksFilter>;
-  ids?: InputMaybe<Array<Scalars['String']['input']>>;
-  last?: InputMaybe<Scalars['Int']['input']>;
-  pathEx?: InputMaybe<Scalars['String']['input']>;
-  paths?: InputMaybe<Array<Scalars['String']['input']>>;
-  search?: InputMaybe<Scalars['String']['input']>;
-  sortBy?: InputMaybe<Scalars['String']['input']>;
-  statuses?: InputMaybe<Array<Scalars['String']['input']>>;
-  tags?: InputMaybe<Array<Scalars['String']['input']>>;
-  taskIds?: InputMaybe<Array<Scalars['String']['input']>>;
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  before?: InputMaybe<Scalars['String']['input']>
+  first?: InputMaybe<Scalars['Int']['input']>
+  hasLinks?: InputMaybe<HasLinksFilter>
+  ids?: InputMaybe<Array<Scalars['String']['input']>>
+  last?: InputMaybe<Scalars['Int']['input']>
+  pathEx?: InputMaybe<Scalars['String']['input']>
+  paths?: InputMaybe<Array<Scalars['String']['input']>>
+  search?: InputMaybe<Scalars['String']['input']>
+  sortBy?: InputMaybe<Scalars['String']['input']>
+  statuses?: InputMaybe<Array<Scalars['String']['input']>>
+  tags?: InputMaybe<Array<Scalars['String']['input']>>
+  taskIds?: InputMaybe<Array<Scalars['String']['input']>>
+}
 
 export type TaskType = {
-  __typename?: 'TaskType';
-  color?: Maybe<Scalars['String']['output']>;
-  icon?: Maybe<Scalars['String']['output']>;
-  name: Scalars['String']['output'];
-  shortName?: Maybe<Scalars['String']['output']>;
-};
+  __typename?: 'TaskType'
+  color?: Maybe<Scalars['String']['output']>
+  icon?: Maybe<Scalars['String']['output']>
+  name: Scalars['String']['output']
+  shortName?: Maybe<Scalars['String']['output']>
+}
 
 export type TasksConnection = {
-  __typename?: 'TasksConnection';
-  edges: Array<TaskEdge>;
-  fieldStats: Array<ColumnStats>;
+  __typename?: 'TasksConnection'
+  edges: Array<TaskEdge>
+  fieldStats: Array<ColumnStats>
   /** Pagination information */
-  pageInfo: PageInfo;
-};
+  pageInfo: PageInfo
+}
 
 export type ThumbnailInfo = {
-  __typename?: 'ThumbnailInfo';
-  id: Scalars['String']['output'];
-  relation?: Maybe<Scalars['String']['output']>;
-  sourceEntityId?: Maybe<Scalars['String']['output']>;
-  sourceEntityType?: Maybe<Scalars['String']['output']>;
-};
+  __typename?: 'ThumbnailInfo'
+  id: Scalars['String']['output']
+  relation?: Maybe<Scalars['String']['output']>
+  sourceEntityId?: Maybe<Scalars['String']['output']>
+  sourceEntityType?: Maybe<Scalars['String']['output']>
+}
 
 export type UserAttribType = {
-  __typename?: 'UserAttribType';
-  avatarUrl?: Maybe<Scalars['String']['output']>;
-  developerMode?: Maybe<Scalars['Boolean']['output']>;
-  email?: Maybe<Scalars['String']['output']>;
-  fullName?: Maybe<Scalars['String']['output']>;
-};
+  __typename?: 'UserAttribType'
+  avatarUrl?: Maybe<Scalars['String']['output']>
+  developerMode?: Maybe<Scalars['Boolean']['output']>
+  email?: Maybe<Scalars['String']['output']>
+  fullName?: Maybe<Scalars['String']['output']>
+}
 
 export type UserEdge = {
-  __typename?: 'UserEdge';
-  cursor?: Maybe<Scalars['String']['output']>;
-  node: UserNode;
-};
+  __typename?: 'UserEdge'
+  cursor?: Maybe<Scalars['String']['output']>
+  node: UserNode
+}
 
 export type UserNode = {
-  __typename?: 'UserNode';
-  accessGroups: Scalars['String']['output'];
-  active: Scalars['Boolean']['output'];
-  allAttrib: Scalars['String']['output'];
-  apiKeyPreview?: Maybe<Scalars['String']['output']>;
-  attrib: UserAttribType;
-  createdAt: Scalars['DateTime']['output'];
-  defaultAccessGroups: Array<Scalars['String']['output']>;
-  deleted: Scalars['Boolean']['output'];
-  disablePasswordLogin: Scalars['Boolean']['output'];
-  hasPassword: Scalars['Boolean']['output'];
-  inviteAcceptedAt?: Maybe<Scalars['DateTime']['output']>;
-  inviteSentAt?: Maybe<Scalars['DateTime']['output']>;
-  isAdmin: Scalars['Boolean']['output'];
-  isDeveloper: Scalars['Boolean']['output'];
-  isGuest: Scalars['Boolean']['output'];
-  isManager: Scalars['Boolean']['output'];
-  isService: Scalars['Boolean']['output'];
-  isStagingAllowed: Scalars['Boolean']['output'];
-  name: Scalars['String']['output'];
-  tasks: TasksConnection;
-  updatedAt: Scalars['DateTime']['output'];
-  userPool?: Maybe<Scalars['String']['output']>;
-};
-
+  __typename?: 'UserNode'
+  accessGroups: Scalars['String']['output']
+  active: Scalars['Boolean']['output']
+  allAttrib: Scalars['String']['output']
+  apiKeyPreview?: Maybe<Scalars['String']['output']>
+  attrib: UserAttribType
+  createdAt: Scalars['DateTime']['output']
+  defaultAccessGroups: Array<Scalars['String']['output']>
+  deleted: Scalars['Boolean']['output']
+  disablePasswordLogin: Scalars['Boolean']['output']
+  hasPassword: Scalars['Boolean']['output']
+  inviteAcceptedAt?: Maybe<Scalars['DateTime']['output']>
+  inviteSentAt?: Maybe<Scalars['DateTime']['output']>
+  isAdmin: Scalars['Boolean']['output']
+  isDeveloper: Scalars['Boolean']['output']
+  isGuest: Scalars['Boolean']['output']
+  isManager: Scalars['Boolean']['output']
+  isService: Scalars['Boolean']['output']
+  isStagingAllowed: Scalars['Boolean']['output']
+  name: Scalars['String']['output']
+  tasks: TasksConnection
+  updatedAt: Scalars['DateTime']['output']
+  userPool?: Maybe<Scalars['String']['output']>
+}
 
 export type UserNodeTasksArgs = {
-  projectName: Scalars['String']['input'];
-};
+  projectName: Scalars['String']['input']
+}
 
 export type UsersConnection = {
-  __typename?: 'UsersConnection';
-  edges: Array<UserEdge>;
-  fieldStats: Array<ColumnStats>;
+  __typename?: 'UsersConnection'
+  edges: Array<UserEdge>
+  fieldStats: Array<ColumnStats>
   /** Pagination information */
-  pageInfo: PageInfo;
-};
+  pageInfo: PageInfo
+}
 
 export type VersionAttribType = {
-  __typename?: 'VersionAttribType';
-  clipIn?: Maybe<Scalars['Int']['output']>;
-  clipOut?: Maybe<Scalars['Int']['output']>;
-  colorSpace?: Maybe<Scalars['String']['output']>;
-  comment?: Maybe<Scalars['String']['output']>;
+  __typename?: 'VersionAttribType'
+  clipIn?: Maybe<Scalars['Int']['output']>
+  clipOut?: Maybe<Scalars['Int']['output']>
+  colorSpace?: Maybe<Scalars['String']['output']>
+  comment?: Maybe<Scalars['String']['output']>
   /** Textual description of the entity */
-  description?: Maybe<Scalars['String']['output']>;
-  families?: Maybe<Array<Scalars['String']['output']>>;
+  description?: Maybe<Scalars['String']['output']>
+  families?: Maybe<Array<Scalars['String']['output']>>
   /** Frame rate */
-  fps?: Maybe<Scalars['Float']['output']>;
-  frameEnd?: Maybe<Scalars['Int']['output']>;
-  frameStart?: Maybe<Scalars['Int']['output']>;
-  handleEnd?: Maybe<Scalars['Int']['output']>;
-  handleStart?: Maybe<Scalars['Int']['output']>;
-  intent?: Maybe<Scalars['String']['output']>;
-  machine?: Maybe<Scalars['String']['output']>;
-  pixelAspect?: Maybe<Scalars['Float']['output']>;
+  fps?: Maybe<Scalars['Float']['output']>
+  frameEnd?: Maybe<Scalars['Int']['output']>
+  frameStart?: Maybe<Scalars['Int']['output']>
+  handleEnd?: Maybe<Scalars['Int']['output']>
+  handleStart?: Maybe<Scalars['Int']['output']>
+  intent?: Maybe<Scalars['String']['output']>
+  machine?: Maybe<Scalars['String']['output']>
+  pixelAspect?: Maybe<Scalars['Float']['output']>
   /** Vertical resolution */
-  resolutionHeight?: Maybe<Scalars['Int']['output']>;
+  resolutionHeight?: Maybe<Scalars['Int']['output']>
   /** Horizontal resolution */
-  resolutionWidth?: Maybe<Scalars['Int']['output']>;
-  site?: Maybe<Scalars['String']['output']>;
-  source?: Maybe<Scalars['String']['output']>;
-};
+  resolutionWidth?: Maybe<Scalars['Int']['output']>
+  site?: Maybe<Scalars['String']['output']>
+  source?: Maybe<Scalars['String']['output']>
+}
 
 export type VersionEdge = {
-  __typename?: 'VersionEdge';
-  cursor?: Maybe<Scalars['String']['output']>;
-  node: VersionNode;
-};
+  __typename?: 'VersionEdge'
+  cursor?: Maybe<Scalars['String']['output']>
+  node: VersionNode
+}
 
 export type VersionListItem = {
-  __typename?: 'VersionListItem';
-  id: Scalars['String']['output'];
+  __typename?: 'VersionListItem'
+  id: Scalars['String']['output']
   /** Version name */
-  name: Scalars['String']['output'];
-  version: Scalars['Int']['output'];
-};
+  name: Scalars['String']['output']
+  version: Scalars['Int']['output']
+}
 
 export type VersionNode = BaseNode & {
-  __typename?: 'VersionNode';
-  active: Scalars['Boolean']['output'];
-  activities: ActivitiesConnection;
-  allAttrib: Scalars['String']['output'];
-  attrib: VersionAttribType;
-  author?: Maybe<Scalars['String']['output']>;
-  createdAt: Scalars['DateTime']['output'];
-  createdBy?: Maybe<Scalars['String']['output']>;
-  data?: Maybe<Scalars['String']['output']>;
-  featuredVersionType?: Maybe<Scalars['String']['output']>;
-  hasReviewables: Scalars['Boolean']['output'];
-  heroVersionId?: Maybe<Scalars['String']['output']>;
-  id: Scalars['String']['output'];
-  isLatest: Scalars['Boolean']['output'];
-  isLatestDone: Scalars['Boolean']['output'];
-  latestComments?: Maybe<Array<EntityComment>>;
-  links: LinksConnection;
-  name: Scalars['String']['output'];
-  parents: Array<Scalars['String']['output']>;
-  path?: Maybe<Scalars['String']['output']>;
+  __typename?: 'VersionNode'
+  active: Scalars['Boolean']['output']
+  activities: ActivitiesConnection
+  allAttrib: Scalars['String']['output']
+  attrib: VersionAttribType
+  author?: Maybe<Scalars['String']['output']>
+  createdAt: Scalars['DateTime']['output']
+  createdBy?: Maybe<Scalars['String']['output']>
+  data?: Maybe<Scalars['String']['output']>
+  featuredVersionType?: Maybe<Scalars['String']['output']>
+  hasReviewables: Scalars['Boolean']['output']
+  heroVersionId?: Maybe<Scalars['String']['output']>
+  id: Scalars['String']['output']
+  isLatest: Scalars['Boolean']['output']
+  isLatestDone: Scalars['Boolean']['output']
+  latestComments?: Maybe<Array<EntityComment>>
+  links: LinksConnection
+  name: Scalars['String']['output']
+  parents: Array<Scalars['String']['output']>
+  path?: Maybe<Scalars['String']['output']>
   /** Parent product of the version */
-  product: ProductNode;
-  productId: Scalars['String']['output'];
-  projectName: Scalars['String']['output'];
+  product: ProductNode
+  productId: Scalars['String']['output']
+  projectName: Scalars['String']['output']
   /** Return a list of representations. */
-  representations: RepresentationsConnection;
-  status: Scalars['String']['output'];
-  tags: Array<Scalars['String']['output']>;
+  representations: RepresentationsConnection
+  status: Scalars['String']['output']
+  tags: Array<Scalars['String']['output']>
   /** Task */
-  task?: Maybe<TaskNode>;
-  taskId?: Maybe<Scalars['String']['output']>;
-  thumbnail?: Maybe<ThumbnailInfo>;
-  thumbnailHash: Scalars['String']['output'];
-  thumbnailId?: Maybe<Scalars['String']['output']>;
-  updatedAt: Scalars['DateTime']['output'];
-  updatedBy?: Maybe<Scalars['String']['output']>;
-  version: Scalars['Int']['output'];
-};
-
+  task?: Maybe<TaskNode>
+  taskId?: Maybe<Scalars['String']['output']>
+  thumbnail?: Maybe<ThumbnailInfo>
+  thumbnailHash: Scalars['String']['output']
+  thumbnailId?: Maybe<Scalars['String']['output']>
+  updatedAt: Scalars['DateTime']['output']
+  updatedBy?: Maybe<Scalars['String']['output']>
+  version: Scalars['Int']['output']
+}
 
 export type VersionNodeActivitiesArgs = {
-  activityTypes?: InputMaybe<Array<Scalars['String']['input']>>;
-  after?: InputMaybe<Scalars['String']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
-  referenceTypes?: InputMaybe<Array<Scalars['String']['input']>>;
-};
-
+  activityTypes?: InputMaybe<Array<Scalars['String']['input']>>
+  after?: InputMaybe<Scalars['String']['input']>
+  before?: InputMaybe<Scalars['String']['input']>
+  first?: InputMaybe<Scalars['Int']['input']>
+  last?: InputMaybe<Scalars['Int']['input']>
+  referenceTypes?: InputMaybe<Array<Scalars['String']['input']>>
+}
 
 export type VersionNodeLinksArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  direction?: InputMaybe<Scalars['String']['input']>;
-  first?: Scalars['Int']['input'];
-  linkTypes?: InputMaybe<Array<Scalars['String']['input']>>;
-  nameEx?: InputMaybe<Scalars['String']['input']>;
-  names?: InputMaybe<Array<Scalars['String']['input']>>;
-};
-
+  after?: InputMaybe<Scalars['String']['input']>
+  direction?: InputMaybe<Scalars['String']['input']>
+  first?: Scalars['Int']['input']
+  linkTypes?: InputMaybe<Array<Scalars['String']['input']>>
+  nameEx?: InputMaybe<Scalars['String']['input']>
+  names?: InputMaybe<Array<Scalars['String']['input']>>
+}
 
 export type VersionNodeRepresentationsArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  filter?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  hasLinks?: InputMaybe<HasLinksFilter>;
-  ids?: InputMaybe<Array<Scalars['String']['input']>>;
-  last?: InputMaybe<Scalars['Int']['input']>;
-  names?: InputMaybe<Array<Scalars['String']['input']>>;
-  search?: InputMaybe<Scalars['String']['input']>;
-  statuses?: InputMaybe<Array<Scalars['String']['input']>>;
-  tags?: InputMaybe<Array<Scalars['String']['input']>>;
-  versionIds?: InputMaybe<Array<Scalars['String']['input']>>;
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  before?: InputMaybe<Scalars['String']['input']>
+  filter?: InputMaybe<Scalars['String']['input']>
+  first?: InputMaybe<Scalars['Int']['input']>
+  hasLinks?: InputMaybe<HasLinksFilter>
+  ids?: InputMaybe<Array<Scalars['String']['input']>>
+  last?: InputMaybe<Scalars['Int']['input']>
+  names?: InputMaybe<Array<Scalars['String']['input']>>
+  search?: InputMaybe<Scalars['String']['input']>
+  statuses?: InputMaybe<Array<Scalars['String']['input']>>
+  tags?: InputMaybe<Array<Scalars['String']['input']>>
+  versionIds?: InputMaybe<Array<Scalars['String']['input']>>
+}
 
 export type VersionsConnection = {
-  __typename?: 'VersionsConnection';
-  edges: Array<VersionEdge>;
-  fieldStats: Array<ColumnStats>;
+  __typename?: 'VersionsConnection'
+  edges: Array<VersionEdge>
+  fieldStats: Array<ColumnStats>
   /** Pagination information */
-  pageInfo: PageInfo;
-};
+  pageInfo: PageInfo
+}
 
 export type WorkfileAttribType = {
-  __typename?: 'WorkfileAttribType';
+  __typename?: 'WorkfileAttribType'
   /** Textual description of the entity */
-  description?: Maybe<Scalars['String']['output']>;
-  extension?: Maybe<Scalars['String']['output']>;
-};
+  description?: Maybe<Scalars['String']['output']>
+  extension?: Maybe<Scalars['String']['output']>
+}
 
 export type WorkfileEdge = {
-  __typename?: 'WorkfileEdge';
-  cursor?: Maybe<Scalars['String']['output']>;
-  node: WorkfileNode;
-};
+  __typename?: 'WorkfileEdge'
+  cursor?: Maybe<Scalars['String']['output']>
+  node: WorkfileNode
+}
 
 export type WorkfileNode = BaseNode & {
-  __typename?: 'WorkfileNode';
-  Parents?: Maybe<Array<Scalars['String']['output']>>;
-  active: Scalars['Boolean']['output'];
-  activities: ActivitiesConnection;
-  allAttrib: Scalars['String']['output'];
-  attrib: WorkfileAttribType;
-  createdAt: Scalars['DateTime']['output'];
-  createdBy?: Maybe<Scalars['String']['output']>;
-  data?: Maybe<Scalars['String']['output']>;
-  id: Scalars['String']['output'];
-  links: LinksConnection;
-  name: Scalars['String']['output'];
-  parents: Array<Scalars['String']['output']>;
-  path: Scalars['String']['output'];
-  projectName: Scalars['String']['output'];
-  status: Scalars['String']['output'];
-  tags: Array<Scalars['String']['output']>;
+  __typename?: 'WorkfileNode'
+  Parents?: Maybe<Array<Scalars['String']['output']>>
+  active: Scalars['Boolean']['output']
+  activities: ActivitiesConnection
+  allAttrib: Scalars['String']['output']
+  attrib: WorkfileAttribType
+  createdAt: Scalars['DateTime']['output']
+  createdBy?: Maybe<Scalars['String']['output']>
+  data?: Maybe<Scalars['String']['output']>
+  id: Scalars['String']['output']
+  links: LinksConnection
+  name: Scalars['String']['output']
+  parents: Array<Scalars['String']['output']>
+  path: Scalars['String']['output']
+  projectName: Scalars['String']['output']
+  status: Scalars['String']['output']
+  tags: Array<Scalars['String']['output']>
   /** Parent task of the workfile */
-  task: TaskNode;
-  taskId?: Maybe<Scalars['String']['output']>;
-  thumbnail?: Maybe<ThumbnailInfo>;
-  thumbnailHash: Scalars['String']['output'];
-  thumbnailId?: Maybe<Scalars['String']['output']>;
-  updatedAt: Scalars['DateTime']['output'];
-  updatedBy?: Maybe<Scalars['String']['output']>;
-};
-
+  task: TaskNode
+  taskId?: Maybe<Scalars['String']['output']>
+  thumbnail?: Maybe<ThumbnailInfo>
+  thumbnailHash: Scalars['String']['output']
+  thumbnailId?: Maybe<Scalars['String']['output']>
+  updatedAt: Scalars['DateTime']['output']
+  updatedBy?: Maybe<Scalars['String']['output']>
+}
 
 export type WorkfileNodeActivitiesArgs = {
-  activityTypes?: InputMaybe<Array<Scalars['String']['input']>>;
-  after?: InputMaybe<Scalars['String']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
-  referenceTypes?: InputMaybe<Array<Scalars['String']['input']>>;
-};
-
+  activityTypes?: InputMaybe<Array<Scalars['String']['input']>>
+  after?: InputMaybe<Scalars['String']['input']>
+  before?: InputMaybe<Scalars['String']['input']>
+  first?: InputMaybe<Scalars['Int']['input']>
+  last?: InputMaybe<Scalars['Int']['input']>
+  referenceTypes?: InputMaybe<Array<Scalars['String']['input']>>
+}
 
 export type WorkfileNodeLinksArgs = {
-  after?: InputMaybe<Scalars['String']['input']>;
-  direction?: InputMaybe<Scalars['String']['input']>;
-  first?: Scalars['Int']['input'];
-  linkTypes?: InputMaybe<Array<Scalars['String']['input']>>;
-  nameEx?: InputMaybe<Scalars['String']['input']>;
-  names?: InputMaybe<Array<Scalars['String']['input']>>;
-};
+  after?: InputMaybe<Scalars['String']['input']>
+  direction?: InputMaybe<Scalars['String']['input']>
+  first?: Scalars['Int']['input']
+  linkTypes?: InputMaybe<Array<Scalars['String']['input']>>
+  nameEx?: InputMaybe<Scalars['String']['input']>
+  names?: InputMaybe<Array<Scalars['String']['input']>>
+}
 
 export type WorkfilesConnection = {
-  __typename?: 'WorkfilesConnection';
-  edges: Array<WorkfileEdge>;
-  fieldStats: Array<ColumnStats>;
+  __typename?: 'WorkfilesConnection'
+  edges: Array<WorkfileEdge>
+  fieldStats: Array<ColumnStats>
   /** Pagination information */
-  pageInfo: PageInfo;
-};
+  pageInfo: PageInfo
+}
 
 export type GetFolderLinkDataQueryVariables = Exact<{
-  projectName: Scalars['String']['input'];
-  folderId: Scalars['String']['input'];
-}>;
+  projectName: string
+  folderId: string
+}>
 
-
-export type GetFolderLinkDataQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', folder?: { __typename: 'FolderNode', label?: string | null, id: string, name: string, parents: Array<string>, subType: string } | null } };
+export type GetFolderLinkDataQuery = {
+  project: {
+    folder: {
+      __typename: 'FolderNode'
+      label: string | null
+      id: string
+      name: string
+      parents: Array<string>
+      subType: string
+    } | null
+  }
+}
 
 export type GetProductLinkDataQueryVariables = Exact<{
-  projectName: Scalars['String']['input'];
-  productId: Scalars['String']['input'];
-}>;
+  projectName: string
+  productId: string
+}>
 
-
-export type GetProductLinkDataQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', product?: { __typename: 'ProductNode', id: string, name: string, parents: Array<string> } | null } };
+export type GetProductLinkDataQuery = {
+  project: {
+    product: { __typename: 'ProductNode'; id: string; name: string; parents: Array<string> } | null
+  }
+}
 
 export type GetRepresentationLinkDataQueryVariables = Exact<{
-  projectName: Scalars['String']['input'];
-  representationId: Scalars['String']['input'];
-}>;
+  projectName: string
+  representationId: string
+}>
 
-
-export type GetRepresentationLinkDataQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', representation?: { __typename: 'RepresentationNode', id: string, name: string, parents: Array<string> } | null } };
+export type GetRepresentationLinkDataQuery = {
+  project: {
+    representation: {
+      __typename: 'RepresentationNode'
+      id: string
+      name: string
+      parents: Array<string>
+    } | null
+  }
+}
 
 export type GetTaskLinkDataQueryVariables = Exact<{
-  projectName: Scalars['String']['input'];
-  taskId: Scalars['String']['input'];
-}>;
+  projectName: string
+  taskId: string
+}>
 
-
-export type GetTaskLinkDataQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', task?: { __typename: 'TaskNode', label?: string | null, id: string, name: string, parents: Array<string>, subType: string } | null } };
+export type GetTaskLinkDataQuery = {
+  project: {
+    task: {
+      __typename: 'TaskNode'
+      label: string | null
+      id: string
+      name: string
+      parents: Array<string>
+      subType: string
+    } | null
+  }
+}
 
 export type GetVersionLinkDataQueryVariables = Exact<{
-  projectName: Scalars['String']['input'];
-  versionId: Scalars['String']['input'];
-}>;
+  projectName: string
+  versionId: string
+}>
 
-
-export type GetVersionLinkDataQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', version?: { __typename: 'VersionNode', hasReviewables: boolean, id: string, name: string, parents: Array<string> } | null } };
+export type GetVersionLinkDataQuery = {
+  project: {
+    version: {
+      __typename: 'VersionNode'
+      hasReviewables: boolean
+      id: string
+      name: string
+      parents: Array<string>
+    } | null
+  }
+}
 
 export type GetWorkfileLinkDataQueryVariables = Exact<{
-  projectName: Scalars['String']['input'];
-  workfileId: Scalars['String']['input'];
-}>;
+  projectName: string
+  workfileId: string
+}>
 
-
-export type GetWorkfileLinkDataQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', workfile?: { __typename: 'WorkfileNode', id: string, name: string, parents: Array<string> } | null } };
+export type GetWorkfileLinkDataQuery = {
+  project: {
+    workfile: {
+      __typename: 'WorkfileNode'
+      id: string
+      name: string
+      parents: Array<string>
+    } | null
+  }
+}
 
 export type GetFoldersLinksQueryVariables = Exact<{
-  projectName: Scalars['String']['input'];
-  entityIds?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
-}>;
+  projectName: string
+  entityIds?: Array<string> | string | null | undefined
+}>
 
-
-export type GetFoldersLinksQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', folders: { __typename?: 'FoldersConnection', edges: Array<{ __typename?: 'FolderEdge', node: { __typename?: 'FolderNode', id: string, links: { __typename?: 'LinksConnection', edges: Array<{ __typename?: 'LinkEdge', id: string, direction: string, linkType: string, entityType: string, node?:
-                | { __typename: 'FolderNode', label?: string | null, id: string, name: string, parents: Array<string>, subType: string }
-                | { __typename: 'ProductNode', id: string, name: string, parents: Array<string> }
-                | { __typename: 'RepresentationNode', id: string, name: string, parents: Array<string> }
-                | { __typename: 'TaskNode', label?: string | null, id: string, name: string, parents: Array<string>, subType: string }
-                | { __typename: 'VersionNode', hasReviewables: boolean, id: string, name: string, parents: Array<string> }
-                | { __typename: 'WorkfileNode', id: string, name: string, parents: Array<string> }
-               | null }> } } }> } } };
+export type GetFoldersLinksQuery = {
+  project: {
+    folders: {
+      edges: Array<{
+        node: {
+          id: string
+          links: {
+            edges: Array<{
+              id: string
+              direction: string
+              linkType: string
+              entityType: string
+              node:
+                | {
+                    __typename: 'FolderNode'
+                    label: string | null
+                    id: string
+                    name: string
+                    parents: Array<string>
+                    subType: string
+                  }
+                | { __typename: 'ProductNode'; id: string; name: string; parents: Array<string> }
+                | {
+                    __typename: 'RepresentationNode'
+                    id: string
+                    name: string
+                    parents: Array<string>
+                  }
+                | {
+                    __typename: 'TaskNode'
+                    label: string | null
+                    id: string
+                    name: string
+                    parents: Array<string>
+                    subType: string
+                  }
+                | {
+                    __typename: 'VersionNode'
+                    hasReviewables: boolean
+                    id: string
+                    name: string
+                    parents: Array<string>
+                  }
+                | { __typename: 'WorkfileNode'; id: string; name: string; parents: Array<string> }
+                | null
+            }>
+          }
+        }
+      }>
+    }
+  }
+}
 
 export type GetProductsLinksQueryVariables = Exact<{
-  projectName: Scalars['String']['input'];
-  entityIds?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
-}>;
+  projectName: string
+  entityIds?: Array<string> | string | null | undefined
+}>
 
-
-export type GetProductsLinksQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', products: { __typename?: 'ProductsConnection', edges: Array<{ __typename?: 'ProductEdge', node: { __typename?: 'ProductNode', id: string, links: { __typename?: 'LinksConnection', edges: Array<{ __typename?: 'LinkEdge', id: string, direction: string, linkType: string, entityType: string, node?:
-                | { __typename: 'FolderNode', label?: string | null, id: string, name: string, parents: Array<string>, subType: string }
-                | { __typename: 'ProductNode', id: string, name: string, parents: Array<string> }
-                | { __typename: 'RepresentationNode', id: string, name: string, parents: Array<string> }
-                | { __typename: 'TaskNode', label?: string | null, id: string, name: string, parents: Array<string>, subType: string }
-                | { __typename: 'VersionNode', hasReviewables: boolean, id: string, name: string, parents: Array<string> }
-                | { __typename: 'WorkfileNode', id: string, name: string, parents: Array<string> }
-               | null }> } } }> } } };
+export type GetProductsLinksQuery = {
+  project: {
+    products: {
+      edges: Array<{
+        node: {
+          id: string
+          links: {
+            edges: Array<{
+              id: string
+              direction: string
+              linkType: string
+              entityType: string
+              node:
+                | {
+                    __typename: 'FolderNode'
+                    label: string | null
+                    id: string
+                    name: string
+                    parents: Array<string>
+                    subType: string
+                  }
+                | { __typename: 'ProductNode'; id: string; name: string; parents: Array<string> }
+                | {
+                    __typename: 'RepresentationNode'
+                    id: string
+                    name: string
+                    parents: Array<string>
+                  }
+                | {
+                    __typename: 'TaskNode'
+                    label: string | null
+                    id: string
+                    name: string
+                    parents: Array<string>
+                    subType: string
+                  }
+                | {
+                    __typename: 'VersionNode'
+                    hasReviewables: boolean
+                    id: string
+                    name: string
+                    parents: Array<string>
+                  }
+                | { __typename: 'WorkfileNode'; id: string; name: string; parents: Array<string> }
+                | null
+            }>
+          }
+        }
+      }>
+    }
+  }
+}
 
 export type GetTasksLinksQueryVariables = Exact<{
-  projectName: Scalars['String']['input'];
-  entityIds?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
-}>;
+  projectName: string
+  entityIds?: Array<string> | string | null | undefined
+}>
 
-
-export type GetTasksLinksQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', tasks: { __typename?: 'TasksConnection', edges: Array<{ __typename?: 'TaskEdge', node: { __typename?: 'TaskNode', id: string, links: { __typename?: 'LinksConnection', edges: Array<{ __typename?: 'LinkEdge', id: string, direction: string, linkType: string, entityType: string, node?:
-                | { __typename: 'FolderNode', label?: string | null, id: string, name: string, parents: Array<string>, subType: string }
-                | { __typename: 'ProductNode', id: string, name: string, parents: Array<string> }
-                | { __typename: 'RepresentationNode', id: string, name: string, parents: Array<string> }
-                | { __typename: 'TaskNode', label?: string | null, id: string, name: string, parents: Array<string>, subType: string }
-                | { __typename: 'VersionNode', hasReviewables: boolean, id: string, name: string, parents: Array<string> }
-                | { __typename: 'WorkfileNode', id: string, name: string, parents: Array<string> }
-               | null }> } } }> } } };
+export type GetTasksLinksQuery = {
+  project: {
+    tasks: {
+      edges: Array<{
+        node: {
+          id: string
+          links: {
+            edges: Array<{
+              id: string
+              direction: string
+              linkType: string
+              entityType: string
+              node:
+                | {
+                    __typename: 'FolderNode'
+                    label: string | null
+                    id: string
+                    name: string
+                    parents: Array<string>
+                    subType: string
+                  }
+                | { __typename: 'ProductNode'; id: string; name: string; parents: Array<string> }
+                | {
+                    __typename: 'RepresentationNode'
+                    id: string
+                    name: string
+                    parents: Array<string>
+                  }
+                | {
+                    __typename: 'TaskNode'
+                    label: string | null
+                    id: string
+                    name: string
+                    parents: Array<string>
+                    subType: string
+                  }
+                | {
+                    __typename: 'VersionNode'
+                    hasReviewables: boolean
+                    id: string
+                    name: string
+                    parents: Array<string>
+                  }
+                | { __typename: 'WorkfileNode'; id: string; name: string; parents: Array<string> }
+                | null
+            }>
+          }
+        }
+      }>
+    }
+  }
+}
 
 export type GetVersionsLinksQueryVariables = Exact<{
-  projectName: Scalars['String']['input'];
-  entityIds?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
-}>;
+  projectName: string
+  entityIds?: Array<string> | string | null | undefined
+}>
 
-
-export type GetVersionsLinksQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', versions: { __typename?: 'VersionsConnection', edges: Array<{ __typename?: 'VersionEdge', node: { __typename?: 'VersionNode', id: string, links: { __typename?: 'LinksConnection', edges: Array<{ __typename?: 'LinkEdge', id: string, direction: string, linkType: string, entityType: string, node?:
-                | { __typename: 'FolderNode', label?: string | null, id: string, name: string, parents: Array<string>, subType: string }
-                | { __typename: 'ProductNode', id: string, name: string, parents: Array<string> }
-                | { __typename: 'RepresentationNode', id: string, name: string, parents: Array<string> }
-                | { __typename: 'TaskNode', label?: string | null, id: string, name: string, parents: Array<string>, subType: string }
-                | { __typename: 'VersionNode', hasReviewables: boolean, id: string, name: string, parents: Array<string> }
-                | { __typename: 'WorkfileNode', id: string, name: string, parents: Array<string> }
-               | null }> } } }> } } };
+export type GetVersionsLinksQuery = {
+  project: {
+    versions: {
+      edges: Array<{
+        node: {
+          id: string
+          links: {
+            edges: Array<{
+              id: string
+              direction: string
+              linkType: string
+              entityType: string
+              node:
+                | {
+                    __typename: 'FolderNode'
+                    label: string | null
+                    id: string
+                    name: string
+                    parents: Array<string>
+                    subType: string
+                  }
+                | { __typename: 'ProductNode'; id: string; name: string; parents: Array<string> }
+                | {
+                    __typename: 'RepresentationNode'
+                    id: string
+                    name: string
+                    parents: Array<string>
+                  }
+                | {
+                    __typename: 'TaskNode'
+                    label: string | null
+                    id: string
+                    name: string
+                    parents: Array<string>
+                    subType: string
+                  }
+                | {
+                    __typename: 'VersionNode'
+                    hasReviewables: boolean
+                    id: string
+                    name: string
+                    parents: Array<string>
+                  }
+                | { __typename: 'WorkfileNode'; id: string; name: string; parents: Array<string> }
+                | null
+            }>
+          }
+        }
+      }>
+    }
+  }
+}
 
 export type GetWorkfilesLinksQueryVariables = Exact<{
-  projectName: Scalars['String']['input'];
-  entityIds?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
-}>;
+  projectName: string
+  entityIds?: Array<string> | string | null | undefined
+}>
 
-
-export type GetWorkfilesLinksQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', workfiles: { __typename?: 'WorkfilesConnection', edges: Array<{ __typename?: 'WorkfileEdge', node: { __typename?: 'WorkfileNode', id: string, links: { __typename?: 'LinksConnection', edges: Array<{ __typename?: 'LinkEdge', id: string, direction: string, linkType: string, entityType: string, node?:
-                | { __typename: 'FolderNode', label?: string | null, id: string, name: string, parents: Array<string>, subType: string }
-                | { __typename: 'ProductNode', id: string, name: string, parents: Array<string> }
-                | { __typename: 'RepresentationNode', id: string, name: string, parents: Array<string> }
-                | { __typename: 'TaskNode', label?: string | null, id: string, name: string, parents: Array<string>, subType: string }
-                | { __typename: 'VersionNode', hasReviewables: boolean, id: string, name: string, parents: Array<string> }
-                | { __typename: 'WorkfileNode', id: string, name: string, parents: Array<string> }
-               | null }> } } }> } } };
+export type GetWorkfilesLinksQuery = {
+  project: {
+    workfiles: {
+      edges: Array<{
+        node: {
+          id: string
+          links: {
+            edges: Array<{
+              id: string
+              direction: string
+              linkType: string
+              entityType: string
+              node:
+                | {
+                    __typename: 'FolderNode'
+                    label: string | null
+                    id: string
+                    name: string
+                    parents: Array<string>
+                    subType: string
+                  }
+                | { __typename: 'ProductNode'; id: string; name: string; parents: Array<string> }
+                | {
+                    __typename: 'RepresentationNode'
+                    id: string
+                    name: string
+                    parents: Array<string>
+                  }
+                | {
+                    __typename: 'TaskNode'
+                    label: string | null
+                    id: string
+                    name: string
+                    parents: Array<string>
+                    subType: string
+                  }
+                | {
+                    __typename: 'VersionNode'
+                    hasReviewables: boolean
+                    id: string
+                    name: string
+                    parents: Array<string>
+                  }
+                | { __typename: 'WorkfileNode'; id: string; name: string; parents: Array<string> }
+                | null
+            }>
+          }
+        }
+      }>
+    }
+  }
+}
 
 export type GetRepresentationsLinksQueryVariables = Exact<{
-  projectName: Scalars['String']['input'];
-  entityIds?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
-}>;
+  projectName: string
+  entityIds?: Array<string> | string | null | undefined
+}>
 
-
-export type GetRepresentationsLinksQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', representations: { __typename?: 'RepresentationsConnection', edges: Array<{ __typename?: 'RepresentationEdge', node: { __typename?: 'RepresentationNode', id: string, links: { __typename?: 'LinksConnection', edges: Array<{ __typename?: 'LinkEdge', id: string, direction: string, linkType: string, entityType: string, node?:
-                | { __typename: 'FolderNode', label?: string | null, id: string, name: string, parents: Array<string>, subType: string }
-                | { __typename: 'ProductNode', id: string, name: string, parents: Array<string> }
-                | { __typename: 'RepresentationNode', id: string, name: string, parents: Array<string> }
-                | { __typename: 'TaskNode', label?: string | null, id: string, name: string, parents: Array<string>, subType: string }
-                | { __typename: 'VersionNode', hasReviewables: boolean, id: string, name: string, parents: Array<string> }
-                | { __typename: 'WorkfileNode', id: string, name: string, parents: Array<string> }
-               | null }> } } }> } } };
+export type GetRepresentationsLinksQuery = {
+  project: {
+    representations: {
+      edges: Array<{
+        node: {
+          id: string
+          links: {
+            edges: Array<{
+              id: string
+              direction: string
+              linkType: string
+              entityType: string
+              node:
+                | {
+                    __typename: 'FolderNode'
+                    label: string | null
+                    id: string
+                    name: string
+                    parents: Array<string>
+                    subType: string
+                  }
+                | { __typename: 'ProductNode'; id: string; name: string; parents: Array<string> }
+                | {
+                    __typename: 'RepresentationNode'
+                    id: string
+                    name: string
+                    parents: Array<string>
+                  }
+                | {
+                    __typename: 'TaskNode'
+                    label: string | null
+                    id: string
+                    name: string
+                    parents: Array<string>
+                    subType: string
+                  }
+                | {
+                    __typename: 'VersionNode'
+                    hasReviewables: boolean
+                    id: string
+                    name: string
+                    parents: Array<string>
+                  }
+                | { __typename: 'WorkfileNode'; id: string; name: string; parents: Array<string> }
+                | null
+            }>
+          }
+        }
+      }>
+    }
+  }
+}
 
 export type GetSearchedFoldersQueryVariables = Exact<{
-  projectName: Scalars['String']['input'];
-  search?: InputMaybe<Scalars['String']['input']>;
-  after?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
-}>;
+  projectName: string
+  search?: string | null | undefined
+  after?: string | null | undefined
+  first?: number | null | undefined
+  before?: string | null | undefined
+  last?: number | null | undefined
+}>
 
-
-export type GetSearchedFoldersQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', name: string, folders: { __typename?: 'FoldersConnection', pageInfo: { __typename?: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean }, edges: Array<{ __typename?: 'FolderEdge', cursor?: string | null, node: { __typename: 'FolderNode', label?: string | null, id: string, name: string, parents: Array<string>, subType: string } }> } } };
+export type GetSearchedFoldersQuery = {
+  project: {
+    name: string
+    folders: {
+      pageInfo: {
+        startCursor: string | null
+        endCursor: string | null
+        hasNextPage: boolean
+        hasPreviousPage: boolean
+      }
+      edges: Array<{
+        cursor: string | null
+        node: {
+          __typename: 'FolderNode'
+          label: string | null
+          id: string
+          name: string
+          parents: Array<string>
+          subType: string
+        }
+      }>
+    }
+  }
+}
 
 export type GetSearchedProductsQueryVariables = Exact<{
-  projectName: Scalars['String']['input'];
-  search?: InputMaybe<Scalars['String']['input']>;
-  parentIds?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
-  after?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
-}>;
+  projectName: string
+  search?: string | null | undefined
+  parentIds?: Array<string> | string | null | undefined
+  after?: string | null | undefined
+  first?: number | null | undefined
+  before?: string | null | undefined
+  last?: number | null | undefined
+}>
 
-
-export type GetSearchedProductsQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', name: string, products: { __typename?: 'ProductsConnection', pageInfo: { __typename?: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean }, edges: Array<{ __typename?: 'ProductEdge', cursor?: string | null, node: { __typename: 'ProductNode', id: string, name: string, parents: Array<string>, subType: string } }> } } };
+export type GetSearchedProductsQuery = {
+  project: {
+    name: string
+    products: {
+      pageInfo: {
+        startCursor: string | null
+        endCursor: string | null
+        hasNextPage: boolean
+        hasPreviousPage: boolean
+      }
+      edges: Array<{
+        cursor: string | null
+        node: {
+          __typename: 'ProductNode'
+          id: string
+          name: string
+          parents: Array<string>
+          subType: string
+        }
+      }>
+    }
+  }
+}
 
 export type GetSearchedRepresentationsQueryVariables = Exact<{
-  projectName: Scalars['String']['input'];
-  search?: InputMaybe<Scalars['String']['input']>;
-  parentIds?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
-  after?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
-}>;
+  projectName: string
+  search?: string | null | undefined
+  parentIds?: Array<string> | string | null | undefined
+  after?: string | null | undefined
+  first?: number | null | undefined
+  before?: string | null | undefined
+  last?: number | null | undefined
+}>
 
-
-export type GetSearchedRepresentationsQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', name: string, representations: { __typename?: 'RepresentationsConnection', pageInfo: { __typename?: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean }, edges: Array<{ __typename?: 'RepresentationEdge', cursor?: string | null, node: { __typename: 'RepresentationNode', id: string, name: string, parents: Array<string> } }> } } };
+export type GetSearchedRepresentationsQuery = {
+  project: {
+    name: string
+    representations: {
+      pageInfo: {
+        startCursor: string | null
+        endCursor: string | null
+        hasNextPage: boolean
+        hasPreviousPage: boolean
+      }
+      edges: Array<{
+        cursor: string | null
+        node: { __typename: 'RepresentationNode'; id: string; name: string; parents: Array<string> }
+      }>
+    }
+  }
+}
 
 export type GetSearchedTasksQueryVariables = Exact<{
-  projectName: Scalars['String']['input'];
-  search?: InputMaybe<Scalars['String']['input']>;
-  parentIds?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
-  after?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
-}>;
+  projectName: string
+  search?: string | null | undefined
+  parentIds?: Array<string> | string | null | undefined
+  after?: string | null | undefined
+  first?: number | null | undefined
+  before?: string | null | undefined
+  last?: number | null | undefined
+}>
 
-
-export type GetSearchedTasksQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', name: string, tasks: { __typename?: 'TasksConnection', pageInfo: { __typename?: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean }, edges: Array<{ __typename?: 'TaskEdge', cursor?: string | null, node: { __typename: 'TaskNode', label?: string | null, id: string, name: string, parents: Array<string>, subType: string } }> } } };
+export type GetSearchedTasksQuery = {
+  project: {
+    name: string
+    tasks: {
+      pageInfo: {
+        startCursor: string | null
+        endCursor: string | null
+        hasNextPage: boolean
+        hasPreviousPage: boolean
+      }
+      edges: Array<{
+        cursor: string | null
+        node: {
+          __typename: 'TaskNode'
+          label: string | null
+          id: string
+          name: string
+          parents: Array<string>
+          subType: string
+        }
+      }>
+    }
+  }
+}
 
 export type GetSearchedVersionsQueryVariables = Exact<{
-  projectName: Scalars['String']['input'];
-  search?: InputMaybe<Scalars['String']['input']>;
-  parentIds?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
-  after?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
-}>;
+  projectName: string
+  search?: string | null | undefined
+  parentIds?: Array<string> | string | null | undefined
+  after?: string | null | undefined
+  first?: number | null | undefined
+  before?: string | null | undefined
+  last?: number | null | undefined
+}>
 
-
-export type GetSearchedVersionsQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', name: string, versions: { __typename?: 'VersionsConnection', pageInfo: { __typename?: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean }, edges: Array<{ __typename?: 'VersionEdge', cursor?: string | null, node: { __typename: 'VersionNode', hasReviewables: boolean, id: string, name: string, parents: Array<string> } }> } } };
+export type GetSearchedVersionsQuery = {
+  project: {
+    name: string
+    versions: {
+      pageInfo: {
+        startCursor: string | null
+        endCursor: string | null
+        hasNextPage: boolean
+        hasPreviousPage: boolean
+      }
+      edges: Array<{
+        cursor: string | null
+        node: {
+          __typename: 'VersionNode'
+          hasReviewables: boolean
+          id: string
+          name: string
+          parents: Array<string>
+        }
+      }>
+    }
+  }
+}
 
 export type GetSearchedWorkfilesQueryVariables = Exact<{
-  projectName: Scalars['String']['input'];
-  search?: InputMaybe<Scalars['String']['input']>;
-  parentIds?: InputMaybe<Array<Scalars['String']['input']> | Scalars['String']['input']>;
-  after?: InputMaybe<Scalars['String']['input']>;
-  first?: InputMaybe<Scalars['Int']['input']>;
-  before?: InputMaybe<Scalars['String']['input']>;
-  last?: InputMaybe<Scalars['Int']['input']>;
-}>;
+  projectName: string
+  search?: string | null | undefined
+  parentIds?: Array<string> | string | null | undefined
+  after?: string | null | undefined
+  first?: number | null | undefined
+  before?: string | null | undefined
+  last?: number | null | undefined
+}>
 
+export type GetSearchedWorkfilesQuery = {
+  project: {
+    name: string
+    workfiles: {
+      pageInfo: {
+        startCursor: string | null
+        endCursor: string | null
+        hasNextPage: boolean
+        hasPreviousPage: boolean
+      }
+      edges: Array<{
+        cursor: string | null
+        node: { __typename: 'WorkfileNode'; id: string; name: string; parents: Array<string> }
+      }>
+    }
+  }
+}
 
-export type GetSearchedWorkfilesQuery = { __typename?: 'Query', project: { __typename?: 'ProjectNode', name: string, workfiles: { __typename?: 'WorkfilesConnection', pageInfo: { __typename?: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean }, edges: Array<{ __typename?: 'WorkfileEdge', cursor?: string | null, node: { __typename: 'WorkfileNode', id: string, name: string, parents: Array<string> } }> } } };
+export type OverviewEntityLinkFragmentFragment = {
+  id: string
+  direction: string
+  linkType: string
+  entityType: string
+  node:
+    | {
+        __typename: 'FolderNode'
+        label: string | null
+        id: string
+        name: string
+        parents: Array<string>
+        subType: string
+      }
+    | { __typename: 'ProductNode'; id: string; name: string; parents: Array<string> }
+    | { __typename: 'RepresentationNode'; id: string; name: string; parents: Array<string> }
+    | {
+        __typename: 'TaskNode'
+        label: string | null
+        id: string
+        name: string
+        parents: Array<string>
+        subType: string
+      }
+    | {
+        __typename: 'VersionNode'
+        hasReviewables: boolean
+        id: string
+        name: string
+        parents: Array<string>
+      }
+    | { __typename: 'WorkfileNode'; id: string; name: string; parents: Array<string> }
+    | null
+}
 
-export type OverviewEntityLinkFragmentFragment = { __typename?: 'LinkEdge', id: string, direction: string, linkType: string, entityType: string, node?:
-    | { __typename: 'FolderNode', label?: string | null, id: string, name: string, parents: Array<string>, subType: string }
-    | { __typename: 'ProductNode', id: string, name: string, parents: Array<string> }
-    | { __typename: 'RepresentationNode', id: string, name: string, parents: Array<string> }
-    | { __typename: 'TaskNode', label?: string | null, id: string, name: string, parents: Array<string>, subType: string }
-    | { __typename: 'VersionNode', hasReviewables: boolean, id: string, name: string, parents: Array<string> }
-    | { __typename: 'WorkfileNode', id: string, name: string, parents: Array<string> }
-   | null };
+type OverviewEntityLinkNodeFragment_FolderNode_Fragment = {
+  __typename: 'FolderNode'
+  label: string | null
+  id: string
+  name: string
+  parents: Array<string>
+  subType: string
+}
 
-type OverviewEntityLinkNodeFragment_FolderNode_Fragment = { __typename: 'FolderNode', label?: string | null, id: string, name: string, parents: Array<string>, subType: string };
+type OverviewEntityLinkNodeFragment_ProductNode_Fragment = {
+  __typename: 'ProductNode'
+  id: string
+  name: string
+  parents: Array<string>
+}
 
-type OverviewEntityLinkNodeFragment_ProductNode_Fragment = { __typename: 'ProductNode', id: string, name: string, parents: Array<string> };
+type OverviewEntityLinkNodeFragment_RepresentationNode_Fragment = {
+  __typename: 'RepresentationNode'
+  id: string
+  name: string
+  parents: Array<string>
+}
 
-type OverviewEntityLinkNodeFragment_RepresentationNode_Fragment = { __typename: 'RepresentationNode', id: string, name: string, parents: Array<string> };
+type OverviewEntityLinkNodeFragment_TaskNode_Fragment = {
+  __typename: 'TaskNode'
+  label: string | null
+  id: string
+  name: string
+  parents: Array<string>
+  subType: string
+}
 
-type OverviewEntityLinkNodeFragment_TaskNode_Fragment = { __typename: 'TaskNode', label?: string | null, id: string, name: string, parents: Array<string>, subType: string };
+type OverviewEntityLinkNodeFragment_VersionNode_Fragment = {
+  __typename: 'VersionNode'
+  hasReviewables: boolean
+  id: string
+  name: string
+  parents: Array<string>
+}
 
-type OverviewEntityLinkNodeFragment_VersionNode_Fragment = { __typename: 'VersionNode', hasReviewables: boolean, id: string, name: string, parents: Array<string> };
-
-type OverviewEntityLinkNodeFragment_WorkfileNode_Fragment = { __typename: 'WorkfileNode', id: string, name: string, parents: Array<string> };
+type OverviewEntityLinkNodeFragment_WorkfileNode_Fragment = {
+  __typename: 'WorkfileNode'
+  id: string
+  name: string
+  parents: Array<string>
+}
 
 export type OverviewEntityLinkNodeFragmentFragment =
   | OverviewEntityLinkNodeFragment_FolderNode_Fragment
@@ -1961,9 +2397,9 @@ export type OverviewEntityLinkNodeFragmentFragment =
   | OverviewEntityLinkNodeFragment_TaskNode_Fragment
   | OverviewEntityLinkNodeFragment_VersionNode_Fragment
   | OverviewEntityLinkNodeFragment_WorkfileNode_Fragment
-;
 
-export const OverviewEntityLinkNodeFragmentFragmentDoc = new TypedDocumentString(`
+export const OverviewEntityLinkNodeFragmentFragmentDoc = new TypedDocumentString(
+  `
     fragment OverviewEntityLinkNodeFragment on BaseNode {
   __typename
   id
@@ -1981,8 +2417,11 @@ export const OverviewEntityLinkNodeFragmentFragmentDoc = new TypedDocumentString
     hasReviewables
   }
 }
-    `, {"fragmentName":"OverviewEntityLinkNodeFragment"});
-export const OverviewEntityLinkFragmentFragmentDoc = new TypedDocumentString(`
+    `,
+  { fragmentName: 'OverviewEntityLinkNodeFragment' },
+)
+export const OverviewEntityLinkFragmentFragmentDoc = new TypedDocumentString(
+  `
     fragment OverviewEntityLinkFragment on LinkEdge {
   id
   direction
@@ -2008,7 +2447,9 @@ export const OverviewEntityLinkFragmentFragmentDoc = new TypedDocumentString(`
   ... on VersionNode {
     hasReviewables
   }
-}`, {"fragmentName":"OverviewEntityLinkFragment"});
+}`,
+  { fragmentName: 'OverviewEntityLinkFragment' },
+)
 export const GetFolderLinkDataDocument = new TypedDocumentString(`
     query GetFolderLinkData($projectName: String!, $folderId: String!) {
   project(name: $projectName) {
@@ -2033,7 +2474,7 @@ export const GetFolderLinkDataDocument = new TypedDocumentString(`
   ... on VersionNode {
     hasReviewables
   }
-}`);
+}`)
 export const GetProductLinkDataDocument = new TypedDocumentString(`
     query GetProductLinkData($projectName: String!, $productId: String!) {
   project(name: $projectName) {
@@ -2058,7 +2499,7 @@ export const GetProductLinkDataDocument = new TypedDocumentString(`
   ... on VersionNode {
     hasReviewables
   }
-}`);
+}`)
 export const GetRepresentationLinkDataDocument = new TypedDocumentString(`
     query GetRepresentationLinkData($projectName: String!, $representationId: String!) {
   project(name: $projectName) {
@@ -2083,7 +2524,7 @@ export const GetRepresentationLinkDataDocument = new TypedDocumentString(`
   ... on VersionNode {
     hasReviewables
   }
-}`);
+}`)
 export const GetTaskLinkDataDocument = new TypedDocumentString(`
     query GetTaskLinkData($projectName: String!, $taskId: String!) {
   project(name: $projectName) {
@@ -2108,7 +2549,7 @@ export const GetTaskLinkDataDocument = new TypedDocumentString(`
   ... on VersionNode {
     hasReviewables
   }
-}`);
+}`)
 export const GetVersionLinkDataDocument = new TypedDocumentString(`
     query GetVersionLinkData($projectName: String!, $versionId: String!) {
   project(name: $projectName) {
@@ -2133,7 +2574,7 @@ export const GetVersionLinkDataDocument = new TypedDocumentString(`
   ... on VersionNode {
     hasReviewables
   }
-}`);
+}`)
 export const GetWorkfileLinkDataDocument = new TypedDocumentString(`
     query GetWorkfileLinkData($projectName: String!, $workfileId: String!) {
   project(name: $projectName) {
@@ -2158,7 +2599,7 @@ export const GetWorkfileLinkDataDocument = new TypedDocumentString(`
   ... on VersionNode {
     hasReviewables
   }
-}`);
+}`)
 export const GetFoldersLinksDocument = new TypedDocumentString(`
     query GetFoldersLinks($projectName: String!, $entityIds: [String!]) {
   project(name: $projectName) {
@@ -2201,7 +2642,7 @@ fragment OverviewEntityLinkNodeFragment on BaseNode {
   ... on VersionNode {
     hasReviewables
   }
-}`);
+}`)
 export const GetProductsLinksDocument = new TypedDocumentString(`
     query GetProductsLinks($projectName: String!, $entityIds: [String!]) {
   project(name: $projectName) {
@@ -2244,7 +2685,7 @@ fragment OverviewEntityLinkNodeFragment on BaseNode {
   ... on VersionNode {
     hasReviewables
   }
-}`);
+}`)
 export const GetTasksLinksDocument = new TypedDocumentString(`
     query GetTasksLinks($projectName: String!, $entityIds: [String!]) {
   project(name: $projectName) {
@@ -2287,7 +2728,7 @@ fragment OverviewEntityLinkNodeFragment on BaseNode {
   ... on VersionNode {
     hasReviewables
   }
-}`);
+}`)
 export const GetVersionsLinksDocument = new TypedDocumentString(`
     query GetVersionsLinks($projectName: String!, $entityIds: [String!]) {
   project(name: $projectName) {
@@ -2330,7 +2771,7 @@ fragment OverviewEntityLinkNodeFragment on BaseNode {
   ... on VersionNode {
     hasReviewables
   }
-}`);
+}`)
 export const GetWorkfilesLinksDocument = new TypedDocumentString(`
     query GetWorkfilesLinks($projectName: String!, $entityIds: [String!]) {
   project(name: $projectName) {
@@ -2373,7 +2814,7 @@ fragment OverviewEntityLinkNodeFragment on BaseNode {
   ... on VersionNode {
     hasReviewables
   }
-}`);
+}`)
 export const GetRepresentationsLinksDocument = new TypedDocumentString(`
     query GetRepresentationsLinks($projectName: String!, $entityIds: [String!]) {
   project(name: $projectName) {
@@ -2416,7 +2857,7 @@ fragment OverviewEntityLinkNodeFragment on BaseNode {
   ... on VersionNode {
     hasReviewables
   }
-}`);
+}`)
 export const GetSearchedFoldersDocument = new TypedDocumentString(`
     query GetSearchedFolders($projectName: String!, $search: String, $after: String, $first: Int, $before: String, $last: Int) {
   project(name: $projectName) {
@@ -2462,7 +2903,7 @@ export const GetSearchedFoldersDocument = new TypedDocumentString(`
   ... on VersionNode {
     hasReviewables
   }
-}`);
+}`)
 export const GetSearchedProductsDocument = new TypedDocumentString(`
     query GetSearchedProducts($projectName: String!, $search: String, $parentIds: [String!], $after: String, $first: Int, $before: String, $last: Int) {
   project(name: $projectName) {
@@ -2508,7 +2949,7 @@ export const GetSearchedProductsDocument = new TypedDocumentString(`
   ... on VersionNode {
     hasReviewables
   }
-}`);
+}`)
 export const GetSearchedRepresentationsDocument = new TypedDocumentString(`
     query GetSearchedRepresentations($projectName: String!, $search: String, $parentIds: [String!], $after: String, $first: Int, $before: String, $last: Int) {
   project(name: $projectName) {
@@ -2552,7 +2993,7 @@ export const GetSearchedRepresentationsDocument = new TypedDocumentString(`
   ... on VersionNode {
     hasReviewables
   }
-}`);
+}`)
 export const GetSearchedTasksDocument = new TypedDocumentString(`
     query GetSearchedTasks($projectName: String!, $search: String, $parentIds: [String!], $after: String, $first: Int, $before: String, $last: Int) {
   project(name: $projectName) {
@@ -2599,7 +3040,7 @@ export const GetSearchedTasksDocument = new TypedDocumentString(`
   ... on VersionNode {
     hasReviewables
   }
-}`);
+}`)
 export const GetSearchedVersionsDocument = new TypedDocumentString(`
     query GetSearchedVersions($projectName: String!, $search: String, $parentIds: [String!], $after: String, $first: Int, $before: String, $last: Int) {
   project(name: $projectName) {
@@ -2643,7 +3084,7 @@ export const GetSearchedVersionsDocument = new TypedDocumentString(`
   ... on VersionNode {
     hasReviewables
   }
-}`);
+}`)
 export const GetSearchedWorkfilesDocument = new TypedDocumentString(`
     query GetSearchedWorkfiles($projectName: String!, $search: String, $parentIds: [String!], $after: String, $first: Int, $before: String, $last: Int) {
   project(name: $projectName) {
@@ -2687,67 +3128,122 @@ export const GetSearchedWorkfilesDocument = new TypedDocumentString(`
   ... on VersionNode {
     hasReviewables
   }
-}`);
+}`)
 
 const injectedRtkApi = api.injectEndpoints({
   endpoints: (build) => ({
     GetFolderLinkData: build.query<GetFolderLinkDataQuery, GetFolderLinkDataQueryVariables>({
-      query: (variables) => ({ document: GetFolderLinkDataDocument, variables })
+      query: (variables) => ({
+        document: GetFolderLinkDataDocument as unknown as string,
+        variables,
+      }),
     }),
     GetProductLinkData: build.query<GetProductLinkDataQuery, GetProductLinkDataQueryVariables>({
-      query: (variables) => ({ document: GetProductLinkDataDocument, variables })
+      query: (variables) => ({
+        document: GetProductLinkDataDocument as unknown as string,
+        variables,
+      }),
     }),
-    GetRepresentationLinkData: build.query<GetRepresentationLinkDataQuery, GetRepresentationLinkDataQueryVariables>({
-      query: (variables) => ({ document: GetRepresentationLinkDataDocument, variables })
+    GetRepresentationLinkData: build.query<
+      GetRepresentationLinkDataQuery,
+      GetRepresentationLinkDataQueryVariables
+    >({
+      query: (variables) => ({
+        document: GetRepresentationLinkDataDocument as unknown as string,
+        variables,
+      }),
     }),
     GetTaskLinkData: build.query<GetTaskLinkDataQuery, GetTaskLinkDataQueryVariables>({
-      query: (variables) => ({ document: GetTaskLinkDataDocument, variables })
+      query: (variables) => ({ document: GetTaskLinkDataDocument as unknown as string, variables }),
     }),
     GetVersionLinkData: build.query<GetVersionLinkDataQuery, GetVersionLinkDataQueryVariables>({
-      query: (variables) => ({ document: GetVersionLinkDataDocument, variables })
+      query: (variables) => ({
+        document: GetVersionLinkDataDocument as unknown as string,
+        variables,
+      }),
     }),
     GetWorkfileLinkData: build.query<GetWorkfileLinkDataQuery, GetWorkfileLinkDataQueryVariables>({
-      query: (variables) => ({ document: GetWorkfileLinkDataDocument, variables })
+      query: (variables) => ({
+        document: GetWorkfileLinkDataDocument as unknown as string,
+        variables,
+      }),
     }),
     GetFoldersLinks: build.query<GetFoldersLinksQuery, GetFoldersLinksQueryVariables>({
-      query: (variables) => ({ document: GetFoldersLinksDocument, variables })
+      query: (variables) => ({ document: GetFoldersLinksDocument as unknown as string, variables }),
     }),
     GetProductsLinks: build.query<GetProductsLinksQuery, GetProductsLinksQueryVariables>({
-      query: (variables) => ({ document: GetProductsLinksDocument, variables })
+      query: (variables) => ({
+        document: GetProductsLinksDocument as unknown as string,
+        variables,
+      }),
     }),
     GetTasksLinks: build.query<GetTasksLinksQuery, GetTasksLinksQueryVariables>({
-      query: (variables) => ({ document: GetTasksLinksDocument, variables })
+      query: (variables) => ({ document: GetTasksLinksDocument as unknown as string, variables }),
     }),
     GetVersionsLinks: build.query<GetVersionsLinksQuery, GetVersionsLinksQueryVariables>({
-      query: (variables) => ({ document: GetVersionsLinksDocument, variables })
+      query: (variables) => ({
+        document: GetVersionsLinksDocument as unknown as string,
+        variables,
+      }),
     }),
     GetWorkfilesLinks: build.query<GetWorkfilesLinksQuery, GetWorkfilesLinksQueryVariables>({
-      query: (variables) => ({ document: GetWorkfilesLinksDocument, variables })
+      query: (variables) => ({
+        document: GetWorkfilesLinksDocument as unknown as string,
+        variables,
+      }),
     }),
-    GetRepresentationsLinks: build.query<GetRepresentationsLinksQuery, GetRepresentationsLinksQueryVariables>({
-      query: (variables) => ({ document: GetRepresentationsLinksDocument, variables })
+    GetRepresentationsLinks: build.query<
+      GetRepresentationsLinksQuery,
+      GetRepresentationsLinksQueryVariables
+    >({
+      query: (variables) => ({
+        document: GetRepresentationsLinksDocument as unknown as string,
+        variables,
+      }),
     }),
     GetSearchedFolders: build.query<GetSearchedFoldersQuery, GetSearchedFoldersQueryVariables>({
-      query: (variables) => ({ document: GetSearchedFoldersDocument, variables })
+      query: (variables) => ({
+        document: GetSearchedFoldersDocument as unknown as string,
+        variables,
+      }),
     }),
     GetSearchedProducts: build.query<GetSearchedProductsQuery, GetSearchedProductsQueryVariables>({
-      query: (variables) => ({ document: GetSearchedProductsDocument, variables })
+      query: (variables) => ({
+        document: GetSearchedProductsDocument as unknown as string,
+        variables,
+      }),
     }),
-    GetSearchedRepresentations: build.query<GetSearchedRepresentationsQuery, GetSearchedRepresentationsQueryVariables>({
-      query: (variables) => ({ document: GetSearchedRepresentationsDocument, variables })
+    GetSearchedRepresentations: build.query<
+      GetSearchedRepresentationsQuery,
+      GetSearchedRepresentationsQueryVariables
+    >({
+      query: (variables) => ({
+        document: GetSearchedRepresentationsDocument as unknown as string,
+        variables,
+      }),
     }),
     GetSearchedTasks: build.query<GetSearchedTasksQuery, GetSearchedTasksQueryVariables>({
-      query: (variables) => ({ document: GetSearchedTasksDocument, variables })
+      query: (variables) => ({
+        document: GetSearchedTasksDocument as unknown as string,
+        variables,
+      }),
     }),
     GetSearchedVersions: build.query<GetSearchedVersionsQuery, GetSearchedVersionsQueryVariables>({
-      query: (variables) => ({ document: GetSearchedVersionsDocument, variables })
+      query: (variables) => ({
+        document: GetSearchedVersionsDocument as unknown as string,
+        variables,
+      }),
     }),
-    GetSearchedWorkfiles: build.query<GetSearchedWorkfilesQuery, GetSearchedWorkfilesQueryVariables>({
-      query: (variables) => ({ document: GetSearchedWorkfilesDocument, variables })
+    GetSearchedWorkfiles: build.query<
+      GetSearchedWorkfilesQuery,
+      GetSearchedWorkfilesQueryVariables
+    >({
+      query: (variables) => ({
+        document: GetSearchedWorkfilesDocument as unknown as string,
+        variables,
+      }),
     }),
   }),
-});
+})
 
-export { injectedRtkApi as api };
-
-
+export { injectedRtkApi as api }

--- a/shared/src/api/queries/columnStats/columnStats.ts
+++ b/shared/src/api/queries/columnStats/columnStats.ts
@@ -1,24 +1,7 @@
+import { ColumnStats } from '@shared/api/generated'
 // Shape of the backend GraphQL `ColumnStats` (connection.fieldStats).
 // `sum` and `distribution` are typed ahead of backend support so wiring them is a no-op.
-export type FieldStats = {
-  columnName: string
-  // numeric for number columns, ISO date string for datetime columns
-  min?: number | string | null
-  max?: number | string | null
-  avg?: number | null
-  sum?: number | null
-  valueFilledCount?: number | null
-  percentageFilled?: number | null
-  valueNotFilledCount?: number | null
-  percentageNotFilled?: number | null
-  checkedCount?: number | null
-  checkedPercentage?: number | null
-  notCheckedCount?: number | null
-  notCheckedPercentage?: number | null
-  distribution?:
-    | { value: string; label?: string | null; color?: string | null; count: number }[]
-    | null
-  // main/count column: primary/secondary entity totals (folders/tasks, products/versions)
+export interface FieldStats extends ColumnStats {
   primaryCount?: number | null
   secondaryCount?: number | null
 }

--- a/shared/src/api/queries/versions/getVersionsProducts.ts
+++ b/shared/src/api/queries/versions/getVersionsProducts.ts
@@ -361,7 +361,7 @@ const injectedVersionsPageApi = enhancedVersionsPageApi.injectEndpoints({
         providesTags: provideTagsForVersionsInfinite,
         // Subscribes to version entity changes and updates cache accordingly
         // Handles: create, update, delete operations
-        onCacheEntryAdded: async (arg, { updateCachedData, cacheEntryRemoved, dispatch }) => {
+        onCacheEntryAdded: async (arg, { getCacheEntry, updateCachedData, cacheEntryRemoved }) => {
           let unsubscribeThumbnails: (() => void) | undefined
 
           unsubscribeThumbnails = subscribeToThumbnailUpdates(
@@ -387,48 +387,98 @@ const injectedVersionsPageApi = enhancedVersionsPageApi.injectEndpoints({
             ['version'],
           )
 
-          const token = PubSub.subscribe('entity.version', async (_topic: string, message: any) => {
-            try {
-              const entityId = message.summary?.entityId
-              if (!entityId) return
+          const handleNewVersionData = (entityId: string) => {
+            // New version data is available either and update or a new version.
+            console.log('New data!')
+          }
 
-              // Re-fetch the specific version with current filters to check if it still matches
-              // If version was deleted or no longer matches filters, result will be empty
-              const result = await dispatch(
-                enhancedVersionsPageApi.endpoints.GetVersions.initiate(
-                  {
-                    projectName: arg.projectName,
-                    versionFilter: arg.versionFilter,
-                    productFilter: arg.productFilter,
-                    taskFilter: arg.taskFilter,
-                    folderIds: arg.folderIds?.length ? arg.folderIds : undefined,
-                    versionIds: [entityId],
-                    first: 1,
-                  },
-                  {
-                    forceRefetch: true,
-                  },
-                ),
+          const handleVersionUpdate = (topic: string, message: any) => {
+            const project = message.project
+            // check we are on the same project
+            if (project !== arg.projectName) return
+            // then get entity id
+            const entityId = message.summary.entityId
+            if (!entityId) return console.log('no entity id found')
+
+            // NEW VERSION
+            if (topic === 'entity.version.created') {
+              console.log('new version created', entityId)
+              handleNewVersionData(entityId)
+            }
+            // DELETED VERSION
+            else if (topic === 'entity.version.deleted') {
+              // remove the version from the cache
+              updateCachedData((draft) => {
+                for (const page of draft?.pages || []) {
+                  const vIndex = page.versions.findIndex((v) => v.id === entityId)
+                  if (vIndex !== -1) {
+                    page.versions.splice(vIndex, 1)
+                    break
+                  }
+                }
+              })
+              return
+            }
+            // CHANGED VERSION
+            else if (topic.startsWith('entity.version.') && topic.endsWith('_changed')) {
+              // current versions on the page
+              const cacheVersions = getCacheEntry().data
+              console.log('cacheVersions', cacheVersions)
+
+              // EFFICIENTLY check if the version is in any of the pages
+              let versionFound = false
+              for (const page of cacheVersions?.pages || []) {
+                const vIndex = page.versions.findIndex((v) => v.id === entityId)
+                if (vIndex !== -1) {
+                  versionFound = true
+                  break
+                }
+              }
+
+              // not found or not on page, skip patch
+              if (!versionFound) {
+                console.log('version not found in cache, skipping patch', entityId)
+                return
+              }
+
+              // entity.task.status_changed
+              const field = topic.split('.')[2].split('_changed')[0]
+              const supportedFields = ['status', 'tags'] as const
+
+              // only patch if value AND field is supported
+              const value = message.summary.value
+              const isFieldSupported = supportedFields.includes(
+                field as (typeof supportedFields)[number],
               )
 
-              if (result.error) return
+              if (!value || !isFieldSupported) {
+                //  we cannot patch with summary data so we must get new data
+                return handleNewVersionData(entityId)
+              }
 
-              // Update the cache: update existing, delete if not found, or add new
+              // try to patch the cache with the summary value
+              // cast the correct type onto value based on the field
+              let castValue: any = value
+              if (field === 'status') {
+                castValue = String(value)
+              } else if (field === 'tags') {
+                castValue = Array.isArray(value) ? (value as string[]) : []
+              }
+
+              // update the cache with the new value
               updateCachedData((draft) => {
-                const updatedVersion = result.data?.versions?.[0]
-                updatePagedCache(
-                  draft.pages,
-                  entityId,
-                  updatedVersion,
-                  'versions',
-                  (arg.sortBy || 'createdAt') as keyof VersionNode,
-                  arg.desc || false,
-                )
+                for (const page of draft?.pages || []) {
+                  for (const version of page?.versions || []) {
+                    if (version && version.id === entityId) {
+                      version[field as (typeof supportedFields)[number]] = castValue
+                    }
+                  }
+                }
               })
-            } catch (error) {
-              // Silently handle errors to prevent UI disruption
             }
-          })
+          }
+
+          const token = PubSub.subscribe('entity.version', handleVersionUpdate)
 
           // Cleanup: unsubscribe when cache entry is removed
           await cacheEntryRemoved

--- a/shared/src/api/queries/versions/getVersionsProducts.ts
+++ b/shared/src/api/queries/versions/getVersionsProducts.ts
@@ -274,6 +274,170 @@ export const VP_INFINITE_QUERY_COUNT = 250 // Number of items to fetch per page
 const VERSIONS_BY_PRODUCT_ID_QUERY_COUNT = 1000 // max number of versions to fetch per product id
 const MAX_PAGES_PER_PRODUCT = 10 // Hard cutoff to prevent infinite loops
 
+const VERSION_UPDATE_BATCH_DEBOUNCE = 5000 // ms to wait before processing batched updates
+const VERSION_UPDATE_ATTRIB_JITTER = 1000 // max ms of random jitter for attribute fetches
+const VERSION_UPDATE_NEW_DATA_DEBOUNCE = 30000 // ms to wait before fetching new version data in batch
+const VERSION_UPDATE_NEW_DATA_JITTER = 1500 // max ms of random jitter for new version data fetches
+
+/**
+ * Reusable handler for websocket version updates to perform efficient batched cache updates
+ */
+function createVersionUpdateBatcher(
+  projectName: string,
+  dispatch: any,
+  handlers: {
+    checkVersionInCache: (entityId: string, parentId?: string) => boolean
+    onBatchUpdate: (changes: {
+      deleted?: { entityId: string; parentId?: string }[]
+      patched?: { entityId: string; field: string; value: any; parentId?: string }[]
+      attribPatched?: { entityId: string; allAttrib: string; parsedAttrib: any }[]
+      fullUpdated?: VersionNode[]
+    }) => void
+    getBaseFilters?: () => any
+  },
+) {
+  let pendingPatchUpdates: { topic: string; message: any }[] = []
+  let patchTimeoutId: ReturnType<typeof setTimeout> | null = null
+
+  let pendingFullFetchIds = new Set<string>()
+  let fullFetchTimeoutId: ReturnType<typeof setTimeout> | null = null
+
+  const processPatches = async () => {
+    const updates = [...pendingPatchUpdates]
+    pendingPatchUpdates = []
+    patchTimeoutId = null
+
+    const deleted: { entityId: string; parentId?: string }[] = []
+    const patched: { entityId: string; field: string; value: any; parentId?: string }[] = []
+    const attribsToFetch = new Set<string>()
+
+    for (const { topic, message: msg } of updates) {
+      const entityId = msg.summary?.entityId
+      const parentId = msg.summary?.parentId
+      if (!entityId) continue
+
+      if (topic === 'entity.version.deleted') {
+        deleted.push({ entityId, parentId })
+      } else if (topic.startsWith('entity.version.') && topic.endsWith('_changed')) {
+        const versionFound = handlers.checkVersionInCache(entityId, parentId)
+        if (!versionFound) continue
+
+        const field = topic.split('.')[2].split('_changed')[0]
+
+        if (field === 'attrib') {
+          attribsToFetch.add(entityId)
+          continue
+        }
+
+        const supportedFields = ['status', 'tags'] as const
+        const isFieldSupported = supportedFields.includes(field as any)
+        const value = msg.summary?.value
+
+        if (!value || !isFieldSupported) {
+          pendingFullFetchIds.add(entityId)
+          continue
+        }
+
+        let castValue: any = value
+        if (field === 'status') {
+          castValue = String(value)
+        } else if (field === 'tags') {
+          castValue = Array.isArray(value) ? (value as string[]) : []
+        }
+
+        patched.push({ entityId, field, value: castValue, parentId })
+      }
+    }
+
+    // Trigger full fetch if any unsupported changes were moved there
+    if (pendingFullFetchIds.size > 0 && !fullFetchTimeoutId) {
+      fullFetchTimeoutId = setTimeout(processFullFetches, VERSION_UPDATE_NEW_DATA_DEBOUNCE)
+    }
+
+    const attribPatched: { entityId: string; allAttrib: string; parsedAttrib: any }[] = []
+    if (attribsToFetch.size > 0 && dispatch) {
+      try {
+        await new Promise((resolve) =>
+          setTimeout(resolve, Math.random() * VERSION_UPDATE_ATTRIB_JITTER),
+        )
+
+        const versionIds = Array.from(attribsToFetch)
+        const result = await dispatch(
+          enhancedVersionsPageApi.endpoints.GetVersions.initiate(
+            { projectName, versionIds },
+            { forceRefetch: true },
+          ),
+        )
+
+        if (result.data?.versions) {
+          for (const node of result.data.versions) {
+            attribPatched.push({
+              entityId: node.id,
+              allAttrib: node.allAttrib,
+              parsedAttrib: node.attrib,
+            })
+          }
+        }
+      } catch (e) {
+        console.error('Failed to fetch patched version attribs', e)
+      }
+    }
+
+    if (deleted.length > 0 || patched.length > 0 || attribPatched.length > 0) {
+      handlers.onBatchUpdate({ deleted, patched, attribPatched })
+    }
+  }
+
+  const processFullFetches = async () => {
+    const versionIds = Array.from(pendingFullFetchIds)
+    pendingFullFetchIds.clear()
+    fullFetchTimeoutId = null
+
+    if (versionIds.length === 0 || !dispatch) return
+
+    try {
+      // Jitter fetch to prevent thundering herd
+      await new Promise((resolve) =>
+        setTimeout(resolve, Math.random() * VERSION_UPDATE_NEW_DATA_JITTER),
+      )
+
+      const baseFilters = handlers.getBaseFilters?.() || {}
+      const result = await dispatch(
+        enhancedVersionsPageApi.endpoints.GetVersions.initiate({
+          ...baseFilters,
+          projectName,
+          versionIds,
+        }),
+      )
+
+      if (result.data?.versions) {
+        handlers.onBatchUpdate({ fullUpdated: result.data.versions })
+      }
+    } catch (e) {
+      console.error('Failed to fetch full version data batch', e)
+    }
+  }
+
+  return (topic: string, message: any) => {
+    const project = message.project
+    if (project !== projectName) return
+
+    const entityId = message.summary?.entityId
+    if (!entityId) return
+
+    if (topic === 'entity.version.created') {
+      pendingFullFetchIds.add(entityId)
+      if (!fullFetchTimeoutId) {
+        fullFetchTimeoutId = setTimeout(processFullFetches, VERSION_UPDATE_NEW_DATA_DEBOUNCE)
+      }
+    } else {
+      pendingPatchUpdates.push({ topic, message })
+      if (patchTimeoutId) clearTimeout(patchTimeoutId)
+      patchTimeoutId = setTimeout(processPatches, VERSION_UPDATE_BATCH_DEBOUNCE)
+    }
+  }
+}
+
 const injectedVersionsPageApi = enhancedVersionsPageApi.injectEndpoints({
   endpoints: (build) => ({
     // enhance GetVersions with an infinite query
@@ -359,9 +523,13 @@ const injectedVersionsPageApi = enhancedVersionsPageApi.injectEndpoints({
           }
         },
         providesTags: provideTagsForVersionsInfinite,
+        keepUnusedDataFor: 30,
         // Subscribes to version entity changes and updates cache accordingly
         // Handles: create, update, delete operations
-        onCacheEntryAdded: async (arg, { getCacheEntry, updateCachedData, cacheEntryRemoved }) => {
+        onCacheEntryAdded: async (
+          arg,
+          { getCacheEntry, updateCachedData, cacheEntryRemoved, dispatch },
+        ) => {
           let unsubscribeThumbnails: (() => void) | undefined
 
           unsubscribeThumbnails = subscribeToThumbnailUpdates(
@@ -387,98 +555,84 @@ const injectedVersionsPageApi = enhancedVersionsPageApi.injectEndpoints({
             ['version'],
           )
 
-          const handleNewVersionData = (entityId: string) => {
-            // New version data is available either and update or a new version.
-            console.log('New data!')
-          }
-
-          const handleVersionUpdate = (topic: string, message: any) => {
-            const project = message.project
-            // check we are on the same project
-            if (project !== arg.projectName) return
-            // then get entity id
-            const entityId = message.summary.entityId
-            if (!entityId) return console.log('no entity id found')
-
-            // NEW VERSION
-            if (topic === 'entity.version.created') {
-              console.log('new version created', entityId)
-              handleNewVersionData(entityId)
-            }
-            // DELETED VERSION
-            else if (topic === 'entity.version.deleted') {
-              // remove the version from the cache
-              updateCachedData((draft) => {
-                for (const page of draft?.pages || []) {
-                  const vIndex = page.versions.findIndex((v) => v.id === entityId)
-                  if (vIndex !== -1) {
-                    page.versions.splice(vIndex, 1)
-                    break
-                  }
+          const token = PubSub.subscribe(
+            'entity.version',
+            createVersionUpdateBatcher(arg.projectName, dispatch, {
+              getBaseFilters: () => ({
+                versionFilter: arg.versionFilter,
+                productFilter: arg.productFilter,
+                taskFilter: arg.taskFilter,
+                folderIds: arg.folderIds?.length ? arg.folderIds : undefined,
+                featuredOnly: arg.featuredOnly,
+                hasReviewables: arg.hasReviewables,
+                sortBy: arg.sortBy,
+              }),
+              checkVersionInCache: (entityId) => {
+                const cacheVersions = getCacheEntry().data
+                if (!cacheVersions) return false
+                for (const page of cacheVersions.pages || []) {
+                  if (page.versions.some((v) => v.id === entityId)) return true
                 }
-              })
-              return
-            }
-            // CHANGED VERSION
-            else if (topic.startsWith('entity.version.') && topic.endsWith('_changed')) {
-              // current versions on the page
-              const cacheVersions = getCacheEntry().data
-              console.log('cacheVersions', cacheVersions)
-
-              // EFFICIENTLY check if the version is in any of the pages
-              let versionFound = false
-              for (const page of cacheVersions?.pages || []) {
-                const vIndex = page.versions.findIndex((v) => v.id === entityId)
-                if (vIndex !== -1) {
-                  versionFound = true
-                  break
-                }
-              }
-
-              // not found or not on page, skip patch
-              if (!versionFound) {
-                console.log('version not found in cache, skipping patch', entityId)
-                return
-              }
-
-              // entity.task.status_changed
-              const field = topic.split('.')[2].split('_changed')[0]
-              const supportedFields = ['status', 'tags'] as const
-
-              // only patch if value AND field is supported
-              const value = message.summary.value
-              const isFieldSupported = supportedFields.includes(
-                field as (typeof supportedFields)[number],
-              )
-
-              if (!value || !isFieldSupported) {
-                //  we cannot patch with summary data so we must get new data
-                return handleNewVersionData(entityId)
-              }
-
-              // try to patch the cache with the summary value
-              // cast the correct type onto value based on the field
-              let castValue: any = value
-              if (field === 'status') {
-                castValue = String(value)
-              } else if (field === 'tags') {
-                castValue = Array.isArray(value) ? (value as string[]) : []
-              }
-
-              // update the cache with the new value
-              updateCachedData((draft) => {
-                for (const page of draft?.pages || []) {
-                  for (const version of page?.versions || []) {
-                    if (version && version.id === entityId) {
-                      version[field as (typeof supportedFields)[number]] = castValue
+                return false
+              },
+              onBatchUpdate: ({ deleted, patched, attribPatched, fullUpdated }) => {
+                updateCachedData((draft) => {
+                  for (const page of draft?.pages || []) {
+                    // Handle deletes
+                    if (deleted) {
+                      for (const { entityId } of deleted) {
+                        const vIndex = page.versions.findIndex((v) => v.id === entityId)
+                        if (vIndex !== -1) page.versions.splice(vIndex, 1)
+                      }
+                    }
+                    // Handle simple patches
+                    if (patched) {
+                      for (const { entityId, field, value } of patched) {
+                        const version = page.versions.find((v) => v.id === entityId)
+                        if (version) {
+                          // @ts-expect-error valid field
+                          version[field] = value
+                        }
+                      }
+                    }
+                    // Handle attrib patched
+                    if (attribPatched) {
+                      for (const { entityId, allAttrib, parsedAttrib } of attribPatched) {
+                        const version = page.versions.find((v) => v.id === entityId)
+                        if (version) {
+                          version.allAttrib = allAttrib
+                          version.attrib = parsedAttrib
+                        }
+                      }
+                    }
+                    // Handle full updates
+                    if (fullUpdated) {
+                      for (const updatedNode of fullUpdated) {
+                        const vIndex = page.versions.findIndex((v) => v.id === updatedNode.id)
+                        if (vIndex !== -1) {
+                          page.versions[vIndex] = updatedNode
+                        } else {
+                          // New version not in cache, try to insert in first page if it fits sort
+                          // (This is a simplification, full refetch is usually better for new items in pagination)
+                          const sortKey = (arg.sortBy || 'createdAt') as keyof VersionNode
+                          const insertIndex = findSortedInsertIndex(
+                            page.versions,
+                            updatedNode,
+                            sortKey,
+                            arg.desc || false,
+                          )
+                          // Only insert if it's within current page bounds or we are on first page
+                          if (page === draft.pages[0]) {
+                            page.versions.splice(insertIndex, 0, updatedNode)
+                          }
+                        }
+                      }
                     }
                   }
-                }
-              })
-            }
-          }
-
-          const token = PubSub.subscribe('entity.version', handleVersionUpdate)
+                })
+              },
+            }),
+          )
 
           // Cleanup: unsubscribe when cache entry is removed
           await cacheEntryRemoved
@@ -602,6 +756,7 @@ const injectedVersionsPageApi = enhancedVersionsPageApi.injectEndpoints({
           },
         }
       },
+      keepUnusedDataFor: 30,
       // Subscribes to version entity changes for expanded products
       // Only updates versions that belong to currently expanded products
       onCacheEntryAdded: async (arg, { updateCachedData, cacheEntryRemoved, dispatch }) => {
@@ -626,45 +781,74 @@ const injectedVersionsPageApi = enhancedVersionsPageApi.injectEndpoints({
           ['version'],
         )
 
-        const token = PubSub.subscribe('entity.version', async (_topic: string, message: any) => {
-          try {
-            const entityId = message.summary?.entityId
-            const parentId = message.summary?.parentId // parentId is the product ID
-            if (!entityId || !parentId) return
-
-            // Only handle versions belonging to currently expanded products
-            // This prevents unnecessary updates for versions in collapsed products
-            if (!arg.productIds.includes(parentId)) return
-
-            // Re-fetch the specific version using GetVersions (supports versionIds filter)
-            // Uses same filters as the base query to ensure consistency
-            const result = await dispatch(
-              enhancedVersionsPageApi.endpoints.GetVersions.initiate(
-                {
-                  projectName: arg.projectName,
-                  productIds: [parentId],
-                  versionIds: [entityId],
-                  versionFilter: arg.versionFilter,
-                  taskFilter: arg.taskFilter,
-                  first: 1,
-                  ...(arg.featuredOnly && { featuredOnly: arg.featuredOnly }),
-                  ...(arg.hasReviewables !== undefined && { hasReviewables: arg.hasReviewables }),
-                },
-                { forceRefetch: true },
-              ),
-            )
-
-            if (result.error) return
-
-            // Update flat versions array: update existing, delete if not found, or add new
-            updateCachedData((draft) => {
-              const updatedVersion = result.data?.versions?.[0]
-              updateFlatCache(draft.versions, entityId, updatedVersion)
-            })
-          } catch (error) {
-            // Silently handle errors to prevent UI disruption
-          }
-        })
+        const token = PubSub.subscribe(
+          'entity.version',
+          createVersionUpdateBatcher(arg.projectName, dispatch, {
+            getBaseFilters: () => ({
+              versionFilter: arg.versionFilter,
+              taskFilter: arg.taskFilter,
+              productIds: arg.productIds,
+            }),
+            checkVersionInCache: (entityId, parentId) => {
+              if (!parentId || !arg.productIds.includes(parentId)) return false
+              let found = false
+              updateCachedData((draft) => {
+                found = draft.versions.some((v) => v.id === entityId)
+              })
+              return found
+            },
+            onBatchUpdate: ({ deleted, patched, attribPatched, fullUpdated }) => {
+              updateCachedData((draft) => {
+                // Handle deletes
+                if (deleted) {
+                  for (const { entityId } of deleted) {
+                    const vIndex = draft.versions.findIndex((v) => v.id === entityId)
+                    if (vIndex !== -1) draft.versions.splice(vIndex, 1)
+                  }
+                }
+                // Handle simple patches
+                if (patched) {
+                  for (const { entityId, field, value } of patched) {
+                    const version = draft.versions.find((v) => v.id === entityId)
+                    if (version) {
+                      // @ts-expect-error valid field
+                      version[field] = value
+                    }
+                  }
+                }
+                // Handle attrib patches
+                if (attribPatched) {
+                  for (const { entityId, allAttrib, parsedAttrib } of attribPatched) {
+                    const version = draft.versions.find((v) => v.id === entityId)
+                    if (version) {
+                      version.allAttrib = allAttrib
+                      version.attrib = parsedAttrib
+                    }
+                  }
+                }
+                // Handle full updates
+                if (fullUpdated) {
+                  for (const updatedNode of fullUpdated) {
+                    const index = draft.versions.findIndex((v) => v.id === updatedNode.id)
+                    if (index !== -1) {
+                      draft.versions[index] = updatedNode
+                    } else {
+                      // Add at correct sorted position
+                      const sortKey = (arg.sortBy || 'createdAt') as keyof VersionNode
+                      const insertIndex = findSortedInsertIndex(
+                        draft.versions,
+                        updatedNode,
+                        sortKey,
+                        arg.desc || false,
+                      )
+                      draft.versions.splice(insertIndex, 0, updatedNode)
+                    }
+                  }
+                }
+              })
+            },
+          }),
+        )
 
         // Cleanup: unsubscribe when cache entry is removed
         await cacheEntryRemoved
@@ -760,6 +944,7 @@ const injectedVersionsPageApi = enhancedVersionsPageApi.injectEndpoints({
           }
         },
         providesTags: provideTagsForProductsInfinite,
+        keepUnusedDataFor: 30,
 
         // Subscribes to product entity changes and updates cache accordingly
         // Handles: create, update, delete operations
@@ -832,6 +1017,15 @@ const injectedVersionsPageApi = enhancedVersionsPageApi.injectEndpoints({
                 const entityId = message.summary?.entityId
                 if (!entityId) return
 
+                let productExistsInCache = false
+                updateCachedData((draft) => {
+                  productExistsInCache = draft.pages.some((page) =>
+                    page.products.some((product: ProductNode) => product.id === entityId),
+                  )
+                })
+
+                if (!productExistsInCache && _topic !== 'entity.product.created') return
+
                 await refetchProduct(entityId)
               } catch (error) {
                 // Silently handle errors to prevent UI disruption
@@ -843,28 +1037,83 @@ const injectedVersionsPageApi = enhancedVersionsPageApi.injectEndpoints({
           // This ensures product's versions list and featuredVersion stay up-to-date
           const versionToken = PubSub.subscribe(
             'entity.version',
-            async (_topic: string, message: any) => {
-              try {
-                const parentId = message.summary?.parentId // parentId is the product ID
-                if (!parentId) return
-
-                // Check if the product exists in our cache before refetching
-                // This prevents unnecessary API calls for products not in our view
-                let productExistsInCache = false
+            createVersionUpdateBatcher(arg.projectName, dispatch, {
+              getBaseFilters: () => ({
+                versionFilter: arg.versionFilter,
+                productFilter: arg.productFilter,
+                taskFilter: arg.taskFilter,
+                folderIds: arg.folderIds?.length ? arg.folderIds : undefined,
+              }),
+              checkVersionInCache: (entityId, parentId) => {
+                let found = false
                 updateCachedData((draft) => {
-                  productExistsInCache = draft.pages.some((page) =>
-                    page.products.some((product: ProductNode) => product.id === parentId),
+                  found = draft.pages.some((page) =>
+                    page.products.some(
+                      (p) => p.id === parentId && p.featuredVersion?.id === entityId,
+                    ),
                   )
                 })
+                return found
+              },
+              onBatchUpdate: ({ deleted, patched, attribPatched, fullUpdated }) => {
+                updateCachedData((draft) => {
+                  for (const page of draft?.pages || []) {
+                    for (const p of page.products) {
+                      const featuredId = p.featuredVersion?.id
+                      if (!featuredId) continue
 
-                if (!productExistsInCache) return
+                      // Handle deletes
+                      if (deleted) {
+                        if (deleted.some((d) => d.entityId === featuredId && d.parentId === p.id)) {
+                          // Version deleted, need to refetch product to update featuredVersion
+                          // Using a set to track which products need refetch to avoid multiple calls
+                          productsToRefetch.add(p.id)
+                        }
+                      }
 
-                await refetchProduct(parentId)
-              } catch (error) {
-                // Silently handle errors to prevent UI disruption
-              }
-            },
+                      // Handle simple patches
+                      if (patched) {
+                        for (const { entityId, field, value, parentId } of patched) {
+                          if (p.id === parentId && featuredId === entityId && p.featuredVersion) {
+                            // @ts-expect-error valid field
+                            p.featuredVersion[field] = value
+                          }
+                        }
+                      }
+
+                      // Handle attrib patches
+                      if (attribPatched) {
+                        for (const { entityId, allAttrib, parsedAttrib } of attribPatched) {
+                          if (featuredId === entityId && p.featuredVersion) {
+                            p.featuredVersion.allAttrib = allAttrib
+                            p.featuredVersion.attrib = parsedAttrib
+                          }
+                        }
+                      }
+
+                      // Handle full updates
+                      if (fullUpdated) {
+                        for (const updatedNode of fullUpdated) {
+                          if (featuredId === updatedNode.id && p.featuredVersion) {
+                            p.featuredVersion = updatedNode
+                          }
+                        }
+                      }
+                    }
+                  }
+                })
+
+                // If any products need full refetch (due to deletes or new version becoming featured)
+                // we trigger that now
+                for (const productId of productsToRefetch) {
+                  refetchProduct(productId)
+                }
+                productsToRefetch.clear()
+              },
+            }),
           )
+
+          const productsToRefetch = new Set<string>()
 
           // Cleanup: unsubscribe when cache entry is removed
           await cacheEntryRemoved
@@ -973,6 +1222,7 @@ const injectedVersionsPageApi = enhancedVersionsPageApi.injectEndpoints({
         }
       },
       providesTags: provideTagsForVersionsResult,
+      keepUnusedDataFor: 30,
       // Subscribes to version entity changes and updates cache accordingly
       // Handles: create, update, delete operations for grouped versions view
       onCacheEntryAdded: async (arg, { updateCachedData, cacheEntryRemoved, dispatch }) => {
@@ -997,96 +1247,69 @@ const injectedVersionsPageApi = enhancedVersionsPageApi.injectEndpoints({
           ['version'],
         )
 
-        const token = PubSub.subscribe('entity.version', async (_topic: string, message: any) => {
-          try {
-            const entityId = message.summary?.entityId
-            if (!entityId) return
-
-            // Re-fetch the specific version with current filters to check if it still matches
-            // If version was deleted or no longer matches filters, result will be empty
-
-            const baseFilters = {
-              projectName: arg.projectName,
+        const token = PubSub.subscribe(
+          'entity.version',
+          createVersionUpdateBatcher(arg.projectName, dispatch, {
+            getBaseFilters: () => ({
               versionFilter: arg.versionFilter,
               productFilter: arg.productFilter,
               taskFilter: arg.taskFilter,
               folderIds: arg.folderIds?.length ? arg.folderIds : undefined,
-              versionIds: [entityId],
-              first: 1,
-              ...(arg.featuredOnly && { featuredOnly: arg.featuredOnly }),
-              ...(arg.hasReviewables !== undefined && { hasReviewables: arg.hasReviewables }),
-            }
-
-            // Track which groups the version belongs to after the update
-            const matchedGroups: { value: string; hasNextPage: undefined }[] = []
-            let latestVersionData: VersionNode | null = null
-
-            for (const group of arg.groups) {
-              const result = await dispatch(
-                enhancedVersionsPageApi.endpoints.GetVersions.initiate(
-                  {
-                    ...baseFilters,
-                    [arg.groupFilterKey as string]: group.filter, // group-specific filter
-                    versionIds: [entityId],
-                  },
-                  { forceRefetch: true }, // Force fresh data to detect group membership changes
-                ),
-              )
-
-              const fetchedVersion = result.data?.versions?.[0]
-              if (fetchedVersion) {
-                // Version matches this group's filter
-                matchedGroups.push({ value: group.value, hasNextPage: undefined })
-                latestVersionData = fetchedVersion
-              }
-            }
-
-            // Now update the cache based on collected results
-            updateCachedData((draft) => {
-              const index = draft.versions.findIndex((v) => v.id === entityId)
-              const versionExistsInCache = index !== -1
-
-              if (matchedGroups.length === 0) {
-                // Version was deleted or no longer matches any group filter - remove it
-                if (versionExistsInCache) {
-                  draft.versions.splice(index, 1)
-                }
-              } else if (latestVersionData) {
-                // Version matches at least one group
-                if (versionExistsInCache) {
-                  const originalGroups = draft.versions[index].groups || []
-                  // Check if group membership has changed (comparing group values)
-                  const originalGroupValues = originalGroups.map((g) => g.value).sort()
-                  const matchedGroupValues = matchedGroups.map((g) => g.value).sort()
-                  const groupsChanged =
-                    originalGroupValues.length !== matchedGroupValues.length ||
-                    originalGroupValues.some((v, i) => v !== matchedGroupValues[i])
-
-                  if (groupsChanged) {
-                    // Group membership changed - use new matched groups (version moved to different group)
-                    draft.versions[index] = { ...latestVersionData, groups: matchedGroups }
-                  } else {
-                    // Same groups - preserve original groups (keeps pagination state like hasNextPage)
-                    draft.versions[index] = { ...latestVersionData, groups: originalGroups }
+              sortBy: arg.sortBy,
+              featuredOnly: arg.featuredOnly,
+              hasReviewables: arg.hasReviewables,
+            }),
+            checkVersionInCache: (entityId) => {
+              let found = false
+              updateCachedData((draft) => {
+                found = draft.versions.some((v) => v.id === entityId)
+              })
+              return found
+            },
+            onBatchUpdate: ({ deleted, patched, attribPatched, fullUpdated }) => {
+              updateCachedData((draft) => {
+                // Handle deletes
+                if (deleted) {
+                  for (const { entityId } of deleted) {
+                    const vIndex = draft.versions.findIndex((v) => v.id === entityId)
+                    if (vIndex !== -1) draft.versions.splice(vIndex, 1)
                   }
-                } else {
-                  // New version not in cache yet - add at sorted position with matched groups
-                  const newVersion = { ...latestVersionData, groups: matchedGroups }
-                  const sortKey = (arg.sortBy || 'createdAt') as keyof VersionNode
-                  const insertIndex = findSortedInsertIndex(
-                    draft.versions,
-                    newVersion,
-                    sortKey,
-                    arg.desc || false,
-                  )
-                  draft.versions.splice(insertIndex, 0, newVersion)
                 }
-              }
-            })
-          } catch (error) {
-            // Silently handle errors to prevent UI disruption
-          }
-        })
+                // Handle patches
+                if (patched) {
+                  for (const { entityId, field, value } of patched) {
+                    const version = draft.versions.find((v) => v.id === entityId)
+                    if (version) {
+                      // @ts-expect-error valid field
+                      version[field] = value
+                    }
+                  }
+                }
+                // Handle attrib patches
+                if (attribPatched) {
+                  for (const { entityId, allAttrib, parsedAttrib } of attribPatched) {
+                    const version = draft.versions.find((v) => v.id === entityId)
+                    if (version) {
+                      version.allAttrib = allAttrib
+                      version.attrib = parsedAttrib
+                    }
+                  }
+                }
+                // Handle full updates
+                if (fullUpdated) {
+                  for (const updatedNode of fullUpdated) {
+                    const index = draft.versions.findIndex((v) => v.id === updatedNode.id)
+                    if (index !== -1) {
+                      // Preserve groups when updating
+                      const originalGroups = draft.versions[index].groups
+                      draft.versions[index] = { ...updatedNode, groups: originalGroups }
+                    }
+                  }
+                }
+              })
+            },
+          }),
+        )
 
         // Cleanup: unsubscribe when cache entry is removed
         await cacheEntryRemoved

--- a/shared/src/api/queries/versions/getVersionsProducts.ts
+++ b/shared/src/api/queries/versions/getVersionsProducts.ts
@@ -41,6 +41,7 @@ import {
   transformProductsResponse,
   transformVersionsResponse,
 } from './getVersionsProductsUtils'
+import { parseAllAttribs } from '../overview'
 import { PubSub, subscribeToThumbnailUpdates, ThumbnailUpdateMessage } from '@shared/util'
 import type { FieldStats } from '../columnStats'
 import { normalizeFieldStats, mergeFieldStats, hasNewTargetFields } from '../columnStats'
@@ -363,19 +364,22 @@ function createVersionUpdateBatcher(
 
         const versionIds = Array.from(attribsToFetch)
         const result = await dispatch(
-          enhancedVersionsPageApi.endpoints.GetVersions.initiate(
+          enhancedVersionsPageApi.endpoints.GetVersionsAttribs.initiate(
             { projectName, versionIds },
             { forceRefetch: true },
           ),
         )
 
-        if (result.data?.versions) {
-          for (const node of result.data.versions) {
-            attribPatched.push({
-              entityId: node.id,
-              allAttrib: node.allAttrib,
-              parsedAttrib: node.attrib,
-            })
+        if (result.data?.project?.versions?.edges) {
+          for (const edge of result.data.project.versions.edges) {
+            const node = edge.node
+            if (node) {
+              attribPatched.push({
+                entityId: node.id,
+                allAttrib: node.allAttrib,
+                parsedAttrib: parseAllAttribs(node.allAttrib),
+              })
+            }
           }
         }
       } catch (e) {

--- a/shared/src/api/queries/versions/gql/GetVersionsAttribs.graphql
+++ b/shared/src/api/queries/versions/gql/GetVersionsAttribs.graphql
@@ -1,0 +1,12 @@
+query GetVersionsAttribs($projectName: String!, $versionIds: [String!]!) {
+  project(name: $projectName) {
+    versions(ids: $versionIds) {
+      edges {
+        node {
+          id
+          allAttrib
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Completely rewrite the real time updating logic for versions.

## Before

Any change to a version would trigger a single request to `GetVersions`. 100 changes in a minute would result in 100 new requests to the server.

## Now

### Delete

Removes the version from the users cache, no api calls required.

### Updates

First checks if the version is even in the users cache and does nothing if it is not.

If the update is a change to `status` or `tags` the version data is patched using the `summary.value` value no api calls required.

If the update is anything else, like an attrib change, a new api request is made to a new simple graphql query `GetVersionsAttribs`.

```
query GetVersionsAttribs($projectName: String!, $versionIds: [String!]!) {
  project(name: $projectName) {
    versions(ids: $versionIds) {
      edges {
        node {
          id
          allAttrib
        }
      }
    }
  }
}
```

Note: In the future attrib change values will be in the message.summary so this api call won't be required.

### New versions

When a new version comes in we must, unfortunately, use the heavy `GetVersions` graphql query to:

1. Find out if the new version matches the current users filters.
2. Get all the version data required for the table.

Once we have the data, it is patched into the cache.

## Debouncing, Batches and Jitter

A big optimisation in the way lots of new messages are handled.

**Debouncing**

For updates we debounce new messages for 5 seconds.
For new versions we debounce for 20 seconds.
This means we updating the users caches far less, improving react performance and usability.

**Batching**

We store the messages in a pool and then handle them all in one query and patch. This means if there are 10 new versions over the space of 20 seconds, we make 1 graphql request for the 10 versions and then update the cache once with the 10 new versions. This should ensure the server does not get overwhelmed when lots of new versions are created and caps the max number of requests to 1 per 20 second.

**Jitter**
For all api requests there is a random jitter of 1500ms to ensure that all users are not making lots of requests at exactly the same time.