### PR TITLE
Staging mode for actions

### DIFF
--- a/shared/src/api/queries/users/getUsers.ts
+++ b/shared/src/api/queries/users/getUsers.ts
@@ -17,6 +17,7 @@ const USER_BY_NAME_QUERY = `
           isManager
           isService
           isDeveloper
+          isStagingAllowed
           isGuest
           active
           accessGroups
@@ -39,6 +40,7 @@ const USERS_QUERY = `
           isManager
           isService
           isDeveloper
+          isStagingAllowed
           isGuest
           active
           userPool

--- a/shared/src/containers/Actions/Actions.tsx
+++ b/shared/src/containers/Actions/Actions.tsx
@@ -9,6 +9,7 @@ import ActionIcon from './ActionIcon'
 import { ActionTriggersProps, useActionTriggers } from '@shared/hooks'
 import { ActionConfigDialog } from './ActionConfigDialog'
 import { InteractiveActionDialog, InteractiveForm } from './InteractiveActionDialog'
+import { BundleMode } from '@shared/util'
 
 const placeholder = {
   identifier: 'placeholder',
@@ -25,7 +26,7 @@ interface ActionsProps extends ActionTriggersProps {
   isLoadingEntity: boolean
   projectActionsProjectName?: string
   featuredCount?: number
-  isDeveloperMode: boolean
+  bundleMode: BundleMode
   align?: ActionsDropdownProps['align']
   pt?: {
     dropdown?: Partial<ActionsDropdownProps>
@@ -40,7 +41,7 @@ export const Actions = ({
   projectActionsProjectName,
   searchParams,
   featuredCount = 2,
-  isDeveloperMode,
+  bundleMode,
   onNavigate,
   onSetSearchParams,
   align,
@@ -93,7 +94,7 @@ export const Actions = ({
   }, [context])
 
   const { data, isFetching: isFetchingActions } = useGetActionsFromContextQuery(
-    { mode: 'simple', actionContext: context as ActionContext },
+    { mode: 'simple', variant: bundleMode, actionContext: context as ActionContext },
     { skip: !context },
   )
 
@@ -326,7 +327,7 @@ export const Actions = ({
         isLoading={isLoading && featuredCount > 0}
         onAction={handleExecuteAction}
         onConfig={handleConfigureAction}
-        isDeveloperMode={isDeveloperMode}
+        bundleMode={bundleMode}
         align={align}
         {...pt?.dropdown}
       />

--- a/shared/src/containers/Actions/ActionsDropdown/ActionsDropdown.styled.ts
+++ b/shared/src/containers/Actions/ActionsDropdown/ActionsDropdown.styled.ts
@@ -2,9 +2,25 @@ import { Dropdown } from '@ynput/ayon-react-components'
 import styled from 'styled-components'
 
 export const StyledDropdown = styled(Dropdown)`
+  --button-bg: unset;
+  --button-bg-hover: var(--md-sys-color-surface-container-highest-hover);
+  --icon-color: var(--md-sys-color-on-surface);
+
+  &.developer {
+    --button-bg: var(--color-hl-developer-container);
+    --button-bg-hover: var(--color-hl-developer-container-hover);
+    --icon-color: var(--color-hl-developer);
+  }
+
+  &.staging {
+    --button-bg: var(--color-hl-staging-container);
+    --button-bg-hover: var(--color-hl-staging-container-hover);
+    --icon-color: var(--color-hl-staging);
+  }
+
   height: unset;
   button {
-    background-color: unset;
+    background-color: var(--button-bg);
     max-height: 28px;
     max-width: 28px;
     min-height: 28px;
@@ -21,24 +37,11 @@ export const StyledDropdown = styled(Dropdown)`
 
     .icon {
       vertical-align: middle;
+      color: var(--icon-color);
     }
 
     &:hover {
-      background-color: var(--md-sys-color-surface-container-highest-hover);
-    }
-  }
-
-  /* developer mode */
-  &.dev {
-    button {
-      background-color: var(--color-hl-developer-container);
-      .icon {
-        color: var(--color-hl-developer);
-      }
-
-      &:hover {
-        background-color: var(--color-hl-developer-container-hover);
-      }
+      background-color: var(--button-bg-hover);
     }
   }
 

--- a/shared/src/containers/Actions/ActionsDropdown/ActionsDropdown.tsx
+++ b/shared/src/containers/Actions/ActionsDropdown/ActionsDropdown.tsx
@@ -12,6 +12,7 @@ import { upperFirst } from 'lodash'
 import ActionIcon from '../ActionIcon'
 import styled from 'styled-components'
 import { IconModel } from '@shared/api'
+import { BundleMode } from '@shared/util'
 
 const ActionItemContainer = styled.div`
   display: flex;
@@ -82,7 +83,7 @@ export const ActionsDropdownItem = ({
 export interface ActionsDropdownProps extends Omit<DropdownProps, 'value'> {
   options: ActionsDropdownItemProps[]
   isLoading?: boolean
-  isDeveloperMode: boolean
+  bundleMode: BundleMode
   onAction: (value: string) => void
   onConfig: (e: any) => void
 }
@@ -90,7 +91,7 @@ export interface ActionsDropdownProps extends Omit<DropdownProps, 'value'> {
 export const ActionsDropdown = ({
   options,
   isLoading,
-  isDeveloperMode,
+  bundleMode,
   onAction,
   onConfig,
   ...props
@@ -105,7 +106,7 @@ export const ActionsDropdown = ({
     <StyledDropdown
       ref={dropdownRef}
       disabled={isLoading}
-      className={clsx('more', { dev: isDeveloperMode })}
+      className={clsx('more', bundleMode)}
       options={options}
       maxOptionsShown={100}
       value={[]}
@@ -115,7 +116,8 @@ export const ActionsDropdown = ({
       onChange={(v) => onAction(v[0])}
       buttonProps={{
         // @ts-expect-error
-        ['data-tooltip']: isDeveloperMode ? 'Actions (dev bundle)' : 'Actions',
+        ['data-tooltip']:
+          bundleMode === 'production' ? 'Actions' : `${upperFirst(bundleMode)} Actions`,
         ['data-tooltip-delay']: 0,
       }}
       {...props}

--- a/shared/src/containers/DetailsPanel/components/DetailsPanelHeader/DetailsPanelHeader.tsx
+++ b/shared/src/containers/DetailsPanel/components/DetailsPanelHeader/DetailsPanelHeader.tsx
@@ -64,7 +64,7 @@ const DetailsPanelHeader = ({
   thumbnailInputRef,
   versionsInputRef,
 }: DetailsPanelHeaderProps) => {
-  const { useSearchParams, useNavigate, isDeveloperMode } = useDetailsPanelContext()
+  const { useSearchParams, useNavigate, bundleMode } = useDetailsPanelContext()
   const navigate = useNavigate()
   const [searchParams, setSearchParams] = useSearchParams()
   const tagsSelectRef = useRef<DropdownRef>(null)
@@ -284,7 +284,7 @@ const DetailsPanelHeader = ({
             entitySubTypes={entitySubTypes}
             isLoadingEntity={!!isFetching || !!isLoading}
             searchParams={searchParams}
-            isDeveloperMode={isDeveloperMode}
+            bundleMode={bundleMode}
             onSetSearchParams={setSearchParams}
             onNavigate={navigate}
           />

--- a/shared/src/context/DetailsPanelContext.tsx
+++ b/shared/src/context/DetailsPanelContext.tsx
@@ -7,6 +7,7 @@ import { useURIContext } from './UriContext'
 import { useLocalStorage, readLocalStorage, writeLocalStorage } from '@shared/hooks'
 import type { SubtasksManagerProps } from '@shared/components'
 import { DetailsPanelContext } from './DetailsPanelContextInstance'
+import { BundleMode, getBundleModeFromUser } from '@shared/util'
 
 // High-level tabs for the details panel
 export type DetailsPanelTab = 'feed' | 'subtasks' | 'details' | 'files'
@@ -82,7 +83,7 @@ export interface DetailsPanelContextProps {
 // Interface for our simplified context
 export interface DetailsPanelContextType extends DetailsPanelContextProps {
   // user
-  isDeveloperMode: boolean
+  bundleMode: BundleMode
   isGuest: boolean
   // Open state for the panel by scope
   panelOpenByScope: OpenStateByScope
@@ -134,10 +135,7 @@ export const DetailsPanelProvider: React.FC<DetailsPanelProviderProps> = ({
   ...forwardedProps
 }) => {
   const user = forwardedProps.user
-  const isDeveloperMode =
-    'isDeveloperMode' in debug
-      ? (debug.isDeveloperMode as boolean)
-      : user?.attrib?.developerMode ?? false
+  const bundleMode = getBundleModeFromUser(user)
   const isGuest = 'isGuest' in debug ? (debug.isGuest as boolean) : user?.data?.isGuest
 
   // get license from powerpack or forwarded down from props
@@ -330,7 +328,7 @@ export const DetailsPanelProvider: React.FC<DetailsPanelProviderProps> = ({
     setEntities,
     feedAnnotations,
     setFeedAnnotations,
-    isDeveloperMode,
+    bundleMode,
     isGuest,
     hasLicense,
     onPowerFeature: setPowerpackDialog,

--- a/shared/src/util/getBundleMode.ts
+++ b/shared/src/util/getBundleMode.ts
@@ -1,0 +1,39 @@
+import { UserModel, useSetFrontendPreferencesMutation } from '@shared/api'
+import { toast } from 'react-toastify'
+
+export type BundleMode = 'production' | 'staging' | 'developer'
+
+export const getBundleModeFromUser = (user: UserModel | undefined): BundleMode => {
+  if (user?.attrib?.developerMode) return 'developer'
+  if (user?.data?.frontendPreferences?.stagingMode) return 'staging'
+  return 'production'
+}
+
+export const useStagingModeState = (user: UserModel, onChange?: (newPrefs: any) => void) => {
+  const [updatePreferences] = useSetFrontendPreferencesMutation()
+
+  const stagingMode = user?.data?.frontendPreferences?.stagingMode ?? false
+
+  const setStagingMode = async (enabled: boolean) => {
+    try {
+      const newPreferences = {
+        ...(user?.data?.frontendPreferences || {}),
+        stagingMode: enabled,
+      }
+      // update user
+      updatePreferences({
+        userName: user.name,
+        patchData: newPreferences,
+      }).unwrap()
+
+      if (onChange) {
+        onChange(newPreferences)
+      }
+    } catch (error) {
+      console.error(error)
+      toast.error('Failed to update staging mode')
+    }
+  }
+
+  return [stagingMode, setStagingMode] as const
+}

--- a/shared/src/util/index.ts
+++ b/shared/src/util/index.ts
@@ -25,6 +25,7 @@ export * from './folderOperations'
 export * from './getProjectDisplayName'
 export * from './getThumbnailUrl'
 export * from './thumbnailWebsocket'
+export * from './getBundleMode'
 
 import isHTMLElement from './isHTMLElement'
 export { isHTMLElement }

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -265,7 +265,7 @@ const App = () => {
         </Suspense>
       </>
     ),
-    [isUser, isTrialing, user.name],
+    [user, isUser, isTrialing, user.name],
   )
 
   const loadingComponent = useMemo(() => <LoadingPage />, [])

--- a/src/containers/header/AppHeader.tsx
+++ b/src/containers/header/AppHeader.tsx
@@ -1,9 +1,7 @@
 import { useEffect, useRef } from 'react'
 import type { MouseEvent } from 'react'
 import { Link, useLocation, useNavigate } from 'react-router-dom'
-import { InputSwitch } from '@ynput/ayon-react-components'
 import { UserImage } from '@shared/components'
-import { useUpdateUserMutation } from '@shared/api'
 
 import Breadcrumbs from '../Breadcrumbs/Breadcrumbs'
 import HeaderButton from './HeaderButton'
@@ -14,14 +12,13 @@ import InstallerDownloadPrompt from '@components/InstallerDownload/InstallerDown
 import { useMenuContext } from '@shared/context/MenuContext'
 import { HelpMenu, UserMenu } from '@components/Menu'
 import { MenuContainer } from '@shared/components'
-import { toast } from 'react-toastify'
-import { toggleDevMode } from '@state/user'
 import styled from 'styled-components'
 import { useRestart } from '@context/RestartContext'
 import clsx from 'clsx'
 import InboxNotificationIcon from './InboxNotification'
 import ReleaseInstallerPrompt from '@containers/ReleaseInstallerDialog/ReleaseInstallerPrompt/ReleaseInstallerPrompt'
 import ChatBubbleButton from './ChatBubbleButton'
+import BundleModeSelector from './BundleMode/BundleMode'
 
 const FlexWrapper = styled.div`
   display: flex;
@@ -32,55 +29,7 @@ const FlexWrapperEnd = styled.div`
   display: flex;
   gap: var(--base-gap-small);
   justify-content: end;
-`
-
-const DeveloperSwitch = styled.div`
-  display: flex;
   align-items: center;
-  gap: var(--base-gap-small);
-  border-radius: var(--border-radius-l);
-  padding: 4px 4px 4px 8px;
-  margin: 4px 0;
-  cursor: pointer;
-  z-index: 10;
-  transition: background-color 0.2s;
-  background-color: var(--md-sys-color-surface-container-highest);
-
-  & > span {
-    user-select: none;
-  }
-
-  &:hover {
-    background-color: var(--md-sys-color-surface-container-highest-hover);
-  }
-
-  &.active {
-    background-color: var(--color-hl-developer-container);
-
-    & > span {
-      color: var(--color-hl-developer);
-    }
-
-    &:hover {
-      background-color: var(--color-hl-developer-container-hover);
-    }
-  }
-`
-
-const StyledSwitch = styled(InputSwitch)`
-  pointer-events: none;
-
-  .switch-body input:checked + .slider {
-    background-color: var(--color-hl-developer);
-    border-color: var(--color-hl-developer);
-
-    &,
-    &:hover {
-      &::before {
-        background-color: var(--color-hl-developer-container);
-      }
-    }
-  }
 `
 
 const ProjectsButton = styled(HeaderButton)`
@@ -105,10 +54,6 @@ const Header: React.FC = () => {
 
   // restart server notification
   const { isSnoozing } = useRestart()
-
-  // Get developer states
-  const isDeveloper = (user?.data as any)?.isDeveloper
-  const developerMode = user?.attrib.developerMode
 
   // BUTTON REFS used to attach menu to buttons
   const helpButtonRef = useRef<HTMLButtonElement>(null)
@@ -139,31 +84,6 @@ const Header: React.FC = () => {
   const handleNavClick = (e: MouseEvent<HTMLElement>) => {
     // if target us nav, then close menu
     if ((e.target as HTMLElement).tagName === 'NAV') handleSetMenu(false)
-  }
-
-  // UPDATE USER DATA
-  const [updateUser] = useUpdateUserMutation()
-  const handleDeveloperMode = async () => {
-    try {
-      const newDeveloperMode = !developerMode
-      // optimistic update the switch
-      dispatch(toggleDevMode(newDeveloperMode))
-
-      await updateUser({
-        name: user.name,
-        patch: {
-          attrib: { developerMode: newDeveloperMode },
-        },
-      }).unwrap()
-
-      // if the request fails, revert the switch
-    } catch (error) {
-      console.error(error)
-      const errorMessage = (error as any)?.details || 'Unknown error'
-      toast.error('Unable to update developer mode: ' + errorMessage)
-      // reset switch on error
-      dispatch(toggleDevMode(developerMode))
-    }
   }
 
   // if on certain page, hide
@@ -199,15 +119,7 @@ const Header: React.FC = () => {
       <FlexWrapperEnd id="header-menu-right">
         <InstallerDownloadPrompt />
         <ReleaseInstallerPrompt isAdmin={user.data.isAdmin} />
-        {isDeveloper && (
-          <DeveloperSwitch
-            className={clsx({ active: developerMode })}
-            onClick={handleDeveloperMode}
-          >
-            <span>Developer Mode</span>
-            <StyledSwitch checked={developerMode} readOnly />
-          </DeveloperSwitch>
-        )}
+        <BundleModeSelector />
 
         {!user.data.isGuest && (
           <>

--- a/src/containers/header/BundleMode/BundleMode.tsx
+++ b/src/containers/header/BundleMode/BundleMode.tsx
@@ -1,0 +1,199 @@
+import { getBundleModeFromUser, useStagingModeState, BundleMode } from '@shared/util'
+import { useAppDispatch, useAppSelector } from '@state/store'
+import { toggleDevMode, updateUserPreferences } from '@state/user'
+import { FC, useMemo } from 'react'
+import { DeveloperSwitch } from './DeveloperSwitch'
+import { toast } from 'react-toastify'
+import { useUpdateUserMutation } from '@shared/api'
+import { DefaultItemTemplate, Dropdown } from '@ynput/ayon-react-components'
+import styled, { css } from 'styled-components'
+
+const modeColorVariables = css`
+  --bg-color: var(--md-sys-color-surface-container-highest);
+  --bg-color-hover: var(--md-sys-color-surface-container-highest-hover);
+  --text-color: var(--md-sys-color-on-surface);
+
+  &.developer {
+    --bg-color: var(--color-hl-developer-container);
+    --bg-color-hover: var(--color-hl-developer-container-hover);
+    --text-color: var(--color-hl-developer);
+  }
+
+  &.staging {
+    --bg-color: var(--color-hl-staging-container);
+    --bg-color-hover: var(--color-hl-staging-container-hover);
+    --text-color: var(--color-hl-staging);
+  }
+`
+
+const StyledDropdown = styled(Dropdown)`
+  button {
+    background-color: unset !important;
+  }
+`
+
+const StyledDropdownValue = styled.div`
+  display: flex;
+  align-items: center;
+  border-radius: var(--border-radius-l);
+  padding: 4px 8px;
+  user-select: none;
+
+  ${modeColorVariables}
+
+  background-color: var(--bg-color);
+  color: var(--text-color);
+
+  &:hover {
+    background-color: var(--bg-color-hover);
+  }
+`
+
+const StyledModeChip = styled.div`
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+
+  ${modeColorVariables}
+
+  background-color: var(--text-color);
+`
+
+interface BundleModeSelectorProps {}
+
+const BundleModeSelector: FC<BundleModeSelectorProps> = ({}) => {
+  const user = useAppSelector((state) => state.user)
+  const dispatch = useAppDispatch()
+  const [updateUser] = useUpdateUserMutation()
+
+  // Get developer states
+  const isDeveloper = (user?.data as any)?.isDeveloper
+  const developerMode = user?.attrib.developerMode
+
+  // is staging is stored in localStorage
+  // NOTE: the field is called isStagingEnabled in the user data but in graphql it is called isStagingAllowed
+  const isStaging = (user?.data as any)?.isStagingEnabled
+
+  const [stagingMode, setStagingMode] = useStagingModeState(
+    user as any, // update redux user state
+    (newPreferences) => dispatch(updateUserPreferences(newPreferences)),
+  )
+
+  const handleDeveloperMode = async () => {
+    try {
+      const newDeveloperMode = !developerMode
+      // optimistic update the switch
+      dispatch(toggleDevMode(newDeveloperMode))
+
+      await updateUser({
+        name: user.name,
+        patch: {
+          attrib: { developerMode: newDeveloperMode },
+        },
+      }).unwrap()
+
+      // if the request fails, revert the switch
+    } catch (error) {
+      console.error(error)
+      const errorMessage = (error as any)?.details || 'Unknown error'
+      toast.error('Unable to update developer mode: ' + errorMessage)
+      // reset switch on error
+      dispatch(toggleDevMode(developerMode))
+    }
+  }
+
+  const bundleMode = getBundleModeFromUser(user as any)
+
+  const handleBundleModeChange = async (mode: BundleMode) => {
+    const isDev = mode === 'developer'
+    const isStag = mode === 'staging'
+
+    const promises = []
+
+    try {
+      if (developerMode !== isDev) {
+        dispatch(toggleDevMode(isDev))
+        promises.push(
+          updateUser({
+            name: user.name,
+            patch: {
+              attrib: { developerMode: isDev },
+            },
+          }).unwrap(),
+        )
+      }
+
+      if (stagingMode !== isStag) {
+        promises.push(setStagingMode(isStag))
+      }
+
+      await Promise.all(promises)
+    } catch (error) {
+      console.error(error)
+      toast.error('Failed to update bundle mode')
+    }
+  }
+
+  const options = useMemo(
+    () => [
+      { label: 'Production', value: 'production' },
+      { label: 'Staging', value: 'staging' },
+      { label: 'Developer', value: 'developer' },
+    ],
+    [],
+  )
+
+  if (isDeveloper && isStaging) {
+    const renderValue = (value: string[]) => {
+      const mode = value[0] as BundleMode
+
+      const label =
+        mode === 'developer'
+          ? 'Developer Mode'
+          : mode === 'staging'
+          ? 'Staging Mode'
+          : 'Set bundle mode'
+
+      return <StyledDropdownValue className={mode}>{label}</StyledDropdownValue>
+    }
+
+    const renderItem = (option: any) => {
+      return (
+        <DefaultItemTemplate
+          option={option}
+          dataKey={'value'}
+          labelKey={'label'}
+          value={[option.value]}
+          selected={[bundleMode]}
+          startContent={<StyledModeChip className={option.value} />}
+        />
+      )
+    }
+
+    return (
+      <StyledDropdown
+        options={options}
+        value={[bundleMode]}
+        valueTemplate={renderValue}
+        itemTemplate={renderItem}
+        onChange={(v) => handleBundleModeChange(v[0] as BundleMode)}
+      />
+    )
+  }
+
+  return (
+    <>
+      {isDeveloper && <DeveloperSwitch value={developerMode} onChange={handleDeveloperMode} />}
+      {isStaging && (
+        <DeveloperSwitch
+          value={stagingMode}
+          onChange={setStagingMode}
+          variant={'staging'}
+          label={'Staging Mode'}
+        />
+      )}
+    </>
+  )
+}
+
+export default BundleModeSelector

--- a/src/containers/header/BundleMode/DeveloperSwitch.tsx
+++ b/src/containers/header/BundleMode/DeveloperSwitch.tsx
@@ -1,0 +1,89 @@
+import { InputSwitch } from '@ynput/ayon-react-components'
+import clsx from 'clsx'
+import { forwardRef } from 'react'
+import styled from 'styled-components'
+
+const StyledDeveloperSwitch = styled.div`
+  display: flex;
+  align-items: center;
+  gap: var(--base-gap-small);
+  border-radius: var(--border-radius-l);
+  padding: 4px 4px 4px 8px;
+  margin: 4px 0;
+  cursor: pointer;
+  z-index: 10;
+  transition: background-color 0.2s;
+  background-color: var(--md-sys-color-surface-container-highest);
+
+  /* default developer variant */
+  --color-hl: var(--color-hl-developer);
+  --color-background: var(--color-hl-developer-container);
+  --color-background-hover: var(--color-hl-developer-container-hover);
+  &.staging {
+    --color-hl: var(--color-hl-staging);
+    --color-background: var(--color-hl-staging-container);
+    --color-background-hover: var(--color-hl-staging-container-hover);
+  }
+
+  & > span {
+    user-select: none;
+  }
+
+  &:hover {
+    background-color: var(--md-sys-color-surface-container-highest-hover);
+  }
+
+  &.active {
+    background-color: var(--color-background);
+
+    & > span {
+      color: var(--color-hl);
+    }
+
+    &:hover {
+      background-color: var(--color-background-hover);
+    }
+  }
+`
+
+const StyledSwitch = styled(InputSwitch)`
+  pointer-events: none;
+
+  .switch-body input:checked + .slider {
+    background-color: var(--color-hl);
+    border-color: var(--color-hl);
+
+    &,
+    &:hover {
+      &::before {
+        background-color: var(--color-background);
+      }
+    }
+  }
+`
+
+interface DeveloperSwitchProps
+  extends Omit<React.HTMLAttributes<HTMLInputElement>, 'checked' | 'onChange' | 'value'> {
+  value: boolean
+  onChange: (value: boolean) => void
+  label?: string
+  variant?: 'developer' | 'staging'
+}
+
+export const DeveloperSwitch = forwardRef<HTMLInputElement, DeveloperSwitchProps>(
+  ({ value, onChange, label = 'Developer Mode', variant = 'developer', ...props }, ref) => {
+    const handleDeveloperMode = () => {
+      onChange(!value)
+    }
+
+    return (
+      <StyledDeveloperSwitch
+        className={clsx({ active: value }, variant)}
+        onClick={handleDeveloperMode}
+      >
+        <span>{label}</span>
+        <StyledSwitch ref={ref} checked={value} {...props} readOnly />
+      </StyledDeveloperSwitch>
+    )
+  },
+)

--- a/src/pages/ProjectListsPage/ProjectListsPage.tsx
+++ b/src/pages/ProjectListsPage/ProjectListsPage.tsx
@@ -67,6 +67,7 @@ import ImportDialogButton from '@containers/ImportDialog/ImportDialogButton.tsx'
 import useStoryboardsCardsModules from './hooks/useStoryboardsCardsModules.tsx'
 import OpenStoryboardButton from '@pages/ReviewPage/OpenStoryboardButton.tsx'
 import { TableGridPlaylistSwitch } from './components/TableGridPlaylistSwitch/TableGridPlaylistSwitch.tsx'
+import { getBundleModeFromUser } from '@shared/util/getBundleMode.ts'
 
 type ProjectListsPageProps = {
   projectName: string
@@ -265,8 +266,8 @@ const ProjectLists: FC<ProjectListsProps> = ({
   dndActiveId, // Destructure new prop
 }) => {
   const dispatch = useAppDispatch()
-  const user = useAppSelector((state) => state.user?.attrib)
-  const isDeveloperMode = user?.developerMode ?? false
+  const user = useAppSelector((state) => state.user)
+  const bundleMode = getBundleModeFromUser(user)
   const navigate = useNavigate()
   const [searchParams, setSearchParams] = useSearchParams()
   const { projectName } = useProjectContext()
@@ -428,7 +429,7 @@ const ProjectLists: FC<ProjectListsProps> = ({
                       onSetSearchParams={setSearchParams}
                       searchParams={searchParams}
                       featuredCount={0}
-                      isDeveloperMode={isDeveloperMode}
+                      bundleMode={bundleMode}
                       align="right"
                     />
                     {!reviewSessionCardsOutdated && isReview && !isStoryboards && (

--- a/src/pages/ProjectOverviewPage/ProjectOverviewPage.tsx
+++ b/src/pages/ProjectOverviewPage/ProjectOverviewPage.tsx
@@ -33,6 +33,7 @@ import { QueryFilter } from '@shared/containers/ProjectTreeTable/types/operation
 import DetailsPanelSplitter from '@components/DetailsPanelSplitter'
 import useGoToEntity from '../../hooks/useGoToEntity'
 import ImportDialogButton from '@containers/ImportDialog/ImportDialogButton'
+import { getBundleModeFromUser } from '@shared/util'
 
 // the tasks resolver task filter does not whitelist folder_type — use the
 // folder-scope folderType chip instead (goes through folderFilter)
@@ -65,7 +66,7 @@ const GroupByDropdown = styled(SortingDropdown)<{
 
 const ProjectOverviewPage: FC = () => {
   const { user } = useGlobalContext()
-  const isDeveloperMode = user?.attrib?.developerMode ?? false
+  const bundleMode = getBundleModeFromUser(user)
 
   const [searchParams, setSearchParams] = useSearchParams()
   const navigate = useNavigate()
@@ -248,7 +249,7 @@ const ProjectOverviewPage: FC = () => {
                 onNavigate={navigate}
                 onSetSearchParams={setSearchParams}
                 searchParams={searchParams}
-                isDeveloperMode={isDeveloperMode}
+                bundleMode={bundleMode}
                 align="right"
               />
               <CustomizeButton />

--- a/src/pages/SettingsPage/UsersSettings/UserAccessForm.jsx
+++ b/src/pages/SettingsPage/UsersSettings/UserAccessForm.jsx
@@ -106,6 +106,24 @@ const UserAccessForm = ({ accessGroupsData, formData, onChange, disabled }) => {
           </div>
         </FormRowStyled>
 
+        <FormRowStyled label="Staging access">
+          <div
+            data-tooltip={
+              'Users can turn on staging mode to test staging bundles, like actions, before they are released.'
+            }
+            data-tooltip-delay={0}
+            style={{ width: 'fit-content' }}
+          >
+            <InputSwitch
+              checked={formData?.isStagingAllowed}
+              onChange={(e) => updateFormData('isStagingAllowed', e.target.checked)}
+              style={{
+                opacity: disabled ? 0.5 : 1,
+              }}
+            />
+          </div>
+        </FormRowStyled>
+
         <FormRowStyled label="Access level">
           <SelectButton
             unselectable={false}

--- a/src/pages/SettingsPage/UsersSettings/userDetail.jsx
+++ b/src/pages/SettingsPage/UsersSettings/userDetail.jsx
@@ -85,6 +85,13 @@ const fields = [
     },
   },
   {
+    name: 'isStagingAllowed',
+    label: 'Staging access',
+    data: {
+      type: 'boolean',
+    },
+  },
+  {
     name: 'defaultAccessGroups',
     label: 'Default access groups',
     data: {
@@ -133,6 +140,11 @@ const mergeMultipleUsers = (users = [], defaultForm = {}, initForm = {}) => {
     if (index !== 0 && initForm.isDeveloper !== user.isDeveloper)
       initForm.isDeveloper = defaultForm.isDeveloper
     else initForm.isDeveloper = user.isDeveloper
+
+    // isStagingAllowed
+    if (index !== 0 && initForm.isStagingAllowed !== user.isStagingAllowed)
+      initForm.isStagingAllowed = defaultForm.isStagingAllowed
+    else initForm.isStagingAllowed = user.isStagingAllowed
 
     // userLevel
     let userLevel = 'user'
@@ -326,6 +338,9 @@ const UserDetail = ({
           data.isGuest = formData.isGuest
         } else if (field === 'isDeveloper') {
           data.isDeveloper = formData.isDeveloper && formData.userLevel === 'admin'
+        } else if (field === 'isStagingAllowed') {
+          // Note: for some reason backend expected isStagingEnabled and then return isStagingAllowed
+          data.isStagingEnabled = formData.isStagingAllowed
         } else if (singleUserEdit && attributes.find((a) => a.name === field)) {
           const value = formData[field]
           attrib[field] = typeof value === 'string' ? value.trim() : value

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -57,6 +57,8 @@ strong {
   --color-hl-production-active: var(--md-sys-color-tertiary-active);
 
   // staging colors
+  --color-hl-staging-container: hsl(21deg 83.13% 20.94%);
+  --color-hl-staging-container-hover: hsl(21deg 83.13% 23.94%);
   --color-hl-staging: hsl(357, 100%, 76%);
   --color-hl-staging-hover: hsl(357, 100%, 73%);
   --color-hl-staging-active: hsl(357, 100%, 70%);


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
Users can now have `Staging access` enabled to give them access to staging actions.

## Give access to Staging Mode

To allow a user enable staging mode they need to have the `Staging access` field enabled on their profile. This can only be done by and admin or manager.

## Enable Staging Mode

Once a user has access to Staging Mode they will see a switch appear at the top of their nav bar, where they can toggle staging mode on/off.

If the user has access to developer mode and staging mode then the switch will become a dropdown. The user can only be in one kind of mode at a time.

<img width="629" height="462" alt="image" src="https://github.com/user-attachments/assets/d5cdfd6c-cabb-4d00-9948-0a8a89528b50" />


## Actions

When a mode is selected the actions menu will be highlighted with the mode color and the actions will be scoped to the bundle with the current mode.