### PR TITLE
Settings: Sortable multi-selection fixes

### DIFF
--- a/src/containers/SettingsEditor/Widgets/OrderSelectionDialog.tsx
+++ b/src/containers/SettingsEditor/Widgets/OrderSelectionDialog.tsx
@@ -1,0 +1,182 @@
+import { useState } from 'react'
+import { Button, Dialog, Icon } from '@ynput/ayon-react-components'
+import styled from 'styled-components'
+import { DndContext, closestCenter, DragEndEvent, DragStartEvent, DragOverlay } from '@dnd-kit/core'
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+  useSortable,
+  arrayMove,
+} from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import { createPortal } from 'react-dom'
+import clsx from 'clsx'
+
+const List = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 320px;
+`
+
+const ItemRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 8px;
+  border-radius: var(--border-radius-m);
+  cursor: pointer;
+
+  &:hover {
+    background: var(--md-sys-color-surface-container-hover);
+  }
+
+  &.dragging {
+    visibility: hidden;
+  }
+`
+
+const DragHandle = styled(Icon)`
+  cursor: grab;
+  opacity: 0.5;
+  &:hover {
+    opacity: 1;
+  }
+`
+
+const ItemLabel = styled.span`
+  flex: 1;
+  font-size: 13px;
+  user-select: none;
+`
+
+const ActionIcon = styled(Icon)`
+  cursor: pointer;
+  opacity: 0.5;
+  font-size: 18px;
+  &:hover {
+    opacity: 1;
+  }
+`
+
+const SortableItem = ({
+  id,
+  label,
+  onRemove,
+  isDragging,
+}: {
+  id: string
+  label: string
+  isDragging: boolean
+  onRemove: () => void
+}) => {
+  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
+    id,
+    animateLayoutChanges: () => false,
+  })
+
+  const style = {
+    transform: CSS.Translate.toString(transform),
+    transition,
+  }
+
+  return (
+    <div ref={setNodeRef} style={style} {...attributes}>
+      <ItemRow className={clsx({ dragging: isDragging })}>
+        <DragHandle {...listeners} icon="drag_indicator" />
+        <ItemLabel>{label}</ItemLabel>
+        <ActionIcon
+          icon="close"
+          onClick={(e: React.MouseEvent) => {
+            e.stopPropagation()
+            onRemove()
+          }}
+        />
+      </ItemRow>
+    </div>
+  )
+}
+
+export interface OrderSelectionDialogProps {
+  value: string[]
+  options: { label: string; value: string }[]
+  onSubmit: (value: string[] | null) => void
+}
+
+const OrderSelectionDialog = ({ value, options, onSubmit }: OrderSelectionDialogProps) => {
+  const [order, setOrder] = useState<string[]>(value)
+  const [draggedId, setDraggedId] = useState<string | null>(null)
+
+  const getLabel = (val: string) => options.find((o) => o.value === val)?.label || val
+
+  const handleDragStart = (event: DragStartEvent) => {
+    setDraggedId(event.active.id as string)
+  }
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    setDraggedId(null)
+    const { active, over } = event
+    if (!over || active.id === over.id) return
+
+    const oldIndex = order.indexOf(active.id as string)
+    const newIndex = order.indexOf(over.id as string)
+    if (oldIndex === -1 || newIndex === -1) return
+
+    setOrder(arrayMove(order, oldIndex, newIndex))
+  }
+
+  const removeItem = (item: string) => {
+    setOrder(order.filter((v) => v !== item))
+  }
+
+  const draggedLabel = draggedId ? getLabel(draggedId) : ''
+
+  const footer = (
+    <>
+      <Button onClick={() => onSubmit(null)} label="Cancel" variant="text" />
+      <Button onClick={() => onSubmit(order)} label="Confirm" />
+    </>
+  )
+
+  return (
+    <Dialog header="Selection order" footer={footer} isOpen size="sm" onClose={() => onSubmit(null)}>
+      <List>
+        <DndContext
+          collisionDetection={closestCenter}
+          onDragStart={handleDragStart}
+          onDragEnd={handleDragEnd}
+        >
+          <SortableContext items={order} strategy={verticalListSortingStrategy}>
+            {order.map((item) => (
+              <SortableItem
+                key={item}
+                id={item}
+                label={getLabel(item)}
+                onRemove={() => removeItem(item)}
+                isDragging={draggedId === item}
+              />
+            ))}
+          </SortableContext>
+          {draggedId &&
+            createPortal(
+              <DragOverlay>
+                <ItemRow
+                  style={{
+                    background: 'var(--md-sys-color-surface-container-high)',
+                    boxShadow: '0 0 4px 1px rgba(0, 0, 0, 0.1)',
+                  }}
+                >
+                  <DragHandle icon="drag_indicator" />
+                  <ItemLabel>{draggedLabel}</ItemLabel>
+                  <ActionIcon icon="close" style={{ opacity: 0.3 }} />
+                </ItemRow>
+              </DragOverlay>,
+              document.body,
+            )}
+        </DndContext>
+      </List>
+    </Dialog>
+  )
+}
+
+export default OrderSelectionDialog

--- a/src/containers/SettingsEditor/Widgets/OrderSelectionDialog.tsx
+++ b/src/containers/SettingsEditor/Widgets/OrderSelectionDialog.tsx
@@ -12,6 +12,12 @@ import { CSS } from '@dnd-kit/utilities'
 import { createPortal } from 'react-dom'
 import clsx from 'clsx'
 
+const StyledDialog = styled(Dialog)`
+  && {
+    max-height: 85vh;
+  }
+`
+
 const List = styled.div`
   display: flex;
   flex-direction: column;
@@ -139,7 +145,13 @@ const OrderSelectionDialog = ({ value, options, onSubmit }: OrderSelectionDialog
   )
 
   return (
-    <Dialog header="Selection order" footer={footer} isOpen size="sm" onClose={() => onSubmit(null)}>
+    <StyledDialog
+      header="Selection order"
+      footer={footer}
+      isOpen
+      size="sm"
+      onClose={() => onSubmit(null)}
+    >
       <List>
         <DndContext
           collisionDetection={closestCenter}
@@ -175,7 +187,7 @@ const OrderSelectionDialog = ({ value, options, onSubmit }: OrderSelectionDialog
             )}
         </DndContext>
       </List>
-    </Dialog>
+    </StyledDialog>
   )
 }
 

--- a/src/containers/SettingsEditor/Widgets/OrderedListWidget.tsx
+++ b/src/containers/SettingsEditor/Widgets/OrderedListWidget.tsx
@@ -1,16 +1,7 @@
-import { useState } from 'react'
-import { Icon, Dropdown, DropdownProps } from '@ynput/ayon-react-components'
+import { useMemo, useState } from 'react'
+import { Button, Dropdown, DropdownProps } from '@ynput/ayon-react-components'
 import styled from 'styled-components'
-import { DndContext, closestCenter, DragEndEvent, DragStartEvent, DragOverlay } from '@dnd-kit/core'
-import {
-  SortableContext,
-  verticalListSortingStrategy,
-  useSortable,
-  arrayMove,
-} from '@dnd-kit/sortable'
-import { CSS } from '@dnd-kit/utilities'
-import { createPortal } from 'react-dom'
-import clsx from 'clsx'
+import OrderSelectionDialog from './OrderSelectionDialog'
 
 const Container = styled.div`
   display: flex;
@@ -20,97 +11,24 @@ const Container = styled.div`
   max-width: 800px;
 `
 
+const Row = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`
+
 const StyledDropdown = styled(Dropdown)`
+  flex: 1;
   button > div > div:has(span) {
     width: 0;
   }
 `
 
-const ItemRow = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 4px 8px;
-  border-radius: var(--border-radius-m);
-  cursor: pointer;
-
-  &:hover {
-    background: var(--md-sys-color-surface-container-hover);
-  }
-
-  &.dragging {
-    visibility: hidden;
-  }
-`
-
-const DragHandle = styled(Icon)`
-  cursor: grab;
-  opacity: 0.5;
-  &:hover {
-    opacity: 1;
-  }
-`
-
-const ItemLabel = styled.span`
-  flex: 1;
-  font-size: 13px;
-  user-select: none;
-`
-
-const ActionIcon = styled(Icon)`
-  cursor: pointer;
-  opacity: 0.5;
-  font-size: 18px;
-  &:hover {
-    opacity: 1;
-  }
-`
-
 const SectionLabel = styled.div`
   font-size: 11px;
-  text-transform: uppercase;
   color: var(--md-sys-color-outline);
   padding: 6px 8px 2px;
-  letter-spacing: 0.5px;
 `
-
-const SortableItem = ({
-  id,
-  label,
-  onRemove,
-  isDragging,
-}: {
-  id: string
-  label: string
-  isDragging: boolean
-  onRemove: () => void
-}) => {
-  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
-    id,
-    animateLayoutChanges: () => false,
-  })
-
-  const style = {
-    transform: CSS.Translate.toString(transform),
-    transition,
-  }
-
-  return (
-    <div ref={setNodeRef} style={style} {...attributes}>
-      <ItemRow className={clsx({ dragging: isDragging })}>
-        <DragHandle {...listeners} icon="drag_indicator" />
-        <ItemLabel>{label}</ItemLabel>
-        <ActionIcon
-          icon="close"
-          onClick={(e: React.MouseEvent) => {
-            e.stopPropagation()
-            onRemove()
-          }}
-        />
-      </ItemRow>
-    </div>
-  )
-}
 
 export interface OrderedListWidgetProps {
   value: string[]
@@ -129,22 +47,13 @@ const OrderedListWidget = ({
   disabled,
   dropdownProps,
 }: OrderedListWidgetProps) => {
-  const [draggedId, setDraggedId] = useState<string | null>(null)
-
-  const getLabel = (val: string) => {
-    const opt = options.find((o) => o.value === val)
-    return opt?.label || val
-  }
+  const [isOpen, setIsOpen] = useState(false)
 
   const handleSelectionChange = (newSelection: string[]) => {
     // Preserve order of already-selected items, append new ones at end
     const kept = value.filter((v) => newSelection.includes(v))
     const added = newSelection.filter((v) => !value.includes(v))
     onChange([...kept, ...added])
-  }
-
-  const removeItem = (item: string) => {
-    onChange(value.filter((v) => v !== item))
   }
 
   const handleSelectAll = () => {
@@ -158,81 +67,51 @@ const OrderedListWidget = ({
     onChange([])
   }
 
-  const handleDragStart = (event: DragStartEvent) => {
-    setDraggedId(event.active.id as string)
+  // Selected items first in their selection order, then the rest in enum order
+  const orderedOptions = useMemo(() => {
+    const byValue = new Map(options.map((o) => [o.value, o]))
+    const selected = value
+      .map((v) => byValue.get(v))
+      .filter((o): o is { label: string; value: string } => Boolean(o))
+    const rest = options.filter((o) => !value.includes(o.value))
+    return [...selected, ...rest]
+  }, [value, options])
+
+  const onDialogSubmit = (newOrder: string[] | null) => {
+    if (newOrder !== null) onChange(newOrder)
+    setIsOpen(false)
   }
-
-  const handleDragEnd = (event: DragEndEvent) => {
-    setDraggedId(null)
-    const { active, over } = event
-    if (!over || active.id === over.id) return
-
-    const oldIndex = value.indexOf(active.id as string)
-    const newIndex = value.indexOf(over.id as string)
-    if (oldIndex === -1 || newIndex === -1) return
-
-    onChange(arrayMove(value, oldIndex, newIndex))
-  }
-
-  const draggedLabel = draggedId ? getLabel(draggedId) : ''
 
   return (
     <Container data-tooltip="">
-      <StyledDropdown
-        widthExpand
-        options={options}
-        value={value}
-        onSelectionChange={handleSelectionChange}
-        multiSelect
-        placeholder={placeholder}
-        disabled={disabled}
-        search={options.length > 10}
-        onSelectAll={options.length > 10 ? handleSelectAll : undefined}
-        onClear={value.length > 0 ? handleClear : undefined}
-        clearTooltip="Clear selection"
-        {...dropdownProps}
-      />
-
-      {value.length > 0 && (
-        <>
-          <SectionLabel>Order selection</SectionLabel>
-          <DndContext
-            collisionDetection={closestCenter}
-            onDragStart={handleDragStart}
-            onDragEnd={handleDragEnd}
-          >
-            <SortableContext items={value} strategy={verticalListSortingStrategy}>
-              {value.map((item) => (
-                <SortableItem
-                  key={item}
-                  id={item}
-                  label={getLabel(item)}
-                  onRemove={() => removeItem(item)}
-                  isDragging={draggedId === item}
-                />
-              ))}
-            </SortableContext>
-            {draggedId &&
-              createPortal(
-                <DragOverlay>
-                  <ItemRow
-                    style={{
-                      background: 'var(--md-sys-color-surface-container-high)',
-                      boxShadow: '0 0 4px 1px rgba(0, 0, 0, 0.1)',
-                    }}
-                  >
-                    <DragHandle icon="drag_indicator" />
-                    <ItemLabel>{draggedLabel}</ItemLabel>
-                    <ActionIcon icon="close" style={{ opacity: 0.3 }} />
-                  </ItemRow>
-                </DragOverlay>,
-                document.body,
-              )}
-          </DndContext>
-        </>
-      )}
+      <Row>
+        <StyledDropdown
+          widthExpand
+          options={orderedOptions}
+          value={value}
+          onSelectionChange={handleSelectionChange}
+          multiSelect
+          placeholder={placeholder}
+          disabled={disabled}
+          search={options.length > 10}
+          onSelectAll={options.length > 10 ? handleSelectAll : undefined}
+          onClear={value.length > 0 ? handleClear : undefined}
+          clearTooltip="Clear selection"
+          {...dropdownProps}
+        />
+        <Button
+          icon="sort"
+          label="Set order"
+          onClick={() => setIsOpen(true)}
+          disabled={disabled || value.length < 2}
+        />
+      </Row>
 
       {options.length === 0 && <SectionLabel>No options available</SectionLabel>}
+
+      {isOpen && (
+        <OrderSelectionDialog value={value} options={options} onSubmit={onDialogSubmit} />
+      )}
     </Container>
   )
 }

--- a/src/containers/SettingsEditor/Widgets/SelectWidget.tsx
+++ b/src/containers/SettingsEditor/Widgets/SelectWidget.tsx
@@ -132,7 +132,10 @@ const SelectWidget = (props: $Any) => {
   const [value, setValue] = useState<string[] | string | null>(null)
 
   const widget = props.schema?.widget
-  const isSortableMultiselect = widget === 'sortable_multiselect'
+  // TODO: remove ID check once backend addon adds widget="sortable_multiselect" to schema
+  const isSortableMultiselect =
+    widget === 'sortable_multiselect' ||
+    (props.multiple && /applications_profiles_\d+_applications$/.test(props.id))
 
   useEffect(() => {
     // Sync the local state with the formData

--- a/src/containers/SettingsEditor/Widgets/SelectWidget.tsx
+++ b/src/containers/SettingsEditor/Widgets/SelectWidget.tsx
@@ -132,10 +132,7 @@ const SelectWidget = (props: $Any) => {
   const [value, setValue] = useState<string[] | string | null>(null)
 
   const widget = props.schema?.widget
-  // TODO: remove ID check once backend addon adds widget="sortable_multiselect" to schema
-  const isSortableMultiselect =
-    widget === 'sortable_multiselect' ||
-    (props.multiple && /applications_profiles_\d+_applications$/.test(props.id))
+  const isSortableMultiselect = widget === 'sortable_multiselect'
 
   useEffect(() => {
     // Sync the local state with the formData


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Moves the ordered-multiselect reordering into a "Set order" dialog next to the dropdown. The dropdown now lists selected items in their chosen order.

## Technical details
<!-- Please state any technical details such as limitations -->

- New `OrderSelectionDialog.tsx` holds the drag-to-reorder list; header reads "Selection order".
- `OrderedListWidget.tsx` reduced to dropdown + "Set order" button; dropdown options sorted selected-first via `orderedOptions` memo.
- `SelectWidget.tsx`: gate on `widget === 'sortable_multiselect'` only; dropped the `applications_profiles` id regex fallback.

## Additional context
<!-- Add any other context or screenshots here. -->
