### PR TITLE
Summaries: Save column config to view, disable unused parent scope

### DIFF
--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ynput/ayon-frontend-shared",
-  "version": "0.3.40",
+  "version": "0.3.41",
   "description": "Shared React components for AYON frontend",
   "main": "dist/index.cjs.js",
   "module": "dist/index.es.js",

--- a/shared/src/containers/ProjectTreeTable/ProjectTreeTable.tsx
+++ b/shared/src/containers/ProjectTreeTable/ProjectTreeTable.tsx
@@ -255,6 +255,13 @@ export const ProjectTreeTable = ({
   } = useProjectTableContext()
   const isGrouping = !!groupBy || !!overrideGroupBy
 
+  // Parent (folder/product) summary scope only applies when those entities are
+  // actually on screen: hierarchy view, or grouping by a parent entity.
+  const groupField = overrideGroupBy?.id ?? groupBy?.id
+  const groupFieldId = Array.isArray(groupField) ? groupField[0] : groupField
+  const parentScopeApplicable =
+    showHierarchy || ['hierarchy', 'folder', 'product'].includes(groupFieldId ?? '')
+
   const { writableFields } = useProjectDataContext()
 
   const isLoading = isLoadingProp || isLoadingData
@@ -790,6 +797,7 @@ export const ProjectTreeTable = ({
                     onScopeChange={(scope) => updateColumnSummaryScope(columnId, scope)}
                     mainCountLabels={mainCountLabels}
                     fieldOptions={options}
+                    parentScopeApplicable={parentScopeApplicable}
                   />
                 )}
                 // Power feature cell for community users (hidden for now), shows a bolt hint in the name column:

--- a/shared/src/containers/ProjectTreeTable/types/index.ts
+++ b/shared/src/containers/ProjectTreeTable/types/index.ts
@@ -47,4 +47,6 @@ export interface SummaryCellContentProps {
   onScopeChange: (scope: RowScope) => void
   mainCountLabels?: MainCountLabels
   fieldOptions?: BuiltInFieldOptions
+  // false when no parent entity (folder/product) is on screen; addon hides + disables the parent scope
+  parentScopeApplicable?: boolean
 }

--- a/shared/src/containers/Views/hooks/pages/useOverviewViewSettings.ts
+++ b/shared/src/containers/Views/hooks/pages/useOverviewViewSettings.ts
@@ -9,7 +9,6 @@
  * Must be used within a ViewsProvider context.
  */
 
-import { useViewsContext } from '../../context/ViewsContext'
 import { OverviewSettings } from '@shared/api'
 import { ColumnsConfig } from '@shared/containers/ProjectTreeTable'
 import {
@@ -21,11 +20,6 @@ import { useState, useEffect, useCallback, useMemo } from 'react'
 
 // Import the internal QueryFilter type that the app uses
 import { QueryFilter } from '@shared/containers/ProjectTreeTable/types/operations'
-import {
-  SummaryCalc,
-  SummaryFormat,
-  RowScope,
-} from '@shared/containers/ProjectTreeTable/types/summaryTypes'
 
 type Return = {
   // Filter management
@@ -56,26 +50,6 @@ export const useOverviewViewSettings = ({ viewSettings, updateViewSettings }: Pr
   const [localFilters, setLocalFilters] = useState<QueryFilter | null>(null)
   const [localHierarchy, setLocalHierarchy] = useState<boolean | null>(null)
   const [localColumns, setLocalColumns] = useState<ColumnsConfig | null>(null)
-
-  // Backend drops summary/summaryScope/summaryFormat from ColumnItemModel, so
-  // the post-save refetch would revert them — hold the selections here, session only.
-  const { selectedView, workingView, isViewWorking, editingViewId } = useViewsContext()
-  const [summaryOverrides, setSummaryOverrides] = useState<{
-    summaries: Record<string, SummaryCalc>
-    scopes: Record<string, RowScope>
-    formats: Record<string, SummaryFormat>
-  }>({ summaries: {}, scopes: {}, formats: {} })
-
-  // Editing a named view forks to the working view (selectedView.id flips), but
-  // editingViewId keeps pointing at the origin, so the key stays stable while editing.
-  const viewKey = isViewWorking
-    ? editingViewId || workingView?.id || 'working'
-    : selectedView?.id
-
-  // Reset overrides when a different view's settings come on screen
-  useEffect(() => {
-    setSummaryOverrides({ summaries: {}, scopes: {}, formats: {} })
-  }, [viewKey])
 
   // Get server settings
   const overviewSettings = viewSettings as OverviewSettings
@@ -113,26 +87,7 @@ export const useOverviewViewSettings = ({ viewSettings, updateViewSettings }: Pr
   // Use local state if available, otherwise use server state
   const filters = localFilters !== null ? localFilters : serverFilters
   const showHierarchy = localHierarchy !== null ? localHierarchy : serverHierarchy
-  const columnsBase = localColumns || serverColumns
-  const columns = useMemo(() => {
-    const hasOverrides =
-      Object.keys(summaryOverrides.summaries).length ||
-      Object.keys(summaryOverrides.scopes).length ||
-      Object.keys(summaryOverrides.formats).length
-    if (!hasOverrides) return columnsBase
-    return {
-      ...columnsBase,
-      columnSummaries: { ...columnsBase.columnSummaries, ...summaryOverrides.summaries },
-      columnSummaryScopes: {
-        ...columnsBase.columnSummaryScopes,
-        ...summaryOverrides.scopes,
-      },
-      columnSummaryFormats: {
-        ...columnsBase.columnSummaryFormats,
-        ...summaryOverrides.formats,
-      },
-    }
-  }, [columnsBase, summaryOverrides])
+  const columns = localColumns || serverColumns
 
   // Slice type update handler
   const noop = useCallback(() => {}, [])
@@ -186,20 +141,6 @@ export const useOverviewViewSettings = ({ viewSettings, updateViewSettings }: Pr
   // Column update handler
   const onUpdateColumns = useCallback(
     async (tableSettings: ColumnsConfig, allColumnIds?: string[]) => {
-      // Keep the summary footer choices alive across the working-view refetch
-      // (backend drops these fields, so server state can't be trusted for them).
-      if (
-        tableSettings.columnSummaries ||
-        tableSettings.columnSummaryScopes ||
-        tableSettings.columnSummaryFormats
-      ) {
-        setSummaryOverrides((prev) => ({
-          summaries: { ...prev.summaries, ...(tableSettings.columnSummaries || {}) },
-          scopes: { ...prev.scopes, ...(tableSettings.columnSummaryScopes || {}) },
-          formats: { ...prev.formats, ...(tableSettings.columnSummaryFormats || {}) },
-        }))
-      }
-
       // Derive a stable allColumnIds if not provided to preserve order and grouping on server
       const derivedAll =
         allColumnIds ||

--- a/shared/src/util/columnConfigConverter.ts
+++ b/shared/src/util/columnConfigConverter.ts
@@ -22,7 +22,7 @@ import {
 // persisted or loaded from saved view settings.
 const INTERNAL_COLUMN_IDS = new Set([ROW_SELECTION_COLUMN_ID, DRAG_HANDLE_COLUMN_ID])
 
-// Backend doesn't store summary/summaryScope/summaryFormat on ColumnItemModel yet
+// summary/summaryScope/summaryFormat persist in the view settings dict but aren't on the generated ColumnItemModel type
 type ColumnItem = ColumnItemModel & {
   summary?: SummaryCalc
   summaryScope?: RowScope


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Column summary settings (aggregation, scope, format) now save with the page view. Parent folder/product counts are excluded and their scope toggle disabled when no parent entity is on screen.

## Technical details
<!-- Please state any technical details such as limitations -->

- Remove the session-only `summaryOverrides` workaround in `useOverviewViewSettings.ts`; summary calc/scope/format now persist via the saved view settings.
- Add `parentScopeApplicable` to `SummaryCellContentProps`; `ProjectTreeTable` derives it from `showHierarchy`/`groupBy` and passes it to the summaries remote.
- Fix stale comment in `columnConfigConverter.ts` (these fields persist now).
- Addon-side behaviour (disable toggle, drop parent counts) ships in a separate ayon-power-pack PR.

## Additional context
<!-- Add any other context or screenshots here. -->

Closes #2079
Part of ynput/ayon-power-pack#72
