### PR TITLE
Links: dialog no longer disappears during table updates

### DIFF
--- a/shared/src/containers/ProjectTreeTable/ProjectTreeTable.tsx
+++ b/shared/src/containers/ProjectTreeTable/ProjectTreeTable.tsx
@@ -1364,7 +1364,7 @@ const TableBody = ({
           <div key={i} style={{ left }} />
         ))}
       </Styled.ColumnDividers>
-      {virtualRows.map((virtualRow, i) => {
+      {virtualRows.map((virtualRow) => {
         const row = rows[virtualRow.index] as Row<TableRow>
         // Add a check for row existence to prevent potential errors if data is out of sync
         if (!row) {
@@ -1373,7 +1373,7 @@ const TableBody = ({
         }
         return (
           <TableBodyRow
-            key={row.id + i.toString()} // dnd-kit needs this key to be stable and match the id in useSortable
+            key={row.id} // stable per-row identity; dnd-kit matches on row.id via SortableContext, not this key
             row={row}
             showHierarchy={showHierarchy}
             visibleCells={row.getVisibleCells()}
@@ -1516,7 +1516,7 @@ const TableBodyRow = ({
         //fake empty column to the left for virtualization scroll padding
         <td style={{ display: 'flex', width: paddingLeft }} />
       ) : null}
-      {virtualColumns.map((vc, i) => {
+      {virtualColumns.map((vc) => {
         const cell = visibleCells[vc.index]
         if (!cell) return null // Should not happen in normal circumstances
 
@@ -1525,7 +1525,7 @@ const TableBodyRow = ({
         if (cell.column.id === DRAG_HANDLE_COLUMN_ID) {
           return (
             <Styled.TD
-              key={cell.id + i.toString()}
+              key={cell.id}
               style={{
                 ...getCommonPinningStyles(cell.column),
                 width: getColumnWidth(cell.column.id),
@@ -1560,7 +1560,7 @@ const TableBodyRow = ({
             cell={cell}
             cellId={cellId}
             rowId={row.id}
-            key={cell.id + i.toString()}
+            key={cell.id}
             showHierarchy={showHierarchy}
             sortableRows={sortableRows}
             rowHeight={rowHeight}

--- a/shared/src/containers/ProjectTreeTable/hooks/useBuildGroupByTableData.ts
+++ b/shared/src/containers/ProjectTreeTable/hooks/useBuildGroupByTableData.ts
@@ -25,7 +25,11 @@ export const UNGROUPED_VALUE = '_ungrouped'
 export const ROW_ID_SEPARATOR = '__'
 
 const valueToStringArray = (value?: any): string[] =>
-  value ? (Array.isArray(value) ? value.map((v) => v.toString()) : [value.toString()]) : []
+  value
+    ? Array.isArray(value)
+      ? [...new Set(value.map((v) => v.toString()))] // dedup so an entity can't land in the same group twice (keeps row.id unique)
+      : [value.toString()]
+    : []
 
 // get group label, color and icon
 const getGroupData = (groupById: string, groupValue: string, groups?: EntityGroup[]): GroupData => {


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Keeps the Breakdown links dialog and in-cell editors open when the project table re-renders, instead of vanishing on scroll or from background entity updates.

## Technical details
<!-- Please state any technical details such as limitations -->

- Row key back to `key={row.id}` and cell keys to `key={cell.id}` in `ProjectTreeTable.tsx`, dropping the virtual-window index suffix that remounted rows/cells on any reflow.
- The dialog is a portal mounted inside the cell, so a row/cell remount tore it down along with its local search state.
- `valueToStringArray` in `useBuildGroupByTableData.ts` now dedups group values with a `Set`, keeping grouped `row.id` unique — the reason the index suffix was added.

## Additional context
<!-- Add any other context or screenshots here. -->
