### PR TITLE
Lists: Right clicking on folder and creating subfolder does not work

### DIFF
--- a/src/pages/ProjectListsPage/components/ListFolderFormDialog/ListFolderFormDialog.tsx
+++ b/src/pages/ProjectListsPage/components/ListFolderFormDialog/ListFolderFormDialog.tsx
@@ -13,7 +13,7 @@ interface ListFolderFormDialogProps {}
 
 export const ListFolderFormDialog: FC<ListFolderFormDialogProps> = ({}) => {
   const {
-    listFolderOpen: { isOpen, initial, folderId },
+    listFolderOpen: { isOpen, initial, folderId, parentId },
     setListFolderOpen,
     onCreateListFolder,
     onUpdateListFolder,
@@ -45,10 +45,13 @@ export const ListFolderFormDialog: FC<ListFolderFormDialogProps> = ({}) => {
     .map((id) => parseListFolderRowId(id))
     .filter((id): id is string => !!id)
 
-  const listIdsToAdd = mode === 'create' && selectedFolderIds.length === 0 ? selectedListIds : []
+  const listIdsToAdd =
+    mode === 'create' && !parentId && selectedFolderIds.length === 0 ? selectedListIds : []
   const parentIdsToCreateIn =
     mode === 'create'
-      ? selectedFolderIds.length > 0
+      ? parentId
+        ? [parentId]
+        : selectedFolderIds.length > 0
         ? selectedFolderIds
         : selectedList?.entityListFolderId
         ? [selectedList.entityListFolderId]

--- a/src/pages/ProjectListsPage/context/ListsContext.ts
+++ b/src/pages/ProjectListsPage/context/ListsContext.ts
@@ -9,10 +9,11 @@ import { ListFolderFormData } from '../components/ListFolderFormDialog'
 export type ListDetailsOpenState = {
   isOpen: boolean
   folderId?: string // id of folder being edited, undefined for create
+  parentId?: string // parent folder to create the new folder inside (create mode)
   initial?: Partial<ListFolderFormData>
 }
 
-export type OnOpenFolderListParams = (params: { folderId?: string }) => void
+export type OnOpenFolderListParams = (params: { folderId?: string; parentId?: string }) => void
 
 export interface ListsContextType {
   rowSelection: RowSelectionState

--- a/src/pages/ProjectListsPage/context/ListsProvider.tsx
+++ b/src/pages/ProjectListsPage/context/ListsProvider.tsx
@@ -256,17 +256,18 @@ export const ListsProvider = ({ children, isReview, isStoryboards }: ListsProvid
     onCreatedFolders: handleCreatedFolders,
   })
 
-  const onOpenFolderList: OnOpenFolderListParams = ({ folderId }) => {
+  const onOpenFolderList: OnOpenFolderListParams = ({ folderId, parentId }) => {
     if (!powerLicense) {
       setPowerpackDialog('listFolders')
       return
     }
     // get folder data
     const folder = listFolders.find((f) => f.id === folderId)
-    // if no folderId, open create dialog
+    // if no folderId, open create dialog (optionally inside parentId)
     if (!folderId) {
       return setListFolderOpen({
         isOpen: true,
+        parentId,
       })
     }
 

--- a/src/pages/ProjectListsPage/hooks/useListContextMenu.ts
+++ b/src/pages/ProjectListsPage/hooks/useListContextMenu.ts
@@ -340,7 +340,7 @@ const useListContextMenu = () => {
               {
                 label: 'Create subfolder',
                 icon: FOLDER_ICON_ADD,
-                command: () => onOpenFolderList({}),
+                command: () => onOpenFolderList({ parentId: selectedFolderIds[0] }),
                 shortcut: 'F',
                 hidden: !allSelectedRowsAreFolders || selectedFolderIds.length !== 1,
               },


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Fixes right-click "Create subfolder" on a folder creating the new folder at root instead of inside it.

## Technical details
<!-- Please state any technical details such as limitations -->

- "Create subfolder" now passes the parent folder id explicitly instead of `{}` (`useListContextMenu.ts`).
- `parentId` added to `OnOpenFolderListParams` + `ListDetailsOpenState`, stored on dialog open (`ListsContext.ts`, `ListsProvider.tsx`).
- Dialog seeds `parentIdsToCreateIn` from the explicit `parentId` (`ListFolderFormDialog.tsx`); selection couldn't carry it because folder ids are stripped from the URL selection param.

## Additional context
<!-- Add any other context or screenshots here. -->

Closes #2032
