### PR TITLE
Seek ready state fix

### DIFF
--- a/src/containers/VideoPlayer/hooks/useVideoSeeking.ts
+++ b/src/containers/VideoPlayer/hooks/useVideoSeeking.ts
@@ -17,7 +17,7 @@ const useVideoSeeking = (
     const videoElement = videoRef.current
     if (!videoElement) return false
     if (newTime === videoElement.currentTime) return false
-    if (videoElement.readyState >= 1) {
+    if (videoElement.readyState >= 2) {
       // HAVE_METADATA
       videoElement.currentTime = newTime
     } else {


### PR DESCRIPTION
This pull request makes a targeted change to the `useVideoSeeking` hook to improve video seeking reliability. The main update is increasing the required `readyState` before seeking, ensuring the video has enough data loaded. That reduces the amount of cancelled requests during scrub