### PR TITLE
Lists: Sort by Product Name errors out

### DIFF
--- a/shared/src/api/generated/graphql.ts
+++ b/shared/src/api/generated/graphql.ts
@@ -2201,7 +2201,7 @@ export type GetListItemsQuery = {
           id: string
           active: boolean
           items: {
-            pageInfo: { hasNextPage: boolean; endCursor: string | null }
+            pageInfo: { hasNextPage: boolean; hasPreviousPage: boolean; endCursor: string | null }
             edges: Array<{
               id: string
               entityId: string
@@ -4661,6 +4661,7 @@ export const GetListItemsDocument = new TypedDocumentString(`
           ) {
             pageInfo {
               hasNextPage
+              hasPreviousPage
               endCursor
             }
             edges {

--- a/shared/src/api/queries/entityLists/getLists.ts
+++ b/shared/src/api/queries/entityLists/getLists.ts
@@ -294,7 +294,10 @@ const getListsGqlApiInjected = getListsGqlApiEnhanced.injectEndpoints({
         initialPageParam: { cursor: '' },
         getNextPageParam: (lastPage) => {
           const { pageInfo } = lastPage
-          if (!pageInfo.hasNextPage || !pageInfo.endCursor) return undefined
+          // ascending paginates via hasNextPage, descending (last/before) via
+          // hasPreviousPage — the backend only sets one depending on direction
+          const hasMore = pageInfo.hasNextPage || pageInfo.hasPreviousPage
+          if (!hasMore || !pageInfo.endCursor) return undefined
 
           return {
             cursor: pageInfo.endCursor,

--- a/shared/src/api/queries/entityLists/gql/GetListItems.graphql
+++ b/shared/src/api/queries/entityLists/gql/GetListItems.graphql
@@ -29,6 +29,7 @@ query GetListItems(
           ) {
             pageInfo {
               hasNextPage
+              hasPreviousPage
               endCursor
             }
             edges {

--- a/shared/src/api/queries/entityLists/types.ts
+++ b/shared/src/api/queries/entityLists/types.ts
@@ -84,6 +84,8 @@ export type EntityListItem = NonNullable<QueryEntityListItemNode> &
 export type GetListItemsResult = {
   pageInfo: {
     hasNextPage: boolean
+    // set when paginating descending (last/before); see getListItemsInfinite
+    hasPreviousPage?: boolean | null
     endCursor?: string | null
   }
   items: (QueryEntityListItemNode &

--- a/shared/src/components/ProjectTableSettings/ProjectTableSettings.tsx
+++ b/shared/src/components/ProjectTableSettings/ProjectTableSettings.tsx
@@ -167,7 +167,7 @@ export const ProjectTableSettings: FC<ProjectTableSettingsProps> = ({
   ).length
 
   const groupBySettings = useGroupBySettings({ scope })
-  const sortBySettings = useSortBySettings()
+  const sortBySettings = useSortBySettings(columns)
 
   const defaultSettings: (SettingConfig | undefined | null)[] = [
     {

--- a/shared/src/containers/ProjectTreeTable/ProjectTreeTable.tsx
+++ b/shared/src/containers/ProjectTreeTable/ProjectTreeTable.tsx
@@ -1106,7 +1106,19 @@ const TableHeadCell = ({
   const menuId = `column-header-menu-${column.id}`
   const { menuOpen } = useMenuContext()
   const isOpen = menuOpen === menuId
-  const { columnPinning } = useColumnSettingsContext()
+  const { columnPinning, sorting: sortingState, updateSorting } = useColumnSettingsContext()
+
+  // toggle sort via the same direct updateSorting call the Customize panel uses;
+  // routing through TanStack's onSortingChange did not apply under manualSorting.
+  const handleToggleSort = () => {
+    const current = sortingState?.find((s) => s.id === column.id)
+    const next = !current
+      ? [{ id: column.id, desc: false }]
+      : !current.desc
+      ? [{ id: column.id, desc: true }]
+      : []
+    updateSorting(next)
+  }
 
   // Check if this column is pinned
   const isThisColumnPinned = columnPinning.left?.includes(column.id) || false
@@ -1197,7 +1209,7 @@ const TableHeadCell = ({
                 style={{
                   transform: sorting === 'asc' ? 'rotate(180deg) scaleX(-1)' : 'none',
                 }}
-                onClick={column.getToggleSortingHandler()}
+                onClick={handleToggleSort}
                 selected={!!column.getIsSorted()}
               />
             )}

--- a/shared/src/containers/ProjectTreeTable/hooks/useSortBySettings.tsx
+++ b/shared/src/containers/ProjectTreeTable/hooks/useSortBySettings.tsx
@@ -12,7 +12,9 @@ const BUILT_IN_SORT_OPTIONS: { id: string; label: string; scopes?: string[] }[] 
   { id: 'updatedAt', label: 'Updated at' },
 ]
 
-export const useSortBySettings = () => {
+type SortColumn = { value: string; label: string }
+
+export const useSortBySettings = (columns: SortColumn[] = []) => {
   const { sorting, updateSorting } = useColumnSettingsContext()
   const { attribFields, scopes } = useProjectTableContext()
 
@@ -28,13 +30,25 @@ export const useSortBySettings = () => {
       })),
   ]
 
-  const value: SortCardType[] = sorting
-    .map((s) => {
-      const option = options.find((o) => o.id === s.id)
-      if (!option) return null
-      return { ...option, sortOrder: !s.desc }
-    })
-    .filter(Boolean) as SortCardType[]
+  const labelFor = (id: string) =>
+    options.find((o) => o.id === id)?.label ?? columns.find((c) => c.value === id)?.label ?? id
+
+  // Mirror the live sorting state so the panel stays in sync with the header
+  // sort icons, even for columns that aren't predefined sort options.
+  const value: SortCardType[] = sorting.map((s) => ({
+    id: s.id,
+    label: labelFor(s.id),
+    sortOrder: !s.desc,
+  }))
+
+  // The dropdown can only render a selected value whose option exists, so add
+  // any active-but-unlisted sort column to the option list.
+  const dropdownOptions = [
+    ...options,
+    ...value
+      .filter((v) => !options.some((o) => o.id === v.id))
+      .map((v) => ({ id: v.id, label: v.label })),
+  ]
 
   const handleChange = (v: SortCardType[]) => {
     updateSorting(v.map((item) => ({ id: item.id, desc: !item.sortOrder })))
@@ -47,7 +61,7 @@ export const useSortBySettings = () => {
         title="Sort by"
         icon="sort"
         value={value}
-        options={options}
+        options={dropdownOptions}
         onChange={handleChange}
         multiSelect={false}
       />

--- a/src/pages/ProjectListsPage/components/ListsTableSettings/ListsTableSettings.tsx
+++ b/src/pages/ProjectListsPage/components/ListsTableSettings/ListsTableSettings.tsx
@@ -6,6 +6,7 @@ import { SettingHighlightedId } from '@shared/context'
 import { confirmDelete } from '@shared/util'
 import { useListsModuleContext } from '@pages/ProjectListsPage/context/ListsModulesContext'
 import { useListsContext } from '@pages/ProjectListsPage/context'
+import { getColumnConfigFromType } from '@pages/ProjectListsPage/util'
 
 export interface ListsTableSettingsProps {
   onGoTo: (name: string) => void
@@ -23,6 +24,10 @@ export const ListsTableSettings: FC<ListsTableSettingsProps> = ({
     useListsAttributesContext()
   const { ListsAttributesSettings, requiredVersion } = useListsModuleContext()
 
+  // mirror the table's excluded columns so the panel doesn't offer dead toggles
+  // (e.g. subType is excluded for version/product lists where productType is the real column)
+  const [hiddenColumns] = getColumnConfigFromType(selectedList?.entityType)
+
   const onSuccess = (message: string) => {
     toast.success(message)
   }
@@ -33,6 +38,7 @@ export const ListsTableSettings: FC<ListsTableSettingsProps> = ({
   return (
     <ProjectTableSettings
       extraColumns={extraColumns}
+      hiddenColumns={hiddenColumns}
       highlighted={highlightedSetting}
       hiddenSettings={['group-by']}
       hideSortBy={isReview}

--- a/src/pages/ProjectListsPage/hooks/useExtraColumns.tsx
+++ b/src/pages/ProjectListsPage/hooks/useExtraColumns.tsx
@@ -66,7 +66,8 @@ const useExtraColumns = ({ entityType }: useExtraColumnsProps) => {
             id: valueColumn.value,
             accessorKey: valueColumn.value,
             header: valueColumn.label,
-            enableSorting: true,
+            // reference value of a related entity — no valid backend sort key, would 400 the query
+            enableSorting: false,
             enableResizing: true,
             enablePinning: true,
             enableHiding: true,
@@ -98,8 +99,8 @@ const useExtraColumns = ({ entityType }: useExtraColumnsProps) => {
           column: {
             id: typeColumn.value,
             accessorKey: typeColumn.value,
-            header: typeColumn.label,
             enableSorting: true,
+            header: typeColumn.label,
             enableResizing: true,
             enablePinning: true,
             enableHiding: true,

--- a/src/pages/ProjectListsPage/hooks/useGetListItemsData.ts
+++ b/src/pages/ProjectListsPage/hooks/useGetListItemsData.ts
@@ -17,12 +17,6 @@ export type EntityListItemWithLinks = EntityListItem & {
   links: EntityLink[]
 }
 
-// column ids that reference another entity sort by its foreign-key field, not the column id
-const ENTITY_REF_SORT_KEYS: Record<string, string> = {
-  product: 'product_id',
-  task: 'task_id',
-}
-
 interface UseGetListItemsDataProps {
   projectName: string
   listId?: string
@@ -71,8 +65,11 @@ const useGetListItemsData = ({
     } else if (sortId.endsWith('Type') && entityType && !sortId.startsWith(entityType)) {
       // if the type is not native to the entity, add the parent prefix
       sortId = 'parent' + sortId[0].toUpperCase() + sortId.slice(1)
-    } else if (ENTITY_REF_SORT_KEYS[sortId]) {
-      sortId = `entity_${ENTITY_REF_SORT_KEYS[sortId]}`
+    } else if (sortId === 'product') {
+      // backend resolves productName to the related product's name (per entity type)
+      sortId = 'productName'
+    } else if (sortId === 'folder') {
+      sortId = 'folderPath'
     } else {
       // add entity prefix to entity fields
       sortId = `entity_${sortId}`

--- a/src/pages/ProjectListsPage/hooks/useGetListItemsData.ts
+++ b/src/pages/ProjectListsPage/hooks/useGetListItemsData.ts
@@ -17,6 +17,12 @@ export type EntityListItemWithLinks = EntityListItem & {
   links: EntityLink[]
 }
 
+// column ids that reference another entity sort by its foreign-key field, not the column id
+const ENTITY_REF_SORT_KEYS: Record<string, string> = {
+  product: 'product_id',
+  task: 'task_id',
+}
+
 interface UseGetListItemsDataProps {
   projectName: string
   listId?: string
@@ -65,6 +71,8 @@ const useGetListItemsData = ({
     } else if (sortId.endsWith('Type') && entityType && !sortId.startsWith(entityType)) {
       // if the type is not native to the entity, add the parent prefix
       sortId = 'parent' + sortId[0].toUpperCase() + sortId.slice(1)
+    } else if (ENTITY_REF_SORT_KEYS[sortId]) {
+      sortId = `entity_${ENTITY_REF_SORT_KEYS[sortId]}`
     } else {
       // add entity prefix to entity fields
       sortId = `entity_${sortId}`


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Sorting an EntityList by Product name no longer errors and now sorts both directions. Also fixes several related list-sorting bugs found alongside.

## Technical details
<!-- Please state any technical details such as limitations -->

- `product - productName`, `folder - folderPath` sort keys; previously sent invalid `entity_*` that 400'd the query (`useGetListItemsData`)
- header sort icon calls `updateSorting` directly; the TanStack `onSortingChange` path was a no-op under `manualSorting` (`ProjectTreeTable`)
- descending sort paginates all pages via `hasPreviousPage` (`getLists`, `GetListItems.graphql`)
- Customize panel hides table-excluded columns; `productBaseType`/`taskLabel` sort disabled, no backend key (`ListsTableSettings`, `useExtraColumns`)

## Additional context
<!-- Add any other context or screenshots here. -->

Closes #2087
Depends on ynput/ayon-backend#1000 merge backend first.
