### PR TITLE
Overview: Fix filtering while grouping by folder

### DIFF
--- a/shared/src/containers/ProjectTreeTable/hooks/useFetchOverviewData.ts
+++ b/shared/src/containers/ProjectTreeTable/hooks/useFetchOverviewData.ts
@@ -265,7 +265,7 @@ export const useFetchOverviewData = ({
     // Filter by selected folders if needed
     if (selectedFolders.length) {
       const selectedPaths = selectedFolders
-        .map((id) => map.get(id)?.path)
+        .map((id) => folders.find((folder) => folder.id === id)?.path)
         .filter(Boolean) as string[]
 
       // Create a new map that only contains selected folders and their children


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Fixes the Overview table going empty when a task filter is applied while grouping by folder with a folder selected in the Slicer.

## Technical details
<!-- Please state any technical details such as limitations -->

- `selectedPaths` now resolves paths from the full `folders` list instead of the already-filtered `foldersMap` (`useFetchOverviewData.ts`).
- A Slicer-selected ancestor dropped by the task filter no longer yields empty `selectedPaths`, so its matching descendants stay in the table.

## Additional context
<!-- Add any other context or screenshots here. -->

Closes #2103
