### PR TITLE
De-sync state between tabs

### DIFF
--- a/shared/src/containers/Slicer/context/SlicerContext.tsx
+++ b/shared/src/containers/Slicer/context/SlicerContext.tsx
@@ -8,7 +8,7 @@ import {
   useSlicerRowSelection,
 } from '@shared/containers/Slicer'
 import { SimpleTableRow } from '@shared/containers/SimpleTable'
-import { useLocalStorage } from '@shared/hooks'
+import { useSessionStorage } from '@shared/hooks'
 import type { ProjectModel, Assignees, AttributeModel, ProductType } from '@shared/api'
 import { SlicerDropdownFallbackProps } from '../components/SlicerDropdownFallback'
 import { DropdownRef } from '@ynput/ayon-react-components'
@@ -125,7 +125,7 @@ export const SlicerProvider = ({ children, page, projectName, ...props }: Slicer
 
   // this is used to store another slice type whilst the user is viewing a different slice type
   // mostly used for preserving the hierarchy selection when switching to another slice type
-  const [pinnedSlice, setPinnedSlice] = useLocalStorage<PinnedSlice | null>(
+  const [pinnedSlice, setPinnedSlice] = useSessionStorage<PinnedSlice | null>(
     `slicer-pinned-slice-${page}`,
     null,
   )

--- a/shared/src/containers/Slicer/hooks/useSlicerRowSelection.ts
+++ b/shared/src/containers/Slicer/hooks/useSlicerRowSelection.ts
@@ -1,4 +1,4 @@
-import { useLocalStorage } from '@shared/hooks'
+import { useSessionStorage } from '@shared/hooks'
 import { ExpandedState, RowSelectionState } from '@tanstack/react-table'
 import { SelectionData, SliceType } from '../types'
 import { useCallback, useMemo } from 'react'
@@ -20,30 +20,28 @@ export const useSlicerRowSelection = ({
   projectName,
   ...props
 }: UseSlicerRowSelectionProps) => {
-  // hierarchy selection is shared across pages with local storage
-  const [hierarchyRowSelection, setHierarchyRowSelection] = useLocalStorage<RowSelectionState>(
+  // hierarchy selection is shared across pages with session storage
+  const [hierarchyRowSelection, setHierarchyRowSelection] = useSessionStorage<RowSelectionState>(
     `slicer-selection-hierarchy-${projectName}`,
     {},
   )
-  const [hierarchyRowSelectionData, setHierarchyRowSelectionData] = useLocalStorage<SelectionData>(
-    `slicer-selection-data-hierarchy-${projectName}`,
-    {},
-  )
+  const [hierarchyRowSelectionData, setHierarchyRowSelectionData] =
+    useSessionStorage<SelectionData>(`slicer-selection-data-hierarchy-${projectName}`, {})
   // other slicer type selections are stored per page with local storage
-  const [otherRowSelection, setOtherRowSelection] = useLocalStorage<RowSelectionState>(
+  const [otherRowSelection, setOtherRowSelection] = useSessionStorage<RowSelectionState>(
     `slicer-selection-${projectName}-${page}`,
     {},
   )
-  const [otherRowSelectionData, setOtherRowSelectionData] = useLocalStorage<SelectionData>(
+  const [otherRowSelectionData, setOtherRowSelectionData] = useSessionStorage<SelectionData>(
     `slicer-selection-data-${projectName}-${page}`,
     {},
   )
 
-  const [hierarchyExpanded, setHierarchyExpanded] = useLocalStorage<ExpandedState>(
+  const [hierarchyExpanded, setHierarchyExpanded] = useSessionStorage<ExpandedState>(
     `slicer-expanded-hierarchy-${projectName}`,
     {},
   )
-  const [otherExpanded, setOtherExpanded] = useLocalStorage<ExpandedState>(
+  const [otherExpanded, setOtherExpanded] = useSessionStorage<ExpandedState>(
     `slicer-expanded-${projectName}-${page}`,
     {},
   )

--- a/shared/src/containers/Slicer/hooks/useSlicerSplitter.ts
+++ b/shared/src/containers/Slicer/hooks/useSlicerSplitter.ts
@@ -1,4 +1,4 @@
-import { useLocalStorage } from '@shared/hooks'
+import { useSessionStorage } from '@shared/hooks'
 
 export const SLICER_SPLITTER_STATE_KEY = 'slicer-splitter'
 export const SLICER_SPLITTER_PANEL_CONFIG = {
@@ -7,7 +7,7 @@ export const SLICER_SPLITTER_PANEL_CONFIG = {
 }
 
 const useSlicerSplitter = () => {
-  const [slicerSize, setSlicerSize] = useLocalStorage<number[]>(SLICER_SPLITTER_STATE_KEY, [
+  const [slicerSize, setSlicerSize] = useSessionStorage<number[]>(SLICER_SPLITTER_STATE_KEY, [
     SLICER_SPLITTER_PANEL_CONFIG.size,
     100 - SLICER_SPLITTER_PANEL_CONFIG.size,
   ])

--- a/shared/src/context/DetailsPanelContext.tsx
+++ b/shared/src/context/DetailsPanelContext.tsx
@@ -4,7 +4,7 @@ import { useLocation, useNavigate, useParams, useSearchParams } from 'react-rout
 import { SavedAnnotationMetadata } from '@shared/containers'
 import { PowerpackFeature, usePowerpack } from './PowerpackContext'
 import { useURIContext } from './UriContext'
-import { useLocalStorage, readLocalStorage, writeLocalStorage } from '@shared/hooks'
+import { useSessionStorage, readLocalStorage, writeLocalStorage } from '@shared/hooks'
 import type { SubtasksManagerProps } from '@shared/components'
 import { DetailsPanelContext } from './DetailsPanelContextInstance'
 import { BundleMode, getBundleModeFromUser } from '@shared/util'
@@ -174,7 +174,7 @@ export const DetailsPanelProvider: React.FC<DetailsPanelProviderProps> = ({
   )
 
   // Use localStorage to persist tab preferences by scope
-  const [tabsByScope, setTabByScope] = useLocalStorage<TabStateByScope>(TABS_BY_SCOPE_KEY, {})
+  const [tabsByScope, setTabByScope] = useSessionStorage<TabStateByScope>(TABS_BY_SCOPE_KEY, {})
 
   // Get the current tab for a specific scope
   const getTabForScope = useCallback(
@@ -358,9 +358,9 @@ export const setDetailsPanelTabForScope = (scope: string, tab: DetailsPanelTab) 
 export const useScopedDetailsPanel = (scope: string) => {
   const { getOpenForScope, setPanelOpen, getTabForScope } = useDetailsPanelContext()
 
-  const [tabsByScope, setTabsByScope] = useLocalStorage<TabStateByScope>(TABS_BY_SCOPE_KEY, {})
+  const [tabsByScope, setTabsByScope] = useSessionStorage<TabStateByScope>(TABS_BY_SCOPE_KEY, {})
 
-  // derived from localStorage state, which useLocalStorage keeps in sync across hook instances
+  // derived from localStorage state, which useSessionStorage keeps in sync across hook instances
   const storedTab = tabsByScope[scope]
   const currentTab = isDetailsPanelTab(storedTab) ? storedTab : getTabForScope(scope)
 

--- a/shared/src/hooks/index.ts
+++ b/shared/src/hooks/index.ts
@@ -1,4 +1,5 @@
 export * from './useLocalStorage'
+export * from './useSessionStorage'
 export * from './useLoadModule'
 export * from './useLoadModules'
 export * from './useScopedStatuses'

--- a/shared/src/hooks/useSessionStorage.ts
+++ b/shared/src/hooks/useSessionStorage.ts
@@ -1,0 +1,93 @@
+import { Dispatch, SetStateAction, useCallback, useEffect, useRef, useState } from 'react'
+
+const parseJSONString = (value: string | null, fallback: any = null) => {
+  if (!value) return fallback
+  try {
+    return JSON.parse(value)
+  } catch {
+    return fallback
+  }
+}
+
+export const readSessionStorage = <T>(key: string, fallback: T): T => {
+  if (typeof window === 'undefined') return fallback
+  try {
+    return parseJSONString(sessionStorage.getItem(key), fallback)
+  } catch {
+    return fallback
+  }
+}
+
+export const writeSessionStorage = <T>(key: string, value: T): void => {
+  if (typeof window === 'undefined') return
+  try {
+    sessionStorage.setItem(key, JSON.stringify(value))
+    // Dispatches to the same tab to keep other mounted hooks in sync
+    window.dispatchEvent(new Event('session-storage'))
+  } catch (e) {
+    console.error(e)
+  }
+}
+
+export function useSessionStorage<T>(
+  key: string,
+  defaultValue: T,
+): [T, Dispatch<SetStateAction<T>>] {
+  const defaultValueRef = useRef(defaultValue)
+  defaultValueRef.current = defaultValue
+
+  const [value, setValue] = useState<T>(() => {
+    if (typeof window === 'undefined') return defaultValue
+    return parseJSONString(sessionStorage.getItem(key), defaultValue)
+  })
+
+  useEffect(() => {
+    const currentItem = sessionStorage.getItem(key)
+    setValue(parseJSONString(currentItem, defaultValueRef.current))
+
+    if (!currentItem) {
+      sessionStorage.setItem(key, JSON.stringify(defaultValueRef.current))
+    }
+
+    function handler(e: Event | StorageEvent) {
+      // If it's a native StorageEvent (e.g., from an iframe), check the key
+      if ('key' in e && e.key && e.key !== key) return
+
+      const ssi = sessionStorage.getItem(key)
+      setValue(parseJSONString(ssi, defaultValueRef.current))
+    }
+
+    // Listen to both native storage events and our custom same-tab event
+    window.addEventListener('session-storage', handler)
+    window.addEventListener('storage', handler)
+
+    return () => {
+      window.removeEventListener('session-storage', handler)
+      window.removeEventListener('storage', handler)
+    }
+  }, [key])
+
+  const setValueWrap: Dispatch<SetStateAction<T>> = useCallback(
+    (valueOrFn) => {
+      try {
+        setValue((prevValue) => {
+          const nextValue =
+            typeof valueOrFn === 'function'
+              ? (valueOrFn as (prevState: T) => T)(prevValue)
+              : valueOrFn
+
+          sessionStorage.setItem(key, JSON.stringify(nextValue))
+          if (typeof window !== 'undefined') {
+            window.dispatchEvent(new Event('session-storage'))
+          }
+          return nextValue
+        })
+      } catch (e) {
+        console.error(e)
+      }
+    },
+    [key],
+  )
+
+  return [value, setValueWrap]
+}

--- a/src/containers/AddonSettings/AddonSettings.jsx
+++ b/src/containers/AddonSettings/AddonSettings.jsx
@@ -51,7 +51,7 @@ import PerProjectBundleConfig, {
   FROZEN_BUNDLE_ICON,
   projectBundleFromName,
 } from '../../components/PerProjectBundleConfig/PerProjectBundleConfig'
-import { useLocalStorage } from '@shared/hooks'
+import { useSessionStorage } from '@shared/hooks'
 import InfoMessage from '@components/InfoMessage'
 
 /*
@@ -121,7 +121,7 @@ const AddonSettings = ({ projectName, showSites = false, bypassPermissions = fal
 
   const { data: { bundles = [] } = {} } = useListBundlesQuery({ archived: false })
 
-  const [selectedBundle, setSelectedBundle] = useLocalStorage('variant-type', {
+  const [selectedBundle, setSelectedBundle] = useSessionStorage('variant-type', {
     variant: 'production',
     bundleName: null,
     projectBundleName: undefined,

--- a/src/containers/ProjectsList/ProjectsTable.tsx
+++ b/src/containers/ProjectsList/ProjectsTable.tsx
@@ -5,7 +5,7 @@ import ProjectsListTableHeader from './ProjectsListTableHeader'
 import { useCreateContextMenu } from '@shared/containers'
 import { ProjectsSimpleTable } from './ProjectsSimpleTable'
 import { PinnedDivider } from './ProjectsListRow.styled'
-import { useLocalStorage } from '@shared/hooks'
+import { useSessionStorage } from '@shared/hooks'
 import { usePowerpack } from '@shared/context'
 
 type ButtonType = 'delete' | 'add' | 'filter' | 'search' | 'select-all'
@@ -85,7 +85,7 @@ const ProjectsTable: FC<ProjectsTableProps> = ({
   const [ctxMenuShow] = useCreateContextMenu([], { powerLicense, setPowerpackDialog })
 
   // Track which table has active selection: 'pinned' | 'all'
-  const [activeTable, setActiveTable] = useLocalStorage<'pinned' | 'all'>(
+  const [activeTable, setActiveTable] = useSessionStorage<'pinned' | 'all'>(
     'project-list-selection',
     'all',
   )

--- a/src/containers/ReleaseInstallerDialog/ReleaseInstallerPrompt/ReleaseInstallerPrompt.tsx
+++ b/src/containers/ReleaseInstallerDialog/ReleaseInstallerPrompt/ReleaseInstallerPrompt.tsx
@@ -1,4 +1,4 @@
-import { useLocalStorage } from '@shared/hooks'
+import { useSessionStorage } from '@shared/hooks'
 import * as Styled from './ReleaseInstallerPrompt.styled'
 import { useNavigate } from 'react-router-dom'
 import { useAppDispatch } from '@state/store'
@@ -14,7 +14,7 @@ const ReleaseInstallerPrompt = ({ isAdmin }: Props) => {
   const navigate = useNavigate()
   const dispatch = useAppDispatch()
 
-  const [showPrompt, setShowPrompt] = useLocalStorage<boolean>('releaseInstallPrompt', true)
+  const [showPrompt, setShowPrompt] = useSessionStorage<boolean>('releaseInstallPrompt', true)
   const notAdminOrDismissed = !showPrompt || !isAdmin
 
   // get installers and dep packages and show if there are no installers or no dep packages

--- a/src/containers/ReleaseInstallerDialog/hooks/useInstallRelease.ts
+++ b/src/containers/ReleaseInstallerDialog/hooks/useInstallRelease.ts
@@ -17,7 +17,7 @@ import {
   InstallMessage,
   useGetInstallEventsQuery,
 } from '@queries/releases/getReleases'
-import { useLocalStorage } from '@shared/hooks'
+import { useSessionStorage } from '@shared/hooks'
 
 type Props = {
   releaseInfo: GetReleaseInfoApiResponse | undefined
@@ -48,7 +48,7 @@ export const useInstallRelease = ({
   const [downloadAddons] = useDownloadAddonsMutation()
 
   const [isSubmitting, setIsSubmitting] = useState(false)
-  const [events, setEvents] = useLocalStorage<Event[]>('install-progress-event-ids', [])
+  const [events, setEvents] = useSessionStorage<Event[]>('install-progress-event-ids', [])
   const eventIds: string[] = events.map((event: any) => event.id)
   const [error, setError] = useState<null | string>(null)
 

--- a/src/containers/SettingsEditor/SettingsPanel.jsx
+++ b/src/containers/SettingsEditor/SettingsPanel.jsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react'
-import { useLocalStorage } from '@shared/hooks'
+import { useSessionStorage } from '@shared/hooks'
 import { Icon } from '@ynput/ayon-react-components'
 import styled from 'styled-components'
 
@@ -122,7 +122,7 @@ const SettingsPanel = ({
   onContextMenu,
   currentId,
 }) => {
-  const [expandedObjects, setExpandedObjects] = useLocalStorage('expanded-settings-keys', [])
+  const [expandedObjects, setExpandedObjects] = useSessionStorage('expanded-settings-keys', [])
 
   const onToggle = () => {
     if (expandedObjects.includes(objId)) {

--- a/src/containers/VideoPlayer/hooks/usePlayerPreferences.ts
+++ b/src/containers/VideoPlayer/hooks/usePlayerPreferences.ts
@@ -1,9 +1,9 @@
-import { useLocalStorage } from '@shared/hooks'
+import { useSessionStorage } from '@shared/hooks'
 
 const usePlayerPreferences = () => {
-  const [showOverlay, setShowOverlay] = useLocalStorage('videoPlayer-showOverlay', false)
-  const [loop, setLoop] = useLocalStorage('videoPlayer-loop', true)
-  const [muted, setMuted] = useLocalStorage('videoPlayer-muted', false)
+  const [showOverlay, setShowOverlay] = useSessionStorage('videoPlayer-showOverlay', false)
+  const [loop, setLoop] = useSessionStorage('videoPlayer-loop', true)
+  const [muted, setMuted] = useSessionStorage('videoPlayer-muted', false)
 
   return { showOverlay, setShowOverlay, loop, setLoop, muted, setMuted }
 }

--- a/src/containers/Viewer/Viewer.tsx
+++ b/src/containers/Viewer/Viewer.tsx
@@ -22,7 +22,7 @@ import {
 } from '@shared/components'
 import { useScopedDetailsPanel } from '@shared/context'
 import { ProjectContextProvider, useProjectContext } from '@shared/context/ProjectContext'
-import { useLocalStorage, useReviewablesKeyboardNavigation } from '@shared/hooks'
+import { useSessionStorage, useReviewablesKeyboardNavigation } from '@shared/hooks'
 
 interface ViewerProps {
   onClose?: () => void
@@ -30,7 +30,7 @@ interface ViewerProps {
 }
 
 const ViewerBody = ({ onClose }: ViewerProps) => {
-  const [theater, setTheater] = useLocalStorage('viewer-theater-mode', false)
+  const [theater, setTheater] = useSessionStorage('viewer-theater-mode', false)
   const {
     productId,
     taskId,

--- a/src/pages/EventsPage/EventsPage.jsx
+++ b/src/pages/EventsPage/EventsPage.jsx
@@ -7,7 +7,7 @@ import { Splitter, SplitterPanel } from 'primereact/splitter'
 import EventList from './EventList'
 import useSearchFilter from '@hooks/useSearchFilter'
 import { toast } from 'react-toastify'
-import { useLocalStorage } from '@shared/hooks'
+import { useSessionStorage } from '@shared/hooks'
 import EventOverview from './EventOverview'
 import { useMemo, useRef, useState } from 'react'
 import { useEffect } from 'react'
@@ -16,7 +16,7 @@ import DocumentTitle from '@components/DocumentTitle/DocumentTitle'
 
 const EventsPage = () => {
   const dispatch = useDispatch()
-  const [showLogs, setShowLogs] = useLocalStorage('events-logs', true)
+  const [showLogs, setShowLogs] = useSessionStorage('events-logs', true)
   // use query param to get selected event
   //let [selectedEventId, setSelectedEvent] = useQueryParam('event', StringParam)
   let [selectedEventId, setSelectedEvent] = useState()
@@ -210,57 +210,57 @@ const EventsPage = () => {
     <>
       <DocumentTitle title="Events • AYON" />
       <main>
-      <Section>
-        <Toolbar>
-          <form onSubmit={handleSearchSubmit}>
-            <InputText
-              style={{ width: '200px' }}
-              placeholder="Filter events..."
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              autoComplete="off"
-            />
-          </form>
-          <InputSwitch
-            checked={showLogs}
-            onChange={() => setShowLogs(!showLogs)}
-            style={{ width: 40, marginLeft: 10 }}
-          />
-          Show With Logs
-        </Toolbar>
-        <Splitter style={{ height: '100%', width: '100%' }}>
-          <SplitterPanel size={70}>
-            <EventList
-              eventData={filteredTreeData}
-              isLoading={isLoading || isFetching}
-              selectedEvent={selectedEvent}
-              setSelectedEvent={setSelectedEvent}
-              onScrollBottom={loadPage}
-            />
-          </SplitterPanel>
-          <SplitterPanel size={30}>
-            {selectedEvent?.id ? (
-              <EventDetail
-                id={selectedEvent?.id}
-                event={selectedEvent}
-                setSelectedEvent={setSelectedEvent}
-                onFilter={handleSearchFilter}
-                events={eventData}
+        <Section>
+          <Toolbar>
+            <form onSubmit={handleSearchSubmit}>
+              <InputText
+                style={{ width: '200px' }}
+                placeholder="Filter events..."
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                autoComplete="off"
               />
-            ) : (
-              <EventOverview
-                onTotal={handleSearchFilter}
-                search={search}
-                events={eventData}
-                logs={logsData}
-                setShowLogs={setShowLogs}
+            </form>
+            <InputSwitch
+              checked={showLogs}
+              onChange={() => setShowLogs(!showLogs)}
+              style={{ width: 40, marginLeft: 10 }}
+            />
+            Show With Logs
+          </Toolbar>
+          <Splitter style={{ height: '100%', width: '100%' }}>
+            <SplitterPanel size={70}>
+              <EventList
+                eventData={filteredTreeData}
+                isLoading={isLoading || isFetching}
+                selectedEvent={selectedEvent}
                 setSelectedEvent={setSelectedEvent}
+                onScrollBottom={loadPage}
               />
-            )}
-          </SplitterPanel>
-        </Splitter>
-      </Section>
-    </main>
+            </SplitterPanel>
+            <SplitterPanel size={30}>
+              {selectedEvent?.id ? (
+                <EventDetail
+                  id={selectedEvent?.id}
+                  event={selectedEvent}
+                  setSelectedEvent={setSelectedEvent}
+                  onFilter={handleSearchFilter}
+                  events={eventData}
+                />
+              ) : (
+                <EventOverview
+                  onTotal={handleSearchFilter}
+                  search={search}
+                  events={eventData}
+                  logs={logsData}
+                  setShowLogs={setShowLogs}
+                  setSelectedEvent={setSelectedEvent}
+                />
+              )}
+            </SplitterPanel>
+          </Splitter>
+        </Section>
+      </main>
     </>
   )
 }

--- a/src/pages/ProjectListsPage/context/ListsProvider.tsx
+++ b/src/pages/ProjectListsPage/context/ListsProvider.tsx
@@ -13,7 +13,7 @@ import { useListsDataContext } from './ListsDataContext'
 import { useQueryParam, withDefault, QueryParamConfig } from 'use-query-params'
 import ListsContext, { ListDetailsOpenState, OnOpenFolderListParams } from './ListsContext'
 import { useGetProductionAddon } from '@shared/hooks'
-import { useLocalStorage } from '@shared/hooks'
+import { useSessionStorage } from '@shared/hooks'
 import { buildListFolderRowId, parseListFolderRowId } from '../util/buildListsTableData'
 import useInitialListsExpanded from '../hooks/useInitialListsExpanded'
 import { usePowerpack, useProjectContext } from '@shared/context'
@@ -124,7 +124,10 @@ export const ListsProvider = ({ children, isReview, isStoryboards }: ListsProvid
   // dialogs
   const [listsFiltersOpen, setListsFiltersOpen] = useState(false)
 
-  const [listDetailsOpen, setListDetailsOpen] = useLocalStorage<boolean>('list-details-open', true)
+  const [listDetailsOpen, setListDetailsOpen] = useSessionStorage<boolean>(
+    'list-details-open',
+    true,
+  )
 
   const [listFolderOpen, setListFolderOpen] = useState<ListDetailsOpenState>({ isOpen: false })
 

--- a/src/pages/ProjectOverviewPage/context/ProjectOverviewContext.tsx
+++ b/src/pages/ProjectOverviewPage/context/ProjectOverviewContext.tsx
@@ -6,7 +6,7 @@ import { ExpandedState } from '@tanstack/react-table'
 import { OverviewSettings } from '@shared/api'
 
 // Shared components and hooks
-import { useLocalStorage, useGetEntityGroups } from '@shared/hooks'
+import { useSessionStorage, useGetEntityGroups } from '@shared/hooks'
 
 // Shared ProjectTreeTable
 import {
@@ -70,7 +70,7 @@ export const ProjectOverviewProvider = ({ children, modules }: ProjectOverviewPr
 
   const page = 'overview'
 
-  const [expanded, setExpanded] = useLocalStorage<ExpandedState>(
+  const [expanded, setExpanded] = useSessionStorage<ExpandedState>(
     createLocalStorageKey(page, 'expanded', projectName),
     {},
   )

--- a/src/pages/SettingsPage/Bundles/AddonSearchContext.tsx
+++ b/src/pages/SettingsPage/Bundles/AddonSearchContext.tsx
@@ -6,7 +6,7 @@ import React, {
   useCallback,
   ChangeEvent,
 } from 'react'
-import { useLocalStorage } from '@shared/hooks'
+import { useSessionStorage } from '@shared/hooks'
 import type { Addon } from './types'
 import { matchSorter } from 'match-sorter'
 
@@ -26,7 +26,7 @@ interface AddonSearchProviderProps {
 }
 
 export const AddonSearchProvider: React.FC<AddonSearchProviderProps> = ({ addons, children }) => {
-  const [search, setSearch] = useLocalStorage('bundles-search', '')
+  const [search, setSearch] = useSessionStorage('bundles-search', '')
 
   const filteredAddons = useMemo(() => {
     if (!search) return addons

--- a/src/services/auth/logout.ts
+++ b/src/services/auth/logout.ts
@@ -18,6 +18,8 @@ const authApiInjected = authenticationApi.enhanceEndpoints({
             localStorage.removeItem(key)
           }
         })
+        // clear session storage
+        sessionStorage.clear()
         // clear dashboard state
         dispatch(onClearDashboard())
         // @ts-expect-error - no args are defined


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
Many different states like slicer selection were using localstorage. This would mean all browser tabs would be in sync and it would make it impossible to work with multiple tabs.

For these kind of states we use session storage instead that is scope to the browser tab. Refreshing the page will keep the state but it won't be synced to different tabs.

### Pages

The biggest culprit was the slicer but other areas have also been fixed:

- Project page slicer
- Details panel tab selection
- Viewer panel configs like mute
- My tasks project selection
- Bundle variant selection
- Addon settings form expansion 

