### PR TITLE
Table: Folder column copying does not work

### DIFF
--- a/shared/src/containers/ProjectTreeTable/context/ClipboardContext.tsx
+++ b/shared/src/containers/ProjectTreeTable/context/ClipboardContext.tsx
@@ -180,6 +180,15 @@ export const ClipboardProvider: React.FC<ClipboardProviderProps> = ({
               // @ts-ignore
               let foundValue = getCellValue(entity, colId)
 
+              // folder is an object on some entities (product/task) or nested under
+              // product (version) - copy the display name the cell shows,
+              // falling back to the last parent (parent folder name on tasks/folders)
+              if (colId === 'folder' && typeof foundValue !== 'string') {
+                const folder = foundValue || (entity as any).product?.folder
+                const parents = 'parents' in entity ? entity.parents : undefined
+                foundValue = folder?.label || folder?.name || parents?.[parents.length - 1] || ''
+              }
+
               if (!foundValue) {
                 // we should look for the default value set out in attribFields
                 const field = attribFields.find((f) => f.name === colId.replace('attrib_', ''))


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Fixes copying Folder column cells returning `[object Object]`. Copied text now matches the folder name shown in the cell.

## Technical details
<!-- Please state any technical details such as limitations -->

- `ClipboardContext.tsx`: folder is an object on entities, resolve display name via `folder.label || folder.name`.
- Versions have folder nested under `product.folder`; tasks/folders fall back to last `parents` entry.
- Also fixes CSV export (same `getSelectionData` path).

## Additional context
<!-- Add any other context or screenshots here. -->

Closes #2104
