### PR TITLE
Optimise Review list updates

### DIFF
--- a/src/pages/ProjectListsPage/ProjectListsPage.tsx
+++ b/src/pages/ProjectListsPage/ProjectListsPage.tsx
@@ -68,6 +68,7 @@ import useStoryboardsCardsModules from './hooks/useStoryboardsCardsModules.tsx'
 import OpenStoryboardButton from '@pages/ReviewPage/OpenStoryboardButton.tsx'
 import { TableGridPlaylistSwitch } from './components/TableGridPlaylistSwitch/TableGridPlaylistSwitch.tsx'
 import { getBundleModeFromUser } from '@shared/util/getBundleMode.ts'
+import usePatchListsCaches from './hooks/usePatchListsCaches'
 
 type ProjectListsPageProps = {
   projectName: string
@@ -201,6 +202,7 @@ const ProjectListsWithInnerProviders: FC<ProjectListsWithInnerProvidersProps> = 
             <ProjectTableQueriesProvider {...{ updateEntities: updateListItems, getFoldersTasks }}>
               <ProjectTableProvider
                 projectName={projectName}
+                // @ts-ignore
                 attribFields={mergedAttribFields}
                 projectInfo={projectInfo}
                 users={props.users}
@@ -306,6 +308,8 @@ const ProjectLists: FC<ProjectListsProps> = ({
 
   const handleOpenPlayer = useTableOpenViewer({ projectName: projectName })
 
+  const patchListsCaches = usePatchListsCaches({ listId: selectedList?.id || '' })
+
   // if the addon is outdated, make sure we land in table view
   useEffect(() => {
     if (!reviewSessionCardsOutdated) return
@@ -374,9 +378,21 @@ const ProjectLists: FC<ProjectListsProps> = ({
                 onOpenInViewer={(state) => {
                   handleOpenPlayer(state, { quickView: true })
                 }}
-                onItemsChanged={() => {
-                  refetchListItems()
-                  refetchLists()
+                onItemsChanged={(clips, promise, type) => {
+                  if (type === 'add') {
+                    void promise?.then(() => {
+                      refetchListItems()
+                      patchListsCaches(clips, 'add')
+                    })
+                  } else if (type === 'delete') {
+                    patchListsCaches(clips, 'delete')
+                  } else if (type === 'reorder') {
+                    patchListsCaches(clips, 'reorder')
+                  } else if (type === 'replace') {
+                    refetchListItems()
+                  } else if (type === 'update') {
+                    refetchListItems()
+                  }
                 }}
               >
                 {selectedList && (
@@ -396,6 +412,7 @@ const ProjectLists: FC<ProjectListsProps> = ({
                       <>
                         <OverviewActions items={['undo', 'redo', deleteListItemAction]} />
                         <ListItemsFilter
+                          // @ts-ignore
                           entityType={selectedList.entityType}
                           projectName={projectName}
                         />
@@ -501,7 +518,7 @@ const ProjectLists: FC<ProjectListsProps> = ({
                           onGoTo={handleGoToCustomAttrib}
                         />
                       ) : (
-                        <ReviewCardsSettings pageDisplayStyle={pageDisplayStyle} />
+                        <ReviewCardsSettings />
                       )}
                     </SplitterPanel>
                   ) : (

--- a/src/pages/ProjectListsPage/hooks/usePatchListsCaches.ts
+++ b/src/pages/ProjectListsPage/hooks/usePatchListsCaches.ts
@@ -1,0 +1,92 @@
+import { useCallback } from 'react'
+import { entityListsQueriesGql } from '@shared/api/queries/entityLists'
+import { useAppDispatch } from '@state/store'
+import store from '@state/store'
+
+export type Clip = { listItemId: string }
+export type PatchActionType = 'add' | 'delete' | 'reorder' | 'update' | 'replace'
+
+type PatchProps = {
+  listId: string
+}
+
+export default function usePatchListsCaches({ listId }: PatchProps) {
+  const dispatch = useAppDispatch()
+
+  const patchListsCaches = useCallback(
+    (clips: Clip[], type: PatchActionType) => {
+      if (!listId) return
+
+      const state = store.getState()
+
+      // --- Patch getListItemsInfinite cache ---
+      if (type === 'delete' || type === 'reorder') {
+        const listItemTags = [{ type: 'entityListItem', id: listId }]
+        const itemInfiniteEntries = entityListsQueriesGql.util
+          .selectInvalidatedBy(state as any, listItemTags)
+          .filter((e) => e.endpointName === 'getListItemsInfinite')
+
+        for (const entry of itemInfiniteEntries) {
+          dispatch(
+            entityListsQueriesGql.util.updateQueryData(
+              'getListItemsInfinite',
+              entry.originalArgs as any,
+              (draft) => {
+                if (type === 'delete') {
+                  const nonDeletedIds = new Set(clips.map((c) => c.listItemId))
+                  draft.pages.forEach((page) => {
+                    page.items = page.items.filter((item) => nonDeletedIds.has(item.id))
+                  })
+                } else if (type === 'reorder') {
+                  // Build an order map from the clips array (clips are in the new desired order)
+                  const orderMap = new Map(clips.map((c, i) => [c.listItemId, i]))
+                  // Gather all items and sort them by their new position
+                  const allItems = draft.pages.flatMap((page) => page.items)
+                  allItems.sort((a, b) => {
+                    const posA = orderMap.has(a.id) ? orderMap.get(a.id)! : Infinity
+                    const posB = orderMap.has(b.id) ? orderMap.get(b.id)! : Infinity
+                    return posA - posB
+                  })
+                  // Re-distribute sorted items back into pages, maintaining original page sizes
+                  let idx = 0
+                  for (const page of draft.pages) {
+                    const size = page.items.length
+                    page.items = allItems.slice(idx, idx + size)
+                    idx += size
+                  }
+                }
+              },
+            ),
+          )
+        }
+      }
+
+      // --- Patch getListsInfinite cache (item count) ---
+      if (type === 'delete' || type === 'add') {
+        const listTags = [{ type: 'entityList', id: listId }]
+        const listInfiniteEntries = entityListsQueriesGql.util
+          .selectInvalidatedBy(state as any, listTags)
+          .filter((e) => e.endpointName === 'getListsInfinite')
+
+        for (const entry of listInfiniteEntries) {
+          dispatch(
+            entityListsQueriesGql.util.updateQueryData(
+              'getListsInfinite',
+              entry.originalArgs as any,
+              (draft) => {
+                for (const page of draft.pages) {
+                  const list = page.lists.find((l) => l.id === listId)
+                  if (!list) continue
+                  list.count = clips.length
+                }
+              },
+            ),
+          )
+        }
+      }
+    },
+    [dispatch, listId],
+  )
+
+  return patchListsCaches
+}

--- a/src/pages/ProjectListsPage/hooks/useReviewSessionCardsModules.tsx
+++ b/src/pages/ProjectListsPage/hooks/useReviewSessionCardsModules.tsx
@@ -1,27 +1,35 @@
-import { RemoteAddonProjectProps, usePowerpack } from "@shared/context"
-import { useLoadModule } from "@shared/hooks"
-import { createContext, PropsWithChildren, useContext } from "react"
+import { RemoteAddonProjectProps, usePowerpack } from '@shared/context'
+import { useLoadModule } from '@shared/hooks'
+import { createContext, PropsWithChildren, useContext } from 'react'
 
-function FallbackReviewCardsProvider({ children }: RemoteAddonProjectProps & PropsWithChildren & {
-  onSelectionChange: (versionIds: string[]) => void
-  onOpenDetails: (versionId: string) => void
-  onItemsChanged?: () => void
-  onOpenInViewer?: (state: {
-    versionId: string
-    productId: string
-    folderId: string
-    taskId?: string
-  }) => void
-  headerContentStart?: JSX.Element
-  headerContentEnd?: JSX.Element
-  api?: any
-  gridSize?: number
-  playlistView?: boolean
-}) { return <>{children}</> }
+export type Clip = { listItemId: string }
+export type UpdateType = 'reorder' | 'add' | 'delete' | 'replace' | 'update'
 
-function FallbackReviewCardsControlsRight({ }: {
-  groupingDisabled?: boolean
-}) { return <></> }
+function FallbackReviewCardsProvider({
+  children,
+}: RemoteAddonProjectProps &
+  PropsWithChildren & {
+    onSelectionChange: (versionIds: string[]) => void
+    onOpenDetails: (versionId: string) => void
+    onItemsChanged?: (clips: Clip[], promise?: Promise<unknown>, updateType?: UpdateType) => void
+    onOpenInViewer?: (state: {
+      versionId: string
+      productId: string
+      folderId: string
+      taskId?: string
+    }) => void
+    headerContentStart?: JSX.Element
+    headerContentEnd?: JSX.Element
+    api?: any
+    gridSize?: number
+    playlistView?: boolean
+  }) {
+  return <>{children}</>
+}
+
+function FallbackReviewCardsControlsRight({}: { groupingDisabled?: boolean }) {
+  return <></>
+}
 
 type UseReviewSessionCardsReturn = {
   clearHighlighted?: () => void
@@ -52,32 +60,36 @@ export default function useReviewSessionCardsModules({ skip }: Args) {
     module: 'ReviewCards',
     fallback: () => <></>,
   })
-  const [ReviewSessionCardsProvider, { isLoaded: reviewSessionCardsProviderLoaded }] = useLoadModule({
-    ...commonOptions,
-    module: 'ReviewCardsProvider',
-    fallback: FallbackReviewCardsProvider,
-  })
-  const [ReviewSessionCardsControlsLeft, { isLoaded: reviewSessionCardsControlsLeftLoaded }] = useLoadModule({
-    ...commonOptions,
-    module: 'ReviewCardsControlsLeft',
-    fallback: () => <></>,
-  })
-  const [ReviewSessionCardsControlsRight, { isLoaded: reviewSessionCardsControlsRightLoaded }] = useLoadModule({
-    ...commonOptions,
-    module: 'ReviewCardsControlsRight',
-    fallback: FallbackReviewCardsControlsRight,
-  })
+  const [ReviewSessionCardsProvider, { isLoaded: reviewSessionCardsProviderLoaded }] =
+    useLoadModule({
+      ...commonOptions,
+      module: 'ReviewCardsProvider',
+      fallback: FallbackReviewCardsProvider,
+    })
+  const [ReviewSessionCardsControlsLeft, { isLoaded: reviewSessionCardsControlsLeftLoaded }] =
+    useLoadModule({
+      ...commonOptions,
+      module: 'ReviewCardsControlsLeft',
+      fallback: () => <></>,
+    })
+  const [ReviewSessionCardsControlsRight, { isLoaded: reviewSessionCardsControlsRightLoaded }] =
+    useLoadModule({
+      ...commonOptions,
+      module: 'ReviewCardsControlsRight',
+      fallback: FallbackReviewCardsControlsRight,
+    })
   const [useReviewSessionCards, { isLoaded: useReviewSessionCardsLoaded }] = useLoadModule({
     ...commonOptions,
     module: 'useReviewSessionCards',
     fallback: fallbackUseReviewSessionCards,
   })
 
-  const allModulesLoaded = reviewSessionCardsLoaded
-    && reviewSessionCardsProviderLoaded
-    && reviewSessionCardsControlsLeftLoaded
-    && reviewSessionCardsControlsRightLoaded
-    && useReviewSessionCardsLoaded
+  const allModulesLoaded =
+    reviewSessionCardsLoaded &&
+    reviewSessionCardsProviderLoaded &&
+    reviewSessionCardsControlsLeftLoaded &&
+    reviewSessionCardsControlsRightLoaded &&
+    useReviewSessionCardsLoaded
 
   return {
     ReviewSessionCards,

--- a/src/pages/ProjectListsPage/hooks/useStoryboardsCardsModules.tsx
+++ b/src/pages/ProjectListsPage/hooks/useStoryboardsCardsModules.tsx
@@ -1,26 +1,32 @@
-import { RemoteAddonProjectProps, usePowerpack } from "@shared/context"
-import { useLoadModule } from "@shared/hooks"
-import { createContext, PropsWithChildren, useContext } from "react"
+import { RemoteAddonProjectProps, usePowerpack } from '@shared/context'
+import { useLoadModule } from '@shared/hooks'
+import { createContext, PropsWithChildren, useContext } from 'react'
+import { Clip, UpdateType } from './useReviewSessionCardsModules'
 
-function FallbackReviewCardsProvider({ children }: RemoteAddonProjectProps & PropsWithChildren & {
-  onSelectionChange: (versionIds: string[]) => void
-  onOpenDetails: (versionId: string) => void
-  onItemsChanged?: () => void
-  onOpenInViewer?: (state: {
-    versionId: string
-    productId: string
-    folderId: string
-    taskId?: string
-  }) => void
-  headerContentStart?: JSX.Element
-  headerContentEnd?: JSX.Element
-  api?: any
-  gridSize?: number
-}) { return <>{children}</> }
+function FallbackReviewCardsProvider({
+  children,
+}: RemoteAddonProjectProps &
+  PropsWithChildren & {
+    onSelectionChange: (versionIds: string[]) => void
+    onOpenDetails: (versionId: string) => void
+    onItemsChanged?: (clips: Clip[], promise?: Promise<unknown>, updateType?: UpdateType) => void
+    onOpenInViewer?: (state: {
+      versionId: string
+      productId: string
+      folderId: string
+      taskId?: string
+    }) => void
+    headerContentStart?: JSX.Element
+    headerContentEnd?: JSX.Element
+    api?: any
+    gridSize?: number
+  }) {
+  return <>{children}</>
+}
 
-function FallbackReviewCardsControlsRight({ }: {
-  groupingDisabled?: boolean
-}) { return <></> }
+function FallbackReviewCardsControlsRight({}: { groupingDisabled?: boolean }) {
+  return <></>
+}
 
 type UseReviewSessionCardsReturn = {
   clearHighlighted?: () => void
@@ -51,32 +57,36 @@ export default function useStoryboardsCardsModules({ skip }: Args) {
     module: 'ReviewCards',
     fallback: () => <></>,
   })
-  const [ReviewSessionCardsProvider, { isLoaded: reviewSessionCardsProviderLoaded }] = useLoadModule({
-    ...commonOptions,
-    module: 'ReviewCardsProvider',
-    fallback: FallbackReviewCardsProvider,
-  })
-  const [ReviewSessionCardsControlsLeft, { isLoaded: reviewSessionCardsControlsLeftLoaded }] = useLoadModule({
-    ...commonOptions,
-    module: 'ReviewCardsControlsLeft',
-    fallback: () => <></>,
-  })
-  const [ReviewSessionCardsControlsRight, { isLoaded: reviewSessionCardsControlsRightLoaded }] = useLoadModule({
-    ...commonOptions,
-    module: 'ReviewCardsControlsRight',
-    fallback: FallbackReviewCardsControlsRight,
-  })
+  const [ReviewSessionCardsProvider, { isLoaded: reviewSessionCardsProviderLoaded }] =
+    useLoadModule({
+      ...commonOptions,
+      module: 'ReviewCardsProvider',
+      fallback: FallbackReviewCardsProvider,
+    })
+  const [ReviewSessionCardsControlsLeft, { isLoaded: reviewSessionCardsControlsLeftLoaded }] =
+    useLoadModule({
+      ...commonOptions,
+      module: 'ReviewCardsControlsLeft',
+      fallback: () => <></>,
+    })
+  const [ReviewSessionCardsControlsRight, { isLoaded: reviewSessionCardsControlsRightLoaded }] =
+    useLoadModule({
+      ...commonOptions,
+      module: 'ReviewCardsControlsRight',
+      fallback: FallbackReviewCardsControlsRight,
+    })
   const [useReviewSessionCards, { isLoaded: useReviewSessionCardsLoaded }] = useLoadModule({
     ...commonOptions,
     module: 'useReviewSessionCards',
     fallback: fallbackUseReviewSessionCards,
   })
 
-  const allModulesLoaded = reviewSessionCardsLoaded
-    && reviewSessionCardsProviderLoaded
-    && reviewSessionCardsControlsLeftLoaded
-    && reviewSessionCardsControlsRightLoaded
-    && useReviewSessionCardsLoaded
+  const allModulesLoaded =
+    reviewSessionCardsLoaded &&
+    reviewSessionCardsProviderLoaded &&
+    reviewSessionCardsControlsLeftLoaded &&
+    reviewSessionCardsControlsRightLoaded &&
+    useReviewSessionCardsLoaded
 
   return {
     ReviewSessionCards,


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
Uses the new `onItemsChanged` changes to patch the lists caches instead of always refetching the lists and lists items queries.

Completely remove the refetching of the `lists` query on every review item change.

Only refetch `list items` query when a new clip is added to review and use the new `clips` data to patch the cache for removing and reordering without any new requests.


Related PR: https://github.com/ynput/ayon-review/pull/240

