### PR TITLE
Smmary: Relative date filter breaks column-stats footer on Lists

### DIFF
--- a/src/pages/ProjectListsPage/context/ListItemsDataContext.tsx
+++ b/src/pages/ProjectListsPage/context/ListItemsDataContext.tsx
@@ -13,6 +13,8 @@ import { useEntityListsContext } from './EntityListsContext'
 import useReorderListItem, { UseReorderListItemReturn } from '../hooks/useReorderListItem'
 import useBuildListItemsTableData from '../hooks/useBuildListItemsTableData'
 import { QueryFilter } from '@shared/containers/ProjectTreeTable/types/operations'
+import { expandRelativeDates } from '@shared/containers/ProjectTreeTable/utils/expandRelativeDates'
+import { sanitizeQueryFilter } from '@shared/containers/ProjectTreeTable/utils/sanitizeQueryFilter'
 import { ListsViewSettings, useListsViewSettings } from '@shared/containers'
 import { SortingState, VisibilityState } from '@tanstack/react-table'
 import { useProjectContext, usePowerpack } from '@shared/context'
@@ -243,7 +245,7 @@ export const ListItemsDataProvider = ({ children }: ListItemsDataProviderProps) 
   )
 
   const statsFilter = listItemsFilters?.conditions?.length
-    ? JSON.stringify(listItemsFilters)
+    ? JSON.stringify(sanitizeQueryFilter(expandRelativeDates(listItemsFilters)))
     : undefined
 
   const {


### PR DESCRIPTION
Lists: Fix relative date filter breaking column-stats footer

<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Fixes the column-summaries footer failing on a List when a relative date filter (e.g. Today) is applied.

## Technical details
<!-- Please state any technical details such as limitations -->

- Expand + sanitize relative date markers before building the stats filter in `ListItemsDataContext.tsx`, matching the items query.
- Marker (`relative:today:0`) was sent raw to the API and rejected as an invalid timestamp.

## Additional context
<!-- Add any other context or screenshots here. -->

Closes #2144
