### PR TITLE
Sumaries: Do not collect stats for disabled columns and by default they should be off 

### DIFF
--- a/shared/src/api/queries/columnStats/metricTargets.ts
+++ b/shared/src/api/queries/columnStats/metricTargets.ts
@@ -1,6 +1,7 @@
 import type { VisibilityState } from '@tanstack/react-table'
 import { StatsOperation } from '@shared/api/generated'
 import { checkColumnVisibility } from '@shared/containers/ProjectTreeTable/utils/checkColumnVisibility'
+import type { SummaryCalc, RowScope } from '@shared/containers/ProjectTreeTable/types/summaryTypes'
 
 export type MetricTarget = {
   field: string // column or dot-path for JSONB, e.g. 'status' / 'attrib.fps'
@@ -14,6 +15,17 @@ type TargetsArg = { targets?: { field: string }[] | { field: string } | null }
 const targetFields = (arg?: TargetsArg): { field: string }[] => {
   const t = arg?.targets
   return Array.isArray(t) ? t : t ? [t] : []
+}
+
+export const isSummaryActive = (
+  columnId: string,
+  columnSummaries?: Record<string, SummaryCalc>,
+  columnSummaryScopes?: Record<string, RowScope>,
+): boolean => {
+  const calc = columnSummaries?.[columnId]
+  const scope = columnSummaryScopes?.[columnId]
+  if (calc === 'none' || scope === 'none') return false
+  return calc != null || scope != null
 }
 
 // refetch only when a target was added — hiding a column needs no query
@@ -66,7 +78,9 @@ type BuildMetricTargetsArgs = {
   // resolved the same way the table resolves it (opt-in): a column absent from
   // both maps is hidden, so it must NOT be aggregated
   defaultColumnVisibility?: VisibilityState
-  extraFields?: string[] // visible page-specific columns, e.g. 'product_base_type'
+  columnSummaries?: Record<string, SummaryCalc>
+  columnSummaryScopes?: Record<string, RowScope>
+  extraFields?: string[] // visible, summary-active page columns, e.g. 'product_base_type'
 }
 
 // Targets for the footer over the columns the user can actually see.
@@ -78,29 +92,32 @@ export const buildMetricTargets = ({
   attribs,
   columnVisibility,
   defaultColumnVisibility,
+  columnSummaries,
+  columnSummaryScopes,
   extraFields = [],
 }: BuildMetricTargetsArgs): MetricTarget[] => {
-  // TanStack visibility map only stores toggled columns — absent means visible.
   const isVisible = (columnId: string) =>
     checkColumnVisibility(columnVisibility, columnId, defaultColumnVisibility)
+ const isActive = (columnId: string) =>
+    isVisible(columnId) && isSummaryActive(columnId, columnSummaries, columnSummaryScopes)
 
   const targets: MetricTarget[] = []
   if (entity === 'version') {
     // versions have no `name` column (display name derives from the version
-    // number) — status is non-null and doubles as the row-count anchor
-    targets.push({ field: 'status', aggregations: ENUM })
+    // number) — status is non-null and doubles as the row-count anchor, so it
+    targets.push({ field: 'status', aggregations: isActive('status') ? ENUM : COUNTS })
   } else {
     // name counts always — they feed the main folders/tasks count cell
     targets.push({ field: 'name', aggregations: COUNTS })
-    if (isVisible('status')) targets.push({ field: 'status', aggregations: ENUM })
+    if (isActive('status')) targets.push({ field: 'status', aggregations: ENUM })
   }
-  if (isVisible('tags')) targets.push({ field: 'tags', aggregations: ENUM })
-  if (entity === 'task' && isVisible('assignees')) {
+  if (isActive('tags')) targets.push({ field: 'tags', aggregations: ENUM })
+  if (entity === 'task' && isActive('assignees')) {
     targets.push({ field: 'assignees', aggregations: ENUM })
   }
 
   const subTypeField = SUB_TYPE_FIELD[entity]
-  if (subTypeField && isVisible('subType')) {
+  if (subTypeField && isActive('subType')) {
     targets.push({ field: subTypeField, aggregations: ENUM })
   }
 
@@ -110,7 +127,7 @@ export const buildMetricTargets = ({
 
   for (const attrib of attribs) {
     if (attrib.scope && !attrib.scope.includes(entity)) continue
-    if (!isVisible(`attrib_${attrib.name}`)) continue
+    if (!isActive(`attrib_${attrib.name}`)) continue
 
     let field = `attrib.${attrib.name}`
     if (['folder', 'task'].includes(entity)) {

--- a/shared/src/api/queries/columnStats/metricTargets.ts
+++ b/shared/src/api/queries/columnStats/metricTargets.ts
@@ -1,5 +1,6 @@
 import type { VisibilityState } from '@tanstack/react-table'
 import { StatsOperation } from '@shared/api/generated'
+import { checkColumnVisibility } from '@shared/containers/ProjectTreeTable/utils/checkColumnVisibility'
 
 export type MetricTarget = {
   field: string // column or dot-path for JSONB, e.g. 'status' / 'attrib.fps'
@@ -62,6 +63,9 @@ type BuildMetricTargetsArgs = {
   entity: StatsEntity
   attribs: AttribFieldLike[]
   columnVisibility: VisibilityState
+  // resolved the same way the table resolves it (opt-in): a column absent from
+  // both maps is hidden, so it must NOT be aggregated
+  defaultColumnVisibility?: VisibilityState
   extraFields?: string[] // visible page-specific columns, e.g. 'product_base_type'
 }
 
@@ -73,10 +77,12 @@ export const buildMetricTargets = ({
   entity,
   attribs,
   columnVisibility,
+  defaultColumnVisibility,
   extraFields = [],
 }: BuildMetricTargetsArgs): MetricTarget[] => {
   // TanStack visibility map only stores toggled columns — absent means visible.
-  const isVisible = (columnId: string) => columnVisibility[columnId] !== false
+  const isVisible = (columnId: string) =>
+    checkColumnVisibility(columnVisibility, columnId, defaultColumnVisibility)
 
   const targets: MetricTarget[] = []
   if (entity === 'version') {

--- a/src/pages/ProjectListsPage/context/ListItemsDataContext.tsx
+++ b/src/pages/ProjectListsPage/context/ListItemsDataContext.tsx
@@ -236,10 +236,19 @@ export const ListItemsDataProvider = ({ children }: ListItemsDataProviderProps) 
               attribs: scopedAttribFields,
               columnVisibility: columns.columnVisibility,
               defaultColumnVisibility,
+              columnSummaries: columns.columnSummaries,
+              columnSummaryScopes: columns.columnSummaryScopes,
             }),
           )
         : [],
-    [statsEntity, scopedAttribFields, defaultColumnVisibility, columns.columnVisibility],
+    [
+      statsEntity,
+      scopedAttribFields,
+      defaultColumnVisibility,
+      columns.columnVisibility,
+      columns.columnSummaries,
+      columns.columnSummaryScopes,
+    ],
   )
 
   const statsFilter = listItemsFilters?.conditions?.length

--- a/src/pages/ProjectListsPage/context/ListItemsDataContext.tsx
+++ b/src/pages/ProjectListsPage/context/ListItemsDataContext.tsx
@@ -234,10 +234,8 @@ export const ListItemsDataProvider = ({ children }: ListItemsDataProviderProps) 
             buildMetricTargets({
               entity: statsEntity,
               attribs: scopedAttribFields,
-              columnVisibility: {
-                ...defaultColumnVisibility,
-                ...columns.columnVisibility,
-              },
+              columnVisibility: columns.columnVisibility,
+              defaultColumnVisibility,
             }),
           )
         : [],

--- a/src/pages/ProjectOverviewPage/containers/ProjectOverviewTable.tsx
+++ b/src/pages/ProjectOverviewPage/containers/ProjectOverviewTable.tsx
@@ -30,7 +30,13 @@ const ProjectOverviewTable = ({}: Props) => {
   // the heavy lifting is done in ProjectTableContext and is where the data is fetched
   const { showHierarchy, isFlatFolderView, isLoading, fetchNextPage, attribFields } =
     useProjectTableContext()
-  const { columnVisibility, defaultColumnVisibility, groupByConfig } = useColumnSettingsContext()
+  const {
+    columnVisibility,
+    defaultColumnVisibility,
+    columnSummaries,
+    columnSummaryScopes,
+    groupByConfig,
+  } = useColumnSettingsContext()
   // hold stats queries until views load, otherwise targets cover every column
   const { isLoadingViews } = useViewsContext()
   // column summaries are a powerpack feature — don't fetch stats without a license
@@ -54,8 +60,10 @@ const ProjectOverviewTable = ({}: Props) => {
         attribs: attribFields,
         columnVisibility,
         defaultColumnVisibility,
+        columnSummaries,
+        columnSummaryScopes,
       }),
-    [attribFields, columnVisibility, defaultColumnVisibility],
+    [attribFields, columnVisibility, defaultColumnVisibility, columnSummaries, columnSummaryScopes],
   )
   const taskTargets = useMemo(
     () =>
@@ -64,8 +72,10 @@ const ProjectOverviewTable = ({}: Props) => {
         attribs: attribFields,
         columnVisibility,
         defaultColumnVisibility,
+        columnSummaries,
+        columnSummaryScopes,
       }),
-    [attribFields, columnVisibility, defaultColumnVisibility],
+    [attribFields, columnVisibility, defaultColumnVisibility, columnSummaries, columnSummaryScopes],
   )
 
   const {

--- a/src/pages/ProjectOverviewPage/containers/ProjectOverviewTable.tsx
+++ b/src/pages/ProjectOverviewPage/containers/ProjectOverviewTable.tsx
@@ -30,7 +30,7 @@ const ProjectOverviewTable = ({}: Props) => {
   // the heavy lifting is done in ProjectTableContext and is where the data is fetched
   const { showHierarchy, isFlatFolderView, isLoading, fetchNextPage, attribFields } =
     useProjectTableContext()
-  const { columnVisibility, groupByConfig } = useColumnSettingsContext()
+  const { columnVisibility, defaultColumnVisibility, groupByConfig } = useColumnSettingsContext()
   // hold stats queries until views load, otherwise targets cover every column
   const { isLoadingViews } = useViewsContext()
   // column summaries are a powerpack feature — don't fetch stats without a license
@@ -48,12 +48,24 @@ const ProjectOverviewTable = ({}: Props) => {
   const scope = `overview-${projectName}`
 
   const folderTargets = useMemo(
-    () => buildMetricTargets({ entity: 'folder', attribs: attribFields, columnVisibility }),
-    [attribFields, columnVisibility],
+    () =>
+      buildMetricTargets({
+        entity: 'folder',
+        attribs: attribFields,
+        columnVisibility,
+        defaultColumnVisibility,
+      }),
+    [attribFields, columnVisibility, defaultColumnVisibility],
   )
   const taskTargets = useMemo(
-    () => buildMetricTargets({ entity: 'task', attribs: attribFields, columnVisibility }),
-    [attribFields, columnVisibility],
+    () =>
+      buildMetricTargets({
+        entity: 'task',
+        attribs: attribFields,
+        columnVisibility,
+        defaultColumnVisibility,
+      }),
+    [attribFields, columnVisibility, defaultColumnVisibility],
   )
 
   const {

--- a/src/pages/VersionsProductsPage/components/VPTable/VPTable.tsx
+++ b/src/pages/VersionsProductsPage/components/VPTable/VPTable.tsx
@@ -11,6 +11,7 @@ import { usePowerpack } from '@shared/context'
 import {
   mergeFieldStats,
   buildMetricTargets,
+  isSummaryActive,
   totalRowsFromStats,
   useGetProductsColumnStatsQuery,
   useGetVersionsColumnStatsQuery,
@@ -31,7 +32,8 @@ const VPTable: FC<VPTableProps> = ({ readOnly = [], contextMenuItems }) => {
   const { fetchNextPage, isLoading, columnStatsArgs } = useVersionsDataContext()
   const { showProducts } = useVPViewsContext()
   const { attribFields } = useProjectDataContext()
-  const { columnVisibility, defaultColumnVisibility } = useColumnSettingsContext()
+  const { columnVisibility, defaultColumnVisibility, columnSummaries, columnSummaryScopes } =
+    useColumnSettingsContext()
   // hold stats queries until views load, otherwise targets cover every column
   const { isLoadingViews } = useViewsContext()
   // column summaries are a powerpack feature — don't fetch stats without a license
@@ -44,11 +46,15 @@ const VPTable: FC<VPTableProps> = ({ readOnly = [], contextMenuItems }) => {
         attribs: attribFields,
         columnVisibility,
         defaultColumnVisibility,
-        extraFields: checkColumnVisibility(columnVisibility, 'productBaseType', defaultColumnVisibility)
-          ? ['product_base_type']
-          : [],
+        columnSummaries,
+        columnSummaryScopes,
+        extraFields:
+          checkColumnVisibility(columnVisibility, 'productBaseType', defaultColumnVisibility) &&
+          isSummaryActive('productBaseType', columnSummaries, columnSummaryScopes)
+            ? ['product_base_type']
+            : [],
       }),
-    [attribFields, columnVisibility, defaultColumnVisibility],
+    [attribFields, columnVisibility, defaultColumnVisibility, columnSummaries, columnSummaryScopes],
   )
   const versionTargets = useMemo(
     () =>
@@ -57,8 +63,10 @@ const VPTable: FC<VPTableProps> = ({ readOnly = [], contextMenuItems }) => {
         attribs: attribFields,
         columnVisibility,
         defaultColumnVisibility,
+        columnSummaries,
+        columnSummaryScopes,
       }),
-    [attribFields, columnVisibility, defaultColumnVisibility],
+    [attribFields, columnVisibility, defaultColumnVisibility, columnSummaries, columnSummaryScopes],
   )
 
   const {

--- a/src/pages/VersionsProductsPage/components/VPTable/VPTable.tsx
+++ b/src/pages/VersionsProductsPage/components/VPTable/VPTable.tsx
@@ -5,7 +5,7 @@ import {
   NEXT_PAGE_ID,
   ProjectTreeTable,
 } from '@shared/containers'
-import { useColumnSettingsContext } from '@shared/containers/ProjectTreeTable'
+import { checkColumnVisibility, useColumnSettingsContext } from '@shared/containers/ProjectTreeTable'
 import { useProjectDataContext, useViewsContext } from '@shared/containers'
 import { usePowerpack } from '@shared/context'
 import {
@@ -31,7 +31,7 @@ const VPTable: FC<VPTableProps> = ({ readOnly = [], contextMenuItems }) => {
   const { fetchNextPage, isLoading, columnStatsArgs } = useVersionsDataContext()
   const { showProducts } = useVPViewsContext()
   const { attribFields } = useProjectDataContext()
-  const { columnVisibility } = useColumnSettingsContext()
+  const { columnVisibility, defaultColumnVisibility } = useColumnSettingsContext()
   // hold stats queries until views load, otherwise targets cover every column
   const { isLoadingViews } = useViewsContext()
   // column summaries are a powerpack feature — don't fetch stats without a license
@@ -43,13 +43,22 @@ const VPTable: FC<VPTableProps> = ({ readOnly = [], contextMenuItems }) => {
         entity: 'product',
         attribs: attribFields,
         columnVisibility,
-        extraFields: columnVisibility['productBaseType'] !== false ? ['product_base_type'] : [],
+        defaultColumnVisibility,
+        extraFields: checkColumnVisibility(columnVisibility, 'productBaseType', defaultColumnVisibility)
+          ? ['product_base_type']
+          : [],
       }),
-    [attribFields, columnVisibility],
+    [attribFields, columnVisibility, defaultColumnVisibility],
   )
   const versionTargets = useMemo(
-    () => buildMetricTargets({ entity: 'version', attribs: attribFields, columnVisibility }),
-    [attribFields, columnVisibility],
+    () =>
+      buildMetricTargets({
+        entity: 'version',
+        attribs: attribFields,
+        columnVisibility,
+        defaultColumnVisibility,
+      }),
+    [attribFields, columnVisibility, defaultColumnVisibility],
   )
 
   const {


### PR DESCRIPTION

<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Column summary stats are no longer requested for hidden columns. This cuts a large amount of server load on Overview, Versions/Products, and Lists, where every default-hidden attribute column was being aggregated.

## Technical details
<!-- Please state any technical details such as limitations -->

- `buildMetricTargets` now resolves visibility with `checkColumnVisibility` (opt-in) instead of `columnVisibility[id] !== false`, and takes a `defaultColumnVisibility` arg.
- Overview and VP tables pass `defaultColumnVisibility` from the column settings context into both target builds.
- VP `product_base_type` extra target is gated through `checkColumnVisibility`.
- Lists page drops the manual defaults/override merge and passes `defaultColumnVisibility` directly.
- Targets now match the table's rendered visible columns exactly; revealing a hidden column still refetches via the existing `hasNewTargetFields` path.

## Additional context
<!-- Add any other context or screenshots here. -->

Closes #2143

changes also in ynput/ayon-power-pack#76
