### PR TITLE
Lists: Copying cells from the lists table skips values

### DIFF
--- a/shared/src/containers/ProjectTreeTable/context/ClipboardContext.tsx
+++ b/shared/src/containers/ProjectTreeTable/context/ClipboardContext.tsx
@@ -202,18 +202,27 @@ export const ClipboardProvider: React.FC<ClipboardProviderProps> = ({
               // convert to string if foundValue is not undefined or null use empty string otherwise
               cellValue = foundValue !== undefined && foundValue !== null ? String(foundValue) : ''
 
-              // Special handling for name field - include full path
+              // Flat tables (lists) key entitiesMap by row id not entityId, so the path can't resolve — fall back to label/name
               if (colId === 'name') {
-                cellValue = getEntityPath(entity.entityId || entity.id, entitiesMap)
+                cellValue =
+                  getEntityPath(entity.entityId || entity.id, entitiesMap) ||
+                  (entity as any).label ||
+                  entity.name ||
+                  ''
               }
 
               if (colId === 'subType') {
-                // get folderType or taskType
-                if ('folderType' in entity) {
-                  cellValue = entity.folderType || ''
-                }
-                if ('taskType' in entity) {
-                  cellValue = entity.taskType || ''
+                // built rows resolve subType (folder/task/product); raw nodes fall back to type-specific fields
+                const resolvedSubType = (entity as any).subType
+                if (typeof resolvedSubType === 'string' && resolvedSubType) {
+                  cellValue = resolvedSubType
+                } else {
+                  if ('folderType' in entity) {
+                    cellValue = entity.folderType || ''
+                  }
+                  if ('taskType' in entity) {
+                    cellValue = entity.taskType || ''
+                  }
                 }
               }
             }

--- a/src/pages/ProjectListsPage/ProjectListsPage.tsx
+++ b/src/pages/ProjectListsPage/ProjectListsPage.tsx
@@ -191,6 +191,15 @@ const ProjectListsWithInnerProviders: FC<ProjectListsWithInnerProvidersProps> = 
     [selectedList],
   )
 
+  // copy/getEntityById needs display-ready rows (name/version/product/task resolved); keep raw link arrays
+  const entitiesMap = useMemo(() => {
+    const map = new Map<string, any>()
+    for (const row of props.listItemsTableData) {
+      map.set(row.id, { ...row, links: props.listItemsMap.get(row.id)?.links ?? [] })
+    }
+    return map
+  }, [props.listItemsTableData, props.listItemsMap])
+
   return (
     <SettingsPanelProvider>
       <ColumnSettingsProvider
@@ -209,7 +218,7 @@ const ProjectListsWithInnerProviders: FC<ProjectListsWithInnerProvidersProps> = 
                 users={props.users}
                 modules={modules}
                 // @ts-ignore
-                entitiesMap={props.listItemsMap}
+                entitiesMap={entitiesMap}
                 foldersMap={props.foldersMap}
                 tasksMap={props.tasksMap}
                 tableRows={props.listItemsTableData}

--- a/src/pages/ProjectListsPage/ProjectListsPage.tsx
+++ b/src/pages/ProjectListsPage/ProjectListsPage.tsx
@@ -191,15 +191,6 @@ const ProjectListsWithInnerProviders: FC<ProjectListsWithInnerProvidersProps> = 
     [selectedList],
   )
 
-  // copy/getEntityById needs display-ready rows (name/version/product/task resolved); keep raw link arrays
-  const entitiesMap = useMemo(() => {
-    const map = new Map<string, any>()
-    for (const row of props.listItemsTableData) {
-      map.set(row.id, { ...row, links: props.listItemsMap.get(row.id)?.links ?? [] })
-    }
-    return map
-  }, [props.listItemsTableData, props.listItemsMap])
-
   return (
     <SettingsPanelProvider>
       <ColumnSettingsProvider
@@ -218,7 +209,7 @@ const ProjectListsWithInnerProviders: FC<ProjectListsWithInnerProvidersProps> = 
                 users={props.users}
                 modules={modules}
                 // @ts-ignore
-                entitiesMap={entitiesMap}
+                entitiesMap={props.listItemsEntitiesMap}
                 foldersMap={props.foldersMap}
                 tasksMap={props.tasksMap}
                 tableRows={props.listItemsTableData}

--- a/src/pages/ProjectListsPage/context/ListItemsDataContext.tsx
+++ b/src/pages/ProjectListsPage/context/ListItemsDataContext.tsx
@@ -49,6 +49,7 @@ export interface ListItemsDataContextValue {
   listItemsData: EntityListItemWithLinks[]
   listItemsTableData: TableRow[]
   listItemsMap: ListItemsMap
+  listItemsEntitiesMap: Map<string, TableRow>
   fetchNextPage: () => void
   isLoadingAll: boolean
   isLoadingMore: boolean
@@ -279,10 +280,11 @@ export const ListItemsDataProvider = ({ children }: ListItemsDataProviderProps) 
     [statsEntity],
   )
 
-  // convert listItemsData into tableData
-  const listItemsTableData = useBuildListItemsTableData({
-    listItemsData,
-  })
+  // convert listItemsData into tableData (+ a display-ready map for copy/getEntityById)
+  const { tableData: listItemsTableData, entitiesMap: listItemsEntitiesMap } =
+    useBuildListItemsTableData({
+      listItemsData,
+    })
 
   const foldersMap: FolderNodeMap = new Map(
     // @ts-ignore
@@ -340,6 +342,7 @@ export const ListItemsDataProvider = ({ children }: ListItemsDataProviderProps) 
         listItemsData,
         listItemsTableData,
         listItemsMap,
+        listItemsEntitiesMap,
         isLoadingAll: isLoading || isLoadingData,
         isLoadingMore: isFetchingNextPage,
         isError,

--- a/src/pages/ProjectListsPage/hooks/useBuildListItemsTableData.ts
+++ b/src/pages/ProjectListsPage/hooks/useBuildListItemsTableData.ts
@@ -18,8 +18,12 @@ const useBuildListItemsTableData = ({ listItemsData }: Props) => {
 
   const getEntityTypeData = useGetEntityTypeData({ projectInfo: project })
 
-  const buildListItemsTableData = (listItemsData: EntityListItemWithLinks[]): TableRow[] => {
-    return listItemsData.map((item) => {
+  const buildListItemsTableData = (listItemsData: EntityListItemWithLinks[]) => {
+    const tableData: TableRow[] = []
+    // copy/getEntityById needs display-ready rows keyed by id; keep the raw link arrays
+    const entitiesMap = new Map<string, TableRow>()
+
+    for (const item of listItemsData) {
       // Check if this is a restricted access entity
       const isRestricted = isEntityRestricted(item.entityType)
 
@@ -35,7 +39,7 @@ const useBuildListItemsTableData = ({ listItemsData }: Props) => {
         extractSubTypes(item, item.entityType).subType,
       )
 
-      return {
+      const row: TableRow = {
         id: item.id,
         name: isRestricted ? RESTRICTED_ENTITY_NAME : item.name,
         label: isRestricted
@@ -74,13 +78,19 @@ const useBuildListItemsTableData = ({ listItemsData }: Props) => {
         subtasks: item.subtasks || [], // Add subtasks if they exist
         latestComments: item.latestComments || [],
       }
-    })
+
+      tableData.push(row)
+      // copy reads link columns via getLinkEntityIdsByColumnId, which expects the raw EntityLink[] array
+      entitiesMap.set(item.id, { ...row, links: (item.links ?? []) as unknown as TableRow['links'] })
+    }
+
+    return { tableData, entitiesMap }
   }
-  const tableData = useMemo(
+  const { tableData, entitiesMap } = useMemo(
     () => buildListItemsTableData(listItemsData),
     [listItemsData, getEntityTypeData],
   )
-  return tableData
+  return { tableData, entitiesMap }
 }
 
 export default useBuildListItemsTableData


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Fixes copying cells from the Lists table into a spreadsheet. The name column and computed columns (version, product, task, base type) came out blank on review/version lists.

## Technical details
<!-- Please state any technical details such as limitations -->

- ProjectListsPage feeds display-ready rows into the table `entitiesMap` (built from `listItemsTableData`, raw link arrays kept) instead of raw list items.
- Copy reads values via `getEntityById`; raw list items lacked resolved `folder`/`version`/`product`/`taskLabel`/`subType`, so those cells copied blank.
- `ClipboardContext` name column falls back to `label`/`name` when `getEntityPath` cannot resolve (lists key `entitiesMap` by list-item id, not entityId).
- `ClipboardContext` subType prefers the built row value, keeping the type-field fallback for raw nodes.

## Additional context
<!-- Add any other context or screenshots here. -->
<img width="1275" height="676" alt="Screenshot 2026-07-09 at 11 57 22" src="https://github.com/user-attachments/assets/58302ab7-12ab-432f-b05e-4c37ad7f8f4f" />



Closes #2080
