### PR TITLE
Summaries: fix column-summary grouping and skip disabled fetches

### DIFF
--- a/gen/graphql.schema.json
+++ b/gen/graphql.schema.json
@@ -2121,6 +2121,30 @@
             "deprecationReason": null
           },
           {
+            "name": "activityCategories",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "allAttrib",
             "description": null,
             "args": [],

--- a/shared/src/api/generated/graphql.ts
+++ b/shared/src/api/generated/graphql.ts
@@ -218,6 +218,7 @@ export type EntityListNode = {
   access: Scalars['String']['output'];
   accessLevel: Scalars['Int']['output'];
   active: Scalars['Boolean']['output'];
+  activityCategories: Array<Scalars['String']['output']>;
   allAttrib: Scalars['String']['output'];
   attributes: Scalars['String']['output'];
   count: Scalars['Int']['output'];
@@ -1910,6 +1911,7 @@ export type ColumnStatsFragmentFragment = { columnName: string, min: number | nu
 export type GetFolderColumnStatsQueryVariables = Exact<{
   projectName: string;
   filter?: string | null | undefined;
+  taskFilter?: string | null | undefined;
   search?: string | null | undefined;
   parentIds?: Array<string> | string | null | undefined;
   ids?: Array<string> | string | null | undefined;
@@ -3361,12 +3363,13 @@ export const GetListsItemsForReviewSessionDocument = new TypedDocumentString(`
 }
     `);
 export const GetFolderColumnStatsDocument = new TypedDocumentString(`
-    query GetFolderColumnStats($projectName: String!, $filter: String, $search: String, $parentIds: [String!], $ids: [String!], $targets: [MetricTargetInput!], $includeFolderChildren: Boolean! = true, $hideEmptyFolders: Boolean) {
+    query GetFolderColumnStats($projectName: String!, $filter: String, $taskFilter: String, $search: String, $parentIds: [String!], $ids: [String!], $targets: [MetricTargetInput!], $includeFolderChildren: Boolean! = true, $hideEmptyFolders: Boolean) {
   project(name: $projectName) {
     name
     folders(
       calculateSpecificStatistics: $targets
       filter: $filter
+      taskFilter: $taskFilter
       search: $search
       parentIds: $parentIds
       ids: $ids

--- a/shared/src/api/generated/graphqlLinks.ts
+++ b/shared/src/api/generated/graphqlLinks.ts
@@ -218,6 +218,7 @@ export type EntityListNode = {
   access: Scalars['String']['output'];
   accessLevel: Scalars['Int']['output'];
   active: Scalars['Boolean']['output'];
+  activityCategories: Array<Scalars['String']['output']>;
   allAttrib: Scalars['String']['output'];
   attributes: Scalars['String']['output'];
   count: Scalars['Int']['output'];

--- a/shared/src/api/queries/columnStats/groupCounts.ts
+++ b/shared/src/api/queries/columnStats/groupCounts.ts
@@ -34,7 +34,6 @@ const TASK_FIELDS: Record<string, string> = {
 const VERSION_FIELDS: Record<string, string> = {
   status: 'status',
   tags: 'tags',
-  productType: 'product_type',
 }
 
 export const groupByToStatsTarget = (

--- a/shared/src/api/queries/columnStats/metricTargets.ts
+++ b/shared/src/api/queries/columnStats/metricTargets.ts
@@ -51,6 +51,19 @@ export const anySummaryActive = (
   return false
 }
 
+// The main count (name column) is on by default, so the footer always has at
+// least that to show. Skip the stats fetch only when the user has explicitly
+// turned the name count off too AND no other column has an active summary —
+// otherwise the name cell has no data and can't be re-enabled.
+export const shouldSkipColumnStats = (
+  columnSummaries?: Record<string, SummaryCalc>,
+  columnSummaryScopes?: Record<string, RowScope>,
+  columnVisibility?: VisibilityState,
+  defaultColumnVisibility?: VisibilityState,
+): boolean =>
+  columnSummaryScopes?.['name'] === 'none' &&
+  !anySummaryActive(columnSummaries, columnSummaryScopes, columnVisibility, defaultColumnVisibility)
+
 // refetch only when a target was added — hiding a column needs no query
 export const hasNewTargetFields = (current?: TargetsArg, previous?: TargetsArg): boolean => {
   if (!current) return false

--- a/shared/src/api/queries/columnStats/metricTargets.ts
+++ b/shared/src/api/queries/columnStats/metricTargets.ts
@@ -28,17 +28,24 @@ export const isSummaryActive = (
   return calc != null || scope != null
 }
 
-// True when at least one column has an active summary — lets callers skip the
-// whole column-stats query when the user has every summary switched off.
+// True when at least one *visible* column has an active summary — lets callers
+// skip the whole column-stats query when the user has every summary switched off.
+// Visibility matters: a hidden column can still carry a stale summary value, but
+// buildMetricTargets skips it, so it must not keep the query alive either.
 export const anySummaryActive = (
   columnSummaries?: Record<string, SummaryCalc>,
   columnSummaryScopes?: Record<string, RowScope>,
+  columnVisibility?: VisibilityState,
+  defaultColumnVisibility?: VisibilityState,
 ): boolean => {
   const ids = new Set([
     ...Object.keys(columnSummaries ?? {}),
     ...Object.keys(columnSummaryScopes ?? {}),
   ])
   for (const id of ids) {
+    if (columnVisibility && !checkColumnVisibility(columnVisibility, id, defaultColumnVisibility)) {
+      continue
+    }
     if (isSummaryActive(id, columnSummaries, columnSummaryScopes)) return true
   }
   return false

--- a/shared/src/api/queries/columnStats/metricTargets.ts
+++ b/shared/src/api/queries/columnStats/metricTargets.ts
@@ -28,6 +28,22 @@ export const isSummaryActive = (
   return calc != null || scope != null
 }
 
+// True when at least one column has an active summary — lets callers skip the
+// whole column-stats query when the user has every summary switched off.
+export const anySummaryActive = (
+  columnSummaries?: Record<string, SummaryCalc>,
+  columnSummaryScopes?: Record<string, RowScope>,
+): boolean => {
+  const ids = new Set([
+    ...Object.keys(columnSummaries ?? {}),
+    ...Object.keys(columnSummaryScopes ?? {}),
+  ])
+  for (const id of ids) {
+    if (isSummaryActive(id, columnSummaries, columnSummaryScopes)) return true
+  }
+  return false
+}
+
 // refetch only when a target was added — hiding a column needs no query
 export const hasNewTargetFields = (current?: TargetsArg, previous?: TargetsArg): boolean => {
   if (!current) return false

--- a/shared/src/api/queries/overview/gql/GetFolderColumnStats.graphql
+++ b/shared/src/api/queries/overview/gql/GetFolderColumnStats.graphql
@@ -4,6 +4,7 @@
 query GetFolderColumnStats(
   $projectName: String!
   $filter: String
+  $taskFilter: String
   $search: String
   $parentIds: [String!]
   $ids: [String!]
@@ -16,6 +17,7 @@ query GetFolderColumnStats(
     folders(
       calculateSpecificStatistics: $targets
       filter: $filter
+      taskFilter: $taskFilter
       search: $search
       parentIds: $parentIds
       ids: $ids

--- a/shared/src/containers/ListTable/ListTableHeader.tsx
+++ b/shared/src/containers/ListTable/ListTableHeader.tsx
@@ -121,7 +121,7 @@ export function SortableTHComponent<TData extends RowData>({
               icon="sort"
               className={clsx('sort-button', { visible: !!isSorted })}
               style={{
-                transform: isSorted === 'asc' ? 'rotate(180deg) scaleX(-1)' : 'none',
+                transform: isSorted === 'desc' ? 'rotate(180deg) scaleX(-1)' : 'none',
               }}
               onClick={column.getToggleSortingHandler()}
               selected={!!isSorted}

--- a/shared/src/containers/ProjectTreeTable/ProjectTreeTable.tsx
+++ b/shared/src/containers/ProjectTreeTable/ProjectTreeTable.tsx
@@ -266,11 +266,14 @@ export const ProjectTreeTable = ({
   const filterErrorMessage = getFilterErrorMessage(getEntitiesLabelFromScopes(scopes))
 
   // Parent (folder/product) summary scope only applies when those entities are
-  // actually on screen: hierarchy view, or grouping by a parent entity.
+  // actually on screen: hierarchy view, grouping by a parent entity, or the
+  // Products tab's product tree (product parent rows -> 'product' in scopes).
   const groupField = overrideGroupBy?.id ?? groupBy?.id
   const groupFieldId = Array.isArray(groupField) ? groupField[0] : groupField
   const parentScopeApplicable =
-    showHierarchy || ['hierarchy', 'folder', 'product'].includes(groupFieldId ?? '')
+    showHierarchy ||
+    ['hierarchy', 'folder', 'product'].includes(groupFieldId ?? '') ||
+    scopes.includes('product')
 
   const { writableFields } = useProjectDataContext()
 

--- a/shared/src/containers/ProjectTreeTable/ProjectTreeTable.tsx
+++ b/shared/src/containers/ProjectTreeTable/ProjectTreeTable.tsx
@@ -171,7 +171,7 @@ export interface ProjectTreeTableProps extends React.HTMLAttributes<HTMLDivEleme
   showColumnSummaries?: boolean // render the fixed summary footer row
   fieldStats?: FieldStats[] // primary-entity stats (tasks/versions) feeding the footer
   groupFieldStats?: FieldStats[] // group-entity stats (folders/products) for the 'all' row scope
-  fieldStatsLoading?: boolean // footer stats still loading -> show skeletons
+  fieldStatsLoading?: boolean // footer stats still loading - click-through shimmer over values
   fieldStatsError?: any // error fetching footer stats
   mainCountLabels?: MainCountLabels // labels for the main cell dual count (defaults folders/tasks)
   onScrollBottomGroupBy?: (groupValue: string) => void // Handle scroll to bottom for grouped data
@@ -621,8 +621,9 @@ export const ProjectTreeTable = ({
     powerLicense &&
     (isFooterLoaded || isFooterModuleLoading) &&
     !!rows.length
-  // shimmer while the remote module or the footer stats are still loading
-  const summariesLoading = isFooterModuleLoading || !isFooterLoaded || !!fieldStatsLoading
+  // Full skeleton only while the remote module itself is loading (no cell to
+  // render yet). Stats loading is handled per-cell so the footer stays clickable.
+  const footerModuleLoading = isFooterModuleLoading || !isFooterLoaded
   // only show the upsell once the license check resolves, so licensed users
   // don't see the bolt flash before the addon loads
   // const showSummaryPowerFeature = !isLicenseLoading && !powerLicense
@@ -797,7 +798,8 @@ export const ProjectTreeTable = ({
                 table={table}
                 virtualPaddingLeft={virtualPaddingLeft}
                 virtualPaddingRight={virtualPaddingRight}
-                isLoading={summariesLoading}
+                isLoading={footerModuleLoading}
+                statsLoading={!!fieldStatsLoading}
                 error={fieldStatsError}
                 // Free-user upsell hidden for now; keep for later:
                 // onClick={showSummaryPowerFeature ? () => setPowerpackDialog('columnSummaries') : undefined}

--- a/shared/src/containers/ProjectTreeTable/ProjectTreeTable.tsx
+++ b/shared/src/containers/ProjectTreeTable/ProjectTreeTable.tsx
@@ -1235,7 +1235,7 @@ const TableHeadCell = ({
                 icon="sort"
                 className={clsx('sort-button', { visible: sorting })}
                 style={{
-                  transform: sorting === 'asc' ? 'rotate(180deg) scaleX(-1)' : 'none',
+                  transform: sorting === 'desc' ? 'rotate(180deg) scaleX(-1)' : 'none',
                 }}
                 onClick={handleToggleSort}
                 selected={!!column.getIsSorted()}

--- a/shared/src/containers/ProjectTreeTable/components/TableFooterRow.tsx
+++ b/shared/src/containers/ProjectTreeTable/components/TableFooterRow.tsx
@@ -92,6 +92,18 @@ const CellSkeleton = styled.div`
   }
 `
 
+// Same shimmer, laid over the still-rendered (and still-clickable) cell content
+// while only the stats are loading. pointer-events: none lets clicks fall
+// through to the summary control underneath, so the footer never goes dead.
+const CellSkeletonOverlay = styled(CellSkeleton)`
+  position: absolute;
+  inset: 1px 0 2px 1px;
+  width: auto;
+  height: auto;
+  margin: 0;
+  pointer-events: none;
+`
+
 export interface TableFooterRowProps {
   columnVirtualizer: Virtualizer<HTMLDivElement, HTMLTableCellElement>
   table: Table<TableRow>
@@ -101,8 +113,11 @@ export interface TableFooterRowProps {
   renderCellContent?: (columnId: string) => ReactNode
   // when set, the whole row is clickable (used for the locked/upsell state)
   onClick?: () => void
-  // show a shimmer skeleton in each cell while the footer stats load
+  // full-cell skeleton while the summaries remote module itself is still loading
   isLoading?: boolean
+  // stats still loading but the module is ready — keep cells clickable and show
+  // a click-through shimmer over the (as yet empty) values
+  statsLoading?: boolean
   // error fetching stats
   error?: any
 }
@@ -117,6 +132,7 @@ export const TableFooterRow: FC<TableFooterRowProps> = ({
   renderCellContent,
   onClick,
   isLoading,
+  statsLoading,
   error,
 }) => {
   const visibleColumns = [
@@ -176,7 +192,14 @@ export const TableFooterRow: FC<TableFooterRowProps> = ({
                   </CellContent>
                 ) : null
               ) : (
-                !isUtility && renderCellContent?.(column.id)
+                !isUtility && (
+                  <>
+                    {renderCellContent?.(column.id)}
+                    {statsLoading && (
+                      <CellSkeletonOverlay className={clsx('loading', 'shimmer-dark')} />
+                    )}
+                  </>
+                )
               )}
             </FooterCell>
           )

--- a/src/pages/ProjectListsPage/context/ListItemsDataContext.tsx
+++ b/src/pages/ProjectListsPage/context/ListItemsDataContext.tsx
@@ -20,6 +20,7 @@ import { SortingState, VisibilityState } from '@tanstack/react-table'
 import { useProjectContext, usePowerpack } from '@shared/context'
 import {
   buildMetricTargets,
+  anySummaryActive,
   mergeFieldStats,
   totalRowsFromStats,
   toListItemsStatsTargets,
@@ -269,7 +270,14 @@ export const ListItemsDataProvider = ({ children }: ListItemsDataProviderProps) 
       filter: statsFilter,
       targets: statsTargets,
     },
-    { skip: !projectName || !selectedListId || !statsEntity || !powerLicense },
+    {
+      skip:
+        !projectName ||
+        !selectedListId ||
+        !statsEntity ||
+        !powerLicense ||
+        !anySummaryActive(columns.columnSummaries, columns.columnSummaryScopes),
+    },
   )
 
   const fieldStats = useMemo(() => {

--- a/src/pages/ProjectListsPage/context/ListItemsDataContext.tsx
+++ b/src/pages/ProjectListsPage/context/ListItemsDataContext.tsx
@@ -20,7 +20,7 @@ import { SortingState, VisibilityState } from '@tanstack/react-table'
 import { useProjectContext, usePowerpack } from '@shared/context'
 import {
   buildMetricTargets,
-  anySummaryActive,
+  shouldSkipColumnStats,
   mergeFieldStats,
   totalRowsFromStats,
   toListItemsStatsTargets,
@@ -276,7 +276,7 @@ export const ListItemsDataProvider = ({ children }: ListItemsDataProviderProps) 
         !selectedListId ||
         !statsEntity ||
         !powerLicense ||
-        !anySummaryActive(
+        shouldSkipColumnStats(
           columns.columnSummaries,
           columns.columnSummaryScopes,
           columns.columnVisibility,

--- a/src/pages/ProjectListsPage/context/ListItemsDataContext.tsx
+++ b/src/pages/ProjectListsPage/context/ListItemsDataContext.tsx
@@ -276,7 +276,12 @@ export const ListItemsDataProvider = ({ children }: ListItemsDataProviderProps) 
         !selectedListId ||
         !statsEntity ||
         !powerLicense ||
-        !anySummaryActive(columns.columnSummaries, columns.columnSummaryScopes),
+        !anySummaryActive(
+          columns.columnSummaries,
+          columns.columnSummaryScopes,
+          columns.columnVisibility,
+          defaultColumnVisibility,
+        ),
     },
   )
 

--- a/src/pages/ProjectOverviewPage/containers/ProjectOverviewTable.tsx
+++ b/src/pages/ProjectOverviewPage/containers/ProjectOverviewTable.tsx
@@ -42,8 +42,13 @@ const ProjectOverviewTable = ({}: Props) => {
   const { isLoadingViews } = useViewsContext()
   // column summaries are a powerpack feature — don't fetch stats without a license
   const { powerLicense } = usePowerpack()
-  // nothing to compute when every summary is switched off — skip the query
-  const noSummaries = !anySummaryActive(columnSummaries, columnSummaryScopes)
+  // nothing to compute when every visible summary is switched off — skip the query
+  const noSummaries = !anySummaryActive(
+    columnSummaries,
+    columnSummaryScopes,
+    columnVisibility,
+    defaultColumnVisibility,
+  )
   const { folderFilters, taskFilters, selectedFolders, selectedTaskIds, foldersMap } =
     useProjectOverviewContext()
 

--- a/src/pages/ProjectOverviewPage/containers/ProjectOverviewTable.tsx
+++ b/src/pages/ProjectOverviewPage/containers/ProjectOverviewTable.tsx
@@ -15,6 +15,7 @@ import { useViewsContext } from '@shared/containers'
 import {
   mergeFieldStats,
   buildMetricTargets,
+  anySummaryActive,
   totalRowsFromStats,
   useGetFolderColumnStatsQuery,
   useGetTaskColumnStatsQuery,
@@ -41,6 +42,8 @@ const ProjectOverviewTable = ({}: Props) => {
   const { isLoadingViews } = useViewsContext()
   // column summaries are a powerpack feature — don't fetch stats without a license
   const { powerLicense } = usePowerpack()
+  // nothing to compute when every summary is switched off — skip the query
+  const noSummaries = !anySummaryActive(columnSummaries, columnSummaryScopes)
   const { folderFilters, taskFilters, selectedFolders, selectedTaskIds, foldersMap } =
     useProjectOverviewContext()
 
@@ -95,7 +98,7 @@ const ProjectOverviewTable = ({}: Props) => {
       // when grouping by folder, not having having "show empty" enabled means we do not count empty folder
       hideEmptyFolders: groupByConfig?.showEmpty === false && !showHierarchy ? true : undefined,
     },
-    { skip: !projectName || isLoadingViews || !powerLicense },
+    { skip: !projectName || isLoadingViews || !powerLicense || noSummaries },
   )
 
   const {
@@ -112,7 +115,7 @@ const ProjectOverviewTable = ({}: Props) => {
       taskIds: statsTaskIds,
       targets: taskTargets,
     },
-    { skip: !projectName || isLoadingViews || !powerLicense },
+    { skip: !projectName || isLoadingViews || !powerLicense || noSummaries },
   )
 
   const fieldStats = useMemo(() => {

--- a/src/pages/ProjectOverviewPage/containers/ProjectOverviewTable.tsx
+++ b/src/pages/ProjectOverviewPage/containers/ProjectOverviewTable.tsx
@@ -15,7 +15,7 @@ import { useViewsContext } from '@shared/containers'
 import {
   mergeFieldStats,
   buildMetricTargets,
-  anySummaryActive,
+  shouldSkipColumnStats,
   totalRowsFromStats,
   useGetFolderColumnStatsQuery,
   useGetTaskColumnStatsQuery,
@@ -42,8 +42,8 @@ const ProjectOverviewTable = ({}: Props) => {
   const { isLoadingViews } = useViewsContext()
   // column summaries are a powerpack feature — don't fetch stats without a license
   const { powerLicense } = usePowerpack()
-  // nothing to compute when every visible summary is switched off — skip the query
-  const noSummaries = !anySummaryActive(
+  // skip the query only when the name count and every other summary are off
+  const noSummaries = shouldSkipColumnStats(
     columnSummaries,
     columnSummaryScopes,
     columnVisibility,

--- a/src/pages/ProjectOverviewPage/containers/ProjectOverviewTable.tsx
+++ b/src/pages/ProjectOverviewPage/containers/ProjectOverviewTable.tsx
@@ -49,7 +49,7 @@ const ProjectOverviewTable = ({}: Props) => {
     columnVisibility,
     defaultColumnVisibility,
   )
-  const { folderFilters, taskFilters, selectedFolders, selectedTaskIds, foldersMap } =
+  const { folderFilters, taskFilters, selectedFolders, selectedTaskIds } =
     useProjectOverviewContext()
 
   // Mirror the task list query: slicer selection narrows rows to the selected
@@ -94,6 +94,7 @@ const ProjectOverviewTable = ({}: Props) => {
     {
       projectName,
       filter: folderFilters?.filterString || undefined,
+      taskFilter: taskFilters?.filterString || undefined,
       search: folderFilters?.search || undefined,
       // show hierarchy never includes it self and only children
       [showHierarchy ? 'parentIds' : 'ids']: selectedFolders?.length ? selectedFolders : undefined,

--- a/src/pages/VersionsProductsPage/components/VPTable/VPTable.tsx
+++ b/src/pages/VersionsProductsPage/components/VPTable/VPTable.tsx
@@ -39,8 +39,13 @@ const VPTable: FC<VPTableProps> = ({ readOnly = [], contextMenuItems }) => {
   const { isLoadingViews } = useViewsContext()
   // column summaries are a powerpack feature — don't fetch stats without a license
   const { powerLicense } = usePowerpack()
-  // nothing to compute when every summary is switched off — skip the query
-  const noSummaries = !anySummaryActive(columnSummaries, columnSummaryScopes)
+  // nothing to compute when every visible summary is switched off — skip the query
+  const noSummaries = !anySummaryActive(
+    columnSummaries,
+    columnSummaryScopes,
+    columnVisibility,
+    defaultColumnVisibility,
+  )
 
   const productTargets = useMemo(
     () =>

--- a/src/pages/VersionsProductsPage/components/VPTable/VPTable.tsx
+++ b/src/pages/VersionsProductsPage/components/VPTable/VPTable.tsx
@@ -12,7 +12,7 @@ import {
   mergeFieldStats,
   buildMetricTargets,
   isSummaryActive,
-  anySummaryActive,
+  shouldSkipColumnStats,
   totalRowsFromStats,
   useGetProductsColumnStatsQuery,
   useGetVersionsColumnStatsQuery,
@@ -39,8 +39,8 @@ const VPTable: FC<VPTableProps> = ({ readOnly = [], contextMenuItems }) => {
   const { isLoadingViews } = useViewsContext()
   // column summaries are a powerpack feature — don't fetch stats without a license
   const { powerLicense } = usePowerpack()
-  // nothing to compute when every visible summary is switched off — skip the query
-  const noSummaries = !anySummaryActive(
+  // skip the query only when the name count and every other summary are off
+  const noSummaries = shouldSkipColumnStats(
     columnSummaries,
     columnSummaryScopes,
     columnVisibility,

--- a/src/pages/VersionsProductsPage/components/VPTable/VPTable.tsx
+++ b/src/pages/VersionsProductsPage/components/VPTable/VPTable.tsx
@@ -12,6 +12,7 @@ import {
   mergeFieldStats,
   buildMetricTargets,
   isSummaryActive,
+  anySummaryActive,
   totalRowsFromStats,
   useGetProductsColumnStatsQuery,
   useGetVersionsColumnStatsQuery,
@@ -38,6 +39,8 @@ const VPTable: FC<VPTableProps> = ({ readOnly = [], contextMenuItems }) => {
   const { isLoadingViews } = useViewsContext()
   // column summaries are a powerpack feature — don't fetch stats without a license
   const { powerLicense } = usePowerpack()
+  // nothing to compute when every summary is switched off — skip the query
+  const noSummaries = !anySummaryActive(columnSummaries, columnSummaryScopes)
 
   const productTargets = useMemo(
     () =>
@@ -75,7 +78,7 @@ const VPTable: FC<VPTableProps> = ({ readOnly = [], contextMenuItems }) => {
     error: productStatsError,
   } = useGetProductsColumnStatsQuery(
     { ...columnStatsArgs, targets: productTargets },
-    { skip: !columnStatsArgs.projectName || isLoadingViews || !powerLicense },
+    { skip: !columnStatsArgs.projectName || isLoadingViews || !powerLicense || noSummaries },
   )
   const {
     data: versionStats,
@@ -83,7 +86,7 @@ const VPTable: FC<VPTableProps> = ({ readOnly = [], contextMenuItems }) => {
     error: versionStatsError,
   } = useGetVersionsColumnStatsQuery(
     { ...columnStatsArgs, targets: versionTargets },
-    { skip: !columnStatsArgs.projectName || isLoadingViews || !powerLicense },
+    { skip: !columnStatsArgs.projectName || isLoadingViews || !powerLicense || noSummaries },
   )
 
   const fieldStats = useMemo(() => {


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Fixes three column-summary issues: the Products summary can now be enabled on the Products tab, grouping products by product/task type no longer errors the stats footer, and no column-stats query is sent when every summary is switched off.

## Technical details
<!-- Please state any technical details such as limitations -->

- Add `anySummaryActive` in `metricTargets.ts`; skip the column-stats query when no summary is active (Overview, Products, Lists).
- `parentScopeApplicable` now also true when `scopes` includes `product`, so the Products (parent) scope is selectable on the Products tab (`ProjectTreeTable.tsx`).
- Drop `productType - product_type` from `VERSION_FIELDS` in `groupCounts.ts`; the versions stats endpoint has no `product_type` column.

## Additional context
<!-- Add any other context or screenshots here. -->
