### PR TITLE
YN-0725: Copy Representation File Path via context menu

### DIFF
--- a/shared/src/api/generated/graphql.ts
+++ b/shared/src/api/generated/graphql.ts
@@ -1812,7 +1812,7 @@ export type GetDetailsPanelVersionQueryVariables = Exact<{
 }>;
 
 
-export type GetDetailsPanelVersionQuery = { project: { projectName: string, code: string, version: { id: string, version: number, name: string, author: string | null, status: string, tags: Array<string>, updatedAt: unknown, createdAt: unknown, thumbnailHash: string, thumbnailId: string | null, hasReviewables: boolean, parents: Array<string>, allAttrib: string, product: { id: string, name: string, productType: string, folder: { id: string, name: string, label: string | null, path: string | null, folderType: string }, latestVersion: { version: number } | null }, task: { id: string, name: string, label: string | null, assignees: Array<string>, taskType: string } | null, representations: { edges: Array<{ node: { id: string, name: string, fileCount: number } }> } } | null } };
+export type GetDetailsPanelVersionQuery = { project: { projectName: string, code: string, version: { id: string, version: number, name: string, author: string | null, status: string, tags: Array<string>, updatedAt: unknown, createdAt: unknown, thumbnailHash: string, thumbnailId: string | null, hasReviewables: boolean, parents: Array<string>, allAttrib: string, product: { id: string, name: string, productType: string, folder: { id: string, name: string, label: string | null, path: string | null, folderType: string }, latestVersion: { version: number } | null }, task: { id: string, name: string, label: string | null, assignees: Array<string>, taskType: string } | null, representations: { edges: Array<{ node: { id: string, name: string, fileCount: number, files: Array<{ path: string }> } }> } } | null } };
 
 export type GetProductVersionsQueryVariables = Exact<{
   projectName: string;
@@ -1826,7 +1826,7 @@ export type DetailsPanelFolderFragmentFragment = { id: string, name: string, lab
 
 export type DetailsPanelProductFragmentFragment = { id: string, name: string, productType: string, latestVersion: { version: number } | null };
 
-export type DetailsPanelRepresentationFragmentFragment = { id: string, name: string, fileCount: number };
+export type DetailsPanelRepresentationFragmentFragment = { id: string, name: string, fileCount: number, files: Array<{ path: string }> };
 
 export type DetailsPanelTaskFragmentFragment = { id: string, name: string, label: string | null, assignees: Array<string>, taskType: string };
 
@@ -2305,6 +2305,9 @@ export const DetailsPanelRepresentationFragmentFragmentDoc = new TypedDocumentSt
   id
   name
   fileCount
+  files {
+    path
+  }
 }
     `, {"fragmentName":"DetailsPanelRepresentationFragment"});
 export const DetailsPanelTaskFragmentFragmentDoc = new TypedDocumentString(`
@@ -3094,6 +3097,9 @@ fragment DetailsPanelRepresentationFragment on RepresentationNode {
   id
   name
   fileCount
+  files {
+    path
+  }
 }
 fragment DetailsPanelTaskFragment on TaskNode {
   id

--- a/shared/src/api/queries/entities/gql/fragments/DetailsPanelRepresentationFragment.graphql
+++ b/shared/src/api/queries/entities/gql/fragments/DetailsPanelRepresentationFragment.graphql
@@ -2,4 +2,7 @@ fragment DetailsPanelRepresentationFragment on RepresentationNode {
   id
   name
   fileCount
+  files {
+    path
+  }
 }

--- a/shared/src/containers/RepresentationsList/RepresentationsList.tsx
+++ b/shared/src/containers/RepresentationsList/RepresentationsList.tsx
@@ -4,11 +4,11 @@ import { TablePanel } from '@ynput/ayon-react-components'
 import { TreeTable } from 'primereact/treetable'
 import { Column } from 'primereact/column'
 
-import { groupResult } from '@shared/util'
+import { copyToClipboard, groupResult, replaceRoot } from '@shared/util'
 import { useCreateContextMenu } from '@shared/containers/ContextMenu'
 import { DetailsDialog } from '@shared/components'
 import versionsToRepresentations from './versionsToRepresentations'
-import { DetailsPanelEntityData } from '@shared/api'
+import { DetailsPanelEntityData, useGetProjectAnatomyQuery } from '@shared/api'
 
 const columns = [
   {
@@ -61,11 +61,40 @@ export const RepresentationsList = ({ entities = [] }: Props) => {
     onRepSelectionChange(e.node.data.id)
   }
 
+  const projectName = representations[0]?.projectName
+
+  const { data: anatomy } = useGetProjectAnatomyQuery(
+    { projectName: projectName as string },
+    { skip: !projectName },
+  )
+
+  const rootsByPlatform = useMemo(() => {
+    const roots = anatomy?.roots ?? []
+    const build = (platform: 'windows' | 'linux' | 'darwin') =>
+      Object.fromEntries(roots.filter((r) => r[platform]).map((r) => [r.name, r[platform]]))
+    return { windows: build('windows'), darwin: build('darwin'), linux: build('linux') }
+  }, [anatomy])
+
+  const copyRepPath = (id: string, platform: 'windows' | 'darwin' | 'linux') => {
+    const rootless = representations.find((rep) => rep.id === id)?.files?.[0]
+    if (!rootless) return
+    copyToClipboard(replaceRoot(rootless, rootsByPlatform[platform]) ?? rootless, true)
+  }
+
   const ctxMenuItems = (id: string) => [
     {
       label: 'Representation detail',
       command: () => setShowDetail(id),
       icon: 'database',
+    },
+    {
+      label: 'Copy path',
+      icon: 'content_copy',
+      items: [
+        { label: 'Copy Windows path', command: () => copyRepPath(id, 'windows') },
+        { label: 'Copy Mac path', command: () => copyRepPath(id, 'darwin') },
+        { label: 'Copy Linux path', command: () => copyRepPath(id, 'linux') },
+      ],
     },
   ]
 

--- a/shared/src/containers/RepresentationsList/RepresentationsList.tsx
+++ b/shared/src/containers/RepresentationsList/RepresentationsList.tsx
@@ -78,7 +78,9 @@ export const RepresentationsList = ({ entities = [] }: Props) => {
   const copyRepPath = (id: string, platform: 'windows' | 'darwin' | 'linux') => {
     const rootless = representations.find((rep) => rep.id === id)?.files?.[0]
     if (!rootless) return
-    copyToClipboard(replaceRoot(rootless, rootsByPlatform[platform]) ?? rootless, true)
+    const resolved = replaceRoot(rootless, rootsByPlatform[platform])
+    if (!resolved || /\{root\[.*?\]\}/.test(resolved)) return
+    copyToClipboard(resolved, true)
   }
 
   const ctxMenuItems = (id: string) => [

--- a/shared/src/containers/RepresentationsList/versionsToRepresentations.ts
+++ b/shared/src/containers/RepresentationsList/versionsToRepresentations.ts
@@ -16,6 +16,7 @@ const versionsToRepresentations = (entities: DetailsPanelEntityData[] = []) => {
         productType: product?.productType,
         fileCount: representation.fileCount,
         projectName: entity.projectName,
+        files: representation.files?.map((file) => file.path) || [],
       })
     }
   }

--- a/shared/src/util/index.ts
+++ b/shared/src/util/index.ts
@@ -26,6 +26,7 @@ export * from './getProjectDisplayName'
 export * from './getThumbnailUrl'
 export * from './thumbnailWebsocket'
 export * from './getBundleMode'
+export * from './replaceRoot'
 
 import isHTMLElement from './isHTMLElement'
 export { isHTMLElement }

--- a/shared/src/util/replaceRoot.ts
+++ b/shared/src/util/replaceRoot.ts
@@ -3,7 +3,7 @@ export const replaceRoot = (
   input?: string | null,
   roots: Record<string, string | undefined> = {},
 ): string | undefined => {
-  if (!input) return input ?? undefined
+  if (input == null) return undefined
   return input.replace(/\{root\[(.*?)\]\}/g, (match, name) => {
     const value = roots[name]
     return value ? value.replace(/[\\/]+$/, '') : match

--- a/shared/src/util/replaceRoot.ts
+++ b/shared/src/util/replaceRoot.ts
@@ -1,0 +1,11 @@
+// Swaps {root[name]} tokens in a rootless path for concrete per-OS root values.
+export const replaceRoot = (
+  input?: string | null,
+  roots: Record<string, string | undefined> = {},
+): string | undefined => {
+  if (!input) return input ?? undefined
+  return input.replace(/\{root\[(.*?)\]\}/g, (match, name) => {
+    const value = roots[name]
+    return value ? value.replace(/[\\/]+$/, '') : match
+  })
+}

--- a/src/pages/WorkfilesPage/WorkfileDetail.jsx
+++ b/src/pages/WorkfilesPage/WorkfileDetail.jsx
@@ -7,22 +7,7 @@ import { useSelector } from 'react-redux'
 import { useGetWorkfileByIdQuery } from '@queries/getWorkfiles'
 import { useGetSiteRootsQuery } from '@queries/customRoots'
 import SiteDropdown from '@containers/SiteDropdown'
-import { getCurrentPlatform } from '@shared/util'
-
-const replaceRoot = (inputStr, replacements) => {
-  if (!inputStr) return inputStr
-  return inputStr.replace(/\{root\[(.*?)\]\}/g, function (match, p1) {
-    //TODO: fix eslint error
-    //eslint-disable-next-line
-    if (replacements.hasOwnProperty(p1)) {
-      let value = replacements[p1]
-      // strip forward and back slashes from the end of the value
-      value = value.replace(/\/$/, '')
-      return value
-    }
-    return match
-  })
-}
+import { getCurrentPlatform, replaceRoot } from '@shared/util'
 
 const WorkfileDetail = ({ style }) => {
   const projectName = useSelector((state) => state.project.name)


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Adds a Copy path submenu to the representation right-click menu, with Copy Windows / Mac / Linux path actions that resolve the file path for each OS.

## Technical details
<!-- Please state any technical details such as limitations -->

- New `replaceRoot` util swaps `{root[name]}` tokens for per-OS anatomy root values (`shared/src/util/replaceRoot.ts`).
- `RepresentationsList` builds per-OS root maps from `useGetProjectAnatomyQuery`, resolves the first file's rootless path, copies via `copyToClipboard`.
- Fragment `DetailsPanelRepresentationFragment` now fetches `files { path }`; carried through `versionsToRepresentations`.
- `WorkfileDetail` reuses the shared `replaceRoot` (removed its local copy).
- Uses generic OS roots only; no site overrides.

## Additional context
<!-- Add any other context or screenshots here. -->
Closes #2036

<img width="522" height="340" alt="Screenshot 2026-07-10 at 13 37 48" src="https://github.com/user-attachments/assets/f88a8f18-0231-4e73-ace5-d24197019240" />
