### PR TITLE
Feed: Show status on version activity

### DIFF
--- a/shared/src/api/generated/graphql.ts
+++ b/shared/src/api/generated/graphql.ts
@@ -1741,7 +1741,7 @@ export type StatsOperation =
   | 'PERCENTAGE_NOT_FILLED'
   | 'SUM';
 
-export type ActivityFragmentFragment = { activityId: string, activityType: string, activityData: string, referenceType: string, referenceId: string, entityId: string | null, body: string, createdAt: unknown, updatedAt: unknown, author: { name: string, deleted: boolean, active: boolean, attrib: { fullName: string | null } } | null, files: Array<{ id: string, name: string | null, size: string, mime: string | null }>, origin: { id: string, name: string, label: string | null, type: string } | null, reactions: Array<{ fullName: string | null, userName: string, reaction: string, timestamp: unknown }>, version: { thumbnailHash: string, attrib: { comment: string | null } } | null };
+export type ActivityFragmentFragment = { activityId: string, activityType: string, activityData: string, referenceType: string, referenceId: string, entityId: string | null, body: string, createdAt: unknown, updatedAt: unknown, author: { name: string, deleted: boolean, active: boolean, attrib: { fullName: string | null } } | null, files: Array<{ id: string, name: string | null, size: string, mime: string | null }>, origin: { id: string, name: string, label: string | null, type: string } | null, reactions: Array<{ fullName: string | null, userName: string, reaction: string, timestamp: unknown }>, version: { thumbnailHash: string, status: string, attrib: { comment: string | null } } | null };
 
 export type GetActivitiesByIdQueryVariables = Exact<{
   projectName: string;
@@ -1750,7 +1750,7 @@ export type GetActivitiesByIdQueryVariables = Exact<{
 }>;
 
 
-export type GetActivitiesByIdQuery = { project: { name: string, activities: { pageInfo: { hasPreviousPage: boolean, hasNextPage: boolean, startCursor: string | null, endCursor: string | null }, edges: Array<{ cursor: string | null, node: { activityId: string, activityType: string, activityData: string, referenceType: string, referenceId: string, entityId: string | null, body: string, createdAt: unknown, updatedAt: unknown, author: { name: string, deleted: boolean, active: boolean, attrib: { fullName: string | null } } | null, files: Array<{ id: string, name: string | null, size: string, mime: string | null }>, origin: { id: string, name: string, label: string | null, type: string } | null, reactions: Array<{ fullName: string | null, userName: string, reaction: string, timestamp: unknown }>, version: { thumbnailHash: string, attrib: { comment: string | null } } | null } }> } } };
+export type GetActivitiesByIdQuery = { project: { name: string, activities: { pageInfo: { hasPreviousPage: boolean, hasNextPage: boolean, startCursor: string | null, endCursor: string | null }, edges: Array<{ cursor: string | null, node: { activityId: string, activityType: string, activityData: string, referenceType: string, referenceId: string, entityId: string | null, body: string, createdAt: unknown, updatedAt: unknown, author: { name: string, deleted: boolean, active: boolean, attrib: { fullName: string | null } } | null, files: Array<{ id: string, name: string | null, size: string, mime: string | null }>, origin: { id: string, name: string, label: string | null, type: string } | null, reactions: Array<{ fullName: string | null, userName: string, reaction: string, timestamp: unknown }>, version: { thumbnailHash: string, status: string, attrib: { comment: string | null } } | null } }> } } };
 
 export type GetActivityUsersQueryVariables = Exact<{
   projects?: Array<string> | string | null | undefined;
@@ -1773,7 +1773,7 @@ export type GetActivitiesQueryVariables = Exact<{
 }>;
 
 
-export type GetActivitiesQuery = { project: { name: string, activities: { pageInfo: { hasPreviousPage: boolean, hasNextPage: boolean, startCursor: string | null, endCursor: string | null }, edges: Array<{ cursor: string | null, node: { activityId: string, activityType: string, activityData: string, referenceType: string, referenceId: string, entityId: string | null, body: string, createdAt: unknown, updatedAt: unknown, author: { name: string, deleted: boolean, active: boolean, attrib: { fullName: string | null } } | null, files: Array<{ id: string, name: string | null, size: string, mime: string | null }>, origin: { id: string, name: string, label: string | null, type: string } | null, reactions: Array<{ fullName: string | null, userName: string, reaction: string, timestamp: unknown }>, version: { thumbnailHash: string, attrib: { comment: string | null } } | null } }> } } };
+export type GetActivitiesQuery = { project: { name: string, activities: { pageInfo: { hasPreviousPage: boolean, hasNextPage: boolean, startCursor: string | null, endCursor: string | null }, edges: Array<{ cursor: string | null, node: { activityId: string, activityType: string, activityData: string, referenceType: string, referenceId: string, entityId: string | null, body: string, createdAt: unknown, updatedAt: unknown, author: { name: string, deleted: boolean, active: boolean, attrib: { fullName: string | null } } | null, files: Array<{ id: string, name: string | null, size: string, mime: string | null }>, origin: { id: string, name: string, label: string | null, type: string } | null, reactions: Array<{ fullName: string | null, userName: string, reaction: string, timestamp: unknown }>, version: { thumbnailHash: string, status: string, attrib: { comment: string | null } } | null } }> } } };
 
 export type GetEntitiesChecklistsQueryVariables = Exact<{
   projectName: string;
@@ -1957,7 +1957,7 @@ export type GetTasksByParentQueryVariables = Exact<{
 }>;
 
 
-export type GetTasksByParentQuery = { project: { name: string, tasks: { edges: Array<{ node: { id: string, folderId: string, label: string | null, name: string, ownAttrib: Array<string>, status: string, tags: Array<string>, taskType: string, updatedAt: unknown, createdAt: unknown, thumbnailHash: string, active: boolean, assignees: Array<string>, allAttrib: string, hasReviewables: boolean, parents: Array<string>, subtasks: Array<{ id: string, name: string, label: string, assignees: Array<string>, description: string | null, startDate: unknown, endDate: unknown, isDone: boolean }>, latestComments?: Array<{ activityId: string, body: string, author: string | null, createdAt: string }> | null, folder: { folderType: string, taskCount: number } } }>, pageInfo: { hasNextPage: boolean, endCursor: string | null } } } };
+export type GetTasksByParentQuery = { project: { name: string, tasks: { edges: Array<{ node: { id: string, folderId: string, label: string | null, name: string, ownAttrib: Array<string>, status: string, tags: Array<string>, taskType: string, updatedAt: unknown, createdAt: unknown, thumbnailHash: string, active: boolean, assignees: Array<string>, allAttrib: string, hasReviewables: boolean, parents: Array<string>, subtasks: Array<{ id: string, name: string, label: string, assignees: Array<string>, description: string | null, startDate: unknown, endDate: unknown, isDone: boolean }>, latestComments?: Array<{ activityId: string, body: string, author: string | null, createdAt: string }> | null, folder: { folderType: string } } }>, pageInfo: { hasNextPage: boolean, endCursor: string | null } } } };
 
 export type GetTasksListQueryVariables = Exact<{
   projectName: string;
@@ -1976,11 +1976,11 @@ export type GetTasksListQueryVariables = Exact<{
 }>;
 
 
-export type GetTasksListQuery = { project: { name: string, tasks: { pageInfo: { startCursor: string | null, endCursor: string | null, hasNextPage: boolean, hasPreviousPage: boolean }, edges: Array<{ cursor: string | null, node: { id: string, folderId: string, label: string | null, name: string, ownAttrib: Array<string>, status: string, tags: Array<string>, taskType: string, updatedAt: unknown, createdAt: unknown, thumbnailHash: string, active: boolean, assignees: Array<string>, allAttrib: string, hasReviewables: boolean, parents: Array<string>, subtasks: Array<{ id: string, name: string, label: string, assignees: Array<string>, description: string | null, startDate: unknown, endDate: unknown, isDone: boolean }>, latestComments?: Array<{ activityId: string, body: string, author: string | null, createdAt: string }> | null, folder: { folderType: string, taskCount: number } } }> } } };
+export type GetTasksListQuery = { project: { name: string, tasks: { pageInfo: { startCursor: string | null, endCursor: string | null, hasNextPage: boolean, hasPreviousPage: boolean }, edges: Array<{ cursor: string | null, node: { id: string, folderId: string, label: string | null, name: string, ownAttrib: Array<string>, status: string, tags: Array<string>, taskType: string, updatedAt: unknown, createdAt: unknown, thumbnailHash: string, active: boolean, assignees: Array<string>, allAttrib: string, hasReviewables: boolean, parents: Array<string>, subtasks: Array<{ id: string, name: string, label: string, assignees: Array<string>, description: string | null, startDate: unknown, endDate: unknown, isDone: boolean }>, latestComments?: Array<{ activityId: string, body: string, author: string | null, createdAt: string }> | null, folder: { folderType: string } } }> } } };
 
 export type SubTaskFragmentFragment = { id: string, name: string, label: string, assignees: Array<string>, description: string | null, startDate: unknown, endDate: unknown, isDone: boolean };
 
-export type TaskPropsFragmentFragment = { id: string, folderId: string, label: string | null, name: string, ownAttrib: Array<string>, status: string, tags: Array<string>, taskType: string, updatedAt: unknown, createdAt: unknown, thumbnailHash: string, active: boolean, assignees: Array<string>, allAttrib: string, hasReviewables: boolean, parents: Array<string>, subtasks: Array<{ id: string, name: string, label: string, assignees: Array<string>, description: string | null, startDate: unknown, endDate: unknown, isDone: boolean }>, latestComments?: Array<{ activityId: string, body: string, author: string | null, createdAt: string }> | null, folder: { folderType: string, taskCount: number } };
+export type TaskPropsFragmentFragment = { id: string, folderId: string, label: string | null, name: string, ownAttrib: Array<string>, status: string, tags: Array<string>, taskType: string, updatedAt: unknown, createdAt: unknown, thumbnailHash: string, active: boolean, assignees: Array<string>, allAttrib: string, hasReviewables: boolean, parents: Array<string>, subtasks: Array<{ id: string, name: string, label: string, assignees: Array<string>, description: string | null, startDate: unknown, endDate: unknown, isDone: boolean }>, latestComments?: Array<{ activityId: string, body: string, author: string | null, createdAt: string }> | null, folder: { folderType: string } };
 
 export type GetFolderProductsQueryVariables = Exact<{
   projectName: string;
@@ -2279,6 +2279,7 @@ export const ActivityFragmentFragmentDoc = new TypedDocumentString(`
   }
   version {
     thumbnailHash
+    status
     attrib {
       comment
     }
@@ -2501,7 +2502,6 @@ export const TaskPropsFragmentFragmentDoc = new TypedDocumentString(`
   }
   folder {
     folderType
-    taskCount
   }
 }
     fragment SubTaskFragment on SubTaskNode {
@@ -2783,6 +2783,7 @@ export const GetActivitiesByIdDocument = new TypedDocumentString(`
   }
   version {
     thumbnailHash
+    status
     attrib {
       comment
     }
@@ -2870,6 +2871,7 @@ export const GetActivitiesDocument = new TypedDocumentString(`
   }
   version {
     thumbnailHash
+    status
     attrib {
       comment
     }
@@ -3525,7 +3527,6 @@ fragment TaskPropsFragment on TaskNode {
   }
   folder {
     folderType
-    taskCount
   }
 }`);
 export const GetTasksListDocument = new TypedDocumentString(`
@@ -3598,7 +3599,6 @@ fragment TaskPropsFragment on TaskNode {
   }
   folder {
     folderType
-    taskCount
   }
 }`);
 export const GetFolderProductsDocument = new TypedDocumentString(`

--- a/shared/src/api/queries/activities/getActivities.ts
+++ b/shared/src/api/queries/activities/getActivities.ts
@@ -6,7 +6,7 @@ import {
   GetActivityUsersQuery,
   GetEntitiesChecklistsQuery,
 } from '@shared/api/generated'
-import { taskProvideTags } from './util/activitiesHelpers'
+import { provideSharedActivityTags, taskProvideTags } from './util/activitiesHelpers'
 import {
   ActivitiesResult,
   countChecklists,
@@ -43,28 +43,7 @@ const enhanceActivitiesApi = gqlApi.enhanceEndpoints<TagTypes, UpdatedDefinition
     GetActivities: {
       transformResponse: (res: GetActivitiesQuery) =>
         transformActivityData(res.project.activities.edges, res.project.activities.pageInfo),
-      // @ts-expect-error - filter is not an query arg
-      providesTags: (result, _e, { entityIds, activityTypes = [], filter }) =>
-        result
-          ? [
-              ...result.activities.map((a) => ({ type: 'activity', id: a.activityId })),
-              { type: 'activity', id: 'LIST' },
-              ...(Array.isArray(entityIds) ? entityIds : [entityIds]).map((id) => ({
-                type: 'entityActivities',
-                id: id,
-              })),
-              { type: 'entityActivities', id: 'LIST' },
-              ...(Array.isArray(activityTypes) ? activityTypes : [activityTypes])?.map((type) => ({
-                type: 'entityActivities',
-                id: type as string,
-              })),
-              // filter is used when a comment is made, to refetch the activities of other filters
-              ...(Array.isArray(entityIds) ? entityIds : [entityIds]).map((id) => ({
-                type: 'entityActivities',
-                id: id + '-' + filterKey(filter),
-              })),
-            ]
-          : [{ type: 'activity', id: 'LIST' }],
+     providesTags: provideSharedActivityTags, 
     },
     GetActivitiesById: {
       transformResponse: (res: GetActivitiesByIdQuery) =>
@@ -94,13 +73,18 @@ const enhanceActivitiesApi = gqlApi.enhanceEndpoints<TagTypes, UpdatedDefinition
   },
 })
 
+export type GetActivitiesInfiniteQueryArgs = Omit<
+  GetActivitiesQueryVariables,
+  'last' | 'first' | 'cursor'
+> & { filter?: any }
+
 const ACTIVITIES_INFINITE_QUERY_COUNT = 30
 
 const getActivitiesGQLApi = enhanceActivitiesApi.injectEndpoints({
   endpoints: (build) => ({
     getActivitiesInfinite: build.infiniteQuery<
       ActivitiesResult,
-      Omit<GetActivitiesQueryVariables, 'last' | 'first' | 'cursor'> & { filter?: any },
+      GetActivitiesInfiniteQueryArgs,
       { cursor: string; first?: number; last?: number }
     >({
       infiniteQueryOptions: {
@@ -168,31 +152,7 @@ const getActivitiesGQLApi = enhanceActivitiesApi.injectEndpoints({
           gqlApi: enhanceActivitiesApi,
         })
       },
-      providesTags: (result, _e, { entityIds, activityTypes, filter }) =>
-        result
-          ? [
-              ...result.pages
-                .flatMap((page) => page.activities)
-                .map((a) => ({ type: 'activity', id: a.activityId })),
-              { type: 'activity', id: 'LIST' },
-              ...(Array.isArray(entityIds) ? entityIds : [entityIds]).filter(Boolean).map((id) => ({
-                type: 'entityActivities',
-                id: id as string,
-              })),
-              { type: 'entityActivities', id: 'LIST' },
-              ...(Array.isArray(activityTypes) ? activityTypes : [activityTypes])
-                ?.filter(Boolean)
-                .map((type) => ({
-                  type: 'entityActivities',
-                  id: type as string,
-                })),
-              // filter is used when a comment is made, to refetch the activities of other filters
-              ...(Array.isArray(entityIds) ? entityIds : [entityIds]).filter(Boolean).map((id) => ({
-                type: 'entityActivities',
-                id: `${id}-${filterKey(filter)}`,
-              })),
-            ]
-          : [{ type: 'activity', id: 'LIST' }],
+providesTags: provideSharedActivityTags,
     }),
     // get data for a reference tooltip based on type,id and projectName
     getEntityTooltip: build.query({

--- a/shared/src/api/queries/activities/gql/ActivityFragment.graphql
+++ b/shared/src/api/queries/activities/gql/ActivityFragment.graphql
@@ -36,6 +36,7 @@ fragment ActivityFragment on ActivityNode {
   }
   version {
     thumbnailHash
+    status
     attrib {
       comment
     }

--- a/shared/src/api/queries/activities/util/activitiesHelpers.ts
+++ b/shared/src/api/queries/activities/util/activitiesHelpers.ts
@@ -5,7 +5,6 @@ import type {
 } from '@shared/api/generated'
 import { ChecklistCount, FeedActivity, FeedActivityData } from '../types'
 import { BaseTypes, EntityTooltipQuery, TaskTypes, VersionTypes } from '../activityQueries'
-import { GetActivitiesInfiniteQueryArgs } from '../getActivities'
 
 // Helper function to get a nested property of an object using a string path
 const getNestedProperty = <T extends Record<string, any>, R = any>(

--- a/shared/src/api/queries/activities/util/activitiesHelpers.ts
+++ b/shared/src/api/queries/activities/util/activitiesHelpers.ts
@@ -5,6 +5,7 @@ import type {
 } from '@shared/api/generated'
 import { ChecklistCount, FeedActivity, FeedActivityData } from '../types'
 import { BaseTypes, EntityTooltipQuery, TaskTypes, VersionTypes } from '../activityQueries'
+import { GetActivitiesInfiniteQueryArgs } from '../getActivities'
 
 // Helper function to get a nested property of an object using a string path
 const getNestedProperty = <T extends Record<string, any>, R = any>(
@@ -228,6 +229,64 @@ export const filterKey = (filter: any): string => {
   } catch {
     return ''
   }
+}
+
+/**
+ * Shared helper to generate activity tags for both standard and infinite queries.
+ */
+export const provideSharedActivityTags = (
+  result: { activities?: any[]; pages?: Array<{ activities: any[] }> } | undefined,
+  _error: unknown,
+  // Widened type signatures to allow string[] | string | null | undefined
+  arg: {
+    entityIds?: string | string[] | null
+    activityTypes?: string | string[] | null
+    filter?: any
+  },
+) => {
+  if (!result) {
+    return [{ type: 'activity' as const, id: 'LIST' }]
+  }
+
+  const { entityIds, activityTypes, filter } = arg
+
+  // Helper now safely skips null/undefined values
+  const normalizeIds = (ids: unknown): string[] =>
+    (Array.isArray(ids) ? ids : [ids]).filter(Boolean) as string[]
+
+  const cleanEntityIds = normalizeIds(entityIds)
+  const cleanActivityTypes = normalizeIds(activityTypes)
+
+  const activities = result.pages
+    ? result.pages.flatMap((page) => page.activities)
+    : result.activities || []
+
+  return [
+    // Individual Activity Tags
+    ...activities.map((a) => ({ type: 'activity' as const, id: a.activityId })),
+    { type: 'activity' as const, id: 'LIST' },
+
+    // Base Entity Activity Tags
+    ...cleanEntityIds.map((id) => ({ type: 'entityActivities' as const, id })),
+    { type: 'entityActivities' as const, id: 'LIST' },
+
+    // Activity Type Tags
+    ...cleanActivityTypes.map((type) => ({ type: 'entityActivities' as const, id: type })),
+
+    // Filtered Entity Activity Tags
+    ...cleanEntityIds.map((id) => ({
+      type: 'entityActivities' as const,
+      id: `${id}-${filterKey(filter)}`,
+    })),
+
+    // Published Version Tags
+    ...activities
+      .filter((a) => a.activityType === 'version.publish')
+      .map((a) => ({
+        type: 'entityActivities' as const,
+        id: `version.publish-${a.origin.id}`,
+      })),
+  ]
 }
 
 export const filterActivityTypes: Record<string, string[]> = {

--- a/shared/src/api/queries/activities/util/activityRealtimeHandler.ts
+++ b/shared/src/api/queries/activities/util/activityRealtimeHandler.ts
@@ -275,8 +275,30 @@ export const handleActivityRealtimeUpdates = async (
             } else {
               console.warn('[Activity RT] Cannot add activity: no pages or activities array')
             }
-          } else if (!existingActivityFound) {
-          } else {
+          }
+
+          // If this is a status change, update any version.publish activities in the cache
+          if (
+            newActivity.activityType === 'status.change' &&
+            newActivity.origin?.type === 'version'
+          ) {
+            const versionId = newActivity.origin.id
+            const newStatus = newActivity.activityData?.newValue
+            if (newStatus) {
+              draft.pages.forEach((page) => {
+                page.activities?.forEach((activity) => {
+                  if (
+                    activity.activityType === 'version.publish' &&
+                    activity.origin?.id === versionId
+                  ) {
+                    if (!activity.version) {
+                      activity.version = {} as any
+                    }
+                    activity.version!.status = newStatus
+                  }
+                })
+              })
+            }
           }
         })
       } catch (error) {

--- a/shared/src/api/queries/entities/updateEntity.ts
+++ b/shared/src/api/queries/entities/updateEntity.ts
@@ -369,12 +369,6 @@ const updateEntity = api.injectEndpoints({
             throw 'Failed to update some tasks'
           }
 
-          const activityTags = []
-
-          if (activityTags.length) {
-            dispatch(api.util.invalidateTags(activityTags))
-          }
-
           return { data: operations }
         } catch (error) {
           console.error(error)
@@ -391,6 +385,13 @@ const updateEntity = api.injectEndpoints({
         if (entityType === 'version') {
           tags.push({ type: 'version', id: 'LIST' }, { type: 'product', id: 'LIST' })
           operations.forEach((o) => tags.push({ type: 'version', id: o.id }))
+          if (operations.some((o) => !!o.data.status)) {
+            console.log('invalidate version.publish activities')
+            // invalidate feeds with that version in it (published versions activity)
+            operations.forEach((o) =>
+              tags.push({ type: 'entityActivities', id: `version.publish-${o.id}` }),
+            )
+          }
         }
 
         return tags

--- a/shared/src/containers/Feed/components/ActivityItem.tsx
+++ b/shared/src/containers/Feed/components/ActivityItem.tsx
@@ -63,7 +63,7 @@ const ActivityItem: React.FC<ActivityItemProps> = ({
     case 'assignee.remove':
       return <ActivityAssigneeChange activity={activity} {...props} />
     case 'version.publish':
-      return <ActivityVersions {...{ activity, projectInfo, filter }} {...props} />
+      return <ActivityVersions {...{ activity, projectInfo, filter, statuses }} {...props} />
     case 'version.review':
       return <ActivityVersionReview activity={activity} isGuest={isGuest} {...props} />
     case 'group':

--- a/shared/src/containers/Feed/components/ActivityStatusChange/ActivityStatusChange.tsx
+++ b/shared/src/containers/Feed/components/ActivityStatusChange/ActivityStatusChange.tsx
@@ -3,6 +3,7 @@ import * as Styled from './ActivityStatusChange.styled'
 import ActivityDate from '../ActivityDate'
 import { Icon } from '@ynput/ayon-react-components'
 import useGetContextParents from './hooks/getContextParents'
+import { ActivityStatusSecondary } from './ActivityStatusSecondary'
 
 interface StatusInfo {
   icon?: string
@@ -34,11 +35,17 @@ const ActivityStatusChange: React.FC<ActivityStatusChangeProps> = ({
       <Styled.Body>
         <Styled.Text>{authorFullName || authorName}</Styled.Text>
         <Styled.Text>- {tagList.join(' / ')} -</Styled.Text>
-        {oldStatus.icon && <Icon icon={oldStatus.icon} style={{ color: oldStatus.color }} />}
-        <Styled.Text>{oldStatus.name}</Styled.Text>
+        <ActivityStatusSecondary
+          icon={oldStatus.icon}
+          color={oldStatus.color}
+          name={oldStatus.name || ''}
+        />
         <Icon icon="trending_flat" />
-        {newStatus.icon && <Icon icon={newStatus.icon} style={{ color: newStatus.color }} />}
-        <Styled.Text>{newStatus.name}</Styled.Text>
+        <ActivityStatusSecondary
+          icon={newStatus.icon}
+          color={newStatus.color}
+          name={newStatus.name || ''}
+        />
       </Styled.Body>
       <ActivityDate date={createdAt} />
     </Styled.StatusChange>

--- a/shared/src/containers/Feed/components/ActivityStatusChange/ActivityStatusSecondary.tsx
+++ b/shared/src/containers/Feed/components/ActivityStatusChange/ActivityStatusSecondary.tsx
@@ -1,0 +1,32 @@
+import { Icon } from '@ynput/ayon-react-components';
+import { forwardRef } from 'react';
+import styled from 'styled-components';
+import { Body } from './ActivityStatusChange.styled';
+
+const StatusText = styled.span`
+      color: var(--md-sys-color-outline);
+  white-space: nowrap;
+  font-size: 12px;
+
+  strong {
+    font-size: 12px;
+    font-weight: 800;
+  }
+`
+
+interface ActivityStatusSecondaryProps extends React.HTMLAttributes<HTMLDivElement> {
+    icon?: string;
+    color?: string;
+    name: string;
+}
+
+export const ActivityStatusSecondary = forwardRef<HTMLDivElement, ActivityStatusSecondaryProps>(({ 
+icon, color, name,
+    ...props }, ref) => {
+  return (
+    <Body {...props} ref={ref}>
+            {icon && <Icon icon={icon} style={{ color: color }} />}
+            <StatusText>{name}</StatusText>
+    </Body>
+  );
+});

--- a/shared/src/containers/Feed/components/ActivityVersions/ActivityVersions.tsx
+++ b/shared/src/containers/Feed/components/ActivityVersions/ActivityVersions.tsx
@@ -5,6 +5,9 @@ import * as Styled from './ActivityVersions.styled'
 import { More } from '../ActivityGroup/ActivityGroup.styled'
 import ActivityDate from '../ActivityDate'
 import { useDetailsPanelContext } from '@shared/context'
+import ActivityStatus from '../ActivityStatus/ActivityStatus'
+import { Status } from '@shared/api'
+import { ActivityStatusSecondary } from '../ActivityStatusChange/ActivityStatusSecondary'
 
 interface Version {
   name: string
@@ -14,6 +17,7 @@ interface Version {
   updatedAt: string
   thumbnailHash?: string
   comment?: string
+  status: string
 }
 
 interface ActivityVersionsProps {
@@ -28,6 +32,7 @@ interface ActivityVersionsProps {
   entityType?: string
   onReferenceClick?: (ref: any) => void
   filter?: any
+  statuses: Status[]
 }
 
 const ActivityVersions: React.FC<ActivityVersionsProps> = ({
@@ -36,6 +41,7 @@ const ActivityVersions: React.FC<ActivityVersionsProps> = ({
   entityType,
   onReferenceClick,
   filter,
+  statuses = [],
 }) => {
   const { onOpenViewer } = useDetailsPanelContext()
   let { authorName, authorFullName, createdAt, versions = [] } = activity
@@ -67,6 +73,7 @@ const ActivityVersions: React.FC<ActivityVersionsProps> = ({
       />
       {versions.flatMap((version, index) => {
         const { name, id, productId, productName, thumbnailHash, comment } = version
+        const status = statuses.find((s) => s.name === version.status)
         return (
           (index < limit || showAll) && (
             <Styled.Card onClick={() => handleClick(id, productId)} key={id}>
@@ -76,7 +83,14 @@ const ActivityVersions: React.FC<ActivityVersionsProps> = ({
                     <span>{productName}</span>
                     <ActivityDate date={createdAt} isExact />
                   </Styled.Title>
-                  <Styled.VersionName className="version">{name}</Styled.VersionName>
+                  <Styled.Title>
+                    <Styled.VersionName className="version">{name}</Styled.VersionName> -
+                    <ActivityStatusSecondary
+                      icon={status?.icon}
+                      color={status?.color}
+                      name={status?.name || ''}
+                    />
+                  </Styled.Title>
                 </div>
                 <Styled.Thumbnail
                   {...{ projectName }}

--- a/shared/src/containers/Feed/components/ActivityVersions/ActivityVersions.tsx
+++ b/shared/src/containers/Feed/components/ActivityVersions/ActivityVersions.tsx
@@ -5,7 +5,6 @@ import * as Styled from './ActivityVersions.styled'
 import { More } from '../ActivityGroup/ActivityGroup.styled'
 import ActivityDate from '../ActivityDate'
 import { useDetailsPanelContext } from '@shared/context'
-import ActivityStatus from '../ActivityStatus/ActivityStatus'
 import { Status } from '@shared/api'
 import { ActivityStatusSecondary } from '../ActivityStatusChange/ActivityStatusSecondary'
 

--- a/shared/src/containers/Feed/helpers/groupActivityVersions.ts
+++ b/shared/src/containers/Feed/helpers/groupActivityVersions.ts
@@ -22,6 +22,7 @@ const activityToVersionItem = (activity: any = {}) => {
     updatedAt,
     createdAt,
     comment: version?.attrib?.comment || null,
+    status: version?.status,
     thumbnailHash: version?.thumbnailHash,
   }
 }


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
The version activity type now shows the status of the version. 

Currently it's not editable and we have used the secondary status style to show this.

The status should update in the feed if the version status is changed elsewhere.


<img width="628" height="251" alt="image" src="https://github.com/user-attachments/assets/bafeafa2-b909-47b3-89bd-94ab678b5899" />


