### PR TITLE
YN-0719: Inbox: Select multiple messages at once

### DIFF
--- a/src/pages/InboxPage/Inbox/Inbox.tsx
+++ b/src/pages/InboxPage/Inbox/Inbox.tsx
@@ -426,7 +426,11 @@ const Inbox = ({ filter }: InboxProps) => {
 
     // keep the multi-selection when right-clicking a row that is part of it
     const isMulti = selected.length > 1 && selected.includes(id)
-    if (!isMulti) setSelected([id])
+    if (!isMulti) {
+      setSelected([id])
+      // move the shift-range anchor to the right-clicked row so a following shift-select is correct
+      lastSelectedIndexRef.current = groupedMessages.findIndex((m) => m.activityId === id)
+    }
 
     // open context menu
     ctxMenuShow(e, contextMenu(id, isMulti))

--- a/src/pages/InboxPage/Inbox/Inbox.tsx
+++ b/src/pages/InboxPage/Inbox/Inbox.tsx
@@ -33,6 +33,7 @@ import type {
   GroupedMessage,
   PlaceholderMessage,
   InboxContextMenuItem,
+  SelectModifiers,
 } from '../types'
 import type { InboxMessage as InboxMessageType } from '@/services/inbox/inboxTransform'
 
@@ -116,9 +117,8 @@ const Inbox = ({ filter }: InboxProps) => {
   // group messages of same entity and type together
   const groupedMessages = useGroupMessages({ messages: messagesSortedByDate, currentUser: user })
 
-  // single select only allow but multi select is possible
-  // it always seems to become multi select so i'll just support it from the start
   const [selected, setSelected] = useState<string[]>([])
+  const lastSelectedIndexRef = useRef<number>(-1)
 
   const listRef = useRef<HTMLUListElement>(null)
 
@@ -126,6 +126,8 @@ const Inbox = ({ filter }: InboxProps) => {
   // we do this so that keyboard navigation works right away
   useEffect(() => {
     setSelected([])
+    // reset the shift-range anchor so it can't point at a stale row in the new list
+    lastSelectedIndexRef.current = -1
     if (!listRef.current || isLoadingInbox) return
 
     const firstChild = listRef.current?.firstElementChild as HTMLElement | null
@@ -152,23 +154,41 @@ const Inbox = ({ filter }: InboxProps) => {
     )
   }
 
-  const handleMessageSelect = async (id: string, ids: string[] = []): Promise<void> => {
+  const handleMessageSelect = (
+    id: string,
+    ids: string[] = [],
+    modifiers?: SelectModifiers,
+    rowIndex?: number,
+  ): void => {
     if (id.includes('placeholder')) return
-    // if the message is already selected, deselect it
-    let newSelection = []
-    if (selected.includes(id)) {
-      newSelection = selected.filter((s) => s !== id)
-      setSelected(newSelection)
-      return
+
+    // mouse/keyboard pass rowIndex; programmatic calls resolve it from the list
+    const currentIndex =
+      rowIndex !== undefined ? rowIndex : groupedMessages.findIndex((m) => m.activityId === id)
+
+    let newSelection: string[]
+    if (modifiers?.shiftKey && lastSelectedIndexRef.current >= 0) {
+      const start = Math.min(lastSelectedIndexRef.current, currentIndex)
+      const end = Math.max(lastSelectedIndexRef.current, currentIndex)
+      newSelection = groupedMessages.slice(start, end + 1).map((m) => m.activityId)
+    } else if (modifiers?.metaKey || modifiers?.ctrlKey) {
+      newSelection = selected.includes(id)
+        ? selected.filter((s) => s !== id)
+        : [...selected, id]
+      lastSelectedIndexRef.current = currentIndex
     } else {
-      newSelection = [id]
+      newSelection = selected.includes(id) ? [] : [id]
+      lastSelectedIndexRef.current = currentIndex
     }
 
-    // select the message
     setSelected(newSelection)
 
-    // get messages and check if it has been read
-    const message = groupedMessages.find((m) => m.activityId === id)
+    if (newSelection.length !== 1) {
+      setHighlightedActivities([])
+      return
+    }
+
+    const message = groupedMessages.find((m) => m.activityId === newSelection[0])
     const group = message?.messages || []
     const unReadMessages = group.filter((m) => !m.read)
     const activityIds = group.map((m) => m.activityId)
@@ -229,6 +249,51 @@ const Inbox = ({ filter }: InboxProps) => {
     clearMessages(id, group.messages, group.projectName)
   }
 
+  const getSelectedGroups = (): GroupedMessage[] =>
+    selected
+      .map((sid) => groupedMessages.find((g) => g.activityId === sid))
+      .filter((g): g is GroupedMessage => Boolean(g))
+
+  // handleUpdateMessages is per-project, so bulk actions must group referenceIds by project
+  const groupReferenceIdsByProject = (
+    groups: GroupedMessage[],
+  ): Record<string, { ids: string[]; reads: boolean[] }> => {
+    const byProject: Record<string, { ids: string[]; reads: boolean[] }> = {}
+    for (const group of groups) {
+      if (!byProject[group.projectName]) byProject[group.projectName] = { ids: [], reads: [] }
+      for (const m of group.messages) {
+        byProject[group.projectName].ids.push(m.referenceId)
+        byProject[group.projectName].reads.push(m.read)
+      }
+    }
+    return byProject
+  }
+
+  const clearSelected = (): void => {
+    const groups = getSelectedGroups()
+    if (!groups.length) return
+
+    const status = isActive ? 'inactive' : 'unread'
+    const byProject = groupReferenceIdsByProject(groups)
+    Object.entries(byProject).forEach(([projectName, { ids, reads }]) => {
+      const isRead = reads.every(Boolean)
+      handleUpdateMessages(ids, status, projectName, true, isRead)
+    })
+    setSelected([])
+    lastSelectedIndexRef.current = -1
+  }
+
+  const toggleReadSelected = (): void => {
+    const groups = getSelectedGroups()
+    if (!groups.length) return
+
+    const allRead = groups.every((g) => g.read)
+    const byProject = groupReferenceIdsByProject(groups)
+    Object.entries(byProject).forEach(([projectName, { ids }]) => {
+      handleUpdateMessages(ids, allRead ? 'unread' : 'read', projectName, false, allRead)
+    })
+  }
+
   const handleClearAll = async (): Promise<void> => {
     let promises = []
     // for all projects, clear all messages
@@ -264,6 +329,11 @@ const Inbox = ({ filter }: InboxProps) => {
   }
 
   const handleReadShortcut = (e: MouseEvent | KeyboardEvent): void => {
+    if (selected.length > 1) {
+      toggleReadSelected()
+      return
+    }
+
     const id = getHoveredMessageId(e)
     if (!id) return
 
@@ -271,6 +341,11 @@ const Inbox = ({ filter }: InboxProps) => {
   }
 
   const handleClearShortcut = (e: MouseEvent | KeyboardEvent): void => {
+    if (selected.length > 1) {
+      clearSelected()
+      return
+    }
+
     const id = getHoveredMessageId(e, '.clearable')
     if (!id) return
 
@@ -284,7 +359,29 @@ const Inbox = ({ filter }: InboxProps) => {
     }
   }
 
-  const contextMenu = (id: string): InboxContextMenuItem[] => {
+  const contextMenu = (id: string, isMulti = false): InboxContextMenuItem[] => {
+    if (isMulti) {
+      const groups = getSelectedGroups()
+      const allRead = groups.every((g) => g.read)
+      return [
+        {
+          id: 'clear',
+          label: `${isActive ? 'Clear' : 'Unclear'} ${selected.length}`,
+          icon: isActive ? 'done' : 'replay',
+          shortcut: 'c',
+          command: clearSelected,
+        },
+        {
+          id: allRead ? 'unread' : 'read',
+          label: allRead ? 'Mark as unread' : 'Mark as read',
+          icon: allRead ? 'mark_email_unread' : 'drafts',
+          disabled: !isActive,
+          shortcut: 'x',
+          command: toggleReadSelected,
+        },
+      ]
+    }
+
     // find the group message with id
     const group = groupedMessages.find((g) => g.activityId === id)
 
@@ -327,11 +424,12 @@ const Inbox = ({ filter }: InboxProps) => {
 
     if (!id) return
 
-    // update selection
-    setSelected([id])
+    // keep the multi-selection when right-clicking a row that is part of it
+    const isMulti = selected.length > 1 && selected.includes(id)
+    if (!isMulti) setSelected([id])
 
     // open context menu
-    ctxMenuShow(e, contextMenu(id))
+    ctxMenuShow(e, contextMenu(id, isMulti))
   }
 
   const shortcuts = useMemo(
@@ -394,9 +492,10 @@ const Inbox = ({ filter }: InboxProps) => {
               onKeyDown={handleKeyDown}
               className={clsx({ isLoading: isLoadingInbox })}
             >
-              {messagesData.map((group) => (
+              {messagesData.map((group, i: number) => (
                 <InboxMessage
                   key={group.activityId}
+                  rowIndex={i}
                   path={group.path}
                   type={group.activityType}
                   entityType={group.entityType ?? undefined}

--- a/src/pages/InboxPage/InboxMessage/InboxMessage.tsx
+++ b/src/pages/InboxPage/InboxMessage/InboxMessage.tsx
@@ -111,10 +111,11 @@ interface InboxMessageProps extends Omit<HTMLAttributes<HTMLLIElement>, 'onSelec
   isSelected?: boolean
   disableHover?: boolean
   isPlaceholder?: boolean
-  onSelect?: (id: string, ids: string[]) => void
+  onSelect?: (id: string, ids: string[], e: MouseEvent<HTMLLIElement>, rowIndex?:number) => void
   projectsInfo?: ProjectsInfo
   isMultiple?: boolean
   customBody?: string
+  rowIndex: number
 }
 
 const InboxMessage = ({
@@ -141,6 +142,7 @@ const InboxMessage = ({
   projectsInfo = {},
   isMultiple, // are there multiple messages in this group
   customBody, // custom body for special message types (e.g. reassignment)
+  rowIndex = 0,
   ...props
 }: InboxMessageProps) => {
   const typeIcon = useMemo(() => {
@@ -184,7 +186,7 @@ const InboxMessage = ({
       // check we are not clicking the clear button
       // use closest to check if the clear button is clicked
       if (!(e.target as HTMLElement).closest('.clear')) {
-        onSelect(id, ids)
+        onSelect(id, ids, e, rowIndex)
       }
     }
   }

--- a/src/pages/InboxPage/hooks/useKeydown.ts
+++ b/src/pages/InboxPage/hooks/useKeydown.ts
@@ -1,14 +1,16 @@
 import { useState, RefObject, KeyboardEvent, Dispatch, SetStateAction } from 'react'
-import type { GroupedMessage } from '../types'
+import type { GroupedMessage, SelectModifiers } from '../types'
 
 interface UseKeydownProps {
   messages: GroupedMessage[]
-  onChange: (id: string, ids?: string[]) => void
+  onChange: (id: string, ids?: string[], modifiers?: SelectModifiers, rowIndex?: number) => void
   selected: string[]
   listRef: RefObject<HTMLUListElement | null>
 }
 
 type UseKeydownReturn = [(e: KeyboardEvent) => void, [boolean, Dispatch<SetStateAction<boolean>>]]
+
+const MESSAGE_ID_PREFIX = 'message-'
 
 const useKeydown = ({
   messages,
@@ -19,6 +21,19 @@ const useKeydown = ({
   // is the user using the keyboard for navigation
   const [usingKeyboard, setUsingKeyboard] = useState(false)
 
+  // the moving cursor is the focused row, so mouse and keyboard stay in sync;
+  // fall back to the first selected row when nothing is focused
+  const getCurrentIndex = (): number => {
+    const active = listRef.current?.ownerDocument?.activeElement as HTMLElement | null
+    const elId = active?.id || ''
+    if (elId.startsWith(MESSAGE_ID_PREFIX)) {
+      const id = elId.slice(MESSAGE_ID_PREFIX.length)
+      const idx = messages.findIndex((m) => m.activityId === id)
+      if (idx >= 0) return idx
+    }
+    return messages.findIndex((m) => selected.includes(m.activityId))
+  }
+
   const handleKeyDown = (e: KeyboardEvent): void => {
     // if there are no messages, do nothing
     if (!messages.length) return
@@ -28,53 +43,36 @@ const useKeydown = ({
     const isUsingKeyboard = ['ArrowDown', 'ArrowUp', 'Tab'].includes(key)
     if (isUsingKeyboard) setUsingKeyboard(true)
 
-    let newSelected: string | null = null
-    // if arrow down, select next task
-    // if arrow down, select next task
+    // shift + arrow extends the selection; Tab keeps its own shift behaviour
+    const isShiftRange = e.shiftKey && (key === 'ArrowDown' || key === 'ArrowUp')
+
+    const currentIndex = getCurrentIndex()
+
+    let targetIndex: number | null = null
     if (key === 'ArrowDown' || (key === 'Tab' && !e.shiftKey)) {
-      // move to the next task
-      const currentIndex = messages.findIndex((m) => selected.includes(m.activityId))
       const nextIndex = currentIndex + 1
-      // if the next index is out of bounds, do nothing
-      if (nextIndex >= messages.length) {
-        if (key === 'Tab') {
-          // clear selected - signal with empty string
-          newSelected = ''
-        }
-        // not calling preventDefault here will allow the browser to focus the next element
-        return
-      }
+      // out of bounds: let the browser move focus to the next element
+      if (nextIndex >= messages.length) return
       e.preventDefault()
-      newSelected = messages[nextIndex].activityId
-    }
-
-    // if arrow up, select previous task
-    if (key === 'ArrowUp' || (key === 'Tab' && e.shiftKey)) {
-      // move to the previous task
-      const currentIndex = messages.findIndex((m) => selected.includes(m.activityId))
+      targetIndex = nextIndex
+    } else if (key === 'ArrowUp' || (key === 'Tab' && e.shiftKey)) {
       const previousIndex = currentIndex - 1
-      // if the previous index is out of bounds, do nothing
-      if (previousIndex < 0) {
-        if (key === 'Tab') {
-          // clear selected - signal with empty string
-          newSelected = ''
-        }
-        // not calling preventDefault here will allow the browser to focus the previous element
-        return
-      }
-
-      newSelected = messages[previousIndex].activityId
+      // out of bounds: let the browser move focus to the previous element
+      if (previousIndex < 0) return
+      e.preventDefault()
+      targetIndex = previousIndex
     }
 
-    e.preventDefault()
-    // update selected
-    if (newSelected) {
-      onChange(newSelected)
+    if (targetIndex === null) return
 
-      // set new focus to the selected task
-      const listEl = listRef.current?.querySelector(`#message-${newSelected}`) as HTMLElement | null
-      if (listEl) listEl.focus()
-    }
+    const target = messages[targetIndex]
+    onChange(target.activityId, undefined, isShiftRange ? { shiftKey: true } : undefined, targetIndex)
+
+    // move focus to the target row so the next key continues from here
+    const listEl = listRef.current?.querySelector(
+      `#${MESSAGE_ID_PREFIX}${target.activityId}`,
+    ) as HTMLElement | null
+    if (listEl) listEl.focus()
   }
 
   return [handleKeyDown, [usingKeyboard, setUsingKeyboard]] as UseKeydownReturn

--- a/src/pages/InboxPage/types.ts
+++ b/src/pages/InboxPage/types.ts
@@ -98,6 +98,13 @@ export interface InboxStatusChange {
   name?: string
 }
 
+// Modifier keys that drive multi-selection, sourced from a mouse or keyboard event
+export interface SelectModifiers {
+  shiftKey?: boolean
+  metaKey?: boolean
+  ctrlKey?: boolean
+}
+
 // Message selection handler type
 export type MessageSelectHandler = (id: string, ids?: string[]) => void
 


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Adds multi-selection to the inbox so messages can be cleared or marked as read in bulk. Supports ctrl/cmd toggle and shift range, with both mouse and keyboard.

## Technical details
<!-- Please state any technical details such as limitations -->

- `handleMessageSelect` handles single / ctrl-cmd toggle / shift-range, anchored by `lastSelectedIndexRef` (Inbox.tsx).
- `clearSelected` + `toggleReadSelected` group referenceIds by project, one mutation per project.
- `c` / `x` shortcuts and context menu act on the whole selection when more than one is selected.
- `useKeydown` shift+arrow extends the range; cursor derived from the focused row.
- Details panel stays single-select only (renders first selected), per ticket scope.

## Additional context
<!-- Add any other context or screenshots here. -->

Closes #1970 · YN-0719

https://github.com/user-attachments/assets/57b2de17-1bbf-46dd-8b01-d907ef44ddb4


