### PR TITLE
Summaries: Show selected count in name summary column

### DIFF
--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ynput/ayon-frontend-shared",
-  "version": "0.3.43",
+  "version": "0.3.44",
   "description": "Shared React components for AYON frontend",
   "main": "dist/index.cjs.js",
   "module": "dist/index.es.js",

--- a/shared/src/containers/ProjectTreeTable/ProjectTreeTable.tsx
+++ b/shared/src/containers/ProjectTreeTable/ProjectTreeTable.tsx
@@ -632,19 +632,23 @@ export const ProjectTreeTable = ({
   // render yet). Stats loading is handled per-cell so the footer stays clickable.
   const footerModuleLoading = isFooterModuleLoading || !isFooterLoaded
 
-  // Unique entity rows across all selected cells (any column), for the footer's
-  // "N selected" count. Mirrors the context menu's row count (group headers
-  // excluded); the checkbox-only `selectedRows` would undercount cell selections.
+  // Unique selected entities for the footer's "N selected" count, deduped by
+  // entityId (group headers / load-more rows excluded). Marked cells win: when
+  // any cell is selected we count only those and ignore checkbox row-selection;
+  // whole-row selection counts on its own.
   const selectedRowCount = useMemo(() => {
-    const entityIds = new Set<string>()
+    const cellEntities = new Set<string>()
+    const rowEntities = new Set<string>()
     for (const cellId of selectedCells) {
-      const rowId = parseCellId(cellId)?.rowId
+      const { rowId, colId } = parseCellId(cellId) || {}
       if (!rowId || isGroupId(rowId)) continue
 
-      const entity = getEntityById(rowId)
-      if (entity?.entityId) entityIds.add(entity.entityId)
+      const id = getEntityById(rowId)?.entityId
+      if (!id) continue
+      if (colId === ROW_SELECTION_COLUMN_ID) rowEntities.add(id)
+      else cellEntities.add(id)
     }
-    return entityIds.size
+    return cellEntities.size || rowEntities.size
   }, [selectedCells, getEntityById])
   // only show the upsell once the license check resolves, so licensed users
   // don't see the bolt flash before the addon loads

--- a/shared/src/containers/ProjectTreeTable/ProjectTreeTable.tsx
+++ b/shared/src/containers/ProjectTreeTable/ProjectTreeTable.tsx
@@ -65,6 +65,7 @@ import { useMoveEntities } from './hooks/useMoveEntities'
 import { useProjectDataContext } from '@shared/containers'
 
 // Utility function imports
+import { isGroupId } from './hooks/useBuildGroupByTableData'
 import { CellId, getCellId, parseCellId } from './utils/cellUtils'
 import { generateLoadingRows, generateDummyAttributes } from './utils/loadingUtils'
 import { isEntityRestricted, isTargetReadOnly } from './utils/restrictedEntity'
@@ -630,6 +631,18 @@ export const ProjectTreeTable = ({
   // Full skeleton only while the remote module itself is loading (no cell to
   // render yet). Stats loading is handled per-cell so the footer stays clickable.
   const footerModuleLoading = isFooterModuleLoading || !isFooterLoaded
+
+  // Unique entity rows across all selected cells (any column), for the footer's
+  // "N selected" count. Mirrors the context menu's row count (group headers
+  // excluded); the checkbox-only `selectedRows` would undercount cell selections.
+  const selectedRowCount = useMemo(() => {
+    const rowIds = new Set<string>()
+    for (const cellId of selectedCells) {
+      const rowId = parseCellId(cellId)?.rowId
+      if (rowId && !isGroupId(rowId)) rowIds.add(rowId)
+    }
+    return rowIds.size
+  }, [selectedCells])
   // only show the upsell once the license check resolves, so licensed users
   // don't see the bolt flash before the addon loads
   // const showSummaryPowerFeature = !isLicenseLoading && !powerLicense
@@ -825,6 +838,7 @@ export const ProjectTreeTable = ({
                     mainCountLabels={mainCountLabels}
                     fieldOptions={options}
                     parentScopeApplicable={parentScopeApplicable}
+                    selectedCount={selectedRowCount}
                   />
                 )}
                 // Power feature cell for community users (hidden for now), shows a bolt hint in the name column:

--- a/shared/src/containers/ProjectTreeTable/ProjectTreeTable.tsx
+++ b/shared/src/containers/ProjectTreeTable/ProjectTreeTable.tsx
@@ -636,13 +636,16 @@ export const ProjectTreeTable = ({
   // "N selected" count. Mirrors the context menu's row count (group headers
   // excluded); the checkbox-only `selectedRows` would undercount cell selections.
   const selectedRowCount = useMemo(() => {
-    const rowIds = new Set<string>()
+    const entityIds = new Set<string>()
     for (const cellId of selectedCells) {
       const rowId = parseCellId(cellId)?.rowId
-      if (rowId && !isGroupId(rowId)) rowIds.add(rowId)
+      if (!rowId || isGroupId(rowId)) continue
+
+      const entity = getEntityById(rowId)
+      if (entity?.entityId) entityIds.add(entity.entityId)
     }
-    return rowIds.size
-  }, [selectedCells])
+    return entityIds.size
+  }, [selectedCells, getEntityById])
   // only show the upsell once the license check resolves, so licensed users
   // don't see the bolt flash before the addon loads
   // const showSummaryPowerFeature = !isLicenseLoading && !powerLicense

--- a/shared/src/containers/ProjectTreeTable/types/index.ts
+++ b/shared/src/containers/ProjectTreeTable/types/index.ts
@@ -55,4 +55,6 @@ export interface SummaryCellContentProps {
   fieldOptions?: BuiltInFieldOptions
   // false when no parent entity (folder/product) is on screen; addon hides + disables the parent scope
   parentScopeApplicable?: boolean
+  // unique entity rows in the current selection; addon shows "N selected" in the main count cell
+  selectedCount?: number
 }


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Adds a "N selected" count to the summary footer's name column, showing how many unique entity rows are in the current cell selection.

## Technical details
<!-- Please state any technical details such as limitations -->

- New `selectedRowCount` memo in `ProjectTreeTable.tsx` counts unique row ids from `selectedCells`, skipping group headers via `isGroupId`.
- Passed as new optional `selectedCount` prop on `SummaryCellContentProps` (`types/index.ts`); the summary addon renders the label.
- Mirrors the context-menu row count; avoids the checkbox-only `selectedRows` undercount.

## Additional context
<!-- Add any other context or screenshots here. -->

Closes #2125
PowerPack PR: ynput/ayon-power-pack#79

https://github.com/user-attachments/assets/911aee80-7d69-46e2-b208-cff2cedfacee


