### PR TITLE
Review: use new reviewables endpoint for review creation

### DIFF
--- a/shared/src/api/generated/actions.ts
+++ b/shared/src/api/generated/actions.ts
@@ -26,8 +26,8 @@ const injectedRtkApi = api.injectEndpoints({
         params: {
           addonName: queryArg.addonName,
           addonVersion: queryArg.addonVersion,
-          variant: queryArg.variant,
           identifier: queryArg.identifier,
+          variant: queryArg.variant,
         },
       }),
     }),
@@ -43,8 +43,8 @@ const injectedRtkApi = api.injectEndpoints({
         params: {
           addonName: queryArg.addonName,
           addonVersion: queryArg.addonVersion,
-          variant: queryArg.variant,
           identifier: queryArg.identifier,
+          variant: queryArg.variant,
         },
       }),
     }),
@@ -75,16 +75,16 @@ export type ConfigureActionApiResponse = /** status 200 Successful Response */ o
 export type ConfigureActionApiArg = {
   addonName: string
   addonVersion: string
-  variant?: string
   identifier: string
+  variant?: string
   actionConfig: ActionConfig
 }
 export type ExecuteActionApiResponse = /** status 200 Successful Response */ ExecuteResponseModel
 export type ExecuteActionApiArg = {
   addonName: string
   addonVersion: string
-  variant?: string
   identifier: string
+  variant?: string
   'x-sender'?: string
   'x-sender-type'?: string
   actionContext: ActionContext
@@ -107,6 +107,11 @@ export type IconModel = {
   /** The URL of the icon (for type url) */
   url?: string
 }
+export type FormFileData = {
+  filename: string
+  payload: string
+  download?: boolean
+}
 export type FormSelectOption = {
   value: string
   label: string
@@ -115,11 +120,20 @@ export type FormSelectOption = {
   badges?: string[]
 }
 export type SimpleFormField = {
-  type: 'text' | 'boolean' | 'select' | 'multiselect' | 'hidden' | 'integer' | 'float' | 'label' | 'file'
+  type:
+    | 'text'
+    | 'boolean'
+    | 'select'
+    | 'multiselect'
+    | 'hidden'
+    | 'integer'
+    | 'float'
+    | 'label'
+    | 'file'
   name: string
   label?: string
   placeholder?: any
-  value?: string | number | number | boolean | string[] | number[] | number[]
+  value?: string | number | number | boolean | string[] | number[] | number[] | FormFileData
   regex?: string
   multiline?: boolean
   syntax?: string
@@ -127,7 +141,7 @@ export type SimpleFormField = {
   highlight?: 'info' | 'warning' | 'error'
   min?: number | number
   max?: number | number
-  valid_extensions?: string[]
+  validExtensions?: string[]
 }
 export type BaseActionManifest = {
   /** The identifier of the action */

--- a/shared/src/api/generated/activityFeed.ts
+++ b/shared/src/api/generated/activityFeed.ts
@@ -6,10 +6,6 @@ const injectedRtkApi = api.injectEndpoints({
         url: `/api/projects/${queryArg.projectName}/${queryArg.entityType}/${queryArg.entityId}/activities`,
         method: 'POST',
         body: queryArg.projectActivityPostModel,
-        headers: {
-          'x-sender': queryArg['x-sender'],
-          'x-sender-type': queryArg['x-sender-type'],
-        },
       }),
     }),
     deleteProjectActivity: build.mutation<
@@ -19,10 +15,6 @@ const injectedRtkApi = api.injectEndpoints({
       query: (queryArg) => ({
         url: `/api/projects/${queryArg.projectName}/activities/${queryArg.activityId}`,
         method: 'DELETE',
-        headers: {
-          'x-sender': queryArg['x-sender'],
-          'x-sender-type': queryArg['x-sender-type'],
-        },
       }),
     }),
     patchProjectActivity: build.mutation<
@@ -33,10 +25,6 @@ const injectedRtkApi = api.injectEndpoints({
         url: `/api/projects/${queryArg.projectName}/activities/${queryArg.activityId}`,
         method: 'PATCH',
         body: queryArg.activityPatchModel,
-        headers: {
-          'x-sender': queryArg['x-sender'],
-          'x-sender-type': queryArg['x-sender-type'],
-        },
       }),
     }),
     getActivityCategories: build.query<
@@ -53,10 +41,6 @@ const injectedRtkApi = api.injectEndpoints({
         url: `/api/projects/${queryArg.projectName}/activities/${queryArg.activityId}/reactions`,
         method: 'POST',
         body: queryArg.createReactionModel,
-        headers: {
-          'x-sender': queryArg['x-sender'],
-          'x-sender-type': queryArg['x-sender-type'],
-        },
       }),
     }),
     deleteReactionToActivity: build.mutation<
@@ -66,10 +50,6 @@ const injectedRtkApi = api.injectEndpoints({
       query: (queryArg) => ({
         url: `/api/projects/${queryArg.projectName}/activities/${queryArg.activityId}/reactions/${queryArg.reaction}`,
         method: 'DELETE',
-        headers: {
-          'x-sender': queryArg['x-sender'],
-          'x-sender-type': queryArg['x-sender-type'],
-        },
       }),
     }),
     suggestEntityMention: build.mutation<
@@ -92,10 +72,6 @@ const injectedRtkApi = api.injectEndpoints({
         url: `/api/projects/${queryArg.projectName}/${queryArg.entityType}/${queryArg.entityId}/watchers`,
         method: 'POST',
         body: queryArg.watchersModel,
-        headers: {
-          'x-sender': queryArg['x-sender'],
-          'x-sender-type': queryArg['x-sender-type'],
-        },
       }),
     }),
   }),
@@ -109,23 +85,17 @@ export type PostProjectActivityApiArg = {
   /** Project level entity type is used in the endpoint path to specify the type of entity to operate on. It is usually one of 'folders', 'products', 'versions', 'representations', 'tasks', 'workfiles'. (trailing 's' is optional). */
   entityType: string
   entityId: string
-  'x-sender'?: string
-  'x-sender-type'?: string
   projectActivityPostModel: ProjectActivityPostModel
 }
 export type DeleteProjectActivityApiResponse = /** status 200 Successful Response */ any
 export type DeleteProjectActivityApiArg = {
   projectName: string
   activityId: string
-  'x-sender'?: string
-  'x-sender-type'?: string
 }
 export type PatchProjectActivityApiResponse = /** status 200 Successful Response */ any
 export type PatchProjectActivityApiArg = {
   projectName: string
   activityId: string
-  'x-sender'?: string
-  'x-sender-type'?: string
   activityPatchModel: ActivityPatchModel
 }
 export type GetActivityCategoriesApiResponse =
@@ -137,8 +107,6 @@ export type CreateReactionToActivityApiResponse = /** status 201 Successful Resp
 export type CreateReactionToActivityApiArg = {
   projectName: string
   activityId: string
-  'x-sender'?: string
-  'x-sender-type'?: string
   createReactionModel: CreateReactionModel
 }
 export type DeleteReactionToActivityApiResponse = unknown
@@ -147,8 +115,6 @@ export type DeleteReactionToActivityApiArg = {
   reaction: string
   projectName: string
   activityId: string
-  'x-sender'?: string
-  'x-sender-type'?: string
 }
 export type SuggestEntityMentionApiResponse = /** status 200 Successful Response */ SuggestResponse
 export type SuggestEntityMentionApiArg = {
@@ -168,11 +134,10 @@ export type SetEntityWatchersApiArg = {
   /** Project level entity type is used in the endpoint path to specify the type of entity to operate on. It is usually one of 'folders', 'products', 'versions', 'representations', 'tasks', 'workfiles'. (trailing 's' is optional). */
   entityType: string
   entityId: string
-  'x-sender'?: string
-  'x-sender-type'?: string
   watchersModel: WatchersModel
 }
 export type CreateActivityResponseModel = {
+  /** Activity ID */
   id: string
 }
 export type ValidationError = {
@@ -194,12 +159,14 @@ export type ProjectActivityPostModel = {
     | 'assignee.add'
     | 'assignee.remove'
     | 'version.publish'
+    | 'version.review'
+    | 'attrib.change'
   body?: string
   tags?: string[]
   files?: string[]
   timestamp?: string
   /** Additional data */
-  data?: Record<string, any>
+  data?: object
 }
 export type ActivityPatchModel = {
   /** When set, update the activity body */
@@ -210,7 +177,7 @@ export type ActivityPatchModel = {
   files?: string[]
   /** When true, append files to the existing ones. replace them otherwise */
   appendFiles?: boolean
-  data?: Record<string, any>
+  data?: object
 }
 export type ActivityCategoriesResponseModel = {
   categories: object[]

--- a/shared/src/api/generated/bundles.ts
+++ b/shared/src/api/generated/bundles.ts
@@ -14,10 +14,6 @@ const injectedRtkApi = api.injectEndpoints({
         url: `/api/bundles`,
         method: 'POST',
         body: queryArg.bundleModel,
-        headers: {
-          'x-sender': queryArg['x-sender'],
-          'x-sender-type': queryArg['x-sender-type'],
-        },
         params: {
           force: queryArg.force,
         },
@@ -51,10 +47,6 @@ const injectedRtkApi = api.injectEndpoints({
         url: `/api/bundles/${queryArg.bundleName}`,
         method: 'PATCH',
         body: queryArg.bundlePatchModel,
-        headers: {
-          'x-sender': queryArg['x-sender'],
-          'x-sender-type': queryArg['x-sender-type'],
-        },
         params: {
           build: queryArg.build,
           force: queryArg.force,
@@ -84,8 +76,6 @@ export type CreateNewBundleApiResponse = /** status 201 Successful Response */ a
 export type CreateNewBundleApiArg = {
   /** Force creation of bundle */
   force?: boolean
-  'x-sender'?: string
-  'x-sender-type'?: string
   bundleModel: BundleModel
 }
 export type CheckBundleCompatibilityApiResponse =
@@ -109,8 +99,6 @@ export type UpdateBundleApiArg = {
   build?: ('windows' | 'linux' | 'darwin')[]
   /** Force creation of bundle */
   force?: boolean
-  'x-sender'?: string
-  'x-sender-type'?: string
   bundlePatchModel: BundlePatchModel
 }
 export type MigrateSettingsByBundleApiResponse = /** status 200 Successful Response */ any

--- a/shared/src/api/generated/configuration.ts
+++ b/shared/src/api/generated/configuration.ts
@@ -17,6 +17,9 @@ const injectedRtkApi = api.injectEndpoints({
         body: queryArg.serverConfigModel,
       }),
     }),
+    updateServerConfig: build.mutation<UpdateServerConfigApiResponse, UpdateServerConfigApiArg>({
+      query: (queryArg) => ({ url: `/api/config`, method: 'PATCH', body: queryArg.payload }),
+    }),
     getServerConfigOverrides: build.query<
       GetServerConfigOverridesApiResponse,
       GetServerConfigOverridesApiArg
@@ -53,6 +56,10 @@ export type GetServerConfigApiArg = void
 export type SetServerConfigApiResponse = /** status 200 Successful Response */ any
 export type SetServerConfigApiArg = {
   serverConfigModel: ServerConfigModel
+}
+export type UpdateServerConfigApiResponse = unknown
+export type UpdateServerConfigApiArg = {
+  payload: object
 }
 export type GetServerConfigOverridesApiResponse = /** status 200 Successful Response */ object
 export type GetServerConfigOverridesApiArg = void
@@ -93,6 +100,9 @@ export type ChangelogSettingsModel = {
   /** If enabled, the changelog will be shown to normal users. */
   show_changelog_to_users?: boolean
 }
+export type CdnSettingsModel = {
+  default_cdn_resolver_url?: string
+}
 export type ServerConfigModel = {
   /** The name of the studio */
   studio_name?: string
@@ -103,6 +113,8 @@ export type ServerConfigModel = {
   project_options?: ProjectOptionsModel
   /** Settings for the changelog feature */
   changelog?: ChangelogSettingsModel
+  /** Settings for the CDN resolver */
+  cdn?: CdnSettingsModel
 }
 export type ValidationError = {
   loc: (string | number)[]

--- a/shared/src/api/generated/dataImport.ts
+++ b/shared/src/api/generated/dataImport.ts
@@ -70,7 +70,7 @@ export type ImportDataApiResponse = /** status 200 Successful Response */ Import
 export type ImportDataApiArg = {
   importType: 'user' | 'folder' | 'task' | 'hierarchy' | 'entity_list_item'
   fileId: string
-  existingStrategy?: 'skip' | 'update' | 'fail'
+  existingStrategy?: ExistingItemStrategy
   projectName?: string
   folderId?: string
   preview?: boolean
@@ -94,6 +94,7 @@ export type EnumItem = {
   /** Icon name (material symbol) or IconModel object */
   icon?: string | IconModel
   color?: string
+  shortName?: string
   /** Enum item is visible, but not selectable */
   disabled?: boolean
   /** Message to show when the option is disabled */
@@ -126,6 +127,8 @@ export type ImportableColumn = {
   enumName?: string
   /** A list of possible error handling modes for this column. Every column can have different available modes: For example: `name` column cannot use `default`, because default name cannot be generated. */
   errorHandlingModes: ('skip' | 'abort' | 'default')[]
+  /** Marker that new items can be created for frontend to decide if Create button should be offered. Entity_type cannot be created for example. */
+  createNewItems?: boolean
 }
 export type ValidationError = {
   loc: (string | number)[]
@@ -149,7 +152,9 @@ export type ImportStatus = {
   failed?: number
   failedItems?: object
   preview?: boolean
+  phase?: 'validating' | 'importing'
 }
+export type ExistingItemStrategy = 'skip' | 'update' | 'fail'
 export type ColumnValueMapping = {
   /** The source value from csv */
   source?: string

--- a/shared/src/api/generated/desktop.ts
+++ b/shared/src/api/generated/desktop.ts
@@ -173,10 +173,11 @@ export type PatchInstallerApiArg = {
 export type SourceModel = {
   /** If set to server, the file is stored on the server. If set to http, the file is downloaded from the specified URL. */
   type: 'server' | 'http'
-  /** URL to download the file from. Only used if type is url */
+  /** URL to download the file from. Only used if type is http */
   url?: string
 }
 export type DependencyPackage = {
+  /** Name of the package file */
   filename: string
   platform: 'windows' | 'linux' | 'darwin'
   size?: number
@@ -184,13 +185,17 @@ export type DependencyPackage = {
   checksumAlgorithm?: 'md5' | 'sha1' | 'sha256'
   /** List of sources to download the file from. Server source is added automatically by the server if the file is uploaded. */
   sources?: SourceModel[]
+  /** Used Python version */
+  pythonVersion?: string
+  /** Short name of the Linux distribution */
+  distroShort?: string
   /** Version of the Ayon installer this package is created with */
   installerVersion: string
-  /** mapping of addon_name:addon_version used to create the package */
+  /** mapping of addon_name:version used to create the package */
   sourceAddons?: {
     [key: string]: string
   }
-  /** mapping of module_name:module_version used to create the package */
+  /** mapping of module_name:version used to create the package */
   pythonModules?: {
     [key: string]:
       | string
@@ -218,6 +223,7 @@ export type SourcesPatchModel = {
   sources?: SourceModel[]
 }
 export type Installer = {
+  /** Name of the package file */
   filename: string
   platform: 'windows' | 'linux' | 'darwin'
   size?: number
@@ -225,10 +231,12 @@ export type Installer = {
   checksumAlgorithm?: 'md5' | 'sha1' | 'sha256'
   /** List of sources to download the file from. Server source is added automatically by the server if the file is uploaded. */
   sources?: SourceModel[]
+  /** Used Python version */
+  pythonVersion?: string
+  /** Short name of the Linux distribution */
+  distroShort?: string
   /** Version of the installer */
   version: string
-  /** Version of Python that the installer is created with */
-  pythonVersion: string
   /** mapping of module name:version used to create the installer */
   pythonModules?: {
     [key: string]:
@@ -237,7 +245,7 @@ export type Installer = {
           [key: string]: string
         }
   }
-  /** mapping of module_name:module_version used to run the installer */
+  /** mapping of module_name:version used to run the installer */
   runtimePythonModules?: {
     [key: string]: string
   }

--- a/shared/src/api/generated/files.ts
+++ b/shared/src/api/generated/files.ts
@@ -6,9 +6,9 @@ const injectedRtkApi = api.injectEndpoints({
         url: `/api/projects/${queryArg.projectName}/files`,
         method: 'POST',
         headers: {
-          'x-file-id': queryArg['x-file-id'],
+          'X-File-ID': queryArg['X-File-ID'],
+          'X-Activity-ID': queryArg['X-Activity-ID'],
           'x-file-name': queryArg['x-file-name'],
-          'x-activity-id': queryArg['x-activity-id'],
           'content-type': queryArg['content-type'],
         },
       }),
@@ -67,9 +67,9 @@ export type UploadProjectFileApiResponse =
   /** status 201 Successful Response */ CreateFileResponseModel
 export type UploadProjectFileApiArg = {
   projectName: string
-  'x-file-id'?: string
+  'X-File-ID'?: string
+  'X-Activity-ID'?: string
   'x-file-name': string
-  'x-activity-id'?: string
   'content-type': string
 }
 export type GetProjectFileApiResponse = /** status 200 Successful Response */ any

--- a/shared/src/api/generated/folders.ts
+++ b/shared/src/api/generated/folders.ts
@@ -129,7 +129,7 @@ export type GetFolderThumbnailApiArg = {
   original?: boolean
 }
 export type CreateFolderThumbnailApiResponse =
-  /** status 201 Successful Response */ CreateThumbnailResponseModel
+  /** status 200 Successful Response */ CreateThumbnailResponseModel
 export type CreateFolderThumbnailApiArg = {
   projectName: string
   folderId: string
@@ -329,6 +329,12 @@ export type HierarchyResponseModel = {
   projectName: string
   hierarchy: HierarchyFolderModel[]
 }
+export type AffectedEntity = {
+  entityType: string
+  entityId: string
+  thumbnailHash: string
+}
 export type CreateThumbnailResponseModel = {
   id: string
+  affectedEntities?: AffectedEntity[]
 }

--- a/shared/src/api/generated/links.ts
+++ b/shared/src/api/generated/links.ts
@@ -17,25 +17,27 @@ const injectedRtkApi = api.injectEndpoints({
         method: 'DELETE',
       }),
     }),
+    createEntityLinksBulk: build.mutation<
+      CreateEntityLinksBulkApiResponse,
+      CreateEntityLinksBulkApiArg
+    >({
+      query: (queryArg) => ({
+        url: `/api/projects/${queryArg.projectName}/links/bulk`,
+        method: 'POST',
+        body: queryArg.createLinksRequestModel,
+      }),
+    }),
     createEntityLink: build.mutation<CreateEntityLinkApiResponse, CreateEntityLinkApiArg>({
       query: (queryArg) => ({
         url: `/api/projects/${queryArg.projectName}/links`,
         method: 'POST',
         body: queryArg.createLinkRequestModel,
-        headers: {
-          'x-sender': queryArg['x-sender'],
-          'x-sender-type': queryArg['x-sender-type'],
-        },
       }),
     }),
     deleteEntityLink: build.mutation<DeleteEntityLinkApiResponse, DeleteEntityLinkApiArg>({
       query: (queryArg) => ({
         url: `/api/projects/${queryArg.projectName}/links/${queryArg.linkId}`,
         method: 'DELETE',
-        headers: {
-          'x-sender': queryArg['x-sender'],
-          'x-sender-type': queryArg['x-sender-type'],
-        },
       }),
     }),
   }),
@@ -57,19 +59,21 @@ export type DeleteLinkTypeApiArg = {
   projectName: string
   linkType: string
 }
+export type CreateEntityLinksBulkApiResponse =
+  /** status 200 Successful Response */ CreateLinksResponseModel
+export type CreateEntityLinksBulkApiArg = {
+  projectName: string
+  createLinksRequestModel: CreateLinksRequestModel
+}
 export type CreateEntityLinkApiResponse = /** status 200 Successful Response */ EntityIdResponse
 export type CreateEntityLinkApiArg = {
   projectName: string
-  'x-sender'?: string
-  'x-sender-type'?: string
   createLinkRequestModel: CreateLinkRequestModel
 }
 export type DeleteEntityLinkApiResponse = unknown
 export type DeleteEntityLinkApiArg = {
   projectName: string
   linkId: string
-  'x-sender'?: string
-  'x-sender-type'?: string
 }
 export type LinkTypeModel = {
   /** Name of the link type */
@@ -81,7 +85,7 @@ export type LinkTypeModel = {
   /** Output entity type */
   outputType: string
   /** Additional link type data */
-  data?: Record<string, any>
+  data?: object
 }
 export type LinkTypeListResponse = {
   /** List of link types defined in the project. */
@@ -97,11 +101,17 @@ export type HttpValidationError = {
 }
 export type CreateLinkTypeRequestModel = {
   /** Additional link type data (appearance, description, etc.). */
-  data?: Record<string, any>
+  data?: object
 }
-export type EntityIdResponse = {
-  /** Entity ID */
+export type LinkCreatedItem = {
   id: string
+  input: string
+  output: string
+  linkType: string
+}
+export type CreateLinksResponseModel = {
+  /** List of successfully created links. */
+  created: LinkCreatedItem[]
 }
 export type CreateLinkRequestModel = {
   /** ID of the link to create. If not provided, will be generated. */
@@ -115,7 +125,15 @@ export type CreateLinkRequestModel = {
   /** Link type to create. */
   linkType?: string
   /** Additional data for the link. */
-  data?: Record<string, any>
+  data?: object
   /** Link type to create. This is deprecated. Use linkType instead. */
   link?: string
+}
+export type CreateLinksRequestModel = {
+  /** List of links to create. */
+  links: CreateLinkRequestModel[]
+}
+export type EntityIdResponse = {
+  /** Entity ID */
+  id: string
 }

--- a/shared/src/api/generated/market.ts
+++ b/shared/src/api/generated/market.ts
@@ -193,10 +193,11 @@ export type ReleaseListModel = {
 export type SourceModel = {
   /** If set to server, the file is stored on the server. If set to http, the file is downloaded from the specified URL. */
   type: 'server' | 'http'
-  /** URL to download the file from. Only used if type is url */
+  /** URL to download the file from. Only used if type is http */
   url?: string
 }
 export type InstallerManifest = {
+  /** Name of the package file */
   filename: string
   platform: 'windows' | 'linux' | 'darwin'
   size?: number
@@ -204,10 +205,12 @@ export type InstallerManifest = {
   checksumAlgorithm?: 'md5' | 'sha1' | 'sha256'
   /** List of sources to download the file from. Server source is added automatically by the server if the file is uploaded. */
   sources?: SourceModel[]
+  /** Used Python version */
+  pythonVersion?: string
+  /** Short name of the Linux distribution */
+  distroShort?: string
   /** Version of the installer */
   version: string
-  /** Version of Python that the installer is created with */
-  pythonVersion: string
   /** mapping of module name:version used to create the installer */
   pythonModules?: {
     [key: string]:
@@ -216,12 +219,13 @@ export type InstallerManifest = {
           [key: string]: string
         }
   }
-  /** mapping of module_name:module_version used to run the installer */
+  /** mapping of module_name:version used to run the installer */
   runtimePythonModules?: {
     [key: string]: string
   }
 }
 export type DependencyPackageManifest = {
+  /** Name of the package file */
   filename: string
   platform: 'windows' | 'linux' | 'darwin'
   size?: number
@@ -229,13 +233,17 @@ export type DependencyPackageManifest = {
   checksumAlgorithm?: 'md5' | 'sha1' | 'sha256'
   /** List of sources to download the file from. Server source is added automatically by the server if the file is uploaded. */
   sources?: SourceModel[]
+  /** Used Python version */
+  pythonVersion?: string
+  /** Short name of the Linux distribution */
+  distroShort?: string
   /** Version of the Ayon installer this package is created with */
   installerVersion: string
-  /** mapping of addon_name:addon_version used to create the package */
+  /** mapping of addon_name:version used to create the package */
   sourceAddons?: {
     [key: string]: string
   }
-  /** mapping of module_name:module_version used to create the package */
+  /** mapping of module_name:version used to create the package */
   pythonModules?: {
     [key: string]:
       | string

--- a/shared/src/api/generated/projectFolders.ts
+++ b/shared/src/api/generated/projectFolders.ts
@@ -106,13 +106,13 @@ export type ProjectFolderPostModel = {
 }
 export type ProjectFolderPatchModel = {
   label?: string
-  parentId?: string | null
+  parentId?: string
   data?: ProjectFolderData
 }
 export type ProjectFolderOrderModel = {
   order: string[]
 }
 export type AssignProjectRequest = {
-  folderId?: string | null
+  folderId?: string
   projectNames: string[]
 }

--- a/shared/src/api/generated/reviewables.ts
+++ b/shared/src/api/generated/reviewables.ts
@@ -7,6 +7,9 @@ const injectedRtkApi = api.injectEndpoints({
     >({
       query: (queryArg) => ({
         url: `/api/projects/${queryArg.projectName}/products/${queryArg.productId}/reviewables`,
+        params: {
+          latest_done: queryArg.latestDone,
+        },
       }),
     }),
     getReviewablesForVersion: build.query<
@@ -15,6 +18,9 @@ const injectedRtkApi = api.injectEndpoints({
     >({
       query: (queryArg) => ({
         url: `/api/projects/${queryArg.projectName}/versions/${queryArg.versionId}/reviewables`,
+        params: {
+          latest_done: queryArg.latestDone,
+        },
       }),
     }),
     uploadReviewable: build.mutation<UploadReviewableApiResponse, UploadReviewableApiArg>({
@@ -22,10 +28,8 @@ const injectedRtkApi = api.injectEndpoints({
         url: `/api/projects/${queryArg.projectName}/versions/${queryArg.versionId}/reviewables`,
         method: 'POST',
         headers: {
-          'content-type': queryArg['content-type'],
           'x-file-name': queryArg['x-file-name'],
-          'x-sender': queryArg['x-sender'],
-          'x-sender-type': queryArg['x-sender-type'],
+          'content-type': queryArg['content-type'],
         },
         params: {
           label: queryArg.label,
@@ -48,6 +52,9 @@ const injectedRtkApi = api.injectEndpoints({
     >({
       query: (queryArg) => ({
         url: `/api/projects/${queryArg.projectName}/tasks/${queryArg.taskId}/reviewables`,
+        params: {
+          latest_done: queryArg.latestDone,
+        },
       }),
     }),
     getReviewablesForFolder: build.query<
@@ -56,6 +63,22 @@ const injectedRtkApi = api.injectEndpoints({
     >({
       query: (queryArg) => ({
         url: `/api/projects/${queryArg.projectName}/folders/${queryArg.folderId}/reviewables`,
+        params: {
+          latest_done: queryArg.latestDone,
+        },
+      }),
+    }),
+    getReviewablesForEntities: build.mutation<
+      GetReviewablesForEntitiesApiResponse,
+      GetReviewablesForEntitiesApiArg
+    >({
+      query: (queryArg) => ({
+        url: `/api/projects/${queryArg.projectName}/${queryArg.entityType}/reviewables/list`,
+        method: 'POST',
+        body: queryArg.reviewablesRequestModel,
+        params: {
+          latest_done: queryArg.latestDone,
+        },
       }),
     }),
     updateReviewable: build.mutation<UpdateReviewableApiResponse, UpdateReviewableApiArg>({
@@ -74,12 +97,16 @@ export type GetReviewablesForProductApiResponse =
 export type GetReviewablesForProductApiArg = {
   projectName: string
   productId: string
+  /** If True, returns only the latest approved versions */
+  latestDone?: boolean
 }
 export type GetReviewablesForVersionApiResponse =
   /** status 200 Successful Response */ VersionReviewablesModel
 export type GetReviewablesForVersionApiArg = {
   projectName: string
   versionId: string
+  /** If True, returns only the latest approved versions */
+  latestDone?: boolean
 }
 export type UploadReviewableApiResponse = /** status 200 Successful Response */ ReviewableModel
 export type UploadReviewableApiArg = {
@@ -87,10 +114,8 @@ export type UploadReviewableApiArg = {
   versionId: string
   /** Label */
   label?: string
-  'content-type': string
   'x-file-name': string
-  'x-sender'?: string
-  'x-sender-type'?: string
+  'content-type': string
 }
 export type SortVersionReviewablesApiResponse = /** status 200 Successful Response */ any
 export type SortVersionReviewablesApiArg = {
@@ -103,12 +128,26 @@ export type GetReviewablesForTaskApiResponse =
 export type GetReviewablesForTaskApiArg = {
   projectName: string
   taskId: string
+  /** If True, returns only the latest approved versions */
+  latestDone?: boolean
 }
 export type GetReviewablesForFolderApiResponse =
   /** status 200 Successful Response */ VersionReviewablesModel[]
 export type GetReviewablesForFolderApiArg = {
   projectName: string
   folderId: string
+  /** If True, returns only the latest approved versions */
+  latestDone?: boolean
+}
+export type GetReviewablesForEntitiesApiResponse =
+  /** status 200 Successful Response */ VersionReviewablesModel[]
+export type GetReviewablesForEntitiesApiArg = {
+  projectName: string
+  /** Project level entity type is used in the endpoint path to specify the type of entity to operate on. It is usually one of 'folders', 'products', 'versions', 'representations', 'tasks', 'workfiles'. (trailing 's' is optional). */
+  entityType: string
+  /** If True, returns only the latest approved versions */
+  latestDone?: boolean
+  reviewablesRequestModel: ReviewablesRequestModel
 }
 export type UpdateReviewableApiResponse = /** status 200 Successful Response */ any
 export type UpdateReviewableApiArg = {
@@ -164,6 +203,10 @@ export type HttpValidationError = {
 export type SortReviewablesRequest = {
   /** List of reviewable (activity) ids in the order you want them to appear in the UI. */
   sort?: string[]
+}
+export type ReviewablesRequestModel = {
+  /** List of target Entity IDs (folders, products, versions, etc.) to fetch reviewables for. */
+  entityIds: string[]
 }
 export type UpdateReviewablesRequest = {
   label?: string

--- a/shared/src/api/generated/reviewables.ts
+++ b/shared/src/api/generated/reviewables.ts
@@ -8,6 +8,7 @@ const injectedRtkApi = api.injectEndpoints({
       query: (queryArg) => ({
         url: `/api/projects/${queryArg.projectName}/products/${queryArg.productId}/reviewables`,
         params: {
+          latest: queryArg.latest,
           latest_done: queryArg.latestDone,
         },
       }),
@@ -19,6 +20,7 @@ const injectedRtkApi = api.injectEndpoints({
       query: (queryArg) => ({
         url: `/api/projects/${queryArg.projectName}/versions/${queryArg.versionId}/reviewables`,
         params: {
+          latest: queryArg.latest,
           latest_done: queryArg.latestDone,
         },
       }),
@@ -53,6 +55,7 @@ const injectedRtkApi = api.injectEndpoints({
       query: (queryArg) => ({
         url: `/api/projects/${queryArg.projectName}/tasks/${queryArg.taskId}/reviewables`,
         params: {
+          latest: queryArg.latest,
           latest_done: queryArg.latestDone,
         },
       }),
@@ -64,6 +67,7 @@ const injectedRtkApi = api.injectEndpoints({
       query: (queryArg) => ({
         url: `/api/projects/${queryArg.projectName}/folders/${queryArg.folderId}/reviewables`,
         params: {
+          latest: queryArg.latest,
           latest_done: queryArg.latestDone,
         },
       }),
@@ -77,6 +81,7 @@ const injectedRtkApi = api.injectEndpoints({
         method: 'POST',
         body: queryArg.reviewablesRequestModel,
         params: {
+          latest: queryArg.latest,
           latest_done: queryArg.latestDone,
         },
       }),
@@ -97,6 +102,8 @@ export type GetReviewablesForProductApiResponse =
 export type GetReviewablesForProductApiArg = {
   projectName: string
   productId: string
+  /** If True, returns only the latest version */
+  latest?: boolean
   /** If True, returns only the latest approved versions */
   latestDone?: boolean
 }
@@ -105,6 +112,8 @@ export type GetReviewablesForVersionApiResponse =
 export type GetReviewablesForVersionApiArg = {
   projectName: string
   versionId: string
+  /** If True, returns only the latest version */
+  latest?: boolean
   /** If True, returns only the latest approved versions */
   latestDone?: boolean
 }
@@ -128,6 +137,8 @@ export type GetReviewablesForTaskApiResponse =
 export type GetReviewablesForTaskApiArg = {
   projectName: string
   taskId: string
+  /** If True, returns only the latest version */
+  latest?: boolean
   /** If True, returns only the latest approved versions */
   latestDone?: boolean
 }
@@ -136,6 +147,8 @@ export type GetReviewablesForFolderApiResponse =
 export type GetReviewablesForFolderApiArg = {
   projectName: string
   folderId: string
+  /** If True, returns only the latest version */
+  latest?: boolean
   /** If True, returns only the latest approved versions */
   latestDone?: boolean
 }
@@ -145,6 +158,8 @@ export type GetReviewablesForEntitiesApiArg = {
   projectName: string
   /** Project level entity type is used in the endpoint path to specify the type of entity to operate on. It is usually one of 'folders', 'products', 'versions', 'representations', 'tasks', 'workfiles'. (trailing 's' is optional). */
   entityType: string
+  /** If True, returns only the latest version */
+  latest?: boolean
   /** If True, returns only the latest approved versions */
   latestDone?: boolean
   reviewablesRequestModel: ReviewablesRequestModel

--- a/shared/src/api/generated/system.ts
+++ b/shared/src/api/generated/system.ts
@@ -36,6 +36,18 @@ const injectedRtkApi = api.injectEndpoints({
     getSystemMetrics: build.query<GetSystemMetricsApiResponse, GetSystemMetricsApiArg>({
       query: () => ({ url: `/api/metrics/system` }),
     }),
+    getTracemallocMetrics: build.query<
+      GetTracemallocMetricsApiResponse,
+      GetTracemallocMetricsApiArg
+    >({
+      query: () => ({ url: `/api/metrics/tracemalloc` }),
+    }),
+    stopTracemallocMetrics: build.mutation<
+      StopTracemallocMetricsApiResponse,
+      StopTracemallocMetricsApiArg
+    >({
+      query: () => ({ url: `/api/metrics/tracemalloc`, method: 'DELETE' }),
+    }),
     getListOfSecrets: build.query<GetListOfSecretsApiResponse, GetListOfSecretsApiArg>({
       query: () => ({ url: `/api/secrets` }),
     }),
@@ -98,6 +110,10 @@ export type GetProductionMetricsApiArg = {
 }
 export type GetSystemMetricsApiResponse = /** status 200 Successful Response */ any
 export type GetSystemMetricsApiArg = void
+export type GetTracemallocMetricsApiResponse = /** status 200 Successful Response */ any
+export type GetTracemallocMetricsApiArg = void
+export type StopTracemallocMetricsApiResponse = /** status 200 Successful Response */ any
+export type StopTracemallocMetricsApiArg = void
 export type GetListOfSecretsApiResponse = /** status 200 Successful Response */ Secret[]
 export type GetListOfSecretsApiArg = void
 export type GetSecretApiResponse = /** status 200 Successful Response */ Secret

--- a/shared/src/api/generated/thumbnails.ts
+++ b/shared/src/api/generated/thumbnails.ts
@@ -109,6 +109,27 @@ const injectedRtkApi = api.injectEndpoints({
         },
       }),
     }),
+    getProjectThumbnail: build.query<GetProjectThumbnailApiResponse, GetProjectThumbnailApiArg>({
+      query: (queryArg) => ({
+        url: `/api/projects/${queryArg.projectName}/thumbnail`,
+        params: {
+          placeholder: queryArg.placeholder,
+          original: queryArg.original,
+        },
+      }),
+    }),
+    createProjectThumbnail: build.mutation<
+      CreateProjectThumbnailApiResponse,
+      CreateProjectThumbnailApiArg
+    >({
+      query: (queryArg) => ({
+        url: `/api/projects/${queryArg.projectName}/thumbnail`,
+        method: 'POST',
+        headers: {
+          'content-type': queryArg['content-type'],
+        },
+      }),
+    }),
   }),
   overrideExisting: false,
 })
@@ -126,7 +147,8 @@ export type GetThumbnailApiArg = {
   placeholder?: 'empty' | 'none'
   original?: boolean
 }
-export type UpdateThumbnailApiResponse = unknown
+export type UpdateThumbnailApiResponse =
+  /** status 200 Successful Response */ CreateThumbnailResponseModel
 export type UpdateThumbnailApiArg = {
   projectName: string
   thumbnailId: string
@@ -140,7 +162,7 @@ export type GetFolderThumbnailApiArg = {
   original?: boolean
 }
 export type CreateFolderThumbnailApiResponse =
-  /** status 201 Successful Response */ CreateThumbnailResponseModel
+  /** status 200 Successful Response */ CreateThumbnailResponseModel
 export type CreateFolderThumbnailApiArg = {
   projectName: string
   folderId: string
@@ -154,7 +176,7 @@ export type GetVersionThumbnailApiArg = {
   original?: boolean
 }
 export type CreateVersionThumbnailApiResponse =
-  /** status 201 Successful Response */ CreateThumbnailResponseModel
+  /** status 200 Successful Response */ CreateThumbnailResponseModel
 export type CreateVersionThumbnailApiArg = {
   projectName: string
   versionId: string
@@ -168,7 +190,7 @@ export type GetWorkfileThumbnailApiArg = {
   original?: boolean
 }
 export type CreateWorkfileThumbnailApiResponse =
-  /** status 201 Successful Response */ CreateThumbnailResponseModel
+  /** status 200 Successful Response */ CreateThumbnailResponseModel
 export type CreateWorkfileThumbnailApiArg = {
   projectName: string
   workfileId: string
@@ -182,14 +204,32 @@ export type GetTaskThumbnailApiArg = {
   original?: boolean
 }
 export type CreateTaskThumbnailApiResponse =
-  /** status 201 Successful Response */ CreateThumbnailResponseModel
+  /** status 200 Successful Response */ CreateThumbnailResponseModel
 export type CreateTaskThumbnailApiArg = {
   projectName: string
   taskId: string
   'content-type'?: string
 }
+export type GetProjectThumbnailApiResponse = /** status 200 Successful Response */ any
+export type GetProjectThumbnailApiArg = {
+  projectName: string
+  placeholder?: 'empty' | 'none'
+  original?: boolean
+}
+export type CreateProjectThumbnailApiResponse =
+  /** status 200 Successful Response */ CreateThumbnailResponseModel
+export type CreateProjectThumbnailApiArg = {
+  projectName: string
+  'content-type'?: string
+}
+export type AffectedEntity = {
+  entityType: string
+  entityId: string
+  thumbnailHash: string
+}
 export type CreateThumbnailResponseModel = {
   id: string
+  affectedEntities?: AffectedEntity[]
 }
 export type ValidationError = {
   loc: (string | number)[]

--- a/shared/src/api/generated/users.ts
+++ b/shared/src/api/generated/users.ts
@@ -101,21 +101,10 @@ const injectedRtkApi = api.injectEndpoints({
         url: `/api/users/${queryArg.userName}`,
         method: 'PUT',
         body: queryArg.newUserModel,
-        headers: {
-          'x-sender': queryArg['x-sender'],
-          'x-sender-type': queryArg['x-sender-type'],
-        },
       }),
     }),
     deleteUser: build.mutation<DeleteUserApiResponse, DeleteUserApiArg>({
-      query: (queryArg) => ({
-        url: `/api/users/${queryArg.userName}`,
-        method: 'DELETE',
-        headers: {
-          'x-sender': queryArg['x-sender'],
-          'x-sender-type': queryArg['x-sender-type'],
-        },
-      }),
+      query: (queryArg) => ({ url: `/api/users/${queryArg.userName}`, method: 'DELETE' }),
     }),
     patchUser: build.mutation<PatchUserApiResponse, PatchUserApiArg>({
       query: (queryArg) => ({
@@ -138,15 +127,18 @@ const injectedRtkApi = api.injectEndpoints({
         body: queryArg.checkPasswordRequestModel,
       }),
     }),
+    renameUser: build.mutation<RenameUserApiResponse, RenameUserApiArg>({
+      query: (queryArg) => ({
+        url: `/api/users/${queryArg.userName}/rename`,
+        method: 'POST',
+        body: queryArg.renameUserRequestModel,
+      }),
+    }),
     changeUserName: build.mutation<ChangeUserNameApiResponse, ChangeUserNameApiArg>({
       query: (queryArg) => ({
         url: `/api/users/${queryArg.userName}/rename`,
         method: 'PATCH',
         body: queryArg.changeUserNameRequestModel,
-        headers: {
-          'x-sender': queryArg['x-sender'],
-          'x-sender-type': queryArg['x-sender-type'],
-        },
       }),
     }),
     getUserSessions: build.query<GetUserSessionsApiResponse, GetUserSessionsApiArg>({
@@ -247,7 +239,8 @@ export type GetUserProjectPermissionsApiArg = {
 }
 export type GetCurrentUserApiResponse = /** status 200 Successful Response */ UserModel
 export type GetCurrentUserApiArg = void
-export type GetUserApiResponse = /** status 200 Successful Response */
+export type GetUserApiResponse =
+  /** status 200 Successful Response */
   | UserModel
   | {
       [key: string]: string
@@ -258,15 +251,11 @@ export type GetUserApiArg = {
 export type CreateUserApiResponse = /** status 200 Successful Response */ any
 export type CreateUserApiArg = {
   userName: string
-  'x-sender'?: string
-  'x-sender-type'?: string
   newUserModel: NewUserModel
 }
 export type DeleteUserApiResponse = /** status 200 Successful Response */ any
 export type DeleteUserApiArg = {
   userName: string
-  'x-sender'?: string
-  'x-sender-type'?: string
 }
 export type PatchUserApiResponse = /** status 200 Successful Response */ any
 export type PatchUserApiArg = {
@@ -283,11 +272,14 @@ export type CheckPasswordApiArg = {
   userName: string
   checkPasswordRequestModel: CheckPasswordRequestModel
 }
+export type RenameUserApiResponse = /** status 200 Successful Response */ any
+export type RenameUserApiArg = {
+  userName: string
+  renameUserRequestModel: RenameUserRequestModel
+}
 export type ChangeUserNameApiResponse = /** status 200 Successful Response */ any
 export type ChangeUserNameApiArg = {
   userName: string
-  'x-sender'?: string
-  'x-sender-type'?: string
   changeUserNameRequestModel: ChangeUserNameRequestModel
 }
 export type GetUserSessionsApiResponse =
@@ -348,9 +340,6 @@ export type ApiKeyPatchModel = {
 export type InviteUserRequest = {
   message?: string
 }
-export type PasswordResetRequestModel = {
-  email: string
-}
 export type UserAttribModel = {
   fullName?: string
   email?: string
@@ -383,6 +372,9 @@ export type LoginResponseModel = {
 export type AcceptInviteRequest = {
   token: string
   password?: string
+}
+export type PasswordResetRequestModel = {
+  email: string
 }
 export type PasswordResetModel = {
   token: string
@@ -500,6 +492,10 @@ export type ChangePasswordRequestModel = {
 }
 export type CheckPasswordRequestModel = {
   password: string
+}
+export type RenameUserRequestModel = {
+  /** New user name */
+  name: string
 }
 export type ChangeUserNameRequestModel = {
   /** New user name */

--- a/shared/src/api/generated/versions.ts
+++ b/shared/src/api/generated/versions.ts
@@ -31,10 +31,6 @@ const injectedRtkApi = api.injectEndpoints({
       query: (queryArg) => ({
         url: `/api/projects/${queryArg.projectName}/versions/${queryArg.versionId}`,
         method: 'DELETE',
-        headers: {
-          'x-sender': queryArg['x-sender'],
-          'x-sender-type': queryArg['x-sender-type'],
-        },
       }),
     }),
     updateVersion: build.mutation<UpdateVersionApiResponse, UpdateVersionApiArg>({
@@ -42,10 +38,6 @@ const injectedRtkApi = api.injectEndpoints({
         url: `/api/projects/${queryArg.projectName}/versions/${queryArg.versionId}`,
         method: 'PATCH',
         body: queryArg.versionPatchModel,
-        headers: {
-          'x-sender': queryArg['x-sender'],
-          'x-sender-type': queryArg['x-sender-type'],
-        },
       }),
     }),
     createVersion: build.mutation<CreateVersionApiResponse, CreateVersionApiArg>({
@@ -53,10 +45,6 @@ const injectedRtkApi = api.injectEndpoints({
         url: `/api/projects/${queryArg.projectName}/versions`,
         method: 'POST',
         body: queryArg.versionPostModel,
-        headers: {
-          'x-sender': queryArg['x-sender'],
-          'x-sender-type': queryArg['x-sender-type'],
-        },
       }),
     }),
   }),
@@ -71,7 +59,7 @@ export type GetVersionThumbnailApiArg = {
   original?: boolean
 }
 export type CreateVersionThumbnailApiResponse =
-  /** status 201 Successful Response */ CreateThumbnailResponseModel
+  /** status 200 Successful Response */ CreateThumbnailResponseModel
 export type CreateVersionThumbnailApiArg = {
   projectName: string
   versionId: string
@@ -86,22 +74,16 @@ export type DeleteVersionApiResponse = unknown
 export type DeleteVersionApiArg = {
   projectName: string
   versionId: string
-  'x-sender'?: string
-  'x-sender-type'?: string
 }
 export type UpdateVersionApiResponse = unknown
 export type UpdateVersionApiArg = {
   projectName: string
   versionId: string
-  'x-sender'?: string
-  'x-sender-type'?: string
   versionPatchModel: VersionPatchModel
 }
 export type CreateVersionApiResponse = /** status 201 Successful Response */ EntityIdResponse
 export type CreateVersionApiArg = {
   projectName: string
-  'x-sender'?: string
-  'x-sender-type'?: string
   versionPostModel: VersionPostModel
 }
 export type ValidationError = {
@@ -112,8 +94,14 @@ export type ValidationError = {
 export type HttpValidationError = {
   detail?: ValidationError[]
 }
+export type AffectedEntity = {
+  entityType: string
+  entityId: string
+  thumbnailHash: string
+}
 export type CreateThumbnailResponseModel = {
   id: string
+  affectedEntities?: AffectedEntity[]
 }
 export type VersionAttribModel = {
   /** Frame rate */

--- a/shared/src/api/generated/views.ts
+++ b/shared/src/api/generated/views.ts
@@ -93,43 +93,19 @@ export type CreateViewApiResponse = /** status 200 Successful Response */ Entity
 export type CreateViewApiArg = {
   viewType: string
   projectName?: string
-  payload:
-    | OverviewViewPostModel
-    | TaskProgressViewPostModel
-    | ListsViewPostModel
-    | ReviewsViewPostModel
-    | VersionsViewPostModel
-    | GenericViewPostModel
+  payload: GenericViewPostModel
 }
-export type GetWorkingViewApiResponse = /** status 200 Successful Response */
-  | OverviewViewModel
-  | TaskProgressViewModel
-  | ListsViewModel
-  | ReviewsViewModel
-  | VersionsViewModel
-  | GenericViewModel
+export type GetWorkingViewApiResponse = /** status 200 Successful Response */ GenericViewModel
 export type GetWorkingViewApiArg = {
   viewType: string
   projectName?: string
 }
-export type GetBaseViewApiResponse = /** status 200 Successful Response */
-  | OverviewViewModel
-  | TaskProgressViewModel
-  | ListsViewModel
-  | ReviewsViewModel
-  | VersionsViewModel
-  | GenericViewModel
+export type GetBaseViewApiResponse = /** status 200 Successful Response */ GenericViewModel
 export type GetBaseViewApiArg = {
   viewType: string
   projectName?: string
 }
-export type GetDefaultViewApiResponse = /** status 200 Successful Response */
-  | OverviewViewModel
-  | TaskProgressViewModel
-  | ListsViewModel
-  | ReviewsViewModel
-  | VersionsViewModel
-  | GenericViewModel
+export type GetDefaultViewApiResponse = /** status 200 Successful Response */ GenericViewModel
 export type GetDefaultViewApiArg = {
   viewType: string
   projectName?: string
@@ -140,13 +116,7 @@ export type SetDefaultViewApiArg = {
   projectName?: string
   setDefaultViewRequestModel: SetDefaultViewRequestModel
 }
-export type GetViewApiResponse = /** status 200 Successful Response */
-  | OverviewViewModel
-  | TaskProgressViewModel
-  | ListsViewModel
-  | ReviewsViewModel
-  | VersionsViewModel
-  | GenericViewModel
+export type GetViewApiResponse = /** status 200 Successful Response */ GenericViewModel
 export type GetViewApiArg = {
   viewType: string
   viewId: string
@@ -163,13 +133,7 @@ export type UpdateViewApiArg = {
   viewType: string
   viewId: string
   projectName?: string
-  payload:
-    | OverviewViewPatchModel
-    | TaskProgressViewPatchModel
-    | ListsViewPatchModel
-    | ReviewsViewPatchModel
-    | VersionsViewPatchModel
-    | GenericViewPatchModel
+  payload: GenericViewPatchModel
 }
 export type ViewListItemModel = {
   /** Unique identifier for the view within the given scope. */
@@ -202,142 +166,6 @@ export type EntityIdResponse = {
   /** Entity ID */
   id: string
 }
-export type QueryCondition = {
-  /** Path to the key separated by slashes */
-  key: string
-  /** Value to compare against */
-  value?: string | number | number | boolean | string[] | number[] | number[]
-  /** Comparison operator */
-  operator?:
-    | 'eq'
-    | 'like'
-    | 'lt'
-    | 'gt'
-    | 'lte'
-    | 'gte'
-    | 'ne'
-    | 'isnull'
-    | 'notnull'
-    | 'in'
-    | 'notin'
-    | 'includes'
-    | 'excludes'
-    | 'includesall'
-    | 'excludesall'
-    | 'includesany'
-    | 'excludesany'
-}
-export type QueryFilter = {
-  /** List of conditions to be evaluated */
-  conditions?: (QueryCondition | QueryFilter)[]
-  /** Operator to use when joining conditions */
-  operator?: 'and' | 'or'
-}
-export type ColumnItemModel = {
-  name: string
-  visible?: boolean
-  pinned?: boolean
-  width?: number
-}
-export type OverviewSettings = {
-  showHierarchy?: boolean
-  rowHeight?: number
-  groupBy?: string
-  groupSortByDesc?: boolean
-  showEmptyGroups?: boolean
-  sortBy?: string
-  sortDesc?: boolean
-  filter?: QueryFilter
-  folderFilter?: QueryFilter
-  sliceType?: string
-  columns?: ColumnItemModel[]
-}
-export type OverviewViewPostModel = {
-  /** Unique identifier for the view within the given scope. */
-  id?: string
-  /** Human-readable name of the view. */
-  label: string
-  /** Working view is a special type of the view that automatically stores the current view settings without explicitly saving them. Working views are always private and scoped to the project  */
-  working?: boolean
-  settings: OverviewSettings
-  viewType?: 'overview'
-}
-export type TaskProgressSettings = {
-  filter?: QueryFilter
-  sliceType?: string
-  columns?: ColumnItemModel[]
-}
-export type TaskProgressViewPostModel = {
-  /** Unique identifier for the view within the given scope. */
-  id?: string
-  /** Human-readable name of the view. */
-  label: string
-  /** Working view is a special type of the view that automatically stores the current view settings without explicitly saving them. Working views are always private and scoped to the project  */
-  working?: boolean
-  settings: TaskProgressSettings
-  viewType?: 'taskProgress'
-}
-export type ListsSettings = {
-  rowHeight?: number
-  sortBy?: string
-  sortDesc?: boolean
-  filter?: QueryFilter
-  columns?: ColumnItemModel[]
-}
-export type ListsViewPostModel = {
-  /** Unique identifier for the view within the given scope. */
-  id?: string
-  /** Human-readable name of the view. */
-  label: string
-  /** Working view is a special type of the view that automatically stores the current view settings without explicitly saving them. Working views are always private and scoped to the project  */
-  working?: boolean
-  settings: ListsSettings
-  viewType?: 'lists'
-}
-export type ReviewsSettings = {
-  rowHeight?: number
-  sortBy?: string
-  sortDesc?: boolean
-  filter?: QueryFilter
-  columns?: ColumnItemModel[]
-  gridHeight?: number
-  displayStyle?: 'cards' | 'table' | 'playlist'
-}
-export type ReviewsViewPostModel = {
-  /** Unique identifier for the view within the given scope. */
-  id?: string
-  /** Human-readable name of the view. */
-  label: string
-  /** Working view is a special type of the view that automatically stores the current view settings without explicitly saving them. Working views are always private and scoped to the project  */
-  working?: boolean
-  settings: ReviewsSettings
-  viewType?: 'reviews'
-}
-export type VersionsSettings = {
-  showProducts?: boolean
-  rowHeight?: number
-  showGrid?: boolean
-  gridHeight?: number
-  featuredVersionOrder?: string[]
-  slicerType?: string
-  groupBy?: string
-  groupSortByDesc?: boolean
-  showEmptyGroups?: boolean
-  sortBy?: string
-  sortDesc?: boolean
-  filter?: QueryFilter
-  columns?: ColumnItemModel[]
-}
-export type VersionsViewPostModel = {
-  /** Unique identifier for the view within the given scope. */
-  id?: string
-  /** Human-readable name of the view. */
-  label: string
-  /** Working view is a special type of the view that automatically stores the current view settings without explicitly saving them. Working views are always private and scoped to the project  */
-  working?: boolean
-  settings: VersionsSettings
-  viewType?: 'versions'
-}
 export type GenericViewPostModel = {
   /** Unique identifier for the view within the given scope. */
   id?: string
@@ -345,103 +173,8 @@ export type GenericViewPostModel = {
   label: string
   /** Working view is a special type of the view that automatically stores the current view settings without explicitly saving them. Working views are always private and scoped to the project  */
   working?: boolean
+  viewType?: string
   settings: object
-  viewType: string
-}
-export type OverviewViewModel = {
-  /** Unique identifier for the view within the given scope. */
-  id?: string
-  /** Human-readable name of the view. */
-  label: string
-  /** Determines whether the view is only available for the given project or for all projects (studio). */
-  scope: 'project' | 'studio'
-  /** Name of the user who created the view. Owners have full control over the view,  */
-  owner: string
-  /** Visibility of the view. Public views are visible to all users, private views are only visible to the owner. */
-  visibility: 'public' | 'private'
-  /** Working view is a special type of the view that automatically stores the current view settings without explicitly saving them. Working views are always private and scoped to the project  */
-  working: boolean
-  position: number
-  accessLevel: number
-  settings: OverviewSettings
-  access: object
-  viewType?: 'overview'
-}
-export type TaskProgressViewModel = {
-  /** Unique identifier for the view within the given scope. */
-  id?: string
-  /** Human-readable name of the view. */
-  label: string
-  /** Determines whether the view is only available for the given project or for all projects (studio). */
-  scope: 'project' | 'studio'
-  /** Name of the user who created the view. Owners have full control over the view,  */
-  owner: string
-  /** Visibility of the view. Public views are visible to all users, private views are only visible to the owner. */
-  visibility: 'public' | 'private'
-  /** Working view is a special type of the view that automatically stores the current view settings without explicitly saving them. Working views are always private and scoped to the project  */
-  working: boolean
-  position: number
-  accessLevel: number
-  settings: TaskProgressSettings
-  access: object
-  viewType?: 'taskProgress'
-}
-export type ListsViewModel = {
-  /** Unique identifier for the view within the given scope. */
-  id?: string
-  /** Human-readable name of the view. */
-  label: string
-  /** Determines whether the view is only available for the given project or for all projects (studio). */
-  scope: 'project' | 'studio'
-  /** Name of the user who created the view. Owners have full control over the view,  */
-  owner: string
-  /** Visibility of the view. Public views are visible to all users, private views are only visible to the owner. */
-  visibility: 'public' | 'private'
-  /** Working view is a special type of the view that automatically stores the current view settings without explicitly saving them. Working views are always private and scoped to the project  */
-  working: boolean
-  position: number
-  accessLevel: number
-  settings: ListsSettings
-  access: object
-  viewType?: 'lists'
-}
-export type ReviewsViewModel = {
-  /** Unique identifier for the view within the given scope. */
-  id?: string
-  /** Human-readable name of the view. */
-  label: string
-  /** Determines whether the view is only available for the given project or for all projects (studio). */
-  scope: 'project' | 'studio'
-  /** Name of the user who created the view. Owners have full control over the view,  */
-  owner: string
-  /** Visibility of the view. Public views are visible to all users, private views are only visible to the owner. */
-  visibility: 'public' | 'private'
-  /** Working view is a special type of the view that automatically stores the current view settings without explicitly saving them. Working views are always private and scoped to the project  */
-  working: boolean
-  position: number
-  accessLevel: number
-  settings: ReviewsSettings
-  access: object
-  viewType?: 'reviews'
-}
-export type VersionsViewModel = {
-  /** Unique identifier for the view within the given scope. */
-  id?: string
-  /** Human-readable name of the view. */
-  label: string
-  /** Determines whether the view is only available for the given project or for all projects (studio). */
-  scope: 'project' | 'studio'
-  /** Name of the user who created the view. Owners have full control over the view,  */
-  owner: string
-  /** Visibility of the view. Public views are visible to all users, private views are only visible to the owner. */
-  visibility: 'public' | 'private'
-  /** Working view is a special type of the view that automatically stores the current view settings without explicitly saving them. Working views are always private and scoped to the project  */
-  working: boolean
-  position: number
-  accessLevel: number
-  settings: VersionsSettings
-  access: object
-  viewType?: 'versions'
 }
 export type GenericViewModel = {
   /** Unique identifier for the view within the given scope. */
@@ -458,46 +191,16 @@ export type GenericViewModel = {
   working: boolean
   position: number
   accessLevel: number
+  viewType: string
   settings: object
   access: object
-  viewType: string
 }
 export type SetDefaultViewRequestModel = {
   viewId: string
 }
-export type OverviewViewPatchModel = {
-  label?: string
-  owner?: string
-  settings?: OverviewSettings
-  viewType?: 'overview'
-}
-export type TaskProgressViewPatchModel = {
-  label?: string
-  owner?: string
-  settings?: TaskProgressSettings
-  viewType?: 'taskProgress'
-}
-export type ListsViewPatchModel = {
-  label?: string
-  owner?: string
-  settings?: ListsSettings
-  viewType?: 'lists'
-}
-export type ReviewsViewPatchModel = {
-  label?: string
-  owner?: string
-  settings?: ReviewsSettings
-  viewType?: 'reviews'
-}
-export type VersionsViewPatchModel = {
-  label?: string
-  owner?: string
-  settings?: VersionsSettings
-  viewType?: 'versions'
-}
 export type GenericViewPatchModel = {
   label?: string
   owner?: string
+  viewType?: string
   settings?: object
-  viewType: string
 }

--- a/shared/src/api/generated/workfiles.ts
+++ b/shared/src/api/generated/workfiles.ts
@@ -31,10 +31,6 @@ const injectedRtkApi = api.injectEndpoints({
       query: (queryArg) => ({
         url: `/api/projects/${queryArg.projectName}/workfiles/${queryArg.workfileId}`,
         method: 'DELETE',
-        headers: {
-          'x-sender': queryArg['x-sender'],
-          'x-sender-type': queryArg['x-sender-type'],
-        },
       }),
     }),
     updateWorkfile: build.mutation<UpdateWorkfileApiResponse, UpdateWorkfileApiArg>({
@@ -42,10 +38,6 @@ const injectedRtkApi = api.injectEndpoints({
         url: `/api/projects/${queryArg.projectName}/workfiles/${queryArg.workfileId}`,
         method: 'PATCH',
         body: queryArg.workfilePatchModel,
-        headers: {
-          'x-sender': queryArg['x-sender'],
-          'x-sender-type': queryArg['x-sender-type'],
-        },
       }),
     }),
     createWorkfile: build.mutation<CreateWorkfileApiResponse, CreateWorkfileApiArg>({
@@ -53,10 +45,6 @@ const injectedRtkApi = api.injectEndpoints({
         url: `/api/projects/${queryArg.projectName}/workfiles`,
         method: 'POST',
         body: queryArg.workfilePostModel,
-        headers: {
-          'x-sender': queryArg['x-sender'],
-          'x-sender-type': queryArg['x-sender-type'],
-        },
       }),
     }),
   }),
@@ -71,7 +59,7 @@ export type GetWorkfileThumbnailApiArg = {
   original?: boolean
 }
 export type CreateWorkfileThumbnailApiResponse =
-  /** status 201 Successful Response */ CreateThumbnailResponseModel
+  /** status 200 Successful Response */ CreateThumbnailResponseModel
 export type CreateWorkfileThumbnailApiArg = {
   projectName: string
   workfileId: string
@@ -86,22 +74,16 @@ export type DeleteWorkfileApiResponse = unknown
 export type DeleteWorkfileApiArg = {
   projectName: string
   workfileId: string
-  'x-sender'?: string
-  'x-sender-type'?: string
 }
 export type UpdateWorkfileApiResponse = unknown
 export type UpdateWorkfileApiArg = {
   projectName: string
   workfileId: string
-  'x-sender'?: string
-  'x-sender-type'?: string
   workfilePatchModel: WorkfilePatchModel
 }
 export type CreateWorkfileApiResponse = /** status 201 Successful Response */ EntityIdResponse
 export type CreateWorkfileApiArg = {
   projectName: string
-  'x-sender'?: string
-  'x-sender-type'?: string
   workfilePostModel: WorkfilePostModel
 }
 export type ValidationError = {
@@ -112,8 +94,14 @@ export type ValidationError = {
 export type HttpValidationError = {
   detail?: ValidationError[]
 }
+export type AffectedEntity = {
+  entityType: string
+  entityId: string
+  thumbnailHash: string
+}
 export type CreateThumbnailResponseModel = {
   id: string
+  affectedEntities?: AffectedEntity[]
 }
 export type WorkfileAttribModel = {
   extension?: string

--- a/shared/src/api/generated/ynputCloud.ts
+++ b/shared/src/api/generated/ynputCloud.ts
@@ -81,6 +81,8 @@ export type YnputCloudInfoModel = {
   subscriptions?: YnputCloudSubscriptionModel[]
   /** Is the instance connected to Ynput Cloud? */
   connected?: boolean
+  /** AYON is in offline mode */
+  offlineMode?: boolean
 }
 export type ValidationError = {
   loc: (string | number)[]

--- a/shared/src/api/queries/review/getReview.ts
+++ b/shared/src/api/queries/review/getReview.ts
@@ -103,6 +103,10 @@ const getViewerReviewablesTags = (
 
 const enhancedApi = reviewablesApi.enhanceEndpoints<TagTypes, UpdatedDefinitions>({
   endpoints: {
+    getReviewablesForEntities: {
+      transformResponse: (result: VersionReviewablesModel[]) =>
+        result.filter((version) => version.reviewables?.length),
+    },
     getReviewablesForVersion: {
       keepUnusedDataFor: 1,
       providesTags: (result, _error, { versionId }) =>
@@ -317,6 +321,7 @@ const getReviewApi = enhancedApi.injectEndpoints({
 
 export const {
   useGetViewerReviewablesQuery,
+  useGetReviewablesForEntitiesMutation,
   useGetReviewablesForVersionQuery,
   useHasTranscoderQuery,
 } = getReviewApi

--- a/shared/src/components/SimpleFormDialog/SimpleFormDialog.tsx
+++ b/shared/src/components/SimpleFormDialog/SimpleFormDialog.tsx
@@ -210,7 +210,7 @@ const FormField = ({ field, value, onChange }: FormFieldProps) => {
       <FormFileUpload
         value={value as FormFileData}
         onChange={onChange}
-        validExtensions={field.valid_extensions}
+        validExtensions={field.validExtensions}
       />
     )
   }

--- a/src/pages/ProjectListsPage/context/EntityListsContext.tsx
+++ b/src/pages/ProjectListsPage/context/EntityListsContext.tsx
@@ -11,6 +11,7 @@ import {
   useGetEntityListFoldersQuery,
   useExecuteActionMutation,
   entityListsQueriesGql,
+  useGetReviewablesForEntitiesMutation,
 } from '@shared/api'
 import { upperFirst } from 'lodash'
 import { useSearchParams } from 'react-router-dom'
@@ -62,7 +63,6 @@ export interface EntityListsContextType {
   ) => {
     id: string
     label: string
-    icon: string
     items: ListSubMenuItem[]
   }
   newListMenuItem: (entityType: ListEntityType, selected: ListEntityInput[]) => ListSubMenuItem
@@ -164,6 +164,44 @@ export const EntityListsProvider = ({ children, projectName }: EntityListsProvid
 
   const [updateEntityListItems] = useUpdateEntityListItemsMutation()
   const [executeAction] = useExecuteActionMutation()
+  const [getReviewablesForEntities] = useGetReviewablesForEntitiesMutation()
+
+  const getReviewableVersions = useCallback(
+    async (entityType: 'folder' | 'task', entities: ListEntityInput[]) => {
+      const result = await getReviewablesForEntities({
+        projectName,
+        entityType: `${entityType}s`,
+        reviewablesRequestModel: {
+          entityIds: entities.map((entity) => entity.entityId),
+        },
+        latest: true,
+      }).unwrap()
+
+      return result.map((version) => ({
+        entityId: version.id,
+        entityType: 'version',
+      }))
+    },
+    [getReviewablesForEntities, projectName],
+  )
+
+  const invalidateListCaches = useCallback(
+    (listId?: string) => {
+      dispatch(
+        entityListsQueriesGql.util.invalidateTags([
+          { type: 'entityList', id: 'LIST' },
+          ...(listId
+            ? [
+                { type: 'entityList', id: listId },
+                { type: 'entityListItem', id: listId },
+                { type: 'entityListItemsColumnStats', id: listId },
+              ]
+            : []),
+        ]),
+      )
+    },
+    [dispatch],
+  )
 
   // add an item to a list
   const addToList: EntityListsContextType['addToList'] = useCallback(
@@ -182,66 +220,36 @@ export const EntityListsProvider = ({ children, projectName }: EntityListsProvid
       const isReviewSession = targetList?.entityListType === 'review-session'
 
       if (isReviewSession && (entityType === 'folder' || entityType === 'task')) {
-        if (!reviewAddonVersion) {
-          toast.error('Review addon not available')
-          return Promise.reject(new Error('Review addon not available'))
-        }
-
-        if (!hasReviewActionsVersion) {
-          toast.error(
-            `Please upgrade Review addon to at least ${MIN_REVIEW_ACTIONS_VERSION} to use this feature with folders and tasks`,
-          )
-          return Promise.reject(new Error('Review addon version too low'))
-        }
+        const selectedEntityCount = filteredEntities.length
 
         try {
-          const actionIdentifier = `review-add-to-session-from-${entityType}s`
-          const result = await executeAction({
-            identifier: actionIdentifier,
-            actionContext: {
-              projectName,
-              entityType,
-              entityIds: filteredEntities.map((e) => e.entityId),
-              // Pass the target list ID as list_id in formData
-              formData: { list_id: listId },
-            },
-            addonName: 'review',
-            addonVersion: reviewAddonVersion,
-          }).unwrap()
-
-          if (result.success) {
-            if (result.payload) {
-              // invalidate the list caches
-              const tags = [
-                { type: 'entityList', id: listId },
-                { type: 'entityListItem', id: listId },
-                { type: 'entityListItemsColumnStats', id: listId },
-              ]
-              dispatch(entityListsQueriesGql.util.invalidateTags(tags))
-            }
-            toast.success(`Item${filteredEntities.length > 1 ? 's' : ''} added to session`)
-            return Promise.resolve()
-          } else {
-            throw new Error(result.message || 'Error adding to session')
-          }
+          filteredEntities = await getReviewableVersions(entityType, filteredEntities)
         } catch (error: any) {
-          console.error('Error adding to session via action', error)
-          toast.error(error?.data?.detail || error?.message || 'Error adding to session')
+          console.error('Error getting reviewables for session', error)
+          toast.error(error?.data?.detail || error?.message || 'Error getting reviewables')
           return Promise.reject(error)
+        }
+
+        const skippedCount = selectedEntityCount - filteredEntities.length
+        if (filteredEntities.length === 0) {
+          toast.error('No reviewable versions found for selected entities')
+          return Promise.reject(new Error('No reviewable versions found'))
+        }
+        if (skippedCount > 0) {
+          toast.warn(
+            skippedCount === 1
+              ? '1 selected entity skipped (no reviewables)'
+              : `${skippedCount} selected entities skipped (no reviewables)`,
+          )
         }
       }
 
-      // Default review session logic for versions: only accept versions with reviewables
       if (isReviewSession && entityType === 'version') {
-        const eligible = filteredEntities.filter((e) => e.hasReviewables !== false)
+        const eligible = filteredEntities.filter((entity) => entity.hasReviewables !== false)
         const skippedCount = filteredEntities.length - eligible.length
-        if (skippedCount > 0 && eligible.length === 0) {
-          toast.error(
-            skippedCount === 1
-              ? 'Cannot add version without reviewables to review session'
-              : `Cannot add ${skippedCount} versions without reviewables to review session`,
-          )
-          return Promise.reject(new Error('No reviewable versions to add'))
+        if (eligible.length === 0) {
+          toast.error('No reviewable versions found for selected entities')
+          return Promise.reject(new Error('No reviewable versions found'))
         }
         if (skippedCount > 0) {
           toast.warn(
@@ -270,6 +278,8 @@ export const EntityListsProvider = ({ children, projectName }: EntityListsProvid
           },
         }).unwrap()
 
+        if (isReviewSession) invalidateListCaches(listId)
+
         toast.success(`Item${entitiesToAdd.length > 1 ? 's' : ''} added to list`)
 
         return Promise.resolve()
@@ -282,9 +292,8 @@ export const EntityListsProvider = ({ children, projectName }: EntityListsProvid
     [
       projectName,
       allLists.data,
-      reviewAddonVersion,
-      hasReviewActionsVersion,
-      executeAction,
+      getReviewableVersions,
+      invalidateListCaches,
       updateEntityListItems,
     ],
   )
@@ -313,85 +322,70 @@ export const EntityListsProvider = ({ children, projectName }: EntityListsProvid
           return Promise.reject(new Error('No entities selected'))
         }
 
-        const { selectedEntities, entityType, entityListType } = newListData
+        const { selectedEntities, entityListType } = newListData
+        let { entityType } = newListData
 
         // filter out entities that do not match entityType
-        const filteredEntities = selectedEntities.filter(
-          (entity) => entity.entityType === entityType,
-        )
+        let filteredEntities = selectedEntities.filter((entity) => entity.entityType === entityType)
+
+        if (
+          entityListType === 'review-session' &&
+          (entityType === 'folder' || entityType === 'task')
+        ) {
+          const selectedEntityCount = filteredEntities.length
+          filteredEntities = await getReviewableVersions(entityType, filteredEntities)
+          const skippedCount = selectedEntityCount - filteredEntities.length
+          if (filteredEntities.length === 0) {
+            throw new Error('No reviewable versions found for selected entities')
+          }
+          if (skippedCount > 0) {
+            toast.warn(
+              skippedCount === 1
+                ? '1 selected entity skipped (no reviewables)'
+                : `${skippedCount} selected entities skipped (no reviewables)`,
+            )
+          }
+          entityType = 'version'
+        }
+
+        if (entityListType === 'review-session' && entityType === 'version') {
+          const eligible = filteredEntities.filter((entity) => entity.hasReviewables !== false)
+          const skippedCount = filteredEntities.length - eligible.length
+          if (skippedCount > 0) {
+            toast.warn(
+              skippedCount === 1
+                ? '1 version skipped (no reviewables)'
+                : `${skippedCount} versions skipped (no reviewables)`,
+            )
+          }
+          filteredEntities = eligible
+        }
+
+        if (entityListType === 'review-session' && filteredEntities.length === 0) {
+          throw new Error('No reviewable versions found for selected entities')
+        }
 
         const entitiesToAdd = filteredEntities.map((entity) => ({ entityId: entity.entityId }))
 
         let listId: string | undefined
 
-        // For review sessions from folders or tasks, use the specialized action
-        if (
-          entityListType === 'review-session' &&
-          (entityType === 'folder' || entityType === 'task')
-        ) {
-          if (!reviewAddonVersion) {
-            toast.error('Review addon not available')
-            return Promise.reject(new Error('Review addon not available'))
-          }
+        const newListResult = await createNewListMutation({
+          projectName,
+          entityListPostModel: {
+            label,
+            entityType,
+            entityListType,
+            items: entitiesToAdd,
+          },
+        }).unwrap()
 
-          if (!hasReviewActionsVersion) {
-            toast.error(
-              `Please upgrade Review addon to at least ${MIN_REVIEW_ACTIONS_VERSION} to use this feature with folders and tasks`,
-            )
-            return Promise.reject(new Error('Review addon version too low'))
-          }
+        listId = newListResult.id
+        invalidateListCaches(listId)
 
-          const actionIdentifier = `review-save-session-from-${entityType}`
-          const result = await executeAction({
-            identifier: actionIdentifier,
-            actionContext: {
-              projectName,
-              entityType,
-              entityIds: entitiesToAdd.map((e) => e.entityId),
-              // Passing label to the action as it might be required for naming the session
-              formData: { label },
-            },
-            addonName: 'review',
-            addonVersion: reviewAddonVersion,
-          }).unwrap()
-
-          if (!result.success) {
-            throw new Error(result.message || 'Error creating review session from action')
-          }
-
-          const payloadData = (result.payload as any)?.data
-          // Try to extract created ID if provided, though standard behavior might vary
-          listId = payloadData?.id
-
-          if (payloadData) {
-            // invalidate the list caches
-            const tags = [
-              { type: 'entityList', id: listId },
-              { type: 'entityListItemsColumnStats', id: listId },
-            ]
-            dispatch(entityListsQueriesGql.util.invalidateTags(tags))
-          }
-
-          toast.success(`Review session ${label} created`)
-        } else {
-          // Default: create via entity list mutation (used for versions and generic lists)
-          const newListResult = await createNewListMutation({
-            projectName,
-            entityListPostModel: {
-              label,
-              entityType,
-              entityListType,
-              items: entitiesToAdd,
-            },
-          }).unwrap()
-
-          listId = newListResult.id
-
-          toast.success(`List ${label} created`)
-          toast.success(
-            `${upperFirst(entityType)}${entitiesToAdd.length > 1 ? 's' : ''} added to list`,
-          )
-        }
+        toast.success(`List ${label} created`)
+        toast.success(
+          `${upperFirst(entityType)}${entitiesToAdd.length > 1 ? 's' : ''} added to list`,
+        )
 
         // close the dialog
         closeCreateNewList()
@@ -416,9 +410,8 @@ export const EntityListsProvider = ({ children, projectName }: EntityListsProvid
       newListData,
       setSearchParams,
       createNewListMutation,
-      executeAction,
-      reviewAddonVersion,
-      hasReviewActionsVersion,
+      getReviewableVersions,
+      invalidateListCaches,
     ],
   )
 

--- a/src/pages/ProjectListsPage/hooks/useBuildListMenuItems.ts
+++ b/src/pages/ProjectListsPage/hooks/useBuildListMenuItems.ts
@@ -338,9 +338,6 @@ export const useBuildListMenuItems = ({
       label?: string,
       filter?: (item: ListSubMenuItem) => boolean,
     ) => {
-      const hasAnyNonReviewable =
-        entityType === 'version' ? entities.some((v) => v.hasReviewables === false) : false
-
       let targetLists = versions
       if (entityType === 'folder') targetLists = folders
       else if (entityType === 'task') targetLists = tasks
@@ -419,7 +416,6 @@ export const useBuildListMenuItems = ({
       const menu: any[] = [buildAddToListMenu(subMenuItems, { label })]
 
       if (hasReviewAddon) {
-        // Build review menu items and add a disabled note if any selected version lacks reviewables
         const reviewItems: ListSubMenuItem[] = [
           {
             id: 'open-session',
@@ -432,12 +428,6 @@ export const useBuildListMenuItems = ({
             label: 'Create new session',
             icon: 'add',
             command: () => {
-              if ((entityType === 'folder' || entityType === 'task') && !hasReviewActionsVersion) {
-                toast.error(
-                  `Please upgrade Review addon to at least ${MIN_REVIEW_ACTIONS_VERSION} to use this feature with folders and tasks`,
-                )
-                return
-              }
               openCreateNewList(entityType, entities, 'review-session')
             },
           },
@@ -450,16 +440,11 @@ export const useBuildListMenuItems = ({
           },
         ]
 
-        const disabledLabel =
-          entityType === 'version' ? ' (all versions need reviewable)' : ' (need reviewable)'
-        const getLabel = (base: string) => (hasAnyNonReviewable ? base + disabledLabel : base)
-
         menu.push({
           id: 'review',
-          label: getLabel('Review'),
+          label: 'Review',
           icon: 'subscriptions',
-          items: hasAnyNonReviewable ? [] : reviewItems,
-          disabled: hasAnyNonReviewable,
+          items: reviewItems,
         })
       }
 


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
"Create new session" and "Add to session" now use the new reviewables endpoint instead of relying on the review addon actions.

Before the changes, we would use different actions provided by the review session to get the latest reviewables of a folder/task. Now it uses a dedicated endpoint https://github.com/ynput/ayon-backend/pull/994#pullrequestreview-4732658260

<img width="1064" height="595" alt="image" src="https://github.com/user-attachments/assets/c44d2f1a-4a16-457a-9496-d3b5ff31a17c" />



## Validation
<!-- Please state any technical details such as limitations -->
- Always max 1 version per selected entity.
- 3 folders = 3 latest versions, from each folder.
- If the latest version does not have a reviewable then it is skipped. 5 tasks = 3 versions (with reviewables).
- Needs to work for `folders`, `tasks`, `versions`.

## Testing
<!-- Add any other context or screenshots here. -->
1. Go to overview page
2. Select some folders that have the `play` icon in the thumbnail.
3. Right click `review / create new session`
4. The latest version from each folder should be in the new list. If the version does NOT have a reviewable, it is skipped.
5. Repeat for `Add to session`
6. Repeat for each entity type `folder`, `task, `version`.
7. Test on each page `overview`, `task progress`, `products`, `lists`, `review`
