### PR TITLE
Products: Ensure table cells are focused properly

### DIFF
--- a/shared/src/containers/ProjectTreeTable/ProjectTreeTable.tsx
+++ b/shared/src/containers/ProjectTreeTable/ProjectTreeTable.tsx
@@ -1772,6 +1772,8 @@ const TD = ({
         // check we are not clicking in a dropdown
         if (target.closest('.options')) return
 
+        e.currentTarget.focus()
+
         // Handle double-click via e.detail (browser's native click count).
         // We handle it here in mousedown instead of relying on the dblclick event,
         // because the 1st mousedown triggers React state updates that can replace

--- a/shared/src/containers/ProjectTreeTable/hooks/useKeyboardNavigation.ts
+++ b/shared/src/containers/ProjectTreeTable/hooks/useKeyboardNavigation.ts
@@ -22,7 +22,8 @@ export default function useKeyboardNavigation() {
   const focusCellElement = useCallback(
     (cellId: string) => {
       focusCell(cellId)
-      requestAnimationFrame(() => document.getElementById(cellId)?.focus())
+      console.log(cellId)
+      requestAnimationFrame(() => document.getElementById(cellId)?.closest('td')?.focus())
     },
     [focusCell],
   )

--- a/shared/src/containers/ProjectTreeTable/hooks/useKeyboardNavigation.ts
+++ b/shared/src/containers/ProjectTreeTable/hooks/useKeyboardNavigation.ts
@@ -19,12 +19,18 @@ export default function useKeyboardNavigation() {
   const { setEditingCellId, editingCellId } = useCellEditing()
   const { setSelectedEntity } = useDetailsPanelEntityContext()
 
+  const focusCellElement = useCallback(
+    (cellId: string) => {
+      focusCell(cellId)
+      requestAnimationFrame(() => document.getElementById(cellId)?.focus())
+    },
+    [focusCell],
+  )
+
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
       const target = e.target as HTMLElement
-      // is target inside table or not body?
-      // NOTE: we must check for body because there is a bug that means the active element goes to body not the table td
-      if (!target?.closest('table') && !target.closest('body')) {
+      if (!target?.closest('tbody td')) {
         return
       }
 
@@ -81,7 +87,7 @@ export default function useKeyboardNavigation() {
             if (newRowId) {
               const newCellId = getCellId(newRowId, colId)
               selectCell(newCellId, e.shiftKey, e.shiftKey)
-              focusCell(newCellId)
+              focusCellElement(newCellId)
 
               // if the player is open, update with new selected cell
               if (playerOpen) {
@@ -97,7 +103,7 @@ export default function useKeyboardNavigation() {
           if (newRowId) {
             const newCellId = getCellId(newRowId, colId)
             selectCell(newCellId, e.shiftKey, e.shiftKey)
-            focusCell(newCellId)
+            focusCellElement(newCellId)
 
             // if the player is open, update with new selected cell
             if (playerOpen) {
@@ -113,7 +119,7 @@ export default function useKeyboardNavigation() {
             if (newColId) {
               const newCellId = getCellId(rowId, newColId)
               selectCell(newCellId, e.shiftKey, e.shiftKey)
-              focusCell(newCellId)
+              focusCellElement(newCellId)
             }
           }
           break
@@ -124,7 +130,7 @@ export default function useKeyboardNavigation() {
           if (newColId) {
             const newCellId = getCellId(rowId, newColId)
             selectCell(newCellId, e.shiftKey, e.shiftKey)
-            focusCell(newCellId)
+            focusCellElement(newCellId)
           }
           break
         }
@@ -171,7 +177,7 @@ export default function useKeyboardNavigation() {
             // Move to next/prev column in same row
             const newCellId = getCellId(rowId, nextColId)
             selectCell(newCellId, false, false)
-            focusCell(newCellId)
+            focusCellElement(newCellId)
           } else if (!e.shiftKey && rowIndex < gridMap.rowIdToIndex.size - 1) {
             // Move to first column of next row
             const newRowId = gridMap.indexToRowId.get(rowIndex + 1)
@@ -179,7 +185,7 @@ export default function useKeyboardNavigation() {
             if (newRowId && firstColId) {
               const newCellId = getCellId(newRowId, firstColId)
               selectCell(newCellId, false, false)
-              focusCell(newCellId)
+              focusCellElement(newCellId)
             }
           } else if (e.shiftKey && rowIndex > 0) {
             // Move to last column of previous row
@@ -188,7 +194,7 @@ export default function useKeyboardNavigation() {
             if (newRowId && lastColId) {
               const newCellId = getCellId(newRowId, lastColId)
               selectCell(newCellId, false, false)
-              focusCell(newCellId)
+              focusCellElement(newCellId)
             }
           }
           break
@@ -221,7 +227,7 @@ export default function useKeyboardNavigation() {
       focusedCellId,
       gridMap,
       selectCell,
-      focusCell,
+      focusCellElement,
       clearSelection,
       setEditingCellId,
       editingCellId,
@@ -245,7 +251,7 @@ export default function useKeyboardNavigation() {
     focusedCellId,
     gridMap,
     selectCell,
-    focusCell,
+    focusCellElement,
     clearSelection,
     setEditingCellId,
     editingCellId,

--- a/src/pages/VersionsProductsPage/components/VPTable/VPTable.tsx
+++ b/src/pages/VersionsProductsPage/components/VPTable/VPTable.tsx
@@ -5,11 +5,14 @@ import {
   NEXT_PAGE_ID,
   ProjectTreeTable,
 } from '@shared/containers'
-import { FC } from 'react'
+import { FC, useMemo } from 'react'
 import { useVersionsDataContext } from '../../context/VPDataContext'
 import { useVPViewsContext } from '@pages/VersionsProductsPage/context/VPViewsContext'
 import { VPContextMenuItems } from '../../hooks/useVPContextMenu'
 import clsx from 'clsx'
+import type { TreeTableExtraColumn } from '@shared/containers/ProjectTreeTable/buildTreeTableColumns'
+
+const VP_EXCLUDED_COLUMNS = ['assignees']
 
 interface VPTableProps {
   readOnly?: string[]
@@ -35,6 +38,123 @@ const VPTable: FC<VPTableProps> = ({ readOnly = [], contextMenuItems }) => {
     versionDetailItem,
   } = contextMenuItems
 
+  const extraColumns = useMemo<TreeTableExtraColumn[]>(
+    () => [
+      {
+        position: 9,
+        column: {
+          id: 'productBaseType',
+          accessorKey: 'productBaseType',
+          header: 'Base type',
+          minSize: COLUMN_MIN_SIZE,
+          enableResizing: true,
+          enablePinning: true,
+          enableHiding: true,
+          cell: ({ row, column, table }) => {
+            const { value, id, type } = getValueIdType(row, column.id)
+            if (['group', NEXT_PAGE_ID].includes(type) || row.original.metaType) return null
+            const meta = table.options.meta as any
+            return (
+              <CellWidget
+                rowId={id}
+                className={clsx('productBaseType', { loading: row.original.isLoading })}
+                columnId={column.id}
+                value={value}
+                options={meta?.options?.productType}
+                attributeData={{ type: 'string' }}
+                isReadOnly={true}
+              />
+            )
+          },
+        },
+      },
+      {
+        position: 10,
+        column: {
+          id: 'taskType',
+          accessorKey: 'taskType',
+          header: 'Task type',
+          minSize: COLUMN_MIN_SIZE,
+          enableResizing: true,
+          enablePinning: true,
+          enableHiding: true,
+
+          cell: ({ row, column, table }) => {
+            const { value, id, type } = getValueIdType(row, column.id)
+            if (['group', NEXT_PAGE_ID].includes(type) || row.original.metaType) return null
+            const meta = table.options.meta as any
+            return (
+              <CellWidget
+                rowId={id}
+                className={clsx('taskType', { loading: row.original.isLoading })}
+                columnId={column.id}
+                value={value}
+                options={meta?.options?.taskType}
+                attributeData={{ type: 'string' }}
+                isReadOnly={true}
+              />
+            )
+          },
+        },
+      },
+      {
+        position: 11,
+        column: {
+          id: 'folderType',
+          accessorKey: 'folderType',
+          header: 'Folder type',
+          minSize: COLUMN_MIN_SIZE,
+          enableResizing: true,
+          enablePinning: true,
+          enableHiding: true,
+          cell: ({ row, column, table }) => {
+            const { value, id, type } = getValueIdType(row, column.id)
+            if (['group', NEXT_PAGE_ID].includes(type) || row.original.metaType) return null
+            const meta = table.options.meta as any
+            return (
+              <CellWidget
+                rowId={id}
+                className={clsx('folderType', { loading: row.original.isLoading })}
+                columnId={column.id}
+                value={value}
+                options={meta?.options?.folderType}
+                attributeData={{ type: 'string' }}
+                isReadOnly={true}
+              />
+            )
+          },
+        },
+      },
+      {
+        position: 12,
+        column: {
+          id: 'taskLabel',
+          accessorKey: 'taskLabel',
+          header: 'Task',
+          minSize: COLUMN_MIN_SIZE,
+          enableResizing: true,
+          enablePinning: true,
+          enableHiding: true,
+          cell: ({ row, column }) => {
+            const { value, id, type } = getValueIdType(row, column.id)
+            if (['group', NEXT_PAGE_ID].includes(type) || row.original.metaType) return null
+            return (
+              <CellWidget
+                rowId={id}
+                className={clsx('taskLabel', { loading: row.original.isLoading })}
+                columnId={column.id}
+                value={value}
+                attributeData={{ type: 'string' }}
+                isReadOnly={true}
+              />
+            )
+          },
+        },
+      },
+    ],
+    [],
+  )
+
   return (
     <ProjectTreeTable
       scope={'versions-and-products'}
@@ -43,7 +163,7 @@ const VPTable: FC<VPTableProps> = ({ readOnly = [], contextMenuItems }) => {
       onScrollBottom={() => fetchNextPage()}
       onScrollBottomGroupBy={(groupValue: string) => fetchNextPage(groupValue)}
       readOnly={readOnly}
-      excludedColumns={['assignees']}
+      excludedColumns={VP_EXCLUDED_COLUMNS}
       isExpandable={showProducts}
       isLoading={isLoading}
       includeLinks={false}
@@ -58,119 +178,7 @@ const VPTable: FC<VPTableProps> = ({ readOnly = [], contextMenuItems }) => {
           display: { path_compact: false, path_full: true },
         },
       }}
-      extraColumns={[
-        {
-          position: 9,
-          column: {
-            id: 'productBaseType',
-            accessorKey: 'productBaseType',
-            header: 'Base type',
-            minSize: COLUMN_MIN_SIZE,
-            enableResizing: true,
-            enablePinning: true,
-            enableHiding: true,
-            cell: ({ row, column, table }) => {
-              const { value, id, type } = getValueIdType(row, column.id)
-              if (['group', NEXT_PAGE_ID].includes(type) || row.original.metaType) return null
-              const meta = table.options.meta as any
-              return (
-                <CellWidget
-                  rowId={id}
-                  className={clsx('productBaseType', { loading: row.original.isLoading })}
-                  columnId={column.id}
-                  value={value}
-                  options={meta?.options?.productType}
-                  attributeData={{ type: 'string' }}
-                  isReadOnly={true}
-                />
-              )
-            },
-          },
-        },
-        {
-          position: 10,
-          column: {
-            id: 'taskType',
-            accessorKey: 'taskType',
-            header: 'Task type',
-            minSize: COLUMN_MIN_SIZE,
-            enableResizing: true,
-            enablePinning: true,
-            enableHiding: true,
-
-            cell: ({ row, column, table }) => {
-              const { value, id, type } = getValueIdType(row, column.id)
-              if (['group', NEXT_PAGE_ID].includes(type) || row.original.metaType) return null
-              const meta = table.options.meta as any
-              return (
-                <CellWidget
-                  rowId={id}
-                  className={clsx('taskType', { loading: row.original.isLoading })}
-                  columnId={column.id}
-                  value={value}
-                  options={meta?.options?.taskType}
-                  attributeData={{ type: 'string' }}
-                  isReadOnly={true}
-                />
-              )
-            },
-          },
-        },
-        {
-          position: 11,
-          column: {
-            id: 'folderType',
-            accessorKey: 'folderType',
-            header: 'Folder type',
-            minSize: COLUMN_MIN_SIZE,
-            enableResizing: true,
-            enablePinning: true,
-            enableHiding: true,
-            cell: ({ row, column, table }) => {
-              const { value, id, type } = getValueIdType(row, column.id)
-              if (['group', NEXT_PAGE_ID].includes(type) || row.original.metaType) return null
-              const meta = table.options.meta as any
-              return (
-                <CellWidget
-                  rowId={id}
-                  className={clsx('folderType', { loading: row.original.isLoading })}
-                  columnId={column.id}
-                  value={value}
-                  options={meta?.options?.folderType}
-                  attributeData={{ type: 'string' }}
-                  isReadOnly={true}
-                />
-              )
-            },
-          },
-        },
-        {
-          position: 12,
-          column: {
-            id: 'taskLabel',
-            accessorKey: 'taskLabel',
-            header: 'Task',
-            minSize: COLUMN_MIN_SIZE,
-            enableResizing: true,
-            enablePinning: true,
-            enableHiding: true,
-            cell: ({ row, column }) => {
-              const { value, id, type } = getValueIdType(row, column.id)
-              if (['group', NEXT_PAGE_ID].includes(type) || row.original.metaType) return null
-              return (
-                <CellWidget
-                  rowId={id}
-                  className={clsx('taskLabel', { loading: row.original.isLoading })}
-                  columnId={column.id}
-                  value={value}
-                  attributeData={{ type: 'string' }}
-                  isReadOnly={true}
-                />
-              )
-            },
-          },
-        },
-      ]}
+      extraColumns={extraColumns}
       contextMenuItems={[
         'copy-paste',
         'show-details',

--- a/src/pages/VersionsProductsPage/context/VPFocusContext.tsx
+++ b/src/pages/VersionsProductsPage/context/VPFocusContext.tsx
@@ -36,18 +36,20 @@ export const VPFocusProvider: FC<VPFocusProviderProps> = ({ children }) => {
 
       // 1. Try to find a selected row first
       let targetElement = versionsTableRef.current.querySelector(
-        'tr .selected[tabindex]',
+        'tbody td.selected[tabindex="0"]',
       ) as HTMLElement
 
-      // 2. If no selected row, find any row with tabindex
-      if (!targetElement) {
-        targetElement = versionsTableRef.current.querySelector('tr [tabindex="0"]') as HTMLElement
-      }
-
-      // 3. If still nothing, try to find any focusable element in the table
+      // 2. If no selected cell, find any body cell with tabindex
       if (!targetElement) {
         targetElement = versionsTableRef.current.querySelector(
-          '[tabindex]:not([tabindex="-1"])',
+          'tbody td[tabindex="0"]',
+        ) as HTMLElement
+      }
+
+      // 3. If still nothing, try to find a focusable body element
+      if (!targetElement) {
+        targetElement = versionsTableRef.current.querySelector(
+          'tbody [tabindex]:not([tabindex="-1"])',
         ) as HTMLElement
       }
 


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->


## Problem
The products page table focus was buggy and often the focus would go to `body`. This would cause all sorts of issues like the shortcuts not working and the context menu not closing properly.

## Description of changes 
There were multiple factors that would cause this specifically on the products page.

**Keyboard Navigation & Focus Management**
- Explicit Cell Focus on Click: Forced body-cell focus on click after mousedown prevents native focus behavior (ProjectTreeTable.tsx).
- Scoped Keyboard Navigation: Filtered out headers, menus, and unrelated page elements from keyboard navigation sequences (useKeyboardNavigation.ts).
- DOM Focus Alignment: Synchronized actual DOM focus with logical selection state when navigating via Arrow keys and Tab (useKeyboardNavigation.ts).
- Header-Safe Focus Scoping: Restricted VP grid-to-table focus targets strictly to body cells, preventing draggable headers from being focused (VPFocusContext.tsx).

**Performance Optimization**
- Table Column Memoization: Stabilized the excluded-column list and memoized extra-column definitions to prevent unnecessary table-column reconstructions (VPTable.tsx).

