### PR TITLE
Details panel: clicking close sometimes does not close

### DIFF
--- a/shared/src/containers/DetailsPanel/DetailsPanel.tsx
+++ b/shared/src/containers/DetailsPanel/DetailsPanel.tsx
@@ -212,7 +212,7 @@ DetailsPanelProps) => {
     if (!contextEntities) uriOpenFiredForId.current = null
   }, [contextEntities])
 
-  // if the details panel is opened vair the uri, run callback
+  // if the details panel is opened via the uri, run callback
   useEffect(() => {
     if (isFetchingEntitiesDetails) return
 
@@ -230,7 +230,7 @@ DetailsPanelProps) => {
       uriOpenFiredForId.current = targetId
       onUriOpen(uriEntity, contextEntities.source)
     }
-  }, [entityDetailsData, isFetchingEntitiesDetails])
+  }, [entityDetailsData, isFetchingEntitiesDetails, contextEntities, onUriOpen])
 
   // TODO:  merge current entities data with fresh details data
 

--- a/shared/src/containers/DetailsPanel/DetailsPanel.tsx
+++ b/shared/src/containers/DetailsPanel/DetailsPanel.tsx
@@ -206,6 +206,12 @@ DetailsPanelProps) => {
     }
   }, [originalArgs, isSlideOut])
 
+  // fire onUriOpen once per context entity — a details refetch must not re-run the jump/filter reset
+  const uriOpenFiredForId = useRef<string | null>(null)
+  useEffect(() => {
+    if (!contextEntities) uriOpenFiredForId.current = null
+  }, [contextEntities])
+
   // if the details panel is opened vair the uri, run callback
   useEffect(() => {
     if (isFetchingEntitiesDetails) return
@@ -215,11 +221,13 @@ DetailsPanelProps) => {
       contextEntities?.entities?.length &&
       !!onUriOpen
     ) {
-      const uriEntity = entityDetailsData.find(
-        (entity) => entity.id === contextEntities.entities[0].id,
-      )
+      const targetId = contextEntities.entities[0].id
+      if (uriOpenFiredForId.current === targetId) return
+
+      const uriEntity = entityDetailsData.find((entity) => entity.id === targetId)
       if (!uriEntity) return
 
+      uriOpenFiredForId.current = targetId
       onUriOpen(uriEntity, contextEntities.source)
     }
   }, [entityDetailsData, isFetchingEntitiesDetails])
@@ -295,6 +303,8 @@ DetailsPanelProps) => {
     onClose?.()
     // also remove any entities in context
     setEntities(null)
+    // drop the uri so an in-flight resolve can't reopen the panel after close
+    setUri('')
     clearSearchUrl()
     closeSlideOut()
   }

--- a/shared/src/context/DetailsPanelContext.tsx
+++ b/shared/src/context/DetailsPanelContext.tsx
@@ -237,6 +237,9 @@ export const DetailsPanelProvider: React.FC<DetailsPanelProviderProps> = ({
 
   // on first load or URL param change, check if there is a uri or URL params and open details panel if present
   useEffect(() => {
+    // closing the panel deletes these params; bail so the stale uri state below can't reopen it
+    if (!project && !type && !id) return
+
     // Priority 1: Check for 'uri' parameter (ayon+entity://...)
     if (uriType === 'entity' && entity && entity.entityType !== 'product') {
       getUriEntities()


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Fixes the details panel not closing when it was opened from a share link. Closing also jumped navigation to the entity and cleared search filters.

## Technical details
<!-- Please state any technical details such as limitations -->

- `DetailsPanelContext`: bail out of the URL-params effect when `project`/`type`/`id` are absent, so stale `uri` state can't reopen the panel.
- `DetailsPanel.handleClose`: clears `uri` state so an in-flight URI resolve can't reopen after close.
- `onUriOpen` fires once per context entity, so a details refetch no longer re-runs the nav jump / filter reset.

## Additional context
<!-- Add any other context or screenshots here. -->

Closes #2180 
