### PR TITLE
Overview: Table rendering unstable causing links picker to close on streaming updates

### DIFF
--- a/shared/src/components/LinksManager/LinksManager.tsx
+++ b/shared/src/components/LinksManager/LinksManager.tsx
@@ -116,7 +116,10 @@ export const LinksManager: FC<LinksManagerProps> = ({
       <Styled.Container
         onMouseDown={(e) => {
           // Blur active input when clicking anywhere in the dialog (so count input commits)
-          if (e.target !== document.activeElement && document.activeElement instanceof HTMLInputElement) {
+          if (
+            e.target !== document.activeElement &&
+            document.activeElement instanceof HTMLInputElement
+          ) {
             document.activeElement.blur()
           }
         }}

--- a/shared/src/containers/ProjectTreeTable/ProjectTreeTable.tsx
+++ b/shared/src/containers/ProjectTreeTable/ProjectTreeTable.tsx
@@ -397,18 +397,6 @@ export const ProjectTreeTable = ({
     return scopes.map((s) => upperFirst(s)).join(' / ')
   }
 
-  // TanStack renders function-valued cell definitions as component types. Keep
-  // those types stable when Overview recreates equivalent metadata arrays.
-  const columnInputKey = JSON.stringify({
-    scopes,
-    columnAttribs,
-    options,
-    linkTypes,
-    excludedColumns,
-    excludedSorting,
-    groupBy,
-  })
-
   const columns = useMemo(() => {
     const baseColumns = buildTreeTableColumns({
       scopes,
@@ -444,14 +432,20 @@ export const ProjectTreeTable = ({
     }
     return baseColumns
   }, [
-    columnInputKey,
+    scopes,
+    JSON.stringify(columnAttribs), // columnAttribs is unstable between renders
     showHierarchy,
     isFlatFolderView,
     isExpandable,
+    options,
+    linkTypes,
     includeLinks,
     extraColumns,
+    excludedColumns,
+    excludedSorting,
     sortableRows,
     enableSorting,
+    groupBy,
   ])
 
   // Keep ColumnSettingsProvider's allColumns ref up to date

--- a/shared/src/containers/ProjectTreeTable/ProjectTreeTable.tsx
+++ b/shared/src/containers/ProjectTreeTable/ProjectTreeTable.tsx
@@ -397,6 +397,18 @@ export const ProjectTreeTable = ({
     return scopes.map((s) => upperFirst(s)).join(' / ')
   }
 
+  // TanStack renders function-valued cell definitions as component types. Keep
+  // those types stable when Overview recreates equivalent metadata arrays.
+  const columnInputKey = JSON.stringify({
+    scopes,
+    columnAttribs,
+    options,
+    linkTypes,
+    excludedColumns,
+    excludedSorting,
+    groupBy,
+  })
+
   const columns = useMemo(() => {
     const baseColumns = buildTreeTableColumns({
       scopes,
@@ -432,20 +444,14 @@ export const ProjectTreeTable = ({
     }
     return baseColumns
   }, [
-    scopes,
-    columnAttribs,
+    columnInputKey,
     showHierarchy,
     isFlatFolderView,
     isExpandable,
-    options,
-    linkTypes,
     includeLinks,
     extraColumns,
-    excludedColumns,
-    excludedSorting,
     sortableRows,
     enableSorting,
-    groupBy,
   ])
 
   // Keep ColumnSettingsProvider's allColumns ref up to date

--- a/shared/src/containers/ProjectTreeTable/types/table.ts
+++ b/shared/src/containers/ProjectTreeTable/types/table.ts
@@ -74,7 +74,6 @@ export type TableRow = {
     // if you want to use a thumbnail from a different entity, e.g. latest version of a product
     entityId: string
     entityType: string
-    updatedAt: string | undefined
     thumbnailHash?: string
   }
 }


### PR DESCRIPTION
## Description of changes
Some object that went into the columns memo builder was unstable, causing the inner table cells to remount when there were data changes, like real time streamed updates.

This would cause render and state stability within the table like flickering dropdowns and dialogs closing.

This was particularly painful on busy servers where there were constant updates streamed in, making picking links a lot more difficult when the dialog would close often.

## Technical details
Uses stringify to stabilize object references for the useMemo deps. (a bit of hack).

## Testing

- Open overview page
- Open links dialog picker
- Open an incognito tab logged in as a different user.
- Make a change to a folder/task in the incognito tab on the same project
- The dialog picker should stay open and the update should be made in the background