### PR TITLE
Lists: Search filter should support fuzzy text strings

### DIFF
--- a/shared/src/api/generated/graphql.ts
+++ b/shared/src/api/generated/graphql.ts
@@ -1842,6 +1842,7 @@ export type GetListItemsQueryVariables = Exact<{
   last?: number | null | undefined;
   sortBy?: string | null | undefined;
   filter?: string | null | undefined;
+  search?: string | null | undefined;
   showComments?: boolean;
 }>;
 
@@ -1859,6 +1860,7 @@ export type GetListItemsColumnStatsQueryVariables = Exact<{
   projectName: string;
   listId: string;
   filter?: string | null | undefined;
+  search?: string | null | undefined;
   targets?: Array<MetricTargetInput> | MetricTargetInput | null | undefined;
 }>;
 
@@ -3129,7 +3131,7 @@ export const GetProductVersionsDocument = new TypedDocumentString(`
 }
     `);
 export const GetListItemsDocument = new TypedDocumentString(`
-    query GetListItems($projectName: String!, $listId: String!, $first: Int, $after: String, $before: String, $last: Int, $sortBy: String, $filter: String, $showComments: Boolean! = false) {
+    query GetListItems($projectName: String!, $listId: String!, $first: Int, $after: String, $before: String, $last: Int, $sortBy: String, $filter: String, $search: String, $showComments: Boolean! = false) {
   project(name: $projectName) {
     entityLists(ids: [$listId]) {
       pageInfo {
@@ -3147,6 +3149,7 @@ export const GetListItemsDocument = new TypedDocumentString(`
             last: $last
             sortBy: $sortBy
             filter: $filter
+            search: $search
           ) {
             pageInfo {
               hasNextPage
@@ -3276,14 +3279,14 @@ fragment SubTaskFragment on SubTaskNode {
   isDone
 }`);
 export const GetListItemsColumnStatsDocument = new TypedDocumentString(`
-    query GetListItemsColumnStats($projectName: String!, $listId: String!, $filter: String, $targets: [MetricTargetInput!]) {
+    query GetListItemsColumnStats($projectName: String!, $listId: String!, $filter: String, $search: String, $targets: [MetricTargetInput!]) {
   project(name: $projectName) {
     name
     entityLists(ids: [$listId]) {
       edges {
         node {
           id
-          items(filter: $filter, calculateSpecificStatistics: $targets) {
+          items(filter: $filter, search: $search, calculateSpecificStatistics: $targets) {
             fieldStats {
               ...ColumnStatsFragment
             }

--- a/shared/src/api/queries/entityLists/gql/GetListItems.graphql
+++ b/shared/src/api/queries/entityLists/gql/GetListItems.graphql
@@ -7,6 +7,7 @@ query GetListItems(
   $last: Int
   $sortBy: String
   $filter: String
+  $search: String
   $showComments: Boolean! = false
 ) {
   project(name: $projectName) {
@@ -26,6 +27,7 @@ query GetListItems(
             last: $last
             sortBy: $sortBy
             filter: $filter
+            search: $search
           ) {
             pageInfo {
               hasNextPage

--- a/shared/src/api/queries/entityLists/gql/GetListItemsColumnStats.graphql
+++ b/shared/src/api/queries/entityLists/gql/GetListItemsColumnStats.graphql
@@ -5,6 +5,7 @@ query GetListItemsColumnStats(
   $projectName: String!
   $listId: String!
   $filter: String
+  $search: String
   $targets: [MetricTargetInput!]
 ) {
   project(name: $projectName) {
@@ -13,7 +14,7 @@ query GetListItemsColumnStats(
       edges {
         node {
           id
-          items(filter: $filter, calculateSpecificStatistics: $targets) {
+          items(filter: $filter, search: $search, calculateSpecificStatistics: $targets) {
             fieldStats {
               ...ColumnStatsFragment
             }

--- a/src/pages/ProjectListsPage/components/ListItemsFilter/ListItemsFilter.tsx
+++ b/src/pages/ProjectListsPage/components/ListItemsFilter/ListItemsFilter.tsx
@@ -27,7 +27,7 @@ const ListItemsFilter: FC<ListItemsFilterProps> = ({ entityType, projectName }) 
       scopes={buildScopes([entityType], UNSUPPORTED_BY_LIST_ITEMS)}
       projectNames={[projectName]}
       projectInfo={projectInfo}
-      enableGlobalSearch={false}
+      enableGlobalSearch={true}
       data={entityType === 'version' ? { productTypes: projectInfo.productTypes } : {}}
       config={{
         prefixes: {

--- a/src/pages/ProjectListsPage/hooks/useGetListItemsData.ts
+++ b/src/pages/ProjectListsPage/hooks/useGetListItemsData.ts
@@ -22,6 +22,7 @@ import {
 import { sanitizeQueryFilter } from '@shared/containers/ProjectTreeTable/utils/sanitizeQueryFilter'
 import { expandRelativeDates } from '@shared/containers/ProjectTreeTable/utils/expandRelativeDates'
 import { useQueryArgumentChangeLoading } from '@shared/hooks'
+import { convertSearchToQueryFilter } from '../util/searchToQueryFilter'
 import { OnSyncDataCallback, usePowerpack, useProjectContext } from '@shared/context'
 import { useListsViewSettings, useProjectDataContext, useViewsContext } from '@shared/containers'
 import { useAppDispatch } from '@state/store'
@@ -87,8 +88,9 @@ const useGetListItemsData = ({
       : undefined
   ) as StatsEntity | undefined
   const statsProjectName = contextProjectName || projectName
-  const queryFilterString = filters.conditions?.length
-    ? JSON.stringify(sanitizeQueryFilter(expandRelativeDates(filters)))
+  const searchedFilters = convertSearchToQueryFilter(filters, entityType)
+  const queryFilterString = searchedFilters.conditions?.length
+    ? JSON.stringify(sanitizeQueryFilter(expandRelativeDates(searchedFilters)))
     : ''
 
   // Create sort params for infinite query
@@ -179,9 +181,7 @@ const useGetListItemsData = ({
     ],
   )
 
-  const statsFilter = filters.conditions?.length
-    ? JSON.stringify(sanitizeQueryFilter(expandRelativeDates(filters)))
-    : undefined
+  const statsFilter = queryFilterString || undefined
   const statsArgs = {
     projectName: statsProjectName,
     listId: listId || '',

--- a/src/pages/ProjectListsPage/hooks/useGetListItemsData.ts
+++ b/src/pages/ProjectListsPage/hooks/useGetListItemsData.ts
@@ -22,7 +22,7 @@ import {
 import { sanitizeQueryFilter } from '@shared/containers/ProjectTreeTable/utils/sanitizeQueryFilter'
 import { expandRelativeDates } from '@shared/containers/ProjectTreeTable/utils/expandRelativeDates'
 import { useQueryArgumentChangeLoading } from '@shared/hooks'
-import { convertSearchToQueryFilter } from '../util/searchToQueryFilter'
+import { extractSearchFromFilters } from '../util/searchToQueryFilter'
 import { OnSyncDataCallback, usePowerpack, useProjectContext } from '@shared/context'
 import { useListsViewSettings, useProjectDataContext, useViewsContext } from '@shared/containers'
 import { useAppDispatch } from '@state/store'
@@ -88,9 +88,9 @@ const useGetListItemsData = ({
       : undefined
   ) as StatsEntity | undefined
   const statsProjectName = contextProjectName || projectName
-  const searchedFilters = convertSearchToQueryFilter(filters, entityType)
-  const queryFilterString = searchedFilters.conditions?.length
-    ? JSON.stringify(sanitizeQueryFilter(expandRelativeDates(searchedFilters)))
+  const { search, filters: filtersWithoutSearch } = extractSearchFromFilters(filters)
+  const queryFilterString = filtersWithoutSearch.conditions?.length
+    ? JSON.stringify(sanitizeQueryFilter(expandRelativeDates(filtersWithoutSearch)))
     : ''
 
   // Create sort params for infinite query
@@ -125,6 +125,7 @@ const useGetListItemsData = ({
     sortBy: parseSorting(singleSort?.id),
     desc: singleSort?.desc,
     filter: queryFilterString || undefined,
+    search,
     showComments,
   }
 
@@ -151,6 +152,7 @@ const useGetListItemsData = ({
       sortBy: parseSorting(singleSort?.id) || '',
       desc: singleSort?.desc || false,
       filter: queryFilterString || '',
+      search: search || '',
     },
     isFetchingListItems,
   )
@@ -186,6 +188,7 @@ const useGetListItemsData = ({
     projectName: statsProjectName,
     listId: listId || '',
     filter: statsFilter,
+    search,
     targets: statsTargets,
   }
   const skipStats =

--- a/src/pages/ProjectListsPage/util/searchToQueryFilter.ts
+++ b/src/pages/ProjectListsPage/util/searchToQueryFilter.ts
@@ -1,0 +1,44 @@
+import { SEARCH_FILTER_ID } from '@ynput/ayon-react-components'
+import { QueryCondition, QueryFilter } from '@shared/containers/ProjectTreeTable/types/operations'
+
+// entity_list_items has no fuzzy `search` arg (ayon-backend#1008), so the global
+// search chip is translated into ILIKE conditions on name/label/path client-side
+const SEARCH_KEYS_BY_TYPE: Record<string, string[]> = {
+  folder: ['label', 'folderPath', 'entity_name', 'entity_label'],
+  task: ['label', 'folderPath', 'entity_name', 'entity_label'],
+  product: ['label', 'folderPath', 'entity_name'],
+  version: ['label', 'folderPath'],
+}
+const DEFAULT_SEARCH_KEYS = ['label', 'folderPath']
+
+const isCondition = (c: QueryCondition | QueryFilter): c is QueryCondition => 'key' in c
+
+export const convertSearchToQueryFilter = (
+  filters: QueryFilter,
+  entityType?: string,
+): QueryFilter => {
+  if (!filters.conditions?.length) return filters
+
+  const keys = SEARCH_KEYS_BY_TYPE[entityType || ''] || DEFAULT_SEARCH_KEYS
+
+  const conditions = filters.conditions
+    .map((c) => {
+      if (!isCondition(c) || c.key !== SEARCH_FILTER_ID) return c
+
+      const terms = (Array.isArray(c.value) ? c.value : [c.value])
+        .map((v) => String(v ?? '').trim())
+        .filter(Boolean)
+      if (!terms.length) return null
+
+      const searchGroup: QueryFilter = {
+        operator: 'or',
+        conditions: terms.flatMap((term) =>
+          keys.map((key): QueryCondition => ({ key, operator: 'like', value: `%${term}%` })),
+        ),
+      }
+      return searchGroup
+    })
+    .filter((c): c is QueryCondition | QueryFilter => c !== null)
+
+  return { ...filters, conditions }
+}

--- a/src/pages/ProjectListsPage/util/searchToQueryFilter.ts
+++ b/src/pages/ProjectListsPage/util/searchToQueryFilter.ts
@@ -9,18 +9,30 @@ export const extractSearchFromFilters = (
   if (!filters.conditions?.length) return { search: undefined, filters }
 
   const searchTerms: string[] = []
-  const conditions = filters.conditions.filter((c) => {
-    if (!isCondition(c) || c.key !== SEARCH_FILTER_ID) return true
 
-    const terms = (Array.isArray(c.value) ? c.value : [c.value])
-      .map((v) => String(v ?? '').trim())
-      .filter(Boolean)
-    searchTerms.push(...terms)
-    return false
+  // multiple search chips become a nested OR group, so strip at any depth
+  const stripSearch = (filter: QueryFilter): QueryFilter => ({
+    ...filter,
+    conditions: filter.conditions?.flatMap((c) => {
+      if (!isCondition(c)) {
+        const nested = stripSearch(c)
+        return nested.conditions?.length ? [nested] : []
+      }
+
+      if (c.key !== SEARCH_FILTER_ID) return [c]
+
+      const terms = (Array.isArray(c.value) ? c.value : [c.value])
+        .map((v) => String(v ?? '').replace(/%/g, '').trim())
+        .filter(Boolean)
+      searchTerms.push(...terms)
+      return []
+    }),
   })
+
+  const strippedFilters = stripSearch(filters)
 
   return {
     search: searchTerms.length ? searchTerms.join(' ') : undefined,
-    filters: { ...filters, conditions },
+    filters: strippedFilters,
   }
 }

--- a/src/pages/ProjectListsPage/util/searchToQueryFilter.ts
+++ b/src/pages/ProjectListsPage/util/searchToQueryFilter.ts
@@ -1,44 +1,26 @@
 import { SEARCH_FILTER_ID } from '@ynput/ayon-react-components'
 import { QueryCondition, QueryFilter } from '@shared/containers/ProjectTreeTable/types/operations'
 
-// entity_list_items has no fuzzy `search` arg (ayon-backend#1008), so the global
-// search chip is translated into ILIKE conditions on name/label/path client-side
-const SEARCH_KEYS_BY_TYPE: Record<string, string[]> = {
-  folder: ['label', 'folderPath', 'entity_name', 'entity_label'],
-  task: ['label', 'folderPath', 'entity_name', 'entity_label'],
-  product: ['label', 'folderPath', 'entity_name'],
-  version: ['label', 'folderPath'],
-}
-const DEFAULT_SEARCH_KEYS = ['label', 'folderPath']
-
 const isCondition = (c: QueryCondition | QueryFilter): c is QueryCondition => 'key' in c
 
-export const convertSearchToQueryFilter = (
+export const extractSearchFromFilters = (
   filters: QueryFilter,
-  entityType?: string,
-): QueryFilter => {
-  if (!filters.conditions?.length) return filters
+): { search: string | undefined; filters: QueryFilter } => {
+  if (!filters.conditions?.length) return { search: undefined, filters }
 
-  const keys = SEARCH_KEYS_BY_TYPE[entityType || ''] || DEFAULT_SEARCH_KEYS
+  const searchTerms: string[] = []
+  const conditions = filters.conditions.filter((c) => {
+    if (!isCondition(c) || c.key !== SEARCH_FILTER_ID) return true
 
-  const conditions = filters.conditions
-    .map((c) => {
-      if (!isCondition(c) || c.key !== SEARCH_FILTER_ID) return c
+    const terms = (Array.isArray(c.value) ? c.value : [c.value])
+      .map((v) => String(v ?? '').trim())
+      .filter(Boolean)
+    searchTerms.push(...terms)
+    return false
+  })
 
-      const terms = (Array.isArray(c.value) ? c.value : [c.value])
-        .map((v) => String(v ?? '').trim())
-        .filter(Boolean)
-      if (!terms.length) return null
-
-      const searchGroup: QueryFilter = {
-        operator: 'or',
-        conditions: terms.flatMap((term) =>
-          keys.map((key): QueryCondition => ({ key, operator: 'like', value: `%${term}%` })),
-        ),
-      }
-      return searchGroup
-    })
-    .filter((c): c is QueryCondition | QueryFilter => c !== null)
-
-  return { ...filters, conditions }
+  return {
+    search: searchTerms.length ? searchTerms.join(' ') : undefined,
+    filters: { ...filters, conditions },
+  }
 }


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Adds fuzzy text search to the Lists page filter bar. Free text matches item name, label and folder path, same as Overview.

## Technical details
<!-- Please state any technical details such as limitations -->

- Search columns vary per entity type; version lists skip `entity_name`
- `useGetListItemsData` applies the conversion to both the items and column-stats queries.
- `ListItemsFilter` turns on `enableGlobalSearch`.

## Additional context
<!-- Add any other context or screenshots here. -->

Closes #2064
