### PR TITLE
Filters: text fields empty and not empty

### DIFF
--- a/shared/package.json
+++ b/shared/package.json
@@ -132,7 +132,7 @@
   "dependencies": {
     "@tanstack/match-sorter-utils": "8.19.4",
     "@tanstack/react-virtual": "3.13.23",
-    "@ynput/ayon-frontend-shared": "^0.3.43",
+    "@ynput/ayon-frontend-shared": "^0.3.51",
     "@ynput/ayon-react-components": "^1.18.8",
     "axios": "1.16.1",
     "clsx": "2.1.1",

--- a/shared/src/components/SearchFilter/useBuildFilterOptions.tsx
+++ b/shared/src/components/SearchFilter/useBuildFilterOptions.tsx
@@ -514,8 +514,17 @@ export const useBuildFilterOptions = ({
           'list_of_submodels',
         ].includes(type || '')
         const isDate = type === 'datetime'
+        const isText = type === 'string'
+        const isNumber = type === 'integer' || type === 'float'
         const enableOperatorChange = isListOf ? config?.enableOperatorChange : false
-        const enableRelativeValues = isListOf || isDate ? config?.enableRelativeValues : false
+        // a project default inherits down to every entity, so nullness filters would never match
+        const alwaysResolvesToValue =
+          attribute.data.default !== undefined &&
+          attribute.data.default !== null &&
+          attribute.data.inherit !== false
+        // booleans excluded: unset already matches "No", so has/no value would just duplicate it
+        const supportsNullness = (isListOf || isDate || isText || isNumber) && !alwaysResolvesToValue
+        const enableRelativeValues = supportsNullness ? config?.enableRelativeValues : false
         // for the attribute, get the option root
         const option = getAttributeFieldOptionRoot(
           attribute,

--- a/shared/src/components/SearchFilter/useDateRangeFilter.ts
+++ b/shared/src/components/SearchFilter/useDateRangeFilter.ts
@@ -144,6 +144,8 @@ export const useDateRangeFilter = (): UseDateRangeFilterReturn => {
 
     // Relative dates (Today, This week, etc.) — let the dropdown open normally
     const rangeValue = datetimeFilter.values?.[0]
+    // Nullness chips (No Value / Has Value) have no date range to edit
+    if (rangeValue?.id === 'noValue' || rangeValue?.id === 'hasValue') return
     if (rangeValue?.id) {
       const content = (rangeValue.id as string).replace('custom-', '')
       const firstZ = content.indexOf('Z')

--- a/shared/src/containers/ProjectTreeTable/utils/clientFilterToQueryFilter.ts
+++ b/shared/src/containers/ProjectTreeTable/utils/clientFilterToQueryFilter.ts
@@ -82,6 +82,24 @@ export const clientFilterToQueryFilter = (filters: FilterForQuery[]): QueryFilte
   }
 }
 
+// Cleared text attribs are stored as "" (not null), so nullness checks on text
+// fields must cover both states. queryFilterToClientFilter reverses these shapes.
+const textEmptyGroup = (key: string): QueryFilter => ({
+  conditions: [
+    { key, operator: 'isnull' },
+    { key, operator: 'eq', value: '' },
+  ],
+  operator: 'or',
+})
+
+const textNotEmptyGroup = (key: string): QueryFilter => ({
+  conditions: [
+    { key, operator: 'notnull' },
+    { key, operator: 'ne', value: '' },
+  ],
+  operator: 'and',
+})
+
 // Helper function to convert a single Filter to a QueryCondition
 const convertFilterToCondition = (filter: FilterForQuery): QueryCondition | QueryFilter => {
   // Extract key from filter ID (split by underscore if needed)
@@ -127,8 +145,13 @@ const convertFilterToCondition = (filter: FilterForQuery): QueryCondition | Quer
     return { key, operator }
   }
 
+  const isTextField = filter.type === 'string' && !isListField
+
   // Handle different filter types
   if (hasSomeValue) {
+    if (isTextField) {
+      return filter.inverted ? textEmptyGroup(key) : textNotEmptyGroup(key)
+    }
     // we set the value to the empty state and then say it should not be that
     value = isListField ? [] : undefined
     operator = isListField
@@ -139,6 +162,9 @@ const convertFilterToCondition = (filter: FilterForQuery): QueryCondition | Quer
       ? 'isnull'
       : 'notnull'
   } else if (hasNoValue) {
+    if (isTextField) {
+      return filter.inverted ? textNotEmptyGroup(key) : textEmptyGroup(key)
+    }
     // we set the value to the empty state and then say it should be that
     value = isListField ? [] : undefined
     operator = isListField

--- a/shared/src/containers/ProjectTreeTable/utils/queryFilterToClientFilter.ts
+++ b/shared/src/containers/ProjectTreeTable/utils/queryFilterToClientFilter.ts
@@ -48,8 +48,13 @@ export const queryFilterToClientFilter = (
     } else {
       // This is a nested QueryFilter - check if it's a datetime range (gte+lte same key)
       const datetimeFilter = tryMergeDatetimeRange(condition, filterOptions)
+      const textNullnessFilter = datetimeFilter
+        ? null
+        : tryMergeTextNullness(condition, filterOptions)
       if (datetimeFilter) {
         filters.push(datetimeFilter)
+      } else if (textNullnessFilter) {
+        filters.push(textNullnessFilter)
       } else {
         // Recursively process other nested QueryFilters
         const nestedFilters = queryFilterToClientFilter(condition, filterOptions)
@@ -176,6 +181,49 @@ export const tryMergeDatetimeRange = (
     icon: filterOption.icon,
     inverted: nestedFilter.operator === 'or',
     values: [rangeValue],
+    singleSelect: filterOption.singleSelect,
+  }
+}
+
+/**
+ * Detects the composite nullness groups produced by clientFilterToQueryFilter for
+ * text fields (isnull OR eq '' / notnull AND ne '') and restores the
+ * noValue/hasValue chip instead of recursing into the group's conditions.
+ */
+export const tryMergeTextNullness = (
+  nestedFilter: QueryFilter,
+  filterOptions: Option[],
+): Filter | null => {
+  const conditions = nestedFilter.conditions?.filter((c): c is QueryCondition => 'key' in c) ?? []
+  if (conditions.length !== 2 || conditions.length !== nestedFilter.conditions?.length) return null
+
+  const key = conditions[0].key
+  if (!conditions.every((c) => c.key === key)) return null
+
+  const isNoValue =
+    nestedFilter.operator === 'or' &&
+    conditions.some((c) => c.operator === 'isnull') &&
+    conditions.some((c) => c.operator === 'eq' && c.value === '')
+  const isHasValue =
+    nestedFilter.operator === 'and' &&
+    conditions.some((c) => c.operator === 'notnull') &&
+    conditions.some((c) => c.operator === 'ne' && c.value === '')
+  if (!isNoValue && !isHasValue) return null
+
+  const filterOption = findFilterOption(key, filterOptions)
+  if (!filterOption) return null
+
+  return {
+    id: filterOption.id,
+    type: filterOption.type as Filter['type'],
+    label: filterOption.label,
+    inverted: false,
+    operator: 'OR',
+    icon: filterOption.icon,
+    values: isNoValue
+      ? [{ id: 'noValue', label: 'No Value' }]
+      : [{ id: 'hasValue', label: 'Has Value' }],
+    isCustom: filterOption.allowsCustomValues,
     singleSelect: filterOption.singleSelect,
   }
 }

--- a/shared/yarn.lock
+++ b/shared/yarn.lock
@@ -1500,6 +1500,37 @@
     turndown "7.2.4"
     uuid "14.0.0"
 
+"@ynput/ayon-frontend-shared@^0.3.51":
+  version "0.3.51"
+  resolved "https://registry.yarnpkg.com/@ynput/ayon-frontend-shared/-/ayon-frontend-shared-0.3.51.tgz#900ef6263cae21af793a082b16de51148803fa95"
+  integrity sha512-4NLH9WmyFSaxRqQDZytA1gk0pjr5ccusmKiwYV7e29wWl/lasAoyZ4COuahQaRGT3sx4GIHoo0x+WMrDdnQ/1A==
+  dependencies:
+    "@tanstack/match-sorter-utils" "8.19.4"
+    "@tanstack/react-virtual" "3.13.23"
+    "@ynput/ayon-frontend-shared" "^0.3.43"
+    "@ynput/ayon-react-components" "^1.18.8"
+    axios "1.16.1"
+    clsx "2.1.1"
+    custom-protocol-check "1.4.0"
+    date-fns "3.6.0"
+    lodash "4.18.1"
+    primeicons "7.0.0"
+    primereact "9.6.2"
+    primereact-context "npm:primereact@9.2.3"
+    quill-magic-url "4.2.0"
+    react-markdown "10.1.0"
+    react-perfect-scrollbar "1.5.8"
+    react-quill-ayon "2.0.2"
+    react-toastify "9.1.3"
+    rehype-raw "7.0.0"
+    remark-directive "3.0.1"
+    remark-directive-rehype "0.4.2"
+    remark-emoji "4.0.1"
+    remark-gfm "4.0.1"
+    short-uuid "4.2.2"
+    turndown "7.2.4"
+    uuid "14.0.0"
+
 "@ynput/ayon-react-components@1.17.1":
   version "1.17.1"
   resolved "https://registry.yarnpkg.com/@ynput/ayon-react-components/-/ayon-react-components-1.17.1.tgz#18ddd98ab7861812e57e802b9d606c7945c0e6a0"

--- a/src/components/SearchFilter/useDateRangeFilter.ts
+++ b/src/components/SearchFilter/useDateRangeFilter.ts
@@ -148,6 +148,8 @@ export const useDateRangeFilter = (): UseDateRangeFilterReturn => {
 
     // Relative dates (Today, This week, etc.) — let the dropdown open normally
     const rangeValue = datetimeFilter.values?.[0]
+    // Nullness chips (No Value / Has Value) have no date range to edit
+    if (rangeValue?.id === 'noValue' || rangeValue?.id === 'hasValue') return
     if (rangeValue?.id) {
       const content = (rangeValue.id as string).replace('custom-', '')
       const firstZ = content.indexOf('Z')

--- a/src/pages/ProjectOverviewPage/containers/SearchFilterWrapper.tsx
+++ b/src/pages/ProjectOverviewPage/containers/SearchFilterWrapper.tsx
@@ -409,6 +409,8 @@ const SearchFilterWrapper: FC<SearchFilterWrapperProps> = ({
 
     // Check if it's a relative date (Today, This week, etc.) — let dropdown open normally
     const rangeValue = datetimeFilter.values?.[0]
+    // Nullness chips (No Value / Has Value) have no date range to edit
+    if (rangeValue?.id === 'noValue' || rangeValue?.id === 'hasValue') return
     if (rangeValue?.id) {
       const customIdContent = (rangeValue.id as string).replace('custom-', '')
       const firstZIndex = customIdContent.indexOf('Z')


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Adds "Has {field}" / "No {field}" options to attribute filters, so entities can be found by whether a field is filled in at all. Available on Overview, Versions & Products and Lists.

## Technical details
<!-- Please state any technical details such as limitations -->

- `useBuildFilterOptions.tsx`: enables the options for string, integer and float attributes.
- Options stay hidden for booleans ("No" already matches unset rows) and for attributes with an inheritable project default (fps, priority, resolution…), where the value always resolves and nullness would never match.
- `clientFilterToQueryFilter.ts`: text nullness compiles to a composite group (`isnull OR eq ''` / `notnull AND ne ''`) because cleared text attributes are stored as `""`, not null.
- `queryFilterToClientFilter.ts`: `tryMergeTextNullness` restores the chip so saved views round-trip.
- Tasks Progress is unaffected — it builds filter options without a config, so the options never render there.

## Additional context
<!-- Add any other context or screenshots here. -->

Closes #2159
