### PR TITLE
Projects: fix code generation for regexes with underscores

### DIFF
--- a/src/pages/ProjectManagerPage/NewProjectDialog/NewProject.jsx
+++ b/src/pages/ProjectManagerPage/NewProjectDialog/NewProject.jsx
@@ -28,6 +28,26 @@ const PROJECT_STATES = [
   { value: 'production', label: 'Production' },
 ]
 
+// prefer unicode mode for \p{...} patterns, but some patterns legal without it (e.g. `\-` outside a class) only compile as non-unicode
+const buildCodeRegex = (pattern) => {
+  try {
+    return new RegExp(pattern, 'gu')
+  } catch (error) {
+    return new RegExp(pattern, 'g')
+  }
+}
+
+const matchProjectCode = (value, pattern) => {
+  const matches = [...value.matchAll(buildCodeRegex(pattern))]
+  if (!matches.length) return ''
+
+  return matches
+    .map((match) => (match.length > 1 ? match.slice(1).filter(Boolean).join('') : match[0]))
+    .join('')
+    .replaceAll(' ', '')
+    .replace(/^_+|_+$/g, '')
+}
+
 const DialogContent = styled.div`
   width: 100%;
   height: 100%;
@@ -151,23 +171,15 @@ const NewProjectDialog = ({ onHide, redirect = true }) => {
   }
 
   const createCode = (name, regexPattern) => {
-    if (!regexPattern) return ''
+    if (!regexPattern || !name) return ''
 
     try {
-      const matchCode = (value) => {
-        const matches = [...value.matchAll(new RegExp(regexPattern, 'g'))]
-        if (!matches.length) return ''
+      const rawCode = matchProjectCode(name, regexPattern)
+      if (PROJECT_CODE_REGEX.test(rawCode)) return rawCode
 
-        const hasCaptureGroups = matches[0].length > 1
-        return matches
-          .map((match) => (hasCaptureGroups ? match[1] : match[0]))
-          .join('')
-          .replaceAll(' ', '')
-      }
-
-      // patterns expecting a literal _ get the raw name; others keep the spaced name so \b and .{n} patterns behave as before
-      if (regexPattern.includes('_')) return matchCode(name)
-      return matchCode(name.replaceAll('_', ' '))
+      // \b and \s never fire on snake_case names, so retry on a spaced name to keep pre-existing configs working
+      const spacedCode = matchProjectCode(name.replaceAll('_', ' '), regexPattern)
+      return PROJECT_CODE_REGEX.test(spacedCode) ? spacedCode : rawCode
     } catch (error) {
       console.warn('Invalid regex pattern for project code', error)
       return ''

--- a/src/pages/ProjectManagerPage/NewProjectDialog/NewProject.jsx
+++ b/src/pages/ProjectManagerPage/NewProjectDialog/NewProject.jsx
@@ -153,29 +153,21 @@ const NewProjectDialog = ({ onHide, redirect = true }) => {
   const createCode = (name, regexPattern) => {
     if (!regexPattern) return ''
 
-    // Always create a new RegExp from the string pattern
     try {
-      // Add 'g' flag to match all occurrences
-      const regex = new RegExp(regexPattern, 'g')
+      const matchCode = (value) => {
+        const matches = [...value.matchAll(new RegExp(regexPattern, 'g'))]
+        if (!matches.length) return ''
 
-      // Use matchAll instead of match for global patterns
-      const matches = [...name.replaceAll('_', ' ').matchAll(regex)]
-      if (!matches.length) return ''
-
-      // Check if the regex has capture groups
-      if (matches[0].length > 1) {
-        // Extract the first capture group from each match
+        const hasCaptureGroups = matches[0].length > 1
         return matches
-          .map((match) => match[1])
-          .join('')
-          .replaceAll(' ', '')
-      } else {
-        // If no capture groups, use the full match
-        return matches
-          .map((match) => match[0])
+          .map((match) => (hasCaptureGroups ? match[1] : match[0]))
           .join('')
           .replaceAll(' ', '')
       }
+
+      // patterns expecting a literal _ get the raw name; others keep the spaced name so \b and .{n} patterns behave as before
+      if (regexPattern.includes('_')) return matchCode(name)
+      return matchCode(name.replaceAll('_', ' '))
     } catch (error) {
       console.warn('Invalid regex pattern for project code', error)
       return ''


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Fixes empty project code in the new project dialog when the configured code regex contains a literal underscore, e.g. `(?:\d{5}_)[A-Za-z]{3}` on `12345_Some_Project`.

## Technical details
<!-- Please state any technical details such as limitations -->

- `createCode` replaced `_` with spaces before matching, so patterns with a literal `_` never matched (`NewProject.jsx`).
- Patterns containing `_` now run against the raw name; all others keep the spaced name, so `\b` initials and the default `^.{0,3}` behave exactly as before.
- Match processing extracted into a `matchCode` helper; capture-group handling and space stripping unchanged.

## Additional context
<!-- Add any other context or screenshots here. -->

Closes #2187
