### PR TITLE
Activity Feed: Show custom full names for anonymous guests

### DIFF
--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ynput/ayon-frontend-shared",
-  "version": "0.3.51",
+  "version": "0.3.52",
   "description": "Shared React components for AYON frontend",
   "main": "dist/index.cjs.js",
   "module": "dist/index.es.js",

--- a/shared/src/containers/Feed/helpers/getActivityUserName.ts
+++ b/shared/src/containers/Feed/helpers/getActivityUserName.ts
@@ -6,7 +6,7 @@ export const getActivityUserName = (user: { name?: string; label?: string | null
   if (!user || !user.name) {
     return UNKNOWN_USER_FULL_NAME
   }
-  if (user.name === ANONYMOUS_GUEST_NAME) {
+  if (user.name === ANONYMOUS_GUEST_NAME && !user.label) {
     return ANONYMOUS_GUEST_FULL_NAME
   }
   if (user.label) {


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

For anonymous guest activities, if there is an `authorFullName` available, it is now shown in the Activity Feed instead of the hardcoded string "Anonymous Guest".

## Technical details
<!-- Please state any technical details such as limitations -->


## Additional context
<!-- Add any other context or screenshots here. -->

required for: https://github.com/ynput/ayon-review/issues/238

