### PR TITLE
Activity Feed: offset annotation ranges by start frame

### DIFF
--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ynput/ayon-frontend-shared",
-  "version": "0.3.53",
+  "version": "0.3.54",
   "description": "Shared React components for AYON frontend",
   "main": "dist/index.cjs.js",
   "module": "dist/index.es.js",

--- a/shared/src/containers/Feed/components/FileUploadCard/FileUploadCard.styled.ts
+++ b/shared/src/containers/Feed/components/FileUploadCard/FileUploadCard.styled.ts
@@ -89,7 +89,8 @@ export const Footer = styled.footer`
     text-overflow: ellipsis;
     white-space: nowrap;
     z-index: 20;
-    display: inherit;
+    display: flex;
+    align-items: center;
 
     .icon {
       font-size: inherit;

--- a/shared/src/containers/Feed/components/FileUploadCard/FileUploadCard.tsx
+++ b/shared/src/containers/Feed/components/FileUploadCard/FileUploadCard.tsx
@@ -1,9 +1,9 @@
 import { Button, getFileSizeString, Icon } from '@ynput/ayon-react-components'
 import * as Styled from './FileUploadCard.styled'
 import clsx from 'clsx'
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { isFilePreviewable } from '../FileUploadPreview'
-import { SavedAnnotationMetadata } from '@shared/containers'
+import { SavedAnnotationMetadata, useFeedContext } from '@shared/containers'
 import { useDetailsPanelContext } from '@shared/context'
 import { AnnotationPreview } from '../CommentInput/hooks/useAnnotationsSync'
 
@@ -97,6 +97,7 @@ const FileUploadCard = ({
 
   const [imageError, setImageError] = useState(false)
   const { feedAnnotationsEnabled } = useDetailsPanelContext()
+  const { entities } = useFeedContext()
 
   // split name and file extension
   const nameParts = name.split('.')
@@ -113,7 +114,34 @@ const FileUploadCard = ({
     </>
   )
 
-  const someAnnotation = unsavedAnnotation ?? savedAnnotation
+  const someAnnotation = useMemo(
+    () => unsavedAnnotation ?? savedAnnotation,
+    [unsavedAnnotation, savedAnnotation],
+  )
+
+  const firstEntity = useMemo(() => {
+    return entities.at(0)
+  }, [entities])
+
+  const annotationDisplayRange = useMemo(() => {
+    if (!someAnnotation?.range) {
+      return [1, 1]
+    }
+
+    if (!firstEntity?.attrib) {
+      return someAnnotation?.range ?? [1, 1]
+    }
+
+    const { frameStart } = firstEntity?.attrib
+    if (Number.isNaN(frameStart)) {
+      return someAnnotation?.range ?? [1, 1]
+    }
+
+    return [
+      frameStart - 1 + someAnnotation.range[0],
+      frameStart - 1 + someAnnotation.range[1],
+    ]
+  }, [someAnnotation])
 
   return (
     <Styled.File
@@ -179,9 +207,9 @@ const FileUploadCard = ({
           {someAnnotation ? (
             <span className="name">
               <Icon icon="draw" />
-              {someAnnotation.range[0]}
-              {someAnnotation.range[1] !== someAnnotation.range[0] &&
-                ` - ${someAnnotation.range[1]}`}
+              {annotationDisplayRange[0]}
+              {annotationDisplayRange[1] !== annotationDisplayRange[0] &&
+                ` - ${annotationDisplayRange[1]}`}
             </span>
           ) : (
             <span className="name">


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Annotations shown in the Activity Feed will now have their frame range offset by the "Start frame" attribute of the current entity.

## Technical details
<!-- Please state any technical details such as limitations -->

## Additional context
<!-- Add any other context or screenshots here. -->

closes https://github.com/ynput/ayon-review/issues/79