### PR TITLE
feat(lists): move lists/folders via single-select dialog (YN-0974)

### DIFF
--- a/src/pages/ProjectListsPage/components/ListsTable/ListsTable.tsx
+++ b/src/pages/ProjectListsPage/components/ListsTable/ListsTable.tsx
@@ -12,6 +12,8 @@ import useListContextMenu, {
   ListRowContextMenuBuilder,
 } from '@pages/ProjectListsPage/hooks/useListContextMenu'
 import ListFolderFormDialog from '../ListFolderFormDialog'
+import MoveToListDialog from '../MoveToListDialog'
+import type { MoveDialogPayload } from '@pages/ProjectListsPage/hooks/useListContextMenu'
 import { parseListFolderRowId } from '@pages/ProjectListsPage/util'
 
 interface ListsTableProps {
@@ -50,7 +52,11 @@ const ListsTable: FC<ListsTableProps> = ({
   // unique menu id in picker mode so the dialog's header menu doesn't collide with the sidepanel's
   const pickerMenuId = useId()
 
-  const rowContextMenuBuildersAll = useListContextMenu(rowContextMenuBuilders)
+  // ✨ YN-0974: "Move list/folder" opens the MoveToListDialog (single-select folder picker)
+  const [moveDialog, setMoveDialog] = useState<MoveDialogPayload | null>(null)
+  const rowContextMenuBuildersAll = useListContextMenu(rowContextMenuBuilders, (payload) =>
+    setMoveDialog(payload),
+  )
   const sessionsLabel = useMemo(
     () => (isStoryboards ? 'Storyboards' : 'Review sessions'),
     [isStoryboards],
@@ -113,7 +119,9 @@ const ListsTable: FC<ListsTableProps> = ({
             }}
             hiddenButtons={hiddenButtons ?? (isReview ? ['filter'] : [])}
             hiddenMenuItemIds={
-              picker ? ['new-folder', 'delete', 'filter', ...(onCreateList ? [] : ['new-list'])] : []
+              picker
+                ? ['new-folder', 'delete', 'filter', ...(onCreateList ? [] : ['new-list'])]
+                : []
             }
             menuId={picker ? pickerMenuId : undefined}
             onCreateList={onCreateList}
@@ -143,6 +151,7 @@ const ListsTable: FC<ListsTableProps> = ({
       </SimpleTableProvider>
       <NewListDialogContainer />
       <ListFolderFormDialog />
+      {moveDialog && <MoveToListDialog {...moveDialog} onClose={() => setMoveDialog(null)} />}
     </>
   )
 }

--- a/src/pages/ProjectListsPage/components/MoveToListDialog/MoveToListDialog.tsx
+++ b/src/pages/ProjectListsPage/components/MoveToListDialog/MoveToListDialog.tsx
@@ -1,0 +1,268 @@
+import { FC, Fragment, ReactNode, useCallback, useMemo, useState } from 'react'
+import { Button, Dialog, Icon, InputText } from '@ynput/ayon-react-components'
+import styled from 'styled-components'
+import {
+  ListsDataProvider,
+  useListsDataContext,
+} from '@pages/ProjectListsPage/context/ListsDataContext'
+import { ListsProvider } from '@pages/ProjectListsPage/context/ListsProvider'
+import { useListsContext } from '@pages/ProjectListsPage/context/ListsContext'
+import { ProjectContextProvider, useOptionalProjectContext } from '@shared/context'
+import { buildFolderHierarchy } from '@shared/util'
+import { EntityListFolderModel } from '@shared/api'
+import {
+  FOLDER_ICON,
+  FOLDER_ICON_REMOVE,
+  wouldCreateCircularDependency,
+} from '../../hooks/useListContextMenu'
+
+// ✨ YN-0974: "Move list should use add to list dialog"
+// Replaces the hard-to-navigate nested "Move" submenus with a dialog that shows
+// only folders (single selection), mirroring the AddToListDialog pattern.
+// Works for both lists (Move list) and folders (Move folder).
+
+export interface MoveToListDialogProps {
+  // lists being moved (Move list) — mutually exclusive with folderIds
+  listIds: string[]
+  // folders being moved (Move folder)
+  folderIds: string[]
+  // owning provider's project — used to supply a ProjectContext where none exists
+  projectName?: string
+  onClose: () => void
+}
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  height: 100%;
+  min-height: 0;
+  width: 100%;
+  gap: var(--base-gap-small, 8px);
+`
+
+const SearchContainer = styled.div`
+  padding: 4px 8px;
+
+  input {
+    width: 100%;
+  }
+`
+
+const FolderList = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  width: 100%;
+`
+
+const FolderRow = styled.div<{ $depth?: number; $selected?: boolean; $disabled?: boolean }>`
+  display: flex;
+  align-items: center;
+  gap: var(--base-gap-small, 8px);
+  padding: 8px 12px;
+  padding-left: ${({ $depth = 0 }) => 12 + $depth * 20}px;
+  border-radius: 8px;
+  cursor: ${({ $disabled }) => ($disabled ? 'not-allowed' : 'pointer')};
+  opacity: ${({ $disabled }) => ($disabled ? 0.4 : 1)};
+  background: ${({ $selected }) => ($selected ? 'var(--md-sys-color-primary)' : 'transparent')};
+  color: ${({ $selected }) => ($selected ? 'var(--md-sys-color-on-primary)' : 'inherit')};
+
+  &:hover {
+    background: ${({ $selected, $disabled }) =>
+      $disabled
+        ? 'transparent'
+        : $selected
+        ? 'var(--md-sys-color-primary-hover)'
+        : 'var(--md-sys-color-surface-container-high)'};
+  }
+
+  .folder-icon {
+    display: flex;
+    font-size: 18px;
+  }
+
+  .folder-label {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+`
+
+const RootRow = styled(FolderRow)`
+  border-bottom: 1px solid var(--md-sys-color-outline-variant);
+  padding-bottom: 12px;
+`
+
+const EmptyState = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  padding: 24px;
+  opacity: 0.6;
+`
+
+const MoveToListDialogInner: FC<MoveToListDialogProps> = ({ listIds, folderIds, onClose }) => {
+  const { listFolders } = useListsDataContext()
+  const {
+    onPutListsInFolder,
+    onPutFoldersInFolder,
+    onRemoveListsFromFolder,
+    onRemoveFoldersFromFolder,
+  } = useListsContext()
+
+  const [search, setSearch] = useState('')
+  // null = "Move to root" (unset folder / make root folder)
+  const [selectedFolderId, setSelectedFolderId] = useState<string | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+
+  const isFolderMove = folderIds.length > 0
+
+  const filteredFolders = useMemo(() => {
+    const q = search.trim().toLowerCase()
+    if (!q) return listFolders
+    return listFolders.filter((f) => f.label.toLowerCase().includes(q))
+  }, [listFolders, search])
+
+  const { rootFolders } = useMemo(() => buildFolderHierarchy(filteredFolders), [filteredFolders])
+
+  // when moving folders, self and descendants can't be destinations
+  const isDisabledFolder = useCallback(
+    (folderId: string) =>
+      isFolderMove &&
+      folderIds.some((fid) => wouldCreateCircularDependency(fid, folderId, listFolders)),
+    [isFolderMove, folderIds, listFolders],
+  )
+
+  const handleMove = async (targetFolderId: string | null) => {
+    setIsLoading(true)
+    try {
+      if (targetFolderId === null) {
+        // root: unset folder / make root folder
+        if (isFolderMove) await onRemoveFoldersFromFolder(folderIds)
+        else await onRemoveListsFromFolder(listIds)
+      } else if (isFolderMove) {
+        await onPutFoldersInFolder(folderIds, targetFolderId)
+      } else {
+        await onPutListsInFolder(listIds, targetFolderId)
+      }
+      onClose()
+    } catch {
+      // onPut*/onRemove* toast their own errors; keep the dialog open so the
+      // user can pick another destination or retry
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const renderFolderRows = (
+    folders: (EntityListFolderModel & { children: EntityListFolderModel[] })[],
+    depth: number,
+  ): ReactNode =>
+    folders.map((folder) => (
+      <Fragment key={folder.id}>
+        <FolderRow
+          $depth={depth}
+          $selected={selectedFolderId === folder.id}
+          $disabled={isDisabledFolder(folder.id)}
+          onClick={() => {
+            if (!isDisabledFolder(folder.id)) setSelectedFolderId(folder.id)
+          }}
+          onDoubleClick={() => {
+            if (!isDisabledFolder(folder.id)) handleMove(folder.id)
+          }}
+        >
+          <span className="folder-icon">
+            <Icon icon={folder.data?.icon || FOLDER_ICON} />
+          </span>
+          <span className="folder-label">{folder.label}</span>
+        </FolderRow>
+        {folder.children.length > 0 &&
+          renderFolderRows(
+            folder.children as (EntityListFolderModel & {
+              children: EntityListFolderModel[]
+            })[],
+            depth + 1,
+          )}
+      </Fragment>
+    ))
+
+  const hasFolders = filteredFolders.length > 0
+  const isRootSelected = selectedFolderId === null
+
+  return (
+    <Dialog
+      isOpen
+      onClose={onClose}
+      size="full"
+      className="move-to-list-dialog block-shortcuts"
+      header={isFolderMove ? 'Move folder to…' : 'Move list to…'}
+      style={{ width: '100%', maxWidth: 520, height: '70vh' }}
+      footer={
+        <Button
+          label={isRootSelected ? 'Move to root' : 'Move here'}
+          variant="filled"
+          disabled={isLoading}
+          // @ts-expect-error - loading prop exists on Button but is missing from its typings
+          loading={isLoading}
+          onClick={() => handleMove(selectedFolderId)}
+        />
+      }
+    >
+      <Container>
+        <SearchContainer>
+          <InputText
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search folders…"
+            autoFocus
+          />
+        </SearchContainer>
+        <FolderList>
+          <RootRow
+            $selected={isRootSelected}
+            onClick={() => setSelectedFolderId(null)}
+            onDoubleClick={() => handleMove(null)}
+          >
+            <span className="folder-icon">
+              <Icon icon={FOLDER_ICON_REMOVE} />
+            </span>
+            <span className="folder-label">
+              {isFolderMove ? 'Make root folder' : 'Unset folder (root)'}
+            </span>
+          </RootRow>
+          {hasFolders ? (
+            renderFolderRows(rootFolders, 0)
+          ) : (
+            <EmptyState>No folders{search ? ' match your search' : ' yet'}</EmptyState>
+          )}
+        </FolderList>
+      </Container>
+    </Dialog>
+  )
+}
+
+export const MoveToListDialog: FC<MoveToListDialogProps> = (props) => {
+  const { projectName } = props
+  const existingProject = useOptionalProjectContext()
+
+  const tree = (
+    <ListsDataProvider picker>
+      <ListsProvider picker>
+        <MoveToListDialogInner {...props} />
+      </ListsProvider>
+    </ListsDataProvider>
+  )
+
+  // ListsDataProvider/ListsProvider read useProjectContext; supply one where the
+  // page doesn't using the owning provider's projectName (same as AddToListDialog)
+  if (existingProject) return tree
+  return <ProjectContextProvider projectName={projectName ?? ''}>{tree}</ProjectContextProvider>
+}
+
+export default MoveToListDialog

--- a/src/pages/ProjectListsPage/components/MoveToListDialog/index.ts
+++ b/src/pages/ProjectListsPage/components/MoveToListDialog/index.ts
@@ -1,0 +1,2 @@
+export { MoveToListDialog, default } from './MoveToListDialog'
+export type { MoveToListDialogProps } from './MoveToListDialog'

--- a/src/pages/ProjectListsPage/hooks/useListContextMenu.ts
+++ b/src/pages/ProjectListsPage/hooks/useListContextMenu.ts
@@ -6,7 +6,6 @@ import useClearListItems from './useClearListItems'
 import { useListsDataContext } from '../context/ListsDataContext'
 import { parseListFolderRowId } from '../util/buildListsTableData'
 import { EntityListFolderModel } from '@shared/api'
-import { getPlatformShortcutKey, KeyMode, buildFolderHierarchy } from '@shared/util'
 import { usePowerpack, useProjectContext } from '@shared/context'
 import {
   canEditList,
@@ -30,8 +29,8 @@ export const FOLDER_ICON_ADD = 'create_new_folder'
 export const FOLDER_ICON_EDIT = 'folder_managed'
 export const FOLDER_ICON_REMOVE = 'folder_off'
 
-// Helper function to prevent circular dependencies
-const wouldCreateCircularDependency = (
+// Helper function to prevent circular dependencies (also used by MoveToListDialog)
+export const wouldCreateCircularDependency = (
   folderId: string,
   targetParentId: string,
   folders: EntityListFolderModel[],
@@ -51,7 +50,15 @@ const wouldCreateCircularDependency = (
   return isDescendant(targetParentId, folderId)
 }
 
-const useListContextMenu = (extraBuilders: ListRowContextMenuBuilder[] = []) => {
+export interface MoveDialogPayload {
+  listIds: string[]
+  folderIds: string[]
+}
+
+const useListContextMenu = (
+  extraBuilders: ListRowContextMenuBuilder[] = [],
+  onOpenMoveDialog?: (payload: MoveDialogPayload) => void,
+) => {
   const user = useAppSelector((state) => state.user)
   const developerMode = user?.attrib.developerMode
   const { projectName } = useProjectContext()
@@ -62,13 +69,9 @@ const useListContextMenu = (extraBuilders: ListRowContextMenuBuilder[] = []) => 
     deleteLists,
     createReviewSessionList,
     isReview,
-    onPutListsInFolder,
-    onRemoveListsFromFolder,
     onOpenFolderList,
     openNewList,
     onDeleteListFolders,
-    onPutFoldersInFolder,
-    onRemoveFoldersFromFolder,
     selectAllLists,
   } = useListsContext()
   const { powerLicense } = usePowerpack()
@@ -138,133 +141,28 @@ const useListContextMenu = (extraBuilders: ListRowContextMenuBuilder[] = []) => 
         : false
       const userCanEditList = selectedList ? canEditList(selectedList, userPermissions) : false
 
-      // Create recursive folder submenu
-      const createFolderHierarchy = (
-        folders: (EntityListFolderModel & { children: EntityListFolderModel[] })[],
-        excludeFolderId?: string,
-        depth = 0,
-      ): any[] => {
-        const items: any[] = []
+      // ✨ YN-0974: "Move" opens the MoveToListDialog (single-select folder picker)
+      // instead of the hard-to-navigate nested folder submenus.
+      const hasFoldersToShow = listFolders.length > 0
+      const hasUnsetOption = allSelectedRowsAreLists
+        ? newSelectedLists.some((l) => l.entityListFolderId)
+        : selectedFoldersAll.some((f) => f.parentId)
 
-        for (const folder of folders) {
-          if (folder.id === excludeFolderId) continue
-
-          const hasChildren = folder.children.length > 0
-          const childItems = hasChildren
-            ? createFolderHierarchy(
-                folder.children as (EntityListFolderModel & {
-                  children: EntityListFolderModel[]
-                })[],
-                excludeFolderId,
-                depth + 1,
-              )
-            : []
-
-          items.push({
-            label: folder.label,
-            icon: folder.data?.icon || FOLDER_ICON,
-            command: allSelectedRowsAreFolders
-              ? () => onPutFoldersInFolder(selectedFolderIds, folder.id)
-              : () =>
-                  onPutListsInFolder(
-                    newSelectedLists.map((l) => l.id),
-                    folder.id,
-                  ),
-            disabled:
-              allSelectedRowsAreFolders &&
-              wouldCreateCircularDependency(selectedFolderId!, folder.id, listFolders),
-            ...(hasChildren && { items: childItems }),
-          })
-        }
-
-        return items
-      }
-
-      // Create folder submenu items for lists
-      const createListFolderSubmenu = () => {
-        if (!allSelectedRowsAreLists || newSelectedLists.length === 0) {
-          return []
-        }
-
-        const submenuItems: any[] = []
-        const selectedListIds = newSelectedLists.map((list) => list.id)
-
-        // Add hierarchy items first (available destination folders)
-        if (listFolders.length > 0) {
-          const { rootFolders } = buildFolderHierarchy(listFolders)
-          const hierarchyItems = createFolderHierarchy(rootFolders)
-          submenuItems.push(...hierarchyItems)
-        }
-
-        // For multiple selections, show "Unset folder" if any list has a folder
-        // For single selection, show "Unset folder" only if that list has a folder
-        const hasAnyFolder = newSelectedLists.some((list) => list.entityListFolderId)
-        if (hasAnyFolder) {
-          if (submenuItems.length > 0) submenuItems.push({ separator: true })
-          submenuItems.push({
-            label: 'Unset folder',
-            icon: FOLDER_ICON_REMOVE,
-            command: () => {
-              onRemoveListsFromFolder(selectedListIds)
-            },
-            shortcut: getPlatformShortcutKey('f', [KeyMode.Shift, KeyMode.Alt]),
-          })
-        }
-
-        return submenuItems
-      }
-
-      // Create folder submenu items for folders
-      const createFolderFolderSubmenu = () => {
-        if (!allSelectedRowsAreFolders || !selectedFolder) {
-          return []
-        }
-
-        const submenuItems: any[] = []
-
-        // Show available parent folders (excluding self and its descendants) first
-        const availableParents = listFolders.filter(
-          (folder) =>
-            folder.id !== selectedFolderId &&
-            !wouldCreateCircularDependency(selectedFolderId!, folder.id, listFolders),
-        )
-
-        if (availableParents.length > 0) {
-          const { rootFolders } = buildFolderHierarchy(availableParents)
-          const hierarchyItems = createFolderHierarchy(rootFolders, selectedFolderId || undefined)
-          submenuItems.push(...hierarchyItems)
-        }
-
-        // Show "Unset parent" (make root) at bottom if folder has a parent
-        if (selectedFolder.parentId) {
-          if (submenuItems.length > 0) submenuItems.push({ separator: true })
-          submenuItems.push({
-            label: 'Make root folder',
-            icon: FOLDER_ICON_REMOVE,
-            command: () => onRemoveFoldersFromFolder(selectedFolderIds),
-            shortcut: getPlatformShortcutKey('f', [KeyMode.Shift, KeyMode.Alt]),
-          })
-        }
-
-        return submenuItems
-      }
-
-      const listFolderSubmenu = createListFolderSubmenu()
-      const folderFolderSubmenu = createFolderFolderSubmenu()
-
-      // Build move submenu (formerly "Folder")
       const moveMenuItems: any[] = []
       if (powerLicense) {
         moveMenuItems.push({
           label: allSelectedRowsAreFolders ? 'Move folder' : 'Move list',
           icon: FOLDER_ICON,
-          items: allSelectedRowsAreLists ? listFolderSubmenu : folderFolderSubmenu,
+          command: () =>
+            onOpenMoveDialog?.({
+              listIds: allSelectedRowsAreLists ? newSelectedLists.map((l) => l.id) : [],
+              folderIds: allSelectedRowsAreFolders ? selectedFolderIds : [],
+            }),
           // Structural disabling only (no selection); ownership handled via hidden
           disabled: !allSelectedRowsAreLists && !allSelectedRowsAreFolders,
           hidden:
             (!allSelectedRowsAreLists && !allSelectedRowsAreFolders) ||
-            (allSelectedRowsAreLists && listFolderSubmenu.length === 0) ||
-            (allSelectedRowsAreFolders && folderFolderSubmenu.length === 0) ||
+            (!hasFoldersToShow && !hasUnsetOption) ||
             // Hide if user doesn't have edit permission on all selected items
             (allSelectedRowsAreLists && !userCanEditAllLists) ||
             (allSelectedRowsAreFolders && !userCanEditAllFolders),
@@ -395,17 +293,15 @@ const useListContextMenu = (extraBuilders: ListRowContextMenuBuilder[] = []) => 
       setListDetailsOpen,
       deleteLists,
       createReviewSessionList,
-      onPutListsInFolder,
-      onRemoveListsFromFolder,
       onOpenFolderList,
       onDeleteListFolders,
-      onPutFoldersInFolder,
-      onRemoveFoldersFromFolder,
       developerMode,
       handleCreateReviewSessionList,
       clearListItems,
       isReview,
       powerLicense,
+      selectAllLists,
+      onOpenMoveDialog,
     ],
   )
 


### PR DESCRIPTION
## What

Implements YN-0974: **Move list should use add to list dialog** instead of nested context-menu submenus.

Replaces the recursive "Move to…" submenus with a single-select folder picker dialog (same UX as the existing "Add to lists" dialog), so the destination folder is always visible while choosing and circular moves are prevented.

## Changes

- **New** `MoveToListDialog` component — single-select folder tree picker built on `ListsDataProvider`/`ListsProvider` in picker mode (same pattern as `AddToListDialog`).
  - Reuses `buildFolderHierarchy` to render folders, disables circular moves via `wouldCreateCircularDependency`, and calls `onPutListsInFolder` / `onPutFoldersInFolder` / `onRemoveListsFromFolder` / `onRemoveFoldersFromFolder` as appropriate.
  - `disabled` while moving, Escape/backdrop close, folder-only selection.
- **`useListContextMenu`** — removed the recursive submenu builders; the "Move list" / "Move folder" menu items now open the dialog with the current selection.
- **`ListsTable`** — wires up the dialog state and renders `MoveToListDialog`.

## How to test

1. Open Project → Lists, right-click a list or folder → **Move list** / **Move folder**.
2. Choose a destination folder in the dialog → items move there.
3. Attempt to move a folder into itself or a descendant → option disabled.

Closes ynput/ayon-frontend#2207 (YN-0974)