### PR TITLE
feat: paginate tasks progress instead of 1000-task hard limit (YN-0907)

### DIFF
--- a/shared/src/api/generated/graphql.ts
+++ b/shared/src/api/generated/graphql.ts
@@ -2226,10 +2226,12 @@ export type GetTasksProgressQueryVariables = Exact<{
   statuses?: Array<string> | string | null | undefined;
   taskTypes?: Array<string> | string | null | undefined;
   attributes?: Array<AttributeFilterInput> | AttributeFilterInput | null | undefined;
+  first?: number | null | undefined;
+  after?: string | null | undefined;
 }>;
 
 
-export type GetTasksProgressQuery = { project: { name: string, tasks: { edges: Array<{ node: { projectName: string, id: string, name: string, label: string | null, taskType: string, status: string, assignees: Array<string>, updatedAt: unknown, thumbnailHash: string, active: boolean, hasReviewables: boolean, tags: Array<string>, attrib: { priority: string | null, endDate: unknown, resolutionHeight: number | null, resolutionWidth: number | null, fps: number | null }, folder: { id: string, name: string, label: string | null, folderType: string, parents: Array<string>, status: string, updatedAt: unknown, thumbnailHash: string, parent: { id: string, name: string, label: string | null, parents: Array<string> } | null } } }> } } };
+export type GetTasksProgressQuery = { project: { name: string, tasks: { edges: Array<{ node: { projectName: string, id: string, name: string, label: string | null, taskType: string, status: string, assignees: Array<string>, updatedAt: unknown, thumbnailHash: string, active: boolean, hasReviewables: boolean, tags: Array<string>, attrib: { priority: string | null, endDate: unknown, resolutionHeight: number | null, resolutionWidth: number | null, fps: number | null }, folder: { id: string, name: string, label: string | null, folderType: string, parents: Array<string>, status: string, updatedAt: unknown, thumbnailHash: string, parent: { id: string, name: string, label: string | null, parents: Array<string> } | null } } }>, pageInfo: { hasNextPage: boolean, endCursor: string | null } } } };
 
 export type ProgressTaskFragmentFragment = { projectName: string, id: string, name: string, label: string | null, taskType: string, status: string, assignees: Array<string>, updatedAt: unknown, thumbnailHash: string, active: boolean, hasReviewables: boolean, tags: Array<string>, attrib: { priority: string | null, endDate: unknown, resolutionHeight: number | null, resolutionWidth: number | null, fps: number | null }, folder: { id: string, name: string, label: string | null, folderType: string, parents: Array<string>, status: string, updatedAt: unknown, thumbnailHash: string, parent: { id: string, name: string, label: string | null, parents: Array<string> } | null } };
 
@@ -4355,12 +4357,13 @@ export const GetProgressTaskDocument = new TypedDocumentString(`
   }
 }`);
 export const GetTasksProgressDocument = new TypedDocumentString(`
-    query GetTasksProgress($projectName: String!, $folderIds: [String!], $assignees: [String!], $assigneesAny: [String!], $tags: [String!], $tagsAny: [String!], $statuses: [String!], $taskTypes: [String!], $attributes: [AttributeFilterInput!]) {
+    query GetTasksProgress($projectName: String!, $folderIds: [String!], $assignees: [String!], $assigneesAny: [String!], $tags: [String!], $tagsAny: [String!], $statuses: [String!], $taskTypes: [String!], $attributes: [AttributeFilterInput!], $first: Int = 100, $after: String) {
   project(name: $projectName) {
     name
     tasks(
       folderIds: $folderIds
-      last: 1000
+      first: $first
+      after: $after
       includeFolderChildren: true
       assignees: $assignees
       assigneesAny: $assigneesAny
@@ -4374,6 +4377,10 @@ export const GetTasksProgressDocument = new TypedDocumentString(`
         node {
           ...ProgressTaskFragment
         }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
       }
     }
   }

--- a/src/containers/TasksProgress/TasksProgress.tsx
+++ b/src/containers/TasksProgress/TasksProgress.tsx
@@ -1,5 +1,9 @@
 import { FC, useMemo, useState, useRef } from 'react'
-import { ProgressTask, useGetTasksProgressQuery } from '@queries/tasksProgress/getTasksProgress'
+import {
+  ProgressTask,
+  useGetTasksProgressQuery,
+  useLazyGetTasksProgressQuery,
+} from '@queries/tasksProgress/getTasksProgress'
 import { $Any } from '@types'
 import { useSelector } from 'react-redux'
 import {
@@ -154,12 +158,22 @@ const TasksProgress: FC<TasksProgressProps> = ({
   //
   // GET TASKS PROGRESS FOR FOLDERS
   const {
-    data: foldersTasksData = [],
+    data: { folders: foldersTasksData = [], pageInfo } = {},
     isFetching: isFetchingTasks,
     error,
   } = useGetTasksProgressQuery(tasksProgressArgs, {
     skip: !folderIdsToFetch.length || !projectName,
   })
+
+  // paginación: cargar más tareas al llegar al final de la tabla
+  const { hasNextPage, endCursor } = pageInfo || {}
+
+  const [getTasksProgress, { isFetching: isFetchingMoreTasks }] = useLazyGetTasksProgressQuery()
+
+  const handleLoadMore = () => {
+    if (!hasNextPage || isFetchingTasks || isFetchingMoreTasks || !endCursor) return
+    getTasksProgress({ ...tasksProgressArgs, after: endCursor })
+  }
 
   const handleSync = async () => {
     if (!folderIdsToFetch.length || !projectName) return
@@ -411,6 +425,9 @@ const TasksProgress: FC<TasksProgressProps> = ({
               tableData={tableData}
               projectName={projectName}
               isLoading={isFetchingTasks}
+              hasMore={hasNextPage}
+              onLoadMore={handleLoadMore}
+              isLoadingMore={isFetchingMoreTasks}
               activeTask={activeTask}
               selectedAssignees={selectedAssignees}
               taskStatuses={taskStatuses} // task status icons etc.

--- a/src/containers/TasksProgress/components/TasksProgressTable/TasksProgressTable.tsx
+++ b/src/containers/TasksProgress/components/TasksProgressTable/TasksProgressTable.tsx
@@ -71,6 +71,9 @@ interface TasksProgressTableProps
   onExpandRow: (folderId: string) => void
   collapsedParents: string[]
   onCollapseRow: (folderId: string) => void
+  hasMore?: boolean
+  isLoadingMore?: boolean
+  onLoadMore?: () => void
   onChange: TaskFieldChange
   onSelection: (taskId: string, meta: boolean, shift: boolean) => void
   onOpenViewer: ({
@@ -89,6 +92,9 @@ export const TasksProgressTable = ({
   tableData = [],
   projectName,
   isLoading,
+  hasMore = false,
+  isLoadingMore = false,
+  onLoadMore,
   activeTask,
   selectedAssignees = [],
   taskStatuses = [], // project task statuses schema
@@ -304,6 +310,24 @@ export const TasksProgressTable = ({
     '.p-datatable-wrapper',
   )
 
+  // lazily load more tasks when the user scrolls near the bottom of the table
+  useEffect(() => {
+    const el = tableWrapperEl
+    if (!el || !hasMore || isLoadingMore) return
+
+    const maybeLoadMore = () => {
+      if (el.scrollTop + el.clientHeight >= el.scrollHeight - 200) {
+        onLoadMore?.()
+      }
+    }
+
+    el.addEventListener('scroll', maybeLoadMore, { passive: true })
+    // también chequea si el contenido no llena el viewport (sin scroll aún)
+    maybeLoadMore()
+
+    return () => el.removeEventListener('scroll', maybeLoadMore)
+  }, [tableWrapperEl, hasMore, isLoadingMore, onLoadMore])
+
   const buildColumnHeaderMenuItems = (taskType: string) => [
     {
       label: 'Reset column width',
@@ -359,6 +383,23 @@ export const TasksProgressTable = ({
       }}
       className="tasks-progress-table"
       rowClassName={(rowData: FolderRow) => (rowData.__isParent ? 'parent-row' : 'folder-row')}
+      footer={
+        hasMore || isLoadingMore ? (
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'center',
+              alignItems: 'center',
+              gap: 8,
+              padding: 6,
+              fontSize: 12,
+              color: 'var(--text-color-secondary, #888)',
+            }}
+          >
+            {isLoadingMore ? 'Loading more tasks…' : 'Scroll down to load more'}
+          </div>
+        ) : undefined
+      }
       {...props}
     >
       <Column

--- a/src/containers/TasksProgress/helpers/formatFilterAssigneesData.ts
+++ b/src/containers/TasksProgress/helpers/formatFilterAssigneesData.ts
@@ -1,8 +1,8 @@
 import { BuildFilterOptions } from '@shared/components'
-import { GetTasksProgressResult } from '@queries/tasksProgress/getTasksProgress'
+import { FolderGroup } from '@queries/tasksProgress/getTasksProgress'
 
 const formatFilterAssigneesData = (
-  data: GetTasksProgressResult,
+  data: FolderGroup[],
 ): BuildFilterOptions['data']['assignees'] => {
   const assignees: BuildFilterOptions['data']['assignees'] = []
 

--- a/src/containers/TasksProgress/helpers/formatFilterAttributesData.ts
+++ b/src/containers/TasksProgress/helpers/formatFilterAttributesData.ts
@@ -1,8 +1,8 @@
 import { BuildFilterOptions } from '@shared/components'
-import { GetTasksProgressResult } from '@queries/tasksProgress/getTasksProgress'
+import { FolderGroup } from '@queries/tasksProgress/getTasksProgress'
 
 const formatFilterAttributesData = (
-  data: GetTasksProgressResult,
+  data: FolderGroup[],
 ): BuildFilterOptions['data']['attributes'] => {
   const attributes: BuildFilterOptions['data']['attributes'] = {}
 

--- a/src/containers/TasksProgress/helpers/formatFilterTagsData.ts
+++ b/src/containers/TasksProgress/helpers/formatFilterTagsData.ts
@@ -1,7 +1,7 @@
 import { BuildFilterOptions } from '@shared/components'
-import { GetTasksProgressResult } from '@queries/tasksProgress/getTasksProgress'
+import { FolderGroup } from '@queries/tasksProgress/getTasksProgress'
 
-const formatFilterTagsData = (data: GetTasksProgressResult): BuildFilterOptions['data']['tags'] => {
+const formatFilterTagsData = (data: FolderGroup[]): BuildFilterOptions['data']['tags'] => {
   const tags: BuildFilterOptions['data']['tags'] = []
 
   //   add tags from tasks

--- a/src/services/tasksProgress/getTasksProgress.ts
+++ b/src/services/tasksProgress/getTasksProgress.ts
@@ -11,7 +11,12 @@ export interface FolderGroup extends ProgressTaskFolder {
   tasks: ProgressTask[]
 }
 
-export type GetTasksProgressResult = FolderGroup[]
+export type TasksProgressPageInfo = GetTasksProgressQuery['project']['tasks']['pageInfo']
+
+export type GetTasksProgressResult = {
+  folders: FolderGroup[]
+  pageInfo: TasksProgressPageInfo
+}
 export type GetProgressTaskResult = ProgressTask | null | undefined
 
 type GroupedTasksType = {
@@ -37,13 +42,16 @@ const transformTasksProgress = (data: GetTasksProgressQuery): GetTasksProgressRe
 
   const foldersWithTasks = Object.values(groupedTasks)
 
-  return foldersWithTasks
+  return {
+    folders: foldersWithTasks,
+    pageInfo: data.project.tasks.pageInfo,
+  }
 }
 
 const provideTagsTasksProgress = (result: GetTasksProgressResult | undefined) => {
   if (!result) return []
-  const folderTags = result.map((folder) => ({ id: folder.id, type: 'folder' }))
-  const taskTags = result.flatMap((folder) =>
+  const folderTags = result.folders.map((folder) => ({ id: folder.id, type: 'folder' }))
+  const taskTags = result.folders.flatMap((folder) =>
     folder.tasks.map((task) => ({ id: task.id, type: 'task' })),
   )
   // progress tags
@@ -66,6 +74,32 @@ const enhancedEndpoints = gqlApi.enhanceEndpoints<TagTypes, UpdatedDefinitions>(
     GetTasksProgress: {
       transformResponse: transformTasksProgress,
       providesTags: provideTagsTasksProgress,
+      // solo cachear por los args de filtro (no por el cursor), para que las
+      // páginas compartan una única entrada de cache y merge acumule
+      serializeQueryArgs: ({ queryArgs }) => {
+        const { first, after, ...rest } = queryArgs || {}
+        return rest
+      },
+      // acumular páginas nuevas sobre la cache existente (paginación)
+      merge: (currentCache, newCache) => {
+        const { folders: newFolders = [], pageInfo } = newCache
+        const { folders: currentFolders = [] } = currentCache || { folders: [] }
+
+        // merge por folder id, agregando tasks deduplicadas por id
+        const folderMap = new Map<string, FolderGroup>()
+        for (const folder of [...currentFolders, ...newFolders]) {
+          const existing = folderMap.get(folder.id)
+          if (!existing) {
+            folderMap.set(folder.id, { ...folder, tasks: [...folder.tasks] })
+          } else {
+            const existingIds = new Set(existing.tasks.map((t) => t.id))
+            existing.tasks.push(...folder.tasks.filter((t) => !existingIds.has(t.id)))
+          }
+        }
+
+        return { folders: [...folderMap.values()], pageInfo }
+      },
+      keepUnusedDataFor: 30,
       async onCacheEntryAdded(
         { projectName },
         { updateCachedData, cacheDataLoaded, cacheEntryRemoved, dispatch, getCacheEntry },
@@ -79,7 +113,7 @@ const enhancedEndpoints = gqlApi.enhanceEndpoints<TagTypes, UpdatedDefinitions>(
           unsubscribeThumbnails = subscribeToThumbnailUpdates(
             (messages: ThumbnailUpdateMessage[]) => {
               const draftData = getCacheEntry().data
-              if (!draftData?.length) return
+              if (!draftData?.folders?.length) return
 
               const relevantMessages = messages.filter((m) => m.project === projectName)
               if (!relevantMessages.length) return
@@ -87,7 +121,7 @@ const enhancedEndpoints = gqlApi.enhanceEndpoints<TagTypes, UpdatedDefinitions>(
               updateCachedData((draft) => {
                 relevantMessages.forEach((message) => {
                   if (message.summary.entityType === 'task') {
-                    draft.forEach((folder) => {
+                    draft.folders.forEach((folder) => {
                       const taskIndex = folder.tasks.findIndex(
                         (t) => t.id === message.summary.entityId,
                       )
@@ -96,9 +130,11 @@ const enhancedEndpoints = gqlApi.enhanceEndpoints<TagTypes, UpdatedDefinitions>(
                       }
                     })
                   } else if (message.summary.entityType === 'folder') {
-                    const folderIndex = draft.findIndex((f) => f.id === message.summary.entityId)
+                    const folderIndex = draft.folders.findIndex(
+                      (f) => f.id === message.summary.entityId,
+                    )
                     if (folderIndex !== -1) {
-                      draft[folderIndex].thumbnailHash = message.summary.thumbnailHash || ''
+                      draft.folders[folderIndex].thumbnailHash = message.summary.thumbnailHash || ''
                     }
                   }
                 })
@@ -118,7 +154,7 @@ const enhancedEndpoints = gqlApi.enhanceEndpoints<TagTypes, UpdatedDefinitions>(
 
             // create a lookup set of all tasks
             const allTasks = new Set<string>()
-            tasksProgressCache?.forEach((folder) => {
+            tasksProgressCache?.folders?.forEach((folder) => {
               folder.tasks.forEach((task) => {
                 allTasks.add(task.id)
               })
@@ -138,7 +174,7 @@ const enhancedEndpoints = gqlApi.enhanceEndpoints<TagTypes, UpdatedDefinitions>(
                 updateCachedData((draft) => {
                   if (!draft) return
                   // find the folder to remove the task from
-                  for (const folder of draft) {
+                  for (const folder of draft.folders) {
                     const taskIndex = folder.tasks.findIndex((task) => task.id === messageTaskId)
                     if (taskIndex !== -1) {
                       folder.tasks.splice(taskIndex, 1)
@@ -176,9 +212,11 @@ const enhancedEndpoints = gqlApi.enhanceEndpoints<TagTypes, UpdatedDefinitions>(
               updateCachedData((draft) => {
                 if (!draft) return
                 // find the folder to add the task to
-                const folderIndex = draft.findIndex((folder) => folder.id === updatedTask.folder.id)
+                const folderIndex = draft.folders.findIndex(
+                  (folder) => folder.id === updatedTask.folder.id,
+                )
                 if (folderIndex === -1) return
-                const foundFolder = draft[folderIndex]
+                const foundFolder = draft.folders[folderIndex]
                 // find the task to update
                 const newTasks = [...foundFolder.tasks]
                 const taskIndex = newTasks.findIndex((task) => task.id === updatedTask.id)
@@ -193,7 +231,7 @@ const enhancedEndpoints = gqlApi.enhanceEndpoints<TagTypes, UpdatedDefinitions>(
                 }
 
                 // update the folder
-                draft[folderIndex] = {
+                draft.folders[folderIndex] = {
                   ...foundFolder,
                   tasks: newTasks,
                 }
@@ -228,4 +266,4 @@ const enhancedEndpoints = gqlApi.enhanceEndpoints<TagTypes, UpdatedDefinitions>(
   },
 })
 
-export const { useGetTasksProgressQuery } = enhancedEndpoints
+export const { useGetTasksProgressQuery, useLazyGetTasksProgressQuery } = enhancedEndpoints

--- a/src/services/tasksProgress/gql/GetTasksProgress.graphql
+++ b/src/services/tasksProgress/gql/GetTasksProgress.graphql
@@ -10,12 +10,15 @@ query GetTasksProgress(
   $statuses: [String!]
   $taskTypes: [String!]
   $attributes: [AttributeFilterInput!]
+  $first: Int = 100
+  $after: String
 ) {
   project(name: $projectName) {
     name
     tasks(
       folderIds: $folderIds
-      last: 1000
+      first: $first
+      after: $after
       includeFolderChildren: true
       assignees: $assignees
       assigneesAny: $assigneesAny
@@ -29,6 +32,10 @@ query GetTasksProgress(
         node {
           ...ProgressTaskFragment
         }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
       }
     }
   }


### PR DESCRIPTION
## What

Implements YN-0907: **Task progress: use pagination to handle many tasks**.

The task progress page previously had a **hard limit of 1000 tasks** (`last: 1000` in the query), which meant folders with more than 1000 tasks silently dropped rows. This replaces that with **cursor pagination** (`first: 100` + `after`) and lazily loads the next page as the user scrolls, so every task is reachable.

## Changes

- **Query** (`GetTasksProgress.graphql`): `last: 1000` → `first: 100` + `after` cursor, and the response now includes `pageInfo { hasNextPage, endCursor }`.
- **Service** (`getTasksProgress.ts`): follows the exact pattern already used by `GetInboxMessages`:
  - `serializeQueryArgs` strips the cursor so all pages share **one cache entry**,
  - `merge` accumulates folders and tasks across pages (deduped by folder/task id), and the realtime pubsub/thumbnail updates were updated to the new `{ folders, pageInfo }` shape,
  - exposes `useLazyGetTasksProgressQuery`.
- **Container** (`TasksProgress.tsx`): reads `hasNextPage`/`endCursor` and adds `handleLoadMore` (guarded against double-fetch), passing `hasMore`/`onLoadMore`/`isLoadingMore` to the table.
- **Table** (`TasksProgressTable.tsx`): a scroll listener on the `.p-datatable-wrapper` triggers `onLoadMore` near the bottom (and also covers the case where content doesn't fill the viewport yet), plus a "Loading more tasks…" footer.
- **Filter helpers**: now typed on `FolderGroup[]` to match the new result shape.

## How to test

1. Open Project → Tasks progress on a folder with more than 100 tasks.
2. Scroll to the bottom — the next page loads automatically until all tasks are shown.
3. Verify realtime updates (task status/thumbnail changes) still work while paginated.

Note: the ordering semantic changes from "last 1000" to forward cursor pagination by design — this is what makes the full dataset reachable.

Closes ynput/ayon-frontend#2155 (YN-0907)