### PR TITLE
Show initials avatar for anonymous guests in the activity feed

### DIFF
--- a/shared/package.json
+++ b/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ynput/ayon-frontend-shared",
-  "version": "0.3.54",
+  "version": "0.3.55",
   "description": "Shared React components for AYON frontend",
   "main": "dist/index.cjs.js",
   "module": "dist/index.es.js",

--- a/shared/src/containers/Feed/components/ActivityHeader/ActivityHeader.tsx
+++ b/shared/src/containers/Feed/components/ActivityHeader/ActivityHeader.tsx
@@ -1,10 +1,10 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import * as Styled from './ActivityHeader.styled'
 import ActivityReference from '../ActivityReference/ActivityReference'
 import ActivityDate from '../ActivityDate'
-import { Icon } from '@ynput/ayon-react-components'
-import UserImage from '../../../../components/UserImage'
+import { Icon, UserImage } from '@ynput/ayon-react-components'
 import { RefTooltip } from '../../context/FeedContext'
+import { ANONYMOUS_GUEST_NAME_PREFIX } from '../ActivityVersionReview/ActivityVersionReview'
 
 interface Origin {
   id: string
@@ -66,12 +66,26 @@ const ActivityHeader: React.FC<ActivityHeaderProps> = ({
   const boldString = isMention ? `mentioned` : 'commented'
   const entityTypeString = isMention ? ` ${entityType} on` : 'on'
 
-  const isGuest = name?.startsWith('guest.')
+  const isGuest = name?.startsWith('guest.') || name?.startsWith(ANONYMOUS_GUEST_NAME_PREFIX)
   const noUser = (activity.author?.deleted || !activity.author?.active) && !isGuest
+
+  const userImageSrc = useMemo(() => {
+    if (name?.startsWith(ANONYMOUS_GUEST_NAME_PREFIX)) {
+      return
+    }
+
+    return `/api/users/${name}/avatar`
+  }, [name])
+
   return (
     <Styled.Header>
       <Styled.Body>
-        {name && !noUser && <UserImage name={name} size={22} />}
+        {name && !noUser && <UserImage
+          name={name}
+          fullName={fullName}
+          src={userImageSrc}
+          size={22}
+        />}
         {noUser && <Icon icon="account_circle" />}
         <h5>{fullName || activity.activityData?.author || 'Unknown'}</h5>
         {isRef && (

--- a/shared/src/containers/Feed/components/ActivityVersionReview/ActivityVersionReview.tsx
+++ b/shared/src/containers/Feed/components/ActivityVersionReview/ActivityVersionReview.tsx
@@ -4,7 +4,7 @@ import ActivityDate from '../ActivityDate'
 import { Icon } from '@ynput/ayon-react-components'
 import { VersionReviewFeedback } from '../CommentInput/types'
 import { clsx } from 'clsx'
-import { UserImage } from '@shared/components'
+import { UserImage } from '@ynput/ayon-react-components'
 import { CategoryTag } from '../ActivityCategorySelect'
 import { useCategoryData } from '../../hooks/useCategoryData'
 import { getActivityUserName } from '../../helpers/getActivityUserName'
@@ -23,6 +23,8 @@ interface ActivityVersionReviewProps {
     [key: string]: any
   }
 }
+
+export const ANONYMOUS_GUEST_NAME_PREFIX = "anonymous.guest"
 
 export const getVerbForFeedback = (feedback: VersionReviewFeedback) => {
   switch (feedback) {
@@ -67,12 +69,25 @@ const ActivityVersionReview: React.FC<ActivityVersionReviewProps> = ({ isGuest, 
 
   const { categoryData, categoryNotFound } = useCategoryData(activityData?.category)
 
+  const userImageSrc = useMemo(() => {
+    if (authorName?.startsWith(ANONYMOUS_GUEST_NAME_PREFIX)) {
+      return
+    }
+
+    return `/api/users/${authorName}/avatar`
+  }, [authorName])
+
   if (!activityData?.feedback) return
 
   return (
     <Styled.VersionReview className={clsx(activityData.feedback)}>
       <Styled.Body>
-        {authorName && <UserImage name={authorName} size={22} />}
+        {authorName && <UserImage
+          name={authorName}
+          fullName={authorFullName}
+          src={userImageSrc}
+          size={22}
+        />}
         <Icon icon={getIconForFeedback(activityData.feedback)} />
         {categoryData && !isGuest && (
           <CategoryTag


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Anonymous guest comments and version reviews in the Activity Feed now show the initials avatar derived from the guest's full name.

## Technical details
<!-- Please state any technical details such as limitations -->

Needs a new publish of ayon-frontend-shared to be brought into the Review addon.

## Additional context
<!-- Add any other context or screenshots here. -->

