### PR TITLE
Overview: Fix sorting tasks by folder

### DIFF
--- a/shared/src/containers/ProjectTreeTable/buildTreeTableColumns.tsx
+++ b/shared/src/containers/ProjectTreeTable/buildTreeTableColumns.tsx
@@ -31,6 +31,41 @@ export const isEntityExpandable = (entityType: string) => ['folder', 'product'].
 
 export const COLUMN_MIN_SIZE = 50
 
+type ColumnSortConfig = {
+  sortKey?: string
+  enabled: boolean
+}
+
+// TanStack column IDs are also used by the UI state. Keep API sort keys here
+// so a column can use a different identifier without leaking that detail into
+// the table state.
+export const COLUMN_SORT_CONFIG: Record<string, ColumnSortConfig> = {
+  thumbnail: { enabled: false },
+  name: { sortKey: 'name', enabled: true },
+  entityType: { enabled: false },
+  status: { sortKey: 'status', enabled: true },
+  subType: { sortKey: 'taskType', enabled: true },
+  assignees: { sortKey: 'assignees', enabled: true },
+  folder: { sortKey: 'folderName', enabled: true },
+  author: { sortKey: 'author', enabled: true },
+  version: { sortKey: 'version', enabled: true },
+  product: { sortKey: 'product', enabled: true },
+  tags: { sortKey: 'tags', enabled: true },
+  createdAt: { sortKey: 'createdAt', enabled: true },
+  updatedAt: { sortKey: 'updatedAt', enabled: true },
+  subtasks: { enabled: false },
+  comments: { enabled: false },
+}
+
+export const isColumnSortable = (columnId: string) =>
+  COLUMN_SORT_CONFIG[columnId]?.enabled ?? !columnId.startsWith('link_')
+
+export const getColumnSortKey = (columnId?: string, showHierarchy = true) => {
+  if (!columnId) return undefined
+  if (columnId === 'name' && !showHierarchy) return 'path'
+  return COLUMN_SORT_CONFIG[columnId]?.sortKey ?? columnId
+}
+
 // Wrapper function for sorting that pushes isLoading rows to the bottom
 const withLoadingStateSort = (sortFn: SortingFn<any>): SortingFn<any> => {
   return (rowA, rowB, ...args) => {
@@ -152,7 +187,8 @@ const buildTreeTableColumns = ({
 
   // Helper to check if a column should be included
   const isIncluded = (id: DefaultColumns | string) => !excluded?.includes(id)
-  const canSort = (id: DefaultColumns | string) => !excludedSorting?.includes(id)
+  const canSort = (id: DefaultColumns | string) =>
+    isColumnSortable(id) && !excludedSorting?.includes(id)
 
   // Conditionally add static columns
   if (isIncluded(ROW_SELECTION_COLUMN_ID)) {
@@ -192,6 +228,7 @@ const buildTreeTableColumns = ({
         }
         // check for thumbnail override
         if (row.original.thumbnail) {
+          // @ts-expect-error
           thumbnail = row.original.thumbnail
         }
         return (
@@ -557,7 +594,7 @@ const buildTreeTableColumns = ({
       header: 'Folder name',
       minSize: COLUMN_MIN_SIZE,
       sortingFn: withLoadingStateSort(pathSort),
-      enableSorting: canSort('folderName'),
+      enableSorting: canSort('folder'),
       enableResizing: true,
       enablePinning: true,
       enableHiding: true,

--- a/shared/src/containers/ProjectTreeTable/hooks/useFetchOverviewData.ts
+++ b/shared/src/containers/ProjectTreeTable/hooks/useFetchOverviewData.ts
@@ -29,6 +29,7 @@ import { OnSyncDataCallback, useProjectFoldersContext } from '@shared/context'
 import { debounce } from 'lodash'
 import { refreshActiveAndPurgeOthers, refreshOtherActiveQueries } from '@shared/api'
 import type { ThunkDispatch, UnknownAction } from '@reduxjs/toolkit'
+import { getColumnSortKey } from '../buildTreeTableColumns'
 
 // how long a folder must stay rendered in the viewport before its tasks are fetched.
 // prevents firing a request per folder while the user is quickly scrolling past them.
@@ -392,9 +393,7 @@ export const useFetchOverviewData = ({
 
   // Create sort params for infinite query
   const singleSort = { ...sorting[0] }
-  // if task list and sorting by name, sort by path instead
-  const sortByPath = singleSort?.id === 'name' && !showHierarchy
-  const sortId = sortByPath ? 'path' : singleSort?.id === 'subType' ? 'taskType' : singleSort?.id
+  const sortId = getColumnSortKey(singleSort?.id, showHierarchy)
   const tasksFolderIdsParams = selectedFolders.length
     ? Array.from(
         new Set([...foldersMap.keys(), ...(excludeSelectedFolders ? selectedFolders : [])]),


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
Sorting by folder now works on the overview page, thanks for backend fixes -> https://github.com/ynput/ayon-backend/pull/1047#




## Technical details
<!-- Please state any technical details such as limitations -->
- Now uses `folderName` sort key.
- Columns builder now has column sorting config for columns that use a different sortKey to the column id.



