### PR TITLE
YN-0974: Lists: Move list should use add to list dialog

### DIFF
--- a/shared/src/util/buildHierarchicalTableRows.ts
+++ b/shared/src/util/buildHierarchicalTableRows.ts
@@ -39,6 +39,8 @@ export interface BuildHierarchicalRowsConfig<TFolder, TItem> {
   getItemCount: (node: HierarchicalFolderNode<TFolder, TItem>) => number
   /** Optional: returns true if the folder is genuinely empty, false if it has items the user can't see (e.g. restricted projects). Hides folders with restricted content regardless of showEmptyFolders. */
   getFolderIsEmpty?: (folder: TFolder) => boolean | undefined
+  /** Optional: why a folder can't be picked (row shown but not selectable); undefined = selectable */
+  getFolderDisabledMessage?: (folder: TFolder) => string | undefined
 }
 
 /**
@@ -61,6 +63,7 @@ export const buildHierarchicalTableRows = <TFolder, TItem>(
     getFolderColor,
     getItemCount,
     getFolderIsEmpty,
+    getFolderDisabledMessage,
   } = config
 
   const isFolderVisible = (node: HierarchicalFolderNode<TFolder, TItem>): boolean => {
@@ -112,6 +115,7 @@ export const buildHierarchicalTableRows = <TFolder, TItem>(
 
     const folderLabel = getFolderLabel(node.folder)
     const folderColor = getFolderColor(node.folder)
+    const folderDisabledMessage = getFolderDisabledMessage?.(node.folder)
 
     // Create folder row
     const folderRow: SimpleTableRow = {
@@ -122,6 +126,8 @@ export const buildHierarchicalTableRows = <TFolder, TItem>(
       icon: getFolderIcon(node.folder),
       iconColor: folderColor,
       iconFilled: true,
+      isDisabled: !!folderDisabledMessage,
+      disabledMessage: folderDisabledMessage,
       subRows: [],
       data: {
         id: node.id,

--- a/src/pages/ProjectListsPage/ProjectListsPage.tsx
+++ b/src/pages/ProjectListsPage/ProjectListsPage.tsx
@@ -48,6 +48,7 @@ import { useAppDispatch, useAppSelector } from '@state/store.ts'
 import { UniqueIdentifier } from '@dnd-kit/core'
 import useTableOpenViewer from '@pages/ProjectOverviewPage/hooks/useTableOpenViewer'
 import ListsShortcuts from './components/ListsShortcuts.tsx'
+import { MoveToFolderDialogContainer } from './components/MoveToFolderDialog'
 import { useSlicerContext, useViewsContext } from '@shared/containers/index.ts'
 import DetailsPanelSplitter from '@components/DetailsPanelSplitter.ts'
 import DndContextWrapper from './components/DndContextWrapper'
@@ -237,6 +238,7 @@ const ProjectListsWithInnerProviders: FC<ProjectListsWithInnerProvidersProps> = 
                       />
                       <ListsShortcuts />
                       <ReplaceListItemsDialog />
+                      <MoveToFolderDialogContainer />
                     </CellEditingProvider>
                   </SelectedRowsProvider>
                 </SelectionCellsProvider>

--- a/src/pages/ProjectListsPage/components/ListsTable/ListsTable.tsx
+++ b/src/pages/ProjectListsPage/components/ListsTable/ListsTable.tsx
@@ -51,11 +51,14 @@ const ListsTable: FC<ListsTableProps> = ({
     setExpanded,
   } = useListsContext()
   const { listsTableData, isLoadingAll, isError, fetchNextPage } = useListsDataContext()
-  const [clientSearch, setClientSearch] = useState<null | string>(null)
+  // folder picker opens with search ready — the destination list is often long
+  const [clientSearch, setClientSearch] = useState<null | string>(
+    picker && foldersOnly ? '' : null,
+  )
   // unique menu id in picker mode so the dialog's header menu doesn't collide with the sidepanel's
   const pickerMenuId = useId()
 
-  const rowContextMenuBuildersAll = useListContextMenu(rowContextMenuBuilders)
+  const rowContextMenuBuildersAll = useListContextMenu(rowContextMenuBuilders, !picker)
   const sessionsLabel = useMemo(
     () => (isStoryboards ? 'Storyboards' : 'Review sessions'),
     [isStoryboards],
@@ -166,7 +169,7 @@ const ListsTable: FC<ListsTableProps> = ({
             onScrollBottom={fetchNextPage}
             isMultiSelect={!singleSelect}
             enableClickToDeselect={false}
-            rowContextMenuBuilders={picker ? [] : rowContextMenuBuildersAll}
+            rowContextMenuBuilders={rowContextMenuBuildersAll}
             renamingId={picker ? undefined : renamingList}
             onRename={picker ? undefined : handleRename}
             onSubmitRename={picker ? undefined : handleSubmitRename}

--- a/src/pages/ProjectListsPage/components/ListsTable/ListsTable.tsx
+++ b/src/pages/ProjectListsPage/components/ListsTable/ListsTable.tsx
@@ -20,8 +20,11 @@ interface ListsTableProps {
   rowContextMenuBuilders?: ListRowContextMenuBuilder[]
   // picker mode: reuse the table inside the add-to-list dialog
   picker?: boolean
+  // folders-only picker: rows are folders and onRowSubmit receives a folder id
+  foldersOnly?: boolean
+  singleSelect?: boolean
   hiddenButtons?: ButtonType[]
-  onRowSubmit?: (listId: string) => void
+  onRowSubmit?: (id: string) => void
   onCreateList?: () => void
 }
 
@@ -30,6 +33,8 @@ const ListsTable: FC<ListsTableProps> = ({
   isStoryboards,
   rowContextMenuBuilders = [],
   picker = false,
+  foldersOnly = false,
+  singleSelect = false,
   hiddenButtons,
   onRowSubmit,
   onCreateList,
@@ -65,30 +70,48 @@ const ListsTable: FC<ListsTableProps> = ({
   const handleRowDoubleClick = useCallback(
     (id: string) => {
       if (picker) {
+        const folderId = parseListFolderRowId(id)
+        // folders-only picker submits folder rows, the list picker submits list rows
+        if (foldersOnly) {
+          if (folderId) onRowSubmit?.(folderId)
+          return
+        }
         // ignore folder rows; double-click a list = instant add + close
-        if (parseListFolderRowId(id)) return
+        if (folderId) return
         onRowSubmit?.(id)
         return
       }
       setListDetailsOpen(true)
     },
-    [picker, onRowSubmit, setListDetailsOpen],
+    [picker, foldersOnly, onRowSubmit, setListDetailsOpen],
   )
 
-  const renderCell = useCallback((props: any, row: any) => {
-    const listId = row.original.id
-    const { isDisabled, disabledMessage, inactive, data } = row.original
+  const renderCell = useCallback(
+    (props: any, row: any) => {
+      const listId = row.original.id
+      const { isDisabled, disabledMessage, inactive, data } = row.original
 
-    return (
-      <SimpleTableCellTemplate
-        {...props}
-        key={listId}
-        iconColor={data.color}
-        enableNonFolderIndent={false}
-        badge={isDisabled ? disabledMessage : inactive ? '(archived)' : data.count}
-      />
-    )
-  }, [])
+      return (
+        <SimpleTableCellTemplate
+          {...props}
+          key={listId}
+          iconColor={data.color}
+          enableNonFolderIndent={false}
+          // no lists are fetched in folders-only mode, so every count would read 0
+          badge={
+            isDisabled
+              ? disabledMessage
+              : inactive
+              ? '(archived)'
+              : foldersOnly
+              ? undefined
+              : data.count
+          }
+        />
+      )
+    },
+    [foldersOnly],
+  )
 
   return (
     <>
@@ -97,7 +120,7 @@ const ListsTable: FC<ListsTableProps> = ({
       >
         <Container>
           <ListsTableHeader
-            title={isReview ? sessionsLabel : undefined}
+            title={foldersOnly ? 'Folders' : isReview ? sessionsLabel : undefined}
             buttonLabels={{
               delete: {
                 tooltip: isReview
@@ -108,12 +131,24 @@ const ListsTable: FC<ListsTableProps> = ({
                 tooltip: isReview ? `Create new ${sessionsLabel.toLowerCase()}` : 'Create new list',
               },
               search: {
-                tooltip: isReview ? `Search ${sessionsLabel.toLowerCase()}` : 'Search lists',
+                tooltip: foldersOnly
+                  ? 'Search folders'
+                  : isReview
+                  ? `Search ${sessionsLabel.toLowerCase()}`
+                  : 'Search lists',
               },
             }}
             hiddenButtons={hiddenButtons ?? (isReview ? ['filter'] : [])}
             hiddenMenuItemIds={
-              picker ? ['new-folder', 'delete', 'filter', ...(onCreateList ? [] : ['new-list'])] : []
+              picker
+                ? [
+                    'new-folder',
+                    'delete',
+                    'filter',
+                    ...(onCreateList ? [] : ['new-list']),
+                    ...(foldersOnly ? ['select-all-lists', 'show-archived'] : []),
+                  ]
+                : []
             }
             menuId={picker ? pickerMenuId : undefined}
             onCreateList={onCreateList}
@@ -129,6 +164,7 @@ const ListsTable: FC<ListsTableProps> = ({
             isLoading={isLoadingAll}
             error={isError ? 'Error loading lists' : undefined}
             onScrollBottom={fetchNextPage}
+            isMultiSelect={!singleSelect}
             enableClickToDeselect={false}
             rowContextMenuBuilders={picker ? [] : rowContextMenuBuildersAll}
             renamingId={picker ? undefined : renamingList}

--- a/src/pages/ProjectListsPage/components/ListsTable/ListsTableHeader.tsx
+++ b/src/pages/ProjectListsPage/components/ListsTable/ListsTableHeader.tsx
@@ -341,9 +341,20 @@ const ListsTableHeader: FC<ListsTableHeaderProps> = ({
     },
   ]
 
-  const visibleMenuItems = hiddenMenuItemIds.length
+  const filteredMenuItems = hiddenMenuItemIds.length
     ? menuItems.filter((item) => !item.id || !hiddenMenuItemIds.includes(item.id))
     : menuItems
+
+  // hiding items can leave dividers doubled up or dangling at either end
+  const isDivider = (item: MenuItemType) => item.id === 'divider'
+  const visibleMenuItems = filteredMenuItems.reduce<MenuItemType[]>((acc, item) => {
+    if (isDivider(item) && (!acc.length || isDivider(acc[acc.length - 1]))) return acc
+    acc.push(item)
+    return acc
+  }, [])
+  while (visibleMenuItems.length && isDivider(visibleMenuItems[visibleMenuItems.length - 1])) {
+    visibleMenuItems.pop()
+  }
 
   // Get pinned items (for buttons)
   const pinnedItems = visibleMenuItems.filter((item) => item.isPinned)

--- a/src/pages/ProjectListsPage/components/MoveToFolderDialog/MoveToFolderDialog.tsx
+++ b/src/pages/ProjectListsPage/components/MoveToFolderDialog/MoveToFolderDialog.tsx
@@ -42,16 +42,27 @@ export interface MoveToFolderDialogProps {
   ids: string[]
   isReview?: boolean
   isStoryboards?: boolean
+  // none of the moved items sit in a folder, so there is nothing to unset
+  canUnset?: boolean
   onMove: (targetFolderId: string) => Promise<void>
+  onUnset: () => Promise<void>
   onClose: () => void
 }
+
+const Footer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+`
 
 const MoveToFolderDialogInner: FC<MoveToFolderDialogProps> = ({
   moving,
   ids,
   isReview,
   isStoryboards,
+  canUnset,
   onMove,
+  onUnset,
   onClose,
 }) => {
   const { selectedRows } = useListsContext()
@@ -66,6 +77,11 @@ const MoveToFolderDialogInner: FC<MoveToFolderDialogProps> = ({
   const moveTo = (folderId: string) => {
     if (disabledFolderMessages.has(folderId)) return
     onMove(folderId).catch(() => {})
+    onClose()
+  }
+
+  const unset = () => {
+    onUnset().catch(() => {})
     onClose()
   }
 
@@ -88,12 +104,28 @@ const MoveToFolderDialogInner: FC<MoveToFolderDialogProps> = ({
       header={header}
       style={{ width: '100%', maxWidth: 800, height: '80vh' }}
       footer={
-        <Button
-          label="Move"
-          variant="filled"
-          disabled={!targetFolderId}
-          onClick={() => targetFolderId && moveTo(targetFolderId)}
-        />
+        <Footer>
+          <Button
+            label={moving === 'folders' ? 'Make root folder' : 'Unset folder'}
+            icon="folder_off"
+            variant="text"
+            disabled={!canUnset}
+            data-tooltip={
+              canUnset
+                ? undefined
+                : moving === 'folders'
+                ? 'Already a root folder'
+                : 'Not in a folder'
+            }
+            onClick={unset}
+          />
+          <Button
+            label="Move"
+            variant="filled"
+            disabled={!targetFolderId}
+            onClick={() => targetFolderId && moveTo(targetFolderId)}
+          />
+        </Footer>
       }
     >
       <TableContainer>

--- a/src/pages/ProjectListsPage/components/MoveToFolderDialog/MoveToFolderDialog.tsx
+++ b/src/pages/ProjectListsPage/components/MoveToFolderDialog/MoveToFolderDialog.tsx
@@ -1,0 +1,131 @@
+import { FC, useCallback } from 'react'
+import { Button, Dialog } from '@ynput/ayon-react-components'
+import styled from 'styled-components'
+import { toast } from 'react-toastify'
+import {
+  ListsDataProvider,
+  useListsDataContext,
+} from '@pages/ProjectListsPage/context/ListsDataContext'
+import { ListsProvider } from '@pages/ProjectListsPage/context/ListsProvider'
+import { useListsContext } from '@pages/ProjectListsPage/context/ListsContext'
+import ListsTable from '../ListsTable/ListsTable'
+import { parseListFolderRowId, wouldCreateCircularDependency } from '../../util'
+import type { EntityListFolderModel } from '@shared/api'
+
+const TableContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  height: 100%;
+  min-height: 0;
+  width: 100%;
+
+  /* circular-move rows: muted, not struck through; the reason gets the space it needs (label truncates first) so it never paints over other text (&& outranks SimpleTable's disabled rule) */
+  && .disabled {
+    .value {
+      text-decoration: none;
+    }
+    .text {
+      min-width: 0;
+    }
+    .badges {
+      flex-shrink: 0;
+    }
+    .badges span {
+      white-space: nowrap;
+    }
+  }
+`
+
+export interface MoveToFolderDialogProps {
+  // what is being moved: list ids or folder ids (never mixed)
+  moving: 'lists' | 'folders'
+  ids: string[]
+  isReview?: boolean
+  isStoryboards?: boolean
+  onMove: (targetFolderId: string) => Promise<void>
+  onClose: () => void
+}
+
+const MoveToFolderDialogInner: FC<MoveToFolderDialogProps> = ({ moving, ids, onMove, onClose }) => {
+  const { selectedRows } = useListsContext()
+  const { disabledFolderIds } = useListsDataContext()
+
+  // right-click selects a row even when disabled, so disabled ids must be dropped here too
+  const [targetFolderId] = selectedRows
+    .map((rowId) => parseListFolderRowId(rowId))
+    .filter((id): id is string => !!id && !disabledFolderIds.has(id))
+
+  // close immediately — the move is optimistic in the cache and rolls back on failure
+  const moveTo = (folderId: string) => {
+    if (disabledFolderIds.has(folderId)) return
+    onMove(folderId).catch((error: any) => {
+      toast.error(error?.message || error || 'Failed to move')
+    })
+    onClose()
+  }
+
+  const count = ids.length
+  const header =
+    moving === 'folders'
+      ? count > 1
+        ? `Move ${count} folders`
+        : 'Move folder'
+      : count > 1
+      ? `Move ${count} lists`
+      : 'Move list'
+
+  return (
+    <Dialog
+      isOpen
+      onClose={onClose}
+      size="full"
+      className="move-to-folder-dialog block-shortcuts"
+      header={header}
+      style={{ width: '100%', maxWidth: 800, height: '80vh' }}
+      footer={
+        <Button
+          label="Move"
+          variant="filled"
+          disabled={!targetFolderId}
+          onClick={() => targetFolderId && moveTo(targetFolderId)}
+        />
+      }
+    >
+      <TableContainer>
+        <ListsTable picker foldersOnly singleSelect onRowSubmit={moveTo} />
+      </TableContainer>
+    </Dialog>
+  )
+}
+
+export const MoveToFolderDialog: FC<MoveToFolderDialogProps> = (props) => {
+  const { moving, ids, isReview, isStoryboards } = props
+
+  const folderDisabled = useCallback(
+    (folder: EntityListFolderModel, folders: EntityListFolderModel[]) => {
+      if (moving !== 'folders') return undefined
+      if (ids.includes(folder.id)) return 'Cannot move into itself'
+      if (ids.some((id) => wouldCreateCircularDependency(id, folder.id, folders)))
+        return 'Cannot move into own subfolder'
+      return undefined
+    },
+    [moving, ids],
+  )
+
+  return (
+    <ListsDataProvider
+      picker
+      foldersOnly
+      isReview={isReview}
+      isStoryboards={isStoryboards}
+      folderDisabled={folderDisabled}
+    >
+      <ListsProvider picker isReview={isReview} isStoryboards={isStoryboards}>
+        <MoveToFolderDialogInner {...props} />
+      </ListsProvider>
+    </ListsDataProvider>
+  )
+}
+
+export default MoveToFolderDialog

--- a/src/pages/ProjectListsPage/components/MoveToFolderDialog/MoveToFolderDialog.tsx
+++ b/src/pages/ProjectListsPage/components/MoveToFolderDialog/MoveToFolderDialog.tsx
@@ -1,7 +1,6 @@
 import { FC, useCallback } from 'react'
 import { Button, Dialog } from '@ynput/ayon-react-components'
 import styled from 'styled-components'
-import { toast } from 'react-toastify'
 import {
   ListsDataProvider,
   useListsDataContext,
@@ -9,7 +8,7 @@ import {
 import { ListsProvider } from '@pages/ProjectListsPage/context/ListsProvider'
 import { useListsContext } from '@pages/ProjectListsPage/context/ListsContext'
 import ListsTable from '../ListsTable/ListsTable'
-import { parseListFolderRowId, wouldCreateCircularDependency } from '../../util'
+import { buildFolderMap, parseListFolderRowId, wouldCreateCircularDependency } from '../../util'
 import type { EntityListFolderModel } from '@shared/api'
 
 const TableContainer = styled.div`
@@ -47,21 +46,26 @@ export interface MoveToFolderDialogProps {
   onClose: () => void
 }
 
-const MoveToFolderDialogInner: FC<MoveToFolderDialogProps> = ({ moving, ids, onMove, onClose }) => {
+const MoveToFolderDialogInner: FC<MoveToFolderDialogProps> = ({
+  moving,
+  ids,
+  isReview,
+  isStoryboards,
+  onMove,
+  onClose,
+}) => {
   const { selectedRows } = useListsContext()
-  const { disabledFolderIds } = useListsDataContext()
+  const { disabledFolderMessages } = useListsDataContext()
 
   // right-click selects a row even when disabled, so disabled ids must be dropped here too
   const [targetFolderId] = selectedRows
     .map((rowId) => parseListFolderRowId(rowId))
-    .filter((id): id is string => !!id && !disabledFolderIds.has(id))
+    .filter((id): id is string => !!id && !disabledFolderMessages.has(id))
 
   // close immediately — the move is optimistic in the cache and rolls back on failure
   const moveTo = (folderId: string) => {
-    if (disabledFolderIds.has(folderId)) return
-    onMove(folderId).catch((error: any) => {
-      toast.error(error?.message || error || 'Failed to move')
-    })
+    if (disabledFolderMessages.has(folderId)) return
+    onMove(folderId).catch(() => {})
     onClose()
   }
 
@@ -93,7 +97,14 @@ const MoveToFolderDialogInner: FC<MoveToFolderDialogProps> = ({ moving, ids, onM
       }
     >
       <TableContainer>
-        <ListsTable picker foldersOnly singleSelect onRowSubmit={moveTo} />
+        <ListsTable
+          picker
+          foldersOnly
+          singleSelect
+          isReview={isReview}
+          isStoryboards={isStoryboards}
+          onRowSubmit={moveTo}
+        />
       </TableContainer>
     </Dialog>
   )
@@ -102,13 +113,18 @@ const MoveToFolderDialogInner: FC<MoveToFolderDialogProps> = ({ moving, ids, onM
 export const MoveToFolderDialog: FC<MoveToFolderDialogProps> = (props) => {
   const { moving, ids, isReview, isStoryboards } = props
 
-  const folderDisabled = useCallback(
-    (folder: EntityListFolderModel, folders: EntityListFolderModel[]) => {
-      if (moving !== 'folders') return undefined
-      if (ids.includes(folder.id)) return 'Cannot move into itself'
-      if (ids.some((id) => wouldCreateCircularDependency(id, folder.id, folders)))
-        return 'Cannot move into own subfolder'
-      return undefined
+  const getDisabledFolders = useCallback(
+    (folders: EntityListFolderModel[]) => {
+      const messages = new Map<string, string>()
+      if (moving !== 'folders') return messages
+
+      const folderMap = buildFolderMap(folders)
+      for (const folder of folders) {
+        if (ids.includes(folder.id)) messages.set(folder.id, 'Cannot move into itself')
+        else if (ids.some((id) => wouldCreateCircularDependency(id, folder.id, folderMap)))
+          messages.set(folder.id, 'Cannot move into own subfolder')
+      }
+      return messages
     },
     [moving, ids],
   )
@@ -119,7 +135,7 @@ export const MoveToFolderDialog: FC<MoveToFolderDialogProps> = (props) => {
       foldersOnly
       isReview={isReview}
       isStoryboards={isStoryboards}
-      folderDisabled={folderDisabled}
+      getDisabledFolders={getDisabledFolders}
     >
       <ListsProvider picker isReview={isReview} isStoryboards={isStoryboards}>
         <MoveToFolderDialogInner {...props} />

--- a/src/pages/ProjectListsPage/components/MoveToFolderDialog/MoveToFolderDialogContainer.tsx
+++ b/src/pages/ProjectListsPage/components/MoveToFolderDialog/MoveToFolderDialogContainer.tsx
@@ -1,5 +1,6 @@
 import { FC } from 'react'
 import { useListsContext } from '@pages/ProjectListsPage/context'
+import { useListsDataContext } from '@pages/ProjectListsPage/context/ListsDataContext'
 import { MoveToFolderDialog } from './MoveToFolderDialog'
 
 interface MoveToFolderDialogContainerProps {}
@@ -10,13 +11,21 @@ const MoveToFolderDialogContainer: FC<MoveToFolderDialogContainerProps> = ({}) =
     closeMoveToFolder,
     onPutListsInFolder,
     onPutFoldersInFolder,
+    onRemoveListsFromFolder,
+    onRemoveFoldersFromFolder,
     isReview,
     isStoryboards,
   } = useListsContext()
+  const { listsData, listFolders } = useListsDataContext()
 
   if (!moveToFolder) return null
 
   const { moving, ids } = moveToFolder
+
+  const canUnset =
+    moving === 'folders'
+      ? ids.some((id) => listFolders.find((folder) => folder.id === id)?.parentId)
+      : ids.some((id) => listsData.find((list) => list.id === id)?.entityListFolderId)
 
   return (
     <MoveToFolderDialog
@@ -24,10 +33,14 @@ const MoveToFolderDialogContainer: FC<MoveToFolderDialogContainerProps> = ({}) =
       ids={ids}
       isReview={isReview}
       isStoryboards={isStoryboards}
+      canUnset={canUnset}
       onMove={(targetFolderId) =>
         moving === 'folders'
           ? onPutFoldersInFolder(ids, targetFolderId)
           : onPutListsInFolder(ids, targetFolderId)
+      }
+      onUnset={() =>
+        moving === 'folders' ? onRemoveFoldersFromFolder(ids) : onRemoveListsFromFolder(ids)
       }
       onClose={closeMoveToFolder}
     />

--- a/src/pages/ProjectListsPage/components/MoveToFolderDialog/MoveToFolderDialogContainer.tsx
+++ b/src/pages/ProjectListsPage/components/MoveToFolderDialog/MoveToFolderDialogContainer.tsx
@@ -1,0 +1,37 @@
+import { FC } from 'react'
+import { useListsContext } from '@pages/ProjectListsPage/context'
+import { MoveToFolderDialog } from './MoveToFolderDialog'
+
+interface MoveToFolderDialogContainerProps {}
+
+const MoveToFolderDialogContainer: FC<MoveToFolderDialogContainerProps> = ({}) => {
+  const {
+    moveToFolder,
+    closeMoveToFolder,
+    onPutListsInFolder,
+    onPutFoldersInFolder,
+    isReview,
+    isStoryboards,
+  } = useListsContext()
+
+  if (!moveToFolder) return null
+
+  const { moving, ids } = moveToFolder
+
+  return (
+    <MoveToFolderDialog
+      moving={moving}
+      ids={ids}
+      isReview={isReview}
+      isStoryboards={isStoryboards}
+      onMove={(targetFolderId) =>
+        moving === 'folders'
+          ? onPutFoldersInFolder(ids, targetFolderId)
+          : onPutListsInFolder(ids, targetFolderId)
+      }
+      onClose={closeMoveToFolder}
+    />
+  )
+}
+
+export default MoveToFolderDialogContainer

--- a/src/pages/ProjectListsPage/components/MoveToFolderDialog/index.ts
+++ b/src/pages/ProjectListsPage/components/MoveToFolderDialog/index.ts
@@ -1,2 +1,3 @@
 export { MoveToFolderDialog, default } from './MoveToFolderDialog'
 export type { MoveToFolderDialogProps } from './MoveToFolderDialog'
+export { default as MoveToFolderDialogContainer } from './MoveToFolderDialogContainer'

--- a/src/pages/ProjectListsPage/components/MoveToFolderDialog/index.ts
+++ b/src/pages/ProjectListsPage/components/MoveToFolderDialog/index.ts
@@ -1,0 +1,2 @@
+export { MoveToFolderDialog, default } from './MoveToFolderDialog'
+export type { MoveToFolderDialogProps } from './MoveToFolderDialog'

--- a/src/pages/ProjectListsPage/context/ListsContext.ts
+++ b/src/pages/ProjectListsPage/context/ListsContext.ts
@@ -15,6 +15,11 @@ export type ListDetailsOpenState = {
 
 export type OnOpenFolderListParams = (params: { folderId?: string; parentId?: string }) => void
 
+export type MoveToFolderState = {
+  moving: 'lists' | 'folders'
+  ids: string[]
+}
+
 export interface ListsContextType {
   rowSelection: RowSelectionState
   setRowSelection: (ids: RowSelectionState) => void
@@ -59,6 +64,10 @@ export interface ListsContextType {
   listFolderOpen: ListDetailsOpenState
   setListFolderOpen: React.Dispatch<React.SetStateAction<ListDetailsOpenState>>
   onOpenFolderList: OnOpenFolderListParams
+  // Move to folder dialog
+  moveToFolder: MoveToFolderState | null
+  openMoveToFolder: (state: MoveToFolderState) => void
+  closeMoveToFolder: () => void
   // helpers
   selectAllLists: (options?: { rowIds?: string[] }) => void
 }

--- a/src/pages/ProjectListsPage/context/ListsDataContext.tsx
+++ b/src/pages/ProjectListsPage/context/ListsDataContext.tsx
@@ -14,6 +14,7 @@ interface ListsDataContextValue {
   listsTableData: SimpleTableRow[]
   listsMap: ListsMap
   disabledListIds: Set<string>
+  disabledFolderIds: Set<string>
   listFolders: EntityListFolderModel[]
   fetchNextPage: () => void
   isLoadingAll: boolean
@@ -37,8 +38,15 @@ interface ListsDataProviderProps {
   isStoryboards?: boolean
   // picker mode: ignore the page's saved list filters (selection dialog, not the Lists page)
   picker?: boolean
+  // folder destination picker: only the folder tree, lists are never fetched or rendered
+  foldersOnly?: boolean
   listsFilter?: (list: EntityList) => boolean
   listDisabled?: (list: EntityList) => string | undefined
+  // why a folder can't be picked; gets the full folder list for ancestry checks
+  folderDisabled?: (
+    folder: EntityListFolderModel,
+    folders: EntityListFolderModel[],
+  ) => string | undefined
 }
 
 // fetch all lists and provide methods to update the lists
@@ -48,8 +56,10 @@ export const ListsDataProvider = ({
   isReview,
   isStoryboards,
   picker,
+  foldersOnly,
   listsFilter,
   listDisabled,
+  folderDisabled,
 }: ListsDataProviderProps) => {
   const { powerLicense, isLoading: isLoadingLicense } = usePowerpack()
   const { projectName, isLoading: isFetchingProject } = useProjectContext()
@@ -105,6 +115,7 @@ export const ListsDataProvider = ({
     projectName,
     filters: listsFilters,
     entityListTypes,
+    skip: foldersOnly,
   })
 
   const listsData = useMemo(
@@ -125,10 +136,27 @@ export const ListsDataProvider = ({
     return ids
   }, [listsData, listDisabled])
 
+  const disabledFolderIds = useMemo(() => {
+    const ids = new Set<string>()
+    if (folderDisabled) {
+      for (const folder of listFolders) if (folderDisabled(folder, listFolders)) ids.add(folder.id)
+    }
+    return ids
+  }, [listFolders, folderDisabled])
+
   // convert listsData into tableData
   const listsTableData = useMemo(
-    () => buildListsTableData(listsData, listFolders, true, powerLicense, showArchived, listDisabled),
-    [listsData, listFolders, powerLicense, showArchived, listDisabled],
+    () =>
+      buildListsTableData(
+        listsData,
+        listFolders,
+        true,
+        powerLicense,
+        showArchived,
+        listDisabled,
+        folderDisabled ? (folder) => folderDisabled(folder, listFolders) : undefined,
+      ),
+    [listsData, listFolders, powerLicense, showArchived, listDisabled, folderDisabled],
   )
 
   return (
@@ -138,6 +166,7 @@ export const ListsDataProvider = ({
         listsTableData,
         listsMap,
         disabledListIds,
+        disabledFolderIds,
         listFolders,
         isLoadingAll:
           isLoadingLists ||

--- a/src/pages/ProjectListsPage/context/ListsDataContext.tsx
+++ b/src/pages/ProjectListsPage/context/ListsDataContext.tsx
@@ -14,7 +14,7 @@ interface ListsDataContextValue {
   listsTableData: SimpleTableRow[]
   listsMap: ListsMap
   disabledListIds: Set<string>
-  disabledFolderIds: Set<string>
+  disabledFolderMessages: Map<string, string>
   listFolders: EntityListFolderModel[]
   fetchNextPage: () => void
   isLoadingAll: boolean
@@ -42,11 +42,8 @@ interface ListsDataProviderProps {
   foldersOnly?: boolean
   listsFilter?: (list: EntityList) => boolean
   listDisabled?: (list: EntityList) => string | undefined
-  // why a folder can't be picked; gets the full folder list for ancestry checks
-  folderDisabled?: (
-    folder: EntityListFolderModel,
-    folders: EntityListFolderModel[],
-  ) => string | undefined
+  // why folders can't be picked, keyed by folder id; batched so ancestry checks run once per render
+  getDisabledFolders?: (folders: EntityListFolderModel[]) => Map<string, string>
 }
 
 // fetch all lists and provide methods to update the lists
@@ -59,7 +56,7 @@ export const ListsDataProvider = ({
   foldersOnly,
   listsFilter,
   listDisabled,
-  folderDisabled,
+  getDisabledFolders,
 }: ListsDataProviderProps) => {
   const { powerLicense, isLoading: isLoadingLicense } = usePowerpack()
   const { projectName, isLoading: isFetchingProject } = useProjectContext()
@@ -136,13 +133,10 @@ export const ListsDataProvider = ({
     return ids
   }, [listsData, listDisabled])
 
-  const disabledFolderIds = useMemo(() => {
-    const ids = new Set<string>()
-    if (folderDisabled) {
-      for (const folder of listFolders) if (folderDisabled(folder, listFolders)) ids.add(folder.id)
-    }
-    return ids
-  }, [listFolders, folderDisabled])
+  const disabledFolderMessages = useMemo(
+    () => getDisabledFolders?.(listFolders) ?? new Map<string, string>(),
+    [listFolders, getDisabledFolders],
+  )
 
   // convert listsData into tableData
   const listsTableData = useMemo(
@@ -154,9 +148,17 @@ export const ListsDataProvider = ({
         powerLicense,
         showArchived,
         listDisabled,
-        folderDisabled ? (folder) => folderDisabled(folder, listFolders) : undefined,
+        getDisabledFolders ? (folder) => disabledFolderMessages.get(folder.id) : undefined,
       ),
-    [listsData, listFolders, powerLicense, showArchived, listDisabled, folderDisabled],
+    [
+      listsData,
+      listFolders,
+      powerLicense,
+      showArchived,
+      listDisabled,
+      getDisabledFolders,
+      disabledFolderMessages,
+    ],
   )
 
   return (
@@ -166,7 +168,7 @@ export const ListsDataProvider = ({
         listsTableData,
         listsMap,
         disabledListIds,
-        disabledFolderIds,
+        disabledFolderMessages,
         listFolders,
         isLoadingAll:
           isLoadingLists ||

--- a/src/pages/ProjectListsPage/context/ListsProvider.tsx
+++ b/src/pages/ProjectListsPage/context/ListsProvider.tsx
@@ -11,7 +11,11 @@ import useDeleteList from '../hooks/useDeleteList'
 import useUpdateList from '../hooks/useUpdateList'
 import { useListsDataContext } from './ListsDataContext'
 import { useQueryParam, withDefault, QueryParamConfig } from 'use-query-params'
-import ListsContext, { ListDetailsOpenState, OnOpenFolderListParams } from './ListsContext'
+import ListsContext, {
+  ListDetailsOpenState,
+  MoveToFolderState,
+  OnOpenFolderListParams,
+} from './ListsContext'
 import { useGetProductionAddon } from '@shared/hooks'
 import { useSessionStorage } from '@shared/hooks'
 import { buildListFolderRowId, parseListFolderRowId } from '../util/buildListsTableData'
@@ -146,6 +150,10 @@ export const ListsProvider = ({
   )
 
   const [listFolderOpen, setListFolderOpen] = useState<ListDetailsOpenState>({ isOpen: false })
+
+  const [moveToFolder, setMoveToFolder] = useState<MoveToFolderState | null>(null)
+  const openMoveToFolder = useCallback((state: MoveToFolderState) => setMoveToFolder(state), [])
+  const closeMoveToFolder = useCallback(() => setMoveToFolder(null), [])
 
   // expanded state for folder hierarchy
   const [expanded, setExpanded] = useState<ExpandedState>({})
@@ -427,6 +435,10 @@ export const ListsProvider = ({
         listFolderOpen,
         setListFolderOpen,
         onOpenFolderList, // helper function to open folder dialog in edit/create mode
+        // Move to folder dialog
+        moveToFolder,
+        openMoveToFolder,
+        closeMoveToFolder,
         // helpers
         selectAllLists,
       }}

--- a/src/pages/ProjectListsPage/hooks/useListContextMenu.ts
+++ b/src/pages/ProjectListsPage/hooks/useListContextMenu.ts
@@ -5,7 +5,7 @@ import { useAppSelector } from '@state/store'
 import useClearListItems from './useClearListItems'
 import { useListsDataContext } from '../context/ListsDataContext'
 import { parseListFolderRowId } from '../util/buildListsTableData'
-import { wouldCreateCircularDependency } from '../util/listFolders'
+import { buildFolderMap, wouldCreateCircularDependency } from '../util/listFolders'
 import { EntityListFolderModel } from '@shared/api'
 import { getPlatformShortcutKey, KeyMode } from '@shared/util'
 import { usePowerpack, useProjectContext } from '@shared/context'
@@ -31,7 +31,8 @@ export const FOLDER_ICON_ADD = 'create_new_folder'
 export const FOLDER_ICON_EDIT = 'folder_managed'
 export const FOLDER_ICON_REMOVE = 'folder_off'
 
-const useListContextMenu = (extraBuilders: ListRowContextMenuBuilder[] = []) => {
+// enabled=false in picker mode: the table renders no row menu there
+const useListContextMenu = (extraBuilders: ListRowContextMenuBuilder[] = [], enabled = true) => {
   const user = useAppSelector((state) => state.user)
   const developerMode = user?.attrib.developerMode
   const { projectName } = useProjectContext()
@@ -120,16 +121,17 @@ const useListContextMenu = (extraBuilders: ListRowContextMenuBuilder[] = []) => 
       const selectedListIds = newSelectedLists.map((list) => list.id)
       const moveIds = allSelectedRowsAreFolders ? selectedFolderIds : selectedListIds
 
-      // destinations the selection can actually go into (a folder can't move into itself or its own subtree)
-      const availableTargetFolders = allSelectedRowsAreFolders
-        ? listFolders.filter(
+      // is there anywhere the selection can actually go? (a folder can't move into itself or its own subtree)
+      const folderMap = buildFolderMap(listFolders)
+      const hasTargetFolders = allSelectedRowsAreFolders
+        ? listFolders.some(
             (folder) =>
               !selectedFolderIds.includes(folder.id) &&
               !selectedFolderIds.some((id) =>
-                wouldCreateCircularDependency(id, folder.id, listFolders),
+                wouldCreateCircularDependency(id, folder.id, folderMap),
               ),
           )
-        : listFolders
+        : listFolders.length > 0
 
       // "Unset folder" only makes sense when at least one selected list is in a folder
       const hasAnyFolder = newSelectedLists.some((list) => list.entityListFolderId)
@@ -149,7 +151,7 @@ const useListContextMenu = (extraBuilders: ListRowContextMenuBuilder[] = []) => 
             hidden:
               (!allSelectedRowsAreLists && !allSelectedRowsAreFolders) ||
               moveIds.length === 0 ||
-              availableTargetFolders.length === 0 ||
+              !hasTargetFolders ||
               // Hide if user doesn't have edit permission on all selected items
               (allSelectedRowsAreLists && !userCanEditAllLists) ||
               (allSelectedRowsAreFolders && !userCanEditAllFolders),
@@ -157,14 +159,15 @@ const useListContextMenu = (extraBuilders: ListRowContextMenuBuilder[] = []) => 
           {
             label: 'Unset folder',
             icon: FOLDER_ICON_REMOVE,
-            command: () => onRemoveListsFromFolder(selectedListIds),
+            // failures already toast inside the mutation hook
+            command: () => onRemoveListsFromFolder(selectedListIds).catch(() => {}),
             shortcut: getPlatformShortcutKey('f', [KeyMode.Shift, KeyMode.Alt]),
             hidden: !allSelectedRowsAreLists || !hasAnyFolder || !userCanEditAllLists,
           },
           {
             label: 'Make root folder',
             icon: FOLDER_ICON_REMOVE,
-            command: () => onRemoveFoldersFromFolder(selectedFolderIds),
+            command: () => onRemoveFoldersFromFolder(selectedFolderIds).catch(() => {}),
             shortcut: getPlatformShortcutKey('f', [KeyMode.Shift, KeyMode.Alt]),
             hidden:
               !allSelectedRowsAreFolders ||
@@ -311,7 +314,10 @@ const useListContextMenu = (extraBuilders: ListRowContextMenuBuilder[] = []) => 
     ],
   )
 
-  return useMemo(() => [buildContextMenu, ...extraBuilders], [buildContextMenu, extraBuilders])
+  return useMemo(
+    () => (enabled ? [buildContextMenu, ...extraBuilders] : []),
+    [enabled, buildContextMenu, extraBuilders],
+  )
 }
 
 export default useListContextMenu

--- a/src/pages/ProjectListsPage/hooks/useListContextMenu.ts
+++ b/src/pages/ProjectListsPage/hooks/useListContextMenu.ts
@@ -7,7 +7,7 @@ import { useListsDataContext } from '../context/ListsDataContext'
 import { parseListFolderRowId } from '../util/buildListsTableData'
 import { wouldCreateCircularDependency } from '../util/listFolders'
 import { EntityListFolderModel } from '@shared/api'
-import { getPlatformShortcutKey, KeyMode, buildFolderHierarchy } from '@shared/util'
+import { getPlatformShortcutKey, KeyMode } from '@shared/util'
 import { usePowerpack, useProjectContext } from '@shared/context'
 import {
   canEditList,
@@ -42,13 +42,12 @@ const useListContextMenu = (extraBuilders: ListRowContextMenuBuilder[] = []) => 
     deleteLists,
     createReviewSessionList,
     isReview,
-    onPutListsInFolder,
     onRemoveListsFromFolder,
     onOpenFolderList,
     openNewList,
     onDeleteListFolders,
-    onPutFoldersInFolder,
     onRemoveFoldersFromFolder,
+    openMoveToFolder,
     selectAllLists,
   } = useListsContext()
   const { powerLicense } = usePowerpack()
@@ -118,137 +117,61 @@ const useListContextMenu = (extraBuilders: ListRowContextMenuBuilder[] = []) => 
         : false
       const userCanEditList = selectedList ? canEditList(selectedList, userPermissions) : false
 
-      // Create recursive folder submenu
-      const createFolderHierarchy = (
-        folders: (EntityListFolderModel & { children: EntityListFolderModel[] })[],
-        excludeFolderId?: string,
-        depth = 0,
-      ): any[] => {
-        const items: any[] = []
+      const selectedListIds = newSelectedLists.map((list) => list.id)
+      const moveIds = allSelectedRowsAreFolders ? selectedFolderIds : selectedListIds
 
-        for (const folder of folders) {
-          if (folder.id === excludeFolderId) continue
+      // destinations the selection can actually go into (a folder can't move into itself or its own subtree)
+      const availableTargetFolders = allSelectedRowsAreFolders
+        ? listFolders.filter(
+            (folder) =>
+              !selectedFolderIds.includes(folder.id) &&
+              !selectedFolderIds.some((id) =>
+                wouldCreateCircularDependency(id, folder.id, listFolders),
+              ),
+          )
+        : listFolders
 
-          const hasChildren = folder.children.length > 0
-          const childItems = hasChildren
-            ? createFolderHierarchy(
-                folder.children as (EntityListFolderModel & {
-                  children: EntityListFolderModel[]
-                })[],
-                excludeFolderId,
-                depth + 1,
-              )
-            : []
+      // "Unset folder" only makes sense when at least one selected list is in a folder
+      const hasAnyFolder = newSelectedLists.some((list) => list.entityListFolderId)
 
-          items.push({
-            label: folder.label,
-            icon: folder.data?.icon || FOLDER_ICON,
-            command: allSelectedRowsAreFolders
-              ? () => onPutFoldersInFolder(selectedFolderIds, folder.id)
-              : () =>
-                  onPutListsInFolder(
-                    newSelectedLists.map((l) => l.id),
-                    folder.id,
-                  ),
-            disabled:
-              allSelectedRowsAreFolders &&
-              wouldCreateCircularDependency(selectedFolderId!, folder.id, listFolders),
-            ...(hasChildren && { items: childItems }),
-          })
-        }
-
-        return items
-      }
-
-      // Create folder submenu items for lists
-      const createListFolderSubmenu = () => {
-        if (!allSelectedRowsAreLists || newSelectedLists.length === 0) {
-          return []
-        }
-
-        const submenuItems: any[] = []
-        const selectedListIds = newSelectedLists.map((list) => list.id)
-
-        // Add hierarchy items first (available destination folders)
-        if (listFolders.length > 0) {
-          const { rootFolders } = buildFolderHierarchy(listFolders)
-          const hierarchyItems = createFolderHierarchy(rootFolders)
-          submenuItems.push(...hierarchyItems)
-        }
-
-        // For multiple selections, show "Unset folder" if any list has a folder
-        // For single selection, show "Unset folder" only if that list has a folder
-        const hasAnyFolder = newSelectedLists.some((list) => list.entityListFolderId)
-        if (hasAnyFolder) {
-          if (submenuItems.length > 0) submenuItems.push({ separator: true })
-          submenuItems.push({
+      // Move opens the folder picker dialog; unsetting the folder is one click, so it stays inline
+      const moveMenuItems: any[] = []
+      if (powerLicense) {
+        moveMenuItems.push(
+          {
+            label: allSelectedRowsAreFolders ? 'Move folder' : 'Move list',
+            icon: FOLDER_ICON,
+            command: () =>
+              openMoveToFolder({
+                moving: allSelectedRowsAreFolders ? 'folders' : 'lists',
+                ids: moveIds,
+              }),
+            hidden:
+              (!allSelectedRowsAreLists && !allSelectedRowsAreFolders) ||
+              moveIds.length === 0 ||
+              availableTargetFolders.length === 0 ||
+              // Hide if user doesn't have edit permission on all selected items
+              (allSelectedRowsAreLists && !userCanEditAllLists) ||
+              (allSelectedRowsAreFolders && !userCanEditAllFolders),
+          },
+          {
             label: 'Unset folder',
             icon: FOLDER_ICON_REMOVE,
-            command: () => {
-              onRemoveListsFromFolder(selectedListIds)
-            },
+            command: () => onRemoveListsFromFolder(selectedListIds),
             shortcut: getPlatformShortcutKey('f', [KeyMode.Shift, KeyMode.Alt]),
-          })
-        }
-
-        return submenuItems
-      }
-
-      // Create folder submenu items for folders
-      const createFolderFolderSubmenu = () => {
-        if (!allSelectedRowsAreFolders || !selectedFolder) {
-          return []
-        }
-
-        const submenuItems: any[] = []
-
-        // Show available parent folders (excluding self and its descendants) first
-        const availableParents = listFolders.filter(
-          (folder) =>
-            folder.id !== selectedFolderId &&
-            !wouldCreateCircularDependency(selectedFolderId!, folder.id, listFolders),
-        )
-
-        if (availableParents.length > 0) {
-          const { rootFolders } = buildFolderHierarchy(availableParents)
-          const hierarchyItems = createFolderHierarchy(rootFolders, selectedFolderId || undefined)
-          submenuItems.push(...hierarchyItems)
-        }
-
-        // Show "Unset parent" (make root) at bottom if folder has a parent
-        if (selectedFolder.parentId) {
-          if (submenuItems.length > 0) submenuItems.push({ separator: true })
-          submenuItems.push({
+            hidden: !allSelectedRowsAreLists || !hasAnyFolder || !userCanEditAllLists,
+          },
+          {
             label: 'Make root folder',
             icon: FOLDER_ICON_REMOVE,
             command: () => onRemoveFoldersFromFolder(selectedFolderIds),
             shortcut: getPlatformShortcutKey('f', [KeyMode.Shift, KeyMode.Alt]),
-          })
-        }
-
-        return submenuItems
-      }
-
-      const listFolderSubmenu = createListFolderSubmenu()
-      const folderFolderSubmenu = createFolderFolderSubmenu()
-
-      // Build move submenu (formerly "Folder")
-      const moveMenuItems: any[] = []
-      if (powerLicense) {
-        moveMenuItems.push({
-          label: allSelectedRowsAreFolders ? 'Move folder' : 'Move list',
-          icon: FOLDER_ICON,
-          items: allSelectedRowsAreLists ? listFolderSubmenu : folderFolderSubmenu,
-          // Structural disabling only (no selection); ownership handled via hidden
-          disabled: !allSelectedRowsAreLists && !allSelectedRowsAreFolders,
-          hidden:
-            (!allSelectedRowsAreLists && !allSelectedRowsAreFolders) ||
-            (allSelectedRowsAreLists && listFolderSubmenu.length === 0) ||
-            (allSelectedRowsAreFolders && folderFolderSubmenu.length === 0) ||
-            // Hide if user doesn't have edit permission on all selected items
-            (allSelectedRowsAreLists && !userCanEditAllLists) ||
-            (allSelectedRowsAreFolders && !userCanEditAllFolders),
-        })
+            hidden:
+              !allSelectedRowsAreFolders ||
+              !selectedFoldersAll.some((folder) => folder.parentId) ||
+              !userCanEditAllFolders,
+          },
+        )
       }
 
       const menuItems: any[] = [
@@ -375,12 +298,11 @@ const useListContextMenu = (extraBuilders: ListRowContextMenuBuilder[] = []) => 
       setListDetailsOpen,
       deleteLists,
       createReviewSessionList,
-      onPutListsInFolder,
       onRemoveListsFromFolder,
       onOpenFolderList,
       onDeleteListFolders,
-      onPutFoldersInFolder,
       onRemoveFoldersFromFolder,
+      openMoveToFolder,
       developerMode,
       handleCreateReviewSessionList,
       clearListItems,

--- a/src/pages/ProjectListsPage/hooks/useListContextMenu.ts
+++ b/src/pages/ProjectListsPage/hooks/useListContextMenu.ts
@@ -5,6 +5,7 @@ import { useAppSelector } from '@state/store'
 import useClearListItems from './useClearListItems'
 import { useListsDataContext } from '../context/ListsDataContext'
 import { parseListFolderRowId } from '../util/buildListsTableData'
+import { wouldCreateCircularDependency } from '../util/listFolders'
 import { EntityListFolderModel } from '@shared/api'
 import { getPlatformShortcutKey, KeyMode, buildFolderHierarchy } from '@shared/util'
 import { usePowerpack, useProjectContext } from '@shared/context'
@@ -29,27 +30,6 @@ export const FOLDER_ICON = 'snippet_folder'
 export const FOLDER_ICON_ADD = 'create_new_folder'
 export const FOLDER_ICON_EDIT = 'folder_managed'
 export const FOLDER_ICON_REMOVE = 'folder_off'
-
-// Helper function to prevent circular dependencies
-const wouldCreateCircularDependency = (
-  folderId: string,
-  targetParentId: string,
-  folders: EntityListFolderModel[],
-): boolean => {
-  if (folderId === targetParentId) return true
-
-  const folderMap = new Map(folders.map((f) => [f.id, f]))
-
-  // Check if targetParentId is a descendant of folderId
-  const isDescendant = (currentId: string, ancestorId: string): boolean => {
-    const current = folderMap.get(currentId)
-    if (!current || !current.parentId) return false
-    if (current.parentId === ancestorId) return true
-    return isDescendant(current.parentId, ancestorId)
-  }
-
-  return isDescendant(targetParentId, folderId)
-}
 
 const useListContextMenu = (extraBuilders: ListRowContextMenuBuilder[] = []) => {
   const user = useAppSelector((state) => state.user)

--- a/src/pages/ProjectListsPage/hooks/useListContextMenu.ts
+++ b/src/pages/ProjectListsPage/hooks/useListContextMenu.ts
@@ -43,7 +43,6 @@ const useListContextMenu = (extraBuilders: ListRowContextMenuBuilder[] = [], ena
     deleteLists,
     createReviewSessionList,
     isReview,
-    onRemoveListsFromFolder,
     onOpenFolderList,
     openNewList,
     onDeleteListFolders,
@@ -133,10 +132,10 @@ const useListContextMenu = (extraBuilders: ListRowContextMenuBuilder[] = [], ena
           )
         : listFolders.length > 0
 
-      // "Unset folder" only makes sense when at least one selected list is in a folder
+      // lists already in a folder can still open the picker to unset it there
       const hasAnyFolder = newSelectedLists.some((list) => list.entityListFolderId)
 
-      // Move opens the folder picker dialog; unsetting the folder is one click, so it stays inline
+      // Move opens the folder picker dialog, which also hosts the unset action
       const moveMenuItems: any[] = []
       if (powerLicense) {
         moveMenuItems.push(
@@ -151,18 +150,10 @@ const useListContextMenu = (extraBuilders: ListRowContextMenuBuilder[] = [], ena
             hidden:
               (!allSelectedRowsAreLists && !allSelectedRowsAreFolders) ||
               moveIds.length === 0 ||
-              !hasTargetFolders ||
+              (!hasTargetFolders && !hasAnyFolder) ||
               // Hide if user doesn't have edit permission on all selected items
               (allSelectedRowsAreLists && !userCanEditAllLists) ||
               (allSelectedRowsAreFolders && !userCanEditAllFolders),
-          },
-          {
-            label: 'Unset folder',
-            icon: FOLDER_ICON_REMOVE,
-            // failures already toast inside the mutation hook
-            command: () => onRemoveListsFromFolder(selectedListIds).catch(() => {}),
-            shortcut: getPlatformShortcutKey('f', [KeyMode.Shift, KeyMode.Alt]),
-            hidden: !allSelectedRowsAreLists || !hasAnyFolder || !userCanEditAllLists,
           },
           {
             label: 'Make root folder',
@@ -301,7 +292,6 @@ const useListContextMenu = (extraBuilders: ListRowContextMenuBuilder[] = [], ena
       setListDetailsOpen,
       deleteLists,
       createReviewSessionList,
-      onRemoveListsFromFolder,
       onOpenFolderList,
       onDeleteListFolders,
       onRemoveFoldersFromFolder,

--- a/src/pages/ProjectListsPage/util/buildListsTableData.ts
+++ b/src/pages/ProjectListsPage/util/buildListsTableData.ts
@@ -20,6 +20,7 @@ export const buildListsTableData = (
   powerLicense: boolean = false,
   showArchived: boolean = false,
   getDisabledMessage?: (list: EntityList) => string | undefined,
+  getFolderDisabledMessage?: (folder: EntityListFolderModel) => string | undefined,
 ): SimpleTableRow[] => {
   // Create lookup maps
   const foldersMap = new Map<string, EntityListFolderModel>()
@@ -165,6 +166,7 @@ export const buildListsTableData = (
         getItemCount: (node) =>
           node.items.length +
           Array.from(node.children.values()).reduce((acc, child) => acc + child.items.length, 0),
+        getFolderDisabledMessage,
       })
     : []
 

--- a/src/pages/ProjectListsPage/util/index.ts
+++ b/src/pages/ProjectListsPage/util/index.ts
@@ -1,3 +1,4 @@
 export * from './getColumnConfigFromType'
 export * from './buildListsTableData'
 export * from './listAccessControl'
+export * from './listFolders'

--- a/src/pages/ProjectListsPage/util/listFolders.ts
+++ b/src/pages/ProjectListsPage/util/listFolders.ts
@@ -1,14 +1,19 @@
 import { EntityListFolderModel } from '@shared/api'
 
+export type FolderMap = Map<string, EntityListFolderModel>
+
+export const buildFolderMap = (folders: EntityListFolderModel[]): FolderMap =>
+  new Map(folders.map((f) => [f.id, f]))
+
 // true when moving folderId under targetParentId would nest the folder inside itself
 export const wouldCreateCircularDependency = (
   folderId: string,
   targetParentId: string,
-  folders: EntityListFolderModel[],
+  folders: EntityListFolderModel[] | FolderMap,
 ): boolean => {
   if (folderId === targetParentId) return true
 
-  const folderMap = new Map(folders.map((f) => [f.id, f]))
+  const folderMap = folders instanceof Map ? folders : buildFolderMap(folders)
 
   // Check if targetParentId is a descendant of folderId
   const isDescendant = (currentId: string, ancestorId: string): boolean => {

--- a/src/pages/ProjectListsPage/util/listFolders.ts
+++ b/src/pages/ProjectListsPage/util/listFolders.ts
@@ -1,0 +1,22 @@
+import { EntityListFolderModel } from '@shared/api'
+
+// true when moving folderId under targetParentId would nest the folder inside itself
+export const wouldCreateCircularDependency = (
+  folderId: string,
+  targetParentId: string,
+  folders: EntityListFolderModel[],
+): boolean => {
+  if (folderId === targetParentId) return true
+
+  const folderMap = new Map(folders.map((f) => [f.id, f]))
+
+  // Check if targetParentId is a descendant of folderId
+  const isDescendant = (currentId: string, ancestorId: string): boolean => {
+    const current = folderMap.get(currentId)
+    if (!current || !current.parentId) return false
+    if (current.parentId === ancestorId) return true
+    return isDescendant(current.parentId, ancestorId)
+  }
+
+  return isDescendant(targetParentId, folderId)
+}


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Moving a list or folder now opens a single-select folder picker dialog instead of nested submenus. Folders you can't move into are shown with the reason, not hidden.

## Technical details
<!-- Please state any technical details such as limitations -->

- New `MoveToFolderDialog` reuses `ListsTable` in `picker foldersOnly singleSelect` mode.
- `foldersOnly` on `ListsDataProvider` skips the lists query entirely, only folders are fetched.
- `useListContextMenu` drops the recursive folder submenus; "Unset folder" / "Make root folder" stay inline.
- Circular moves gated by `getDisabledFolders`, one batched pass returning folder id → reason.
- Dialog closes on submit; the move is optimistic in cache and covered by undo.
- Search opens focused in the picker.

## Additional context
<!-- Add any other context or screenshots here. -->

<!-- TODO: attach screenshot / video -->

Closes #2207 
<img width="812" height="789" alt="Screenshot 2026-08-12 at 15 57 23" src="https://github.com/user-attachments/assets/63f20ea5-8523-40c3-8b32-533a978c80a1" />
