### PR TITLE
YN-0997 - Overview: Fix folder count stats when searching for tasks

### DIFF
--- a/gen/graphql.schema.json
+++ b/gen/graphql.schema.json
@@ -9003,7 +9003,19 @@
               },
               {
                 "name": "taskFilter",
-                "description": "Fitler folders by tasks",
+                "description": "Filter folders by tasks",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                },
+                "defaultValue": "null",
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "taskSearch",
+                "description": "Fuzzy search folders by tasks",
                 "type": {
                   "kind": "SCALAR",
                   "name": "String",

--- a/shared/src/api/generated/graphql.ts
+++ b/shared/src/api/generated/graphql.ts
@@ -1936,8 +1936,9 @@ export type ColumnStatsFragmentFragment = { columnName: string, min: number | nu
 export type GetFolderColumnStatsQueryVariables = Exact<{
   projectName: string;
   filter?: string | null | undefined;
-  taskFilter?: string | null | undefined;
   search?: string | null | undefined;
+  taskFilter?: string | null | undefined;
+  taskSearch?: string | null | undefined;
   parentIds?: Array<string> | string | null | undefined;
   ids?: Array<string> | string | null | undefined;
   targets?: Array<MetricTargetInput> | MetricTargetInput | null | undefined;
@@ -3447,14 +3448,15 @@ export const GetUpdatedAndNewFoldersDocument = new TypedDocumentString(`
 }
     `);
 export const GetFolderColumnStatsDocument = new TypedDocumentString(`
-    query GetFolderColumnStats($projectName: String!, $filter: String, $taskFilter: String, $search: String, $parentIds: [String!], $ids: [String!], $targets: [MetricTargetInput!], $includeFolderChildren: Boolean! = true, $hideEmptyFolders: Boolean) {
+    query GetFolderColumnStats($projectName: String!, $filter: String, $search: String, $taskFilter: String, $taskSearch: String, $parentIds: [String!], $ids: [String!], $targets: [MetricTargetInput!], $includeFolderChildren: Boolean! = true, $hideEmptyFolders: Boolean) {
   project(name: $projectName) {
     name
     folders(
       calculateSpecificStatistics: $targets
       filter: $filter
-      taskFilter: $taskFilter
       search: $search
+      taskFilter: $taskFilter
+      taskSearch: $taskSearch
       parentIds: $parentIds
       ids: $ids
       includeFolderChildren: $includeFolderChildren

--- a/shared/src/api/generated/graphql.ts
+++ b/shared/src/api/generated/graphql.ts
@@ -905,6 +905,7 @@ export type ProjectNodeFoldersArgs = {
   statuses?: InputMaybe<Array<Scalars['String']['input']>>;
   tags?: InputMaybe<Array<Scalars['String']['input']>>;
   taskFilter?: InputMaybe<Scalars['String']['input']>;
+  taskSearch?: InputMaybe<Scalars['String']['input']>;
 };
 
 

--- a/shared/src/api/generated/graphqlLinks.ts
+++ b/shared/src/api/generated/graphqlLinks.ts
@@ -905,6 +905,7 @@ export type ProjectNodeFoldersArgs = {
   statuses?: InputMaybe<Array<Scalars['String']['input']>>;
   tags?: InputMaybe<Array<Scalars['String']['input']>>;
   taskFilter?: InputMaybe<Scalars['String']['input']>;
+  taskSearch?: InputMaybe<Scalars['String']['input']>;
 };
 
 

--- a/shared/src/api/queries/overview/gql/GetFolderColumnStats.graphql
+++ b/shared/src/api/queries/overview/gql/GetFolderColumnStats.graphql
@@ -4,8 +4,9 @@
 query GetFolderColumnStats(
   $projectName: String!
   $filter: String
-  $taskFilter: String
   $search: String
+  $taskFilter: String
+  $taskSearch: String
   $parentIds: [String!]
   $ids: [String!]
   $targets: [MetricTargetInput!]
@@ -17,8 +18,9 @@ query GetFolderColumnStats(
     folders(
       calculateSpecificStatistics: $targets
       filter: $filter
-      taskFilter: $taskFilter
       search: $search
+      taskFilter: $taskFilter
+      taskSearch: $taskSearch
       parentIds: $parentIds
       ids: $ids
       includeFolderChildren: $includeFolderChildren

--- a/src/pages/ProjectOverviewPage/hooks/useProjectOverviewStats.ts
+++ b/src/pages/ProjectOverviewPage/hooks/useProjectOverviewStats.ts
@@ -2,6 +2,8 @@ import { useMemo } from 'react'
 
 import {
   buildMetricTargets,
+  GetFolderColumnStatsQueryVariables,
+  GetTaskColumnStatsQueryVariables,
   shouldSkipColumnStats,
   useGetFolderColumnStatsQuery,
   useGetTaskColumnStatsQuery,
@@ -95,11 +97,12 @@ export const useProjectOverviewStats = ({
 
   const skip = !projectName || isLoadingViews || !powerLicense || noSummaries
 
-  const folderStatsArgs = {
+  const folderStatsArgs: GetFolderColumnStatsQueryVariables = {
     projectName,
     filter: folderFilter || undefined,
-    taskFilter: taskFilter || undefined,
     search: folderSearch || undefined,
+    taskFilter: taskFilter || undefined,
+    taskSearch: taskSearch || undefined,
     [showHierarchy ? 'parentIds' : 'ids']: selectedFolders.length ? selectedFolders : undefined,
     targets: folderTargets,
     includeFolderChildren: true,
@@ -108,7 +111,7 @@ export const useProjectOverviewStats = ({
 
   const folderQuery = useGetFolderColumnStatsQuery(folderStatsArgs, { skip })
 
-  const taskStatsArgs = {
+  const taskStatsArgs: GetTaskColumnStatsQueryVariables = {
     projectName,
     filter: taskFilter || undefined,
     folderFilter: folderFilter || undefined,


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 
Searching in the overview page is actually searching for tasks. This search on tasks was not passed to the folders resolver and so the count of folders was wrong.

Now the folders resolver has an `taskSearch` argument that can be passed to it to properly count the left over folders from the task search.

<img width="1287" height="873" alt="image" src="https://github.com/user-attachments/assets/ae2bd3fe-ba1f-431b-a4e1-1e8967584a94" />