### PR TITLE
Slicer: Fix selection of redundant children being sent to server

### DIFF
--- a/shared/src/containers/ProjectTreeTable/hooks/useFetchOverviewData.ts
+++ b/shared/src/containers/ProjectTreeTable/hooks/useFetchOverviewData.ts
@@ -119,7 +119,7 @@ export const useFetchOverviewData = ({
     isLoading: isLoadingFolders,
     isUninitialized: isUninitializedFolders,
     getFolderById,
-    getParentFolderIds,
+    getFolderIdsWithoutChildren,
   } = useProjectFoldersContext()
 
   const expandedParentIds = Object.entries(expanded)
@@ -401,13 +401,10 @@ export const useFetchOverviewData = ({
       )
     : undefined
 
-  const selectedFolderIdsWithoutChildren = useMemo(() => {
-    const selectedFolderIds = new Set(selectedFolders)
-
-    return selectedFolders.filter((folderId) => {
-      return !getParentFolderIds(folderId).some((parentId) => selectedFolderIds.has(parentId))
-    })
-  }, [selectedFolders, getParentFolderIds])
+  const selectedFolderIdsWithoutChildren = useMemo(
+    () => getFolderIdsWithoutChildren(selectedFolders),
+    [selectedFolders, getFolderIdsWithoutChildren],
+  )
 
   // In hierarchy mode with slicer-selected folders, use GetTasksList with folderIds to fetch
   // tasks directly under those folders in a single paginated request, rather than firing one

--- a/shared/src/containers/ProjectTreeTable/hooks/useFetchOverviewData.ts
+++ b/shared/src/containers/ProjectTreeTable/hooks/useFetchOverviewData.ts
@@ -119,6 +119,7 @@ export const useFetchOverviewData = ({
     isLoading: isLoadingFolders,
     isUninitialized: isUninitializedFolders,
     getFolderById,
+    getParentFolderIds,
   } = useProjectFoldersContext()
 
   const expandedParentIds = Object.entries(expanded)
@@ -400,25 +401,40 @@ export const useFetchOverviewData = ({
       )
     : undefined
 
+  const selectedFolderIdsWithoutChildren = useMemo(() => {
+    const selectedFolderIds = new Set(selectedFolders)
+
+    return selectedFolders.filter((folderId) => {
+      return !getParentFolderIds(folderId).some((parentId) => selectedFolderIds.has(parentId))
+    })
+  }, [selectedFolders, getParentFolderIds])
+
   // In hierarchy mode with slicer-selected folders, use GetTasksList with folderIds to fetch
   // tasks directly under those folders in a single paginated request, rather than firing one
   // request per folder via getOverviewTasksByFolders.
-  const hierarchySlicerFolderIds =
-    showHierarchy && excludeSelectedFolders && selectedFolders.length ? selectedFolders : undefined
+  const getTasksDirectlyUnderFolder = showHierarchy && excludeSelectedFolders
+
+  const getTasksListFolderIds = () => {
+    if (taskIds?.length) {
+      // we are getting specific task ids so we do not need to tasks based on folder ids
+      return undefined
+    } else {
+      // we are in hierarchy slicer mode, so we return the selected folders
+      return selectedFolderIdsWithoutChildren
+    }
+  }
 
   const tasksListArgs: GetTasksListArgs = {
     projectName,
     filter: taskFilters.filterString,
     folderFilter: folderFilters.filterString,
     search: taskFilters.search,
-    folderIds: taskIds?.length
-      ? undefined
-      : hierarchySlicerFolderIds ?? (selectedFolders.length ? selectedFolders : undefined),
+    folderIds: getTasksListFolderIds(),
     taskIds: taskIds?.length ? taskIds : undefined,
     sortBy: taskSortId ? taskSortId.replace('_', '.') : undefined,
     desc: !!singleSort?.desc,
     showComments,
-    includeFolderChildren: !hierarchySlicerFolderIds,
+    includeFolderChildren: !getTasksDirectlyUnderFolder,
   }
 
   // Use the new infinite query hook for tasks list with correct name
@@ -436,7 +452,7 @@ export const useFetchOverviewData = ({
     // Always run it when entity list provides specific task IDs.
     skip:
       isLoadingViews ||
-      (((showHierarchy && !hierarchySlicerFolderIds) || isFlatFolderView) && !taskIds?.length),
+      (((showHierarchy && !getTasksDirectlyUnderFolder) || isFlatFolderView) && !taskIds?.length),
     initialPageParam: {
       cursor: '',
       desc: !!singleSort?.desc,
@@ -517,7 +533,7 @@ export const useFetchOverviewData = ({
     if (showHierarchy) {
       // In hierarchy+slicer mode, merge per-folder expanded tasks with tasks fetched via
       // GetTasksList for the slicer-selected (but not displayed) folders.
-      if (hierarchySlicerFolderIds) return [...expandedFoldersTasks, ...tasksList]
+      if (getTasksDirectlyUnderFolder) return [...expandedFoldersTasks, ...tasksList]
       return expandedFoldersTasks
     }
     if (groupBy) return groupTasks
@@ -525,7 +541,7 @@ export const useFetchOverviewData = ({
   }, [
     taskIds,
     showHierarchy,
-    hierarchySlicerFolderIds,
+    getTasksDirectlyUnderFolder,
     isFlatFolderView,
     groupBy,
     tasksList,

--- a/shared/src/containers/SimpleTable/SimpleTable.tsx
+++ b/shared/src/containers/SimpleTable/SimpleTable.tsx
@@ -98,13 +98,6 @@ function getRowRange<TData extends RowData>(
   idA: string,
   idB: string,
 ): Array<Row<TData>> {
-  const range: Array<Row<TData>> = []
-  // If idA and idB are the same, or one is not found, handle appropriately
-  if (idA === idB) {
-    const singleRow = rows.find((row) => row.id === idA)
-    return singleRow ? [singleRow] : []
-  }
-
   let indexA = -1
   let indexB = -1
 
@@ -119,10 +112,7 @@ function getRowRange<TData extends RowData>(
   const start = Math.min(indexA, indexB)
   const end = Math.max(indexA, indexB)
 
-  for (let i = start; i <= end; i++) {
-    range.push(rows[i])
-  }
-  return range
+  return rows.slice(start, end + 1)
 }
 
 const SimpleTable: FC<SimpleTableProps> = ({
@@ -210,14 +200,16 @@ const SimpleTable: FC<SimpleTableProps> = ({
       isCtrlOrMeta: boolean,
     ): RowSelectionState => {
       const currentId = rowId
-      const allProcessableRows = tableInstance.getFilteredRowModel().flatRows
-      const currentRow = allProcessableRows.find((r) => r.id === currentId)
+      const rowModel = tableInstance.getRowModel()
+      const visibleRows = rowModel.rows
+      const currentRow = rowModel.rowsById[currentId]
+      const currentSelection = tableInstance.getState().rowSelection || {}
 
-      if (!currentRow) return { ...(tableInstance.getState().rowSelection || {}) }
+      if (!currentRow) return { ...currentSelection }
 
       // Prevent selection of disabled rows
       if (currentRow.original.isDisabled) {
-        return { ...(tableInstance.getState().rowSelection || {}) }
+        return { ...currentSelection }
       }
 
       // If click-to-deselect is enabled and only one row is selected and it's the current row
@@ -225,8 +217,8 @@ const SimpleTable: FC<SimpleTableProps> = ({
         enableClickToDeselect &&
         !isShift &&
         !isCtrlOrMeta &&
-        Object.keys(tableInstance.getState().rowSelection || {}).length === 1 &&
-        (tableInstance.getState().rowSelection || {})[currentId]
+        Object.keys(currentSelection).length === 1 &&
+        currentSelection[currentId]
       ) {
         tableInstance.setRowSelection({})
         lastSelectedIdRef.current = null
@@ -236,19 +228,18 @@ const SimpleTable: FC<SimpleTableProps> = ({
       let nextSelection: RowSelectionState
       if (isMultiSelect && isShift && lastSelectedIdRef.current) {
         const lastId = lastSelectedIdRef.current
-        const anchorRow = allProcessableRows.find((r) => r.id === lastId)
+        const rowsToToggle = getRowRange(visibleRows, currentId, lastId)
 
-        if (!anchorRow) {
-          nextSelection = { [currentId]: true }
+        if (rowsToToggle.length === 0) {
+          nextSelection = { ...currentSelection, [currentId]: true }
         } else {
-          const rowsToToggle = getRowRange(allProcessableRows, currentId, lastId)
-          nextSelection = {}
+          nextSelection = { ...currentSelection }
           rowsToToggle.forEach((r) => (nextSelection[r.id] = true))
         }
       } else if (isMultiSelect && isCtrlOrMeta) {
         // write a concrete object from live state; toggleSelected()'s functional updater runs
         // against a stale rowSelection closure and drops the other selected rows
-        nextSelection = { ...(tableInstance.getState().rowSelection || {}) }
+        nextSelection = { ...currentSelection }
         if (nextSelection[currentId]) {
           delete nextSelection[currentId]
         } else {
@@ -256,7 +247,7 @@ const SimpleTable: FC<SimpleTableProps> = ({
         }
       } else {
         // If it's already selected and it's the only one, don't update selection to avoid unnecessary re-renders
-        nextSelection = { ...(tableInstance.getState().rowSelection || {}) }
+        nextSelection = { ...currentSelection }
         if (!(Object.keys(nextSelection).length === 1 && nextSelection[currentId])) {
           nextSelection = { [currentId]: true }
         }

--- a/shared/src/context/ProjectFoldersContext.tsx
+++ b/shared/src/context/ProjectFoldersContext.tsx
@@ -14,6 +14,7 @@ export interface ProjectFoldersContextValue {
     projectAttrib?: Record<string, any>,
   ) => Record<string, any>
   getParentFolderIds: (folderId: string) => string[]
+  getFolderIdsWithoutChildren: (folderIds: string[]) => string[]
   getChildFolderIds: (folderIds: string[], includeSelf?: boolean) => string[]
   isLoading: boolean
   isFetching: boolean
@@ -132,6 +133,18 @@ export const ProjectFoldersContextProvider: React.FC<ProjectFoldersProviderProps
     [folderMap],
   )
 
+  const getFolderIdsWithoutChildren = useMemo(
+    () =>
+      (folderIds: string[]): string[] => {
+        const selectedFolderIds = new Set(folderIds)
+
+        return folderIds.filter((folderId) => {
+          return !getParentFolderIds(folderId).some((parentId) => selectedFolderIds.has(parentId))
+        })
+      },
+    [getParentFolderIds],
+  )
+
   // function to get all child folder IDs recursively for a given folder IDs
   const getChildFolderIds = useMemo(
     () =>
@@ -162,6 +175,7 @@ export const ProjectFoldersContextProvider: React.FC<ProjectFoldersProviderProps
       getFolderById,
       findNonInheritedValues,
       getParentFolderIds,
+      getFolderIdsWithoutChildren,
       getChildFolderIds,
       isLoading: isLoadingFolders, // first time and when args change
       isFetching, // any background fetching
@@ -175,6 +189,7 @@ export const ProjectFoldersContextProvider: React.FC<ProjectFoldersProviderProps
       getFolderById,
       findNonInheritedValues,
       getParentFolderIds,
+      getFolderIdsWithoutChildren,
       getChildFolderIds,
       isLoadingFolders,
       isFetching,

--- a/src/containers/TasksProgress/TasksProgress.tsx
+++ b/src/containers/TasksProgress/TasksProgress.tsx
@@ -39,6 +39,7 @@ import { useSlicerContext } from '@shared/containers/Slicer'
 import formatSearchQueryFilters from './helpers/formatSearchQueryFilters'
 import { QueryFilter } from '@shared/containers/ProjectTreeTable/types/operations'
 import { clientFilterToQueryFilter } from '@shared/containers/ProjectTreeTable/utils'
+import { useProjectFoldersContext } from '@shared/context'
 
 // what to search by
 const searchFilterTypes: FilterFieldType[] = [
@@ -129,13 +130,21 @@ const TasksProgress: FC<TasksProgressProps> = ({
 
   // when the slice type is not hierarchy we need to get the root folders
   const rootFolderIds = useRootFolders()
+  const { getParentFolderIds } = useProjectFoldersContext()
 
-  const folderIdsToFetch = resolveSelectedFolders(
-    rowSelection,
-    pinnedSlice?.rowSelection,
-    rootFolderIds,
-    sliceType,
-  )
+  const folderIdsToFetch = useMemo(() => {
+    const selectedFolderIds = resolveSelectedFolders(
+      rowSelection,
+      pinnedSlice?.rowSelection,
+      rootFolderIds,
+      sliceType,
+    )
+    const selectedFolderIdSet = new Set(selectedFolderIds)
+
+    return selectedFolderIds.filter((folderId) => {
+      return !getParentFolderIds(folderId).some((parentId) => selectedFolderIdSet.has(parentId))
+    })
+  }, [rowSelection, pinnedSlice?.rowSelection, rootFolderIds, sliceType, getParentFolderIds])
 
   const tasksProgressArgs = {
     projectName,

--- a/src/containers/TasksProgress/TasksProgress.tsx
+++ b/src/containers/TasksProgress/TasksProgress.tsx
@@ -130,7 +130,7 @@ const TasksProgress: FC<TasksProgressProps> = ({
 
   // when the slice type is not hierarchy we need to get the root folders
   const rootFolderIds = useRootFolders()
-  const { getParentFolderIds } = useProjectFoldersContext()
+  const { getFolderIdsWithoutChildren } = useProjectFoldersContext()
 
   const folderIdsToFetch = useMemo(() => {
     const selectedFolderIds = resolveSelectedFolders(
@@ -139,12 +139,14 @@ const TasksProgress: FC<TasksProgressProps> = ({
       rootFolderIds,
       sliceType,
     )
-    const selectedFolderIdSet = new Set(selectedFolderIds)
-
-    return selectedFolderIds.filter((folderId) => {
-      return !getParentFolderIds(folderId).some((parentId) => selectedFolderIdSet.has(parentId))
-    })
-  }, [rowSelection, pinnedSlice?.rowSelection, rootFolderIds, sliceType, getParentFolderIds])
+    return getFolderIdsWithoutChildren(selectedFolderIds)
+  }, [
+    rowSelection,
+    pinnedSlice?.rowSelection,
+    rootFolderIds,
+    sliceType,
+    getFolderIdsWithoutChildren,
+  ])
 
   const tasksProgressArgs = {
     projectName,

--- a/src/pages/ProjectOverviewPage/hooks/useProjectOverviewStats.ts
+++ b/src/pages/ProjectOverviewPage/hooks/useProjectOverviewStats.ts
@@ -14,7 +14,7 @@ import {
   useScopedAttributeFields,
 } from '@shared/containers/ProjectTreeTable'
 import { useViewsContext } from '@shared/containers'
-import { usePowerpack, useProjectContext } from '@shared/context'
+import { usePowerpack, useProjectContext, useProjectFoldersContext } from '@shared/context'
 
 interface UseProjectOverviewStatsParams {
   folderFilter?: string
@@ -39,6 +39,7 @@ export const useProjectOverviewStats = ({
   const { attribFields } = useProjectDataContext()
   const { powerLicense } = usePowerpack()
   const { isLoadingViews } = useViewsContext()
+  const { getFolderIdsWithoutChildren } = useProjectFoldersContext()
   const {
     columnVisibility,
     defaultColumnVisibility,
@@ -97,13 +98,20 @@ export const useProjectOverviewStats = ({
 
   const skip = !projectName || isLoadingViews || !powerLicense || noSummaries
 
+  const selectedFolderIdsWithoutChildren = useMemo(
+    () => getFolderIdsWithoutChildren(selectedFolders),
+    [selectedFolders, getFolderIdsWithoutChildren],
+  )
+
   const folderStatsArgs: GetFolderColumnStatsQueryVariables = {
     projectName,
     filter: folderFilter || undefined,
     search: folderSearch || undefined,
     taskFilter: taskFilter || undefined,
     taskSearch: taskSearch || undefined,
-    [showHierarchy ? 'parentIds' : 'ids']: selectedFolders.length ? selectedFolders : undefined,
+    [showHierarchy ? 'parentIds' : 'ids']: selectedFolderIdsWithoutChildren.length
+      ? selectedFolderIdsWithoutChildren
+      : undefined,
     targets: folderTargets,
     includeFolderChildren: true,
     hideEmptyFolders: groupByConfig?.showEmpty === false && !showHierarchy ? true : undefined,
@@ -116,7 +124,9 @@ export const useProjectOverviewStats = ({
     filter: taskFilter || undefined,
     folderFilter: folderFilter || undefined,
     search: taskSearch || undefined,
-    folderIds: selectedFolders.length ? selectedFolders : undefined,
+    folderIds: selectedFolderIdsWithoutChildren.length
+      ? selectedFolderIdsWithoutChildren
+      : undefined,
     taskIds: selectedTaskIds.length ? selectedTaskIds : undefined,
     targets: taskTargets,
   }

--- a/src/pages/VersionsProductsPage/context/VPDataContext.tsx
+++ b/src/pages/VersionsProductsPage/context/VPDataContext.tsx
@@ -45,7 +45,7 @@ import { useSlicerContext, useSelectedEntityIds } from '@shared/containers/Slice
 import { useVPViewsContext } from './VPViewsContext'
 import { useQueryArgumentChangeLoading } from '@shared/hooks'
 import { toast } from 'react-toastify'
-import { OnSyncDataCallback } from '@shared/context'
+import { OnSyncDataCallback, useProjectFoldersContext } from '@shared/context'
 import type { FieldStats } from '@shared/api'
 import { refreshActiveAndPurgeOthers, refreshOtherActiveQueries } from '@shared/api'
 import {
@@ -175,6 +175,7 @@ export const VersionsDataProvider: FC<VersionsDataProviderProps> = ({
 }) => {
   const dispatch = useAppDispatch()
   const { attribFields } = useProjectDataContext()
+  const { getParentFolderIds } = useProjectFoldersContext()
   const {
     filters,
     showProducts,
@@ -285,12 +286,19 @@ export const VersionsDataProvider: FC<VersionsDataProviderProps> = ({
   })
 
   // get selected folders from slicer
-  const slicerFolderIds = useSelectedFolders({
+  const selectedSlicerFolderIds = useSelectedFolders({
     rowSelection,
     sliceType,
     pinnedRowSelection: pinnedSlice?.rowSelection || null,
     entityListFolderIds: entityIds.folderIds,
   })
+  const slicerFolderIds = useMemo(() => {
+    const selectedFolderIds = new Set(selectedSlicerFolderIds)
+
+    return selectedSlicerFolderIds.filter((folderId) => {
+      return !getParentFolderIds(folderId).some((parentId) => selectedFolderIds.has(parentId))
+    })
+  }, [selectedSlicerFolderIds, getParentFolderIds])
   // combine slicer filters with version/product filters
   const combinedVersionFilter = useQueryFilters({
     queryFilters: versionFilter,

--- a/src/pages/VersionsProductsPage/context/VPDataContext.tsx
+++ b/src/pages/VersionsProductsPage/context/VPDataContext.tsx
@@ -175,7 +175,7 @@ export const VersionsDataProvider: FC<VersionsDataProviderProps> = ({
 }) => {
   const dispatch = useAppDispatch()
   const { attribFields } = useProjectDataContext()
-  const { getParentFolderIds } = useProjectFoldersContext()
+  const { getFolderIdsWithoutChildren } = useProjectFoldersContext()
   const {
     filters,
     showProducts,
@@ -292,13 +292,10 @@ export const VersionsDataProvider: FC<VersionsDataProviderProps> = ({
     pinnedRowSelection: pinnedSlice?.rowSelection || null,
     entityListFolderIds: entityIds.folderIds,
   })
-  const slicerFolderIds = useMemo(() => {
-    const selectedFolderIds = new Set(selectedSlicerFolderIds)
-
-    return selectedSlicerFolderIds.filter((folderId) => {
-      return !getParentFolderIds(folderId).some((parentId) => selectedFolderIds.has(parentId))
-    })
-  }, [selectedSlicerFolderIds, getParentFolderIds])
+  const slicerFolderIds = useMemo(
+    () => getFolderIdsWithoutChildren(selectedSlicerFolderIds),
+    [selectedSlicerFolderIds, getFolderIdsWithoutChildren],
+  )
   // combine slicer filters with version/product filters
   const combinedVersionFilter = useQueryFilters({
     queryFilters: versionFilter,

--- a/src/pages/VersionsProductsPage/hooks/useVPColumnStats.ts
+++ b/src/pages/VersionsProductsPage/hooks/useVPColumnStats.ts
@@ -14,7 +14,7 @@ import {
   useProjectDataContext,
   useViewsContext,
 } from '@shared/containers'
-import { usePowerpack, useProjectContext } from '@shared/context'
+import { usePowerpack, useProjectContext, useProjectFoldersContext } from '@shared/context'
 import { useMemo } from 'react'
 
 type Params = {
@@ -46,6 +46,7 @@ export const useVPColumnStats = ({
   const { attribFields } = useProjectDataContext()
   const { powerLicense } = usePowerpack()
   const { isLoadingViews } = useViewsContext()
+  const { getFolderIdsWithoutChildren } = useProjectFoldersContext()
   const { columnVisibility, defaultColumnVisibility, columnSummaries, columnSummaryScopes } =
     useColumnSettingsContext()
 
@@ -86,13 +87,18 @@ export const useVPColumnStats = ({
     [attribFields, columnVisibility, defaultColumnVisibility, columnSummaries, columnSummaryScopes],
   )
 
+  const folderIdsWithoutChildren = useMemo(
+    () => (folderIds ? getFolderIdsWithoutChildren(folderIds) : undefined),
+    [folderIds, getFolderIdsWithoutChildren],
+  )
+
   const columnStatsBaseArgs = {
     projectName,
     productFilter,
     versionFilter,
     taskFilter,
     folderFilter,
-    folderIds,
+    folderIds: folderIdsWithoutChildren,
     versionIds,
     productIds,
   }


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Problem
There was an edge case where using shift select on parent folders would cause all child folders to be selected as well.

These child folders would then be included in tasks and versions queries along with `includeFolderChildren` even though their parent has been selected as well.

This would be very inefficient as every folder would scan it all it's children.

## Description of changes
1. When requesting data using folder ids and includeFolderChildren, filter out child folders so that only top level parent folders are left.
2. When using shift select, ensure child rows are not selected if their parent is collapsed.

