### PR TITLE
Summaries: show column summaries for multi-select attributes

### DIFF
--- a/shared/src/api/queries/columnStats/metricTargets.ts
+++ b/shared/src/api/queries/columnStats/metricTargets.ts
@@ -120,9 +120,10 @@ type BuildMetricTargetsArgs = {
 }
 
 // Targets for the footer over the columns the user can actually see.
-// Skipped on purpose (backend SQL can't aggregate them safely yet):
-// datetime (numeric cast fails), boolean attribs (text-vs-bool compare on
-// JSONB), and list-type attribs.
+// Skipped on purpose — the backend errors on these, and one bad target fails
+// the whole query, killing every other column's stats too:
+// datetime ("cannot cast type timestamp with time zone to numeric") and
+// boolean attribs ("operator does not exist: text = boolean").
 export const buildMetricTargets = ({
   entity,
   attribs,
@@ -174,6 +175,9 @@ export const buildMetricTargets = ({
       targets.push({ field, aggregations: NUMERIC })
     } else if (type === 'string') {
       targets.push({ field, aggregations: attrib.data?.enum?.length ? ENUM : COUNTS })
+    } else if (type === 'list_of_strings' || type === 'list_of_integers') {
+      // backend buckets the whole array as one serialized value; normalizeDistribution unnests it
+      targets.push({ field, aggregations: ENUM })
     }
   }
 


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Fixes multi-select attributes always showing `—` in the column summaries footer. They were never sent to the stats query at all.

## Technical details
<!-- Please state any technical details such as limitations -->

- `buildMetricTargets` now emits ENUM targets for `list_of_strings` and `list_of_integers` attribs (`metricTargets.ts`).
- Backend buckets the whole array as one serialized value; `normalizeDistribution` in `columnStats.ts` already unnests it.
- `datetime` and boolean attribs stay skipped — both still error on the backend, and one bad target fails the whole query.
- `list_of_integers` untested, no such attribute in any test project.

## Additional context
<!-- Add any other context or screenshots here. -->
