### PR TITLE
Lists: Creating new review session from context menu does not show new list

### DIFF
--- a/src/pages/ProjectListsPage/context/EntityListsContext.tsx
+++ b/src/pages/ProjectListsPage/context/EntityListsContext.tsx
@@ -307,14 +307,17 @@ export const EntityListsProvider = ({ children, projectName }: EntityListsProvid
           // Try to extract created ID if provided, though standard behavior might vary
           listId = payloadData?.id
 
-          if (payloadData) {
-            // invalidate the list caches
-            const tags = [
-              { type: 'entityList', id: listId },
-              { type: 'entityListItemsColumnStats', id: listId },
-            ]
-            dispatch(entityListsQueriesGql.util.invalidateTags(tags))
-          }
+          // 'LIST' invalidates getListsInfinite — a new list id matches no existing cache tag
+          const tags = [
+            { type: 'entityList', id: 'LIST' },
+            ...(listId
+              ? [
+                  { type: 'entityList', id: listId },
+                  { type: 'entityListItemsColumnStats', id: listId },
+                ]
+              : []),
+          ]
+          dispatch(entityListsQueriesGql.util.invalidateTags(tags))
 
           toast.success(`Review session ${label} created`)
         } else {


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Fixes a review session created from the folder/task context menu not appearing in the Reviews list until the page was reloaded.

## Technical details
<!-- Please state any technical details such as limitations -->

- `EntityListsContext.createNewList` now invalidates `{ entityList, LIST }` after the `review-save-session-from-*` action. The previous tags used the newly created list id, which no cache entry provides.
- Per-list tags are still sent, but only when the action returns an id.
- Only affects the addon action path (folder/task). Version lists already invalidated correctly via `createEntityList`.

## Additional context
<!-- Add any other context or screenshots here. -->

Closes #2147
