### PR TITLE
Summaries: Name breakdown of folder and task types

### DIFF
--- a/shared/src/api/queries/columnStats/metricTargets.ts
+++ b/shared/src/api/queries/columnStats/metricTargets.ts
@@ -153,8 +153,10 @@ export const buildMetricTargets = ({
     targets.push({ field: 'assignees', aggregations: ENUM })
   }
 
-  // name breakdown needs the type distribution even when the subType column is hidden
-  const nameBreakdown = columnSummaries?.['name'] === 'breakdown'
+  // no visibility check: it's opt-in, and a name column missing from both maps would kill this
+  const nameBreakdown =
+    columnSummaries?.['name'] === 'breakdown' &&
+    isSummaryActive('name', columnSummaries, columnSummaryScopes)
   const subTypeField = SUB_TYPE_FIELD[entity]
   if (subTypeField && (isActive('subType') || nameBreakdown)) {
     targets.push({ field: subTypeField, aggregations: ENUM })

--- a/shared/src/api/queries/columnStats/metricTargets.ts
+++ b/shared/src/api/queries/columnStats/metricTargets.ts
@@ -154,8 +154,7 @@ export const buildMetricTargets = ({
   }
 
   // name breakdown needs the type distribution even when the subType column is hidden
-  const nameBreakdown =
-    (entity === 'folder' || entity === 'task') && columnSummaries?.['name'] === 'breakdown'
+  const nameBreakdown = columnSummaries?.['name'] === 'breakdown'
   const subTypeField = SUB_TYPE_FIELD[entity]
   if (subTypeField && (isActive('subType') || nameBreakdown)) {
     targets.push({ field: subTypeField, aggregations: ENUM })

--- a/shared/src/api/queries/columnStats/metricTargets.ts
+++ b/shared/src/api/queries/columnStats/metricTargets.ts
@@ -153,8 +153,11 @@ export const buildMetricTargets = ({
     targets.push({ field: 'assignees', aggregations: ENUM })
   }
 
+  // name breakdown needs the type distribution even when the subType column is hidden
+  const nameBreakdown =
+    (entity === 'folder' || entity === 'task') && columnSummaries?.['name'] === 'breakdown'
   const subTypeField = SUB_TYPE_FIELD[entity]
-  if (subTypeField && isActive('subType')) {
+  if (subTypeField && (isActive('subType') || nameBreakdown)) {
     targets.push({ field: subTypeField, aggregations: ENUM })
   }
 

--- a/shared/src/containers/ProjectTreeTable/ProjectTreeTable.tsx
+++ b/shared/src/containers/ProjectTreeTable/ProjectTreeTable.tsx
@@ -73,6 +73,7 @@ import {
   ProjectTableAttribute,
   BuiltInFieldOptions,
   MainCountLabels,
+  MainBreakdownFields,
   SummaryCellContentProps,
 } from './types'
 import type { EnumItem } from '@shared/api'
@@ -174,6 +175,7 @@ export interface ProjectTreeTableProps extends React.HTMLAttributes<HTMLDivEleme
   fieldStatsLoading?: boolean // footer stats still loading - click-through shimmer over values
   fieldStatsError?: any // error fetching footer stats
   mainCountLabels?: MainCountLabels // labels for the main cell dual count (defaults folders/tasks)
+  mainBreakdownFields?: MainBreakdownFields // subTypes the name summary breaks down by, per side
   onScrollBottomGroupBy?: (groupValue: string) => void // Handle scroll to bottom for grouped data
   contextMenuItems?: ContextMenuItemConstructors // Additional context menu items to merge with defaults
   onColumnVisibleChange?: (changes: Record<string, boolean>) => void
@@ -212,6 +214,7 @@ export const ProjectTreeTable = ({
   fieldStatsLoading,
   fieldStatsError,
   mainCountLabels,
+  mainBreakdownFields,
   onScrollBottomGroupBy, // Destructure new prop for group-by load more
   contextMenuItems: propsContextMenuItems, // Additional context menu items from props
   onColumnVisibleChange,
@@ -808,6 +811,7 @@ export const ProjectTreeTable = ({
                     fieldOptions={options}
                     parentScopeApplicable={parentScopeApplicable}
                     selectedCount={selectedRowCount}
+                    mainBreakdownFields={mainBreakdownFields}
                   />
                 )}
                 // Power feature cell for community users (hidden for now), shows a bolt hint in the name column:

--- a/shared/src/containers/ProjectTreeTable/types/index.ts
+++ b/shared/src/containers/ProjectTreeTable/types/index.ts
@@ -35,6 +35,14 @@ export type BuiltInFieldOptions = {
   [key in BuiltInFieldOptionKey]: EnumOption[]
 }
 
+// Which subType each side of the main count breaks down by, per page: folders +
+// tasks on Overview, products on Versions/Products (versions have no subType).
+// Absent = the host doesn't request those distributions, so no Breakdown option.
+export type MainBreakdownFields = {
+  primary?: TreeTableSubType
+  secondary?: TreeTableSubType
+}
+
 // Props contract for one summary footer cell's content, implemented by the
 // powerpack `summaries/SummaryCellContent` remote module. The host owns the
 // footer row structure (borders, widths, pinning); the remote renders only
@@ -57,4 +65,7 @@ export interface SummaryCellContentProps {
   parentScopeApplicable?: boolean
   // unique entity rows in the current selection; addon shows "N selected" in the main count cell
   selectedCount?: number
+  // set only where the host requests subType distributions for the name column;
+  // addon hides the Breakdown aggregation when absent
+  mainBreakdownFields?: MainBreakdownFields
 }

--- a/shared/src/containers/ProjectTreeTable/types/index.ts
+++ b/shared/src/containers/ProjectTreeTable/types/index.ts
@@ -35,9 +35,7 @@ export type BuiltInFieldOptions = {
   [key in BuiltInFieldOptionKey]: EnumOption[]
 }
 
-// Which subType each side of the main count breaks down by, per page: folders +
-// tasks on Overview, products on Versions/Products (versions have no subType).
-// Absent = the host doesn't request those distributions, so no Breakdown option.
+// which subType each side of the main count breaks down by; a side with no subType stays unset
 export type MainBreakdownFields = {
   primary?: TreeTableSubType
   secondary?: TreeTableSubType
@@ -65,7 +63,6 @@ export interface SummaryCellContentProps {
   parentScopeApplicable?: boolean
   // unique entity rows in the current selection; addon shows "N selected" in the main count cell
   selectedCount?: number
-  // set only where the host requests subType distributions for the name column;
-  // addon hides the Breakdown aggregation when absent
+  // absent = host fetches no subType distributions, addon hides the Breakdown aggregation
   mainBreakdownFields?: MainBreakdownFields
 }

--- a/shared/src/containers/ProjectTreeTable/types/summaryTypes.ts
+++ b/shared/src/containers/ProjectTreeTable/types/summaryTypes.ts
@@ -5,8 +5,10 @@ export type BooleanCalc = 'checked' | 'notChecked'
 export type TextCalc = 'filled' | 'notFilled'
 // enum bar mode: value distribution vs filled/empty split
 export type EnumCalc = 'values' | 'fill'
+// main (name) column: per-type hover breakdown; plain count is the absent default
+export type MainCalc = 'breakdown'
 
-export type SummaryCalc = NumberCalc | BooleanCalc | TextCalc | EnumCalc
+export type SummaryCalc = NumberCalc | BooleanCalc | TextCalc | EnumCalc | MainCalc
 
 // Display format for count-style summaries, driven by the Count/Percentage toggles.
 export type SummaryFormat = 'count' | 'percent' | 'both' | 'none'

--- a/shared/src/containers/ProjectTreeTable/types/summaryTypes.ts
+++ b/shared/src/containers/ProjectTreeTable/types/summaryTypes.ts
@@ -5,8 +5,8 @@ export type BooleanCalc = 'checked' | 'notChecked'
 export type TextCalc = 'filled' | 'notFilled'
 // enum bar mode: value distribution vs filled/empty split
 export type EnumCalc = 'values' | 'fill'
-// main (name) column: per-type hover breakdown; plain count is the absent default
-export type MainCalc = 'breakdown'
+// main (name) column: plain count (also the absent default) or per-type hover breakdown
+export type MainCalc = 'count' | 'breakdown'
 
 export type SummaryCalc = NumberCalc | BooleanCalc | TextCalc | EnumCalc | MainCalc
 

--- a/src/pages/ProjectOverviewPage/containers/ProjectOverviewTable.tsx
+++ b/src/pages/ProjectOverviewPage/containers/ProjectOverviewTable.tsx
@@ -79,6 +79,7 @@ const ProjectOverviewTable = ({}: Props) => {
         groupFieldStats={folderStats}
         fieldStatsLoading={folderStatsLoading || taskStatsLoading}
         fieldStatsError={folderStatsError || taskStatsError}
+        mainBreakdownFields={{ primary: 'folderType', secondary: 'taskType' }}
         onVisibleRowsChange={setVisibleEntityIds}
       />
     </Section>

--- a/src/pages/VersionsProductsPage/components/VPTable/VPTable.tsx
+++ b/src/pages/VersionsProductsPage/components/VPTable/VPTable.tsx
@@ -217,6 +217,8 @@ const VPTable: FC<VPTableProps> = ({ readOnly = [], contextMenuItems }) => {
       fieldStatsLoading={fieldStatsLoading}
       fieldStatsError={fieldStatsError}
       mainCountLabels={{ primary: 'products', secondary: 'versions' }}
+      // versions have no subType, so only the products side breaks down
+      mainBreakdownFields={{ primary: 'productType' }}
       columnsConfig={{
         name: {
           display: { path_compact: false, path_full: true },


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Adds a Breakdown option to the name column summary. The footer keeps showing the plain count, hovering now shows the type split.



## Technical details
<!-- Please state any technical details such as limitations -->
- `breakdown` added to `SummaryCalc`, this is what gets persisted per view
- stats query asks for the subType distribution when breakdown is on, even when the subType column is hidden
- new `mainBreakdownFields` prop tells the addon what each side breaks down by: Overview folder + task types, Versions/Products product types
- versions have no type, so there only the products side shows up
- Lists doesn't set the prop, so the option stays hidden there

## Additional context
<!-- Add any other context or screenshots here. -->

Closes #2247
Powerpack PR: ynput/ayon-power-pack#81