### PR TITLE
Products: product type should not enum dropdown and string type

### DIFF
--- a/shared/src/containers/ProjectTreeTable/buildTreeTableColumns.tsx
+++ b/shared/src/containers/ProjectTreeTable/buildTreeTableColumns.tsx
@@ -608,7 +608,8 @@ const buildTreeTableColumns = ({
       cell: ({ row, column, table }) => {
         const { value, id, type } = getValueIdType(row, column.id)
         if (['group', NEXT_PAGE_ID].includes(type) || row.original.metaType) return null
-        const fieldId = type === 'folder' ? 'folderType' : 'taskType'
+        const isProductType = type === 'product' || type === 'version'
+        const fieldId = type === 'folder' ? 'folderType' : isProductType ? 'productType' : 'taskType'
         const meta = table.options.meta
         const folderHasVersions = type === 'folder' && row.original.hasVersions
         return (
@@ -623,7 +624,7 @@ const buildTreeTableColumns = ({
                 ? meta?.options?.folderType
                 : type === 'task'
                 ? meta?.options?.taskType
-                : type === 'product' || type === 'version'
+                : isProductType
                 ? meta?.options?.productType
                 : []
             }
@@ -635,6 +636,7 @@ const buildTreeTableColumns = ({
               )
             }
             isReadOnly={
+              isProductType ||
               meta?.readOnly?.includes(column.id) ||
               meta?.readOnly?.includes(fieldId) ||
               folderHasVersions

--- a/shared/src/containers/ProjectTreeTable/context/ClipboardContext.tsx
+++ b/shared/src/containers/ProjectTreeTable/context/ClipboardContext.tsx
@@ -489,7 +489,9 @@ export const ClipboardProvider: React.FC<ClipboardProviderProps> = ({
       // First pass: validate all values
       for (let rowIndex = 0; rowIndex < sortedRows.length; rowIndex++) {
         const rowId = sortedRows[rowIndex]
-        const isFolder = getEntityDataById<'folder'>(rowId, entitiesMap)?.entityType === 'folder'
+        const rowEntityType = getEntityDataById(rowId, entitiesMap)?.entityType
+        const isFolder = rowEntityType === 'folder'
+        const isProductType = rowEntityType === 'product' || rowEntityType === 'version'
 
         const pasteRowIndex = rowIndex % parsedData.length
         const clipboardRow = parsedData[pasteRowIndex]
@@ -501,6 +503,7 @@ export const ClipboardProvider: React.FC<ClipboardProviderProps> = ({
 
         // Validate each mapped value
         for (const colId of selectedColIds) {
+          if (colId === 'subType' && isProductType) continue
           const pasteValue = mappedValues[colId] || ''
 
           const isValid = validateClipboardData({
@@ -827,6 +830,7 @@ export const ClipboardProvider: React.FC<ClipboardProviderProps> = ({
 
           // Special handling for subType (convert to folderType or taskType)
           if (colId === 'subType') {
+            if (entityType === 'product' || entityType === 'version') continue
             fieldToUpdate = isFolder ? 'folderType' : 'taskType'
             isAttrib = false
 


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

The type column no longer opens a dropdown on products and versions.
Custom product types now show as plain text instead of a red invalid chip.

## Technical details
<!-- Please state any technical details such as limitations -->

- `subType` cell is read only for product/version rows, known types keep their icon chip (`buildTreeTableColumns.tsx`)
- field id for those rows was `taskType`, now `productType`
- paste into `subType` is skipped on product/version rows, it was validated against task types and cancelled the whole paste (`ClipboardContext.tsx`)

## Additional context
<!-- Add any other context or screenshots here. -->

Closes #2232
<img width="159" height="211" alt="Screenshot 2026-08-21 at 15 50 50" src="https://github.com/user-attachments/assets/65ff0fde-2baa-4b4d-a793-cc69de2a29e8" />
