### PR TITLE
Summaries: Do not show main breakdown type when active

### DIFF
--- a/shared/src/api/queries/columnStats/metricTargets.ts
+++ b/shared/src/api/queries/columnStats/metricTargets.ts
@@ -154,9 +154,15 @@ export const buildMetricTargets = ({
   }
 
   // no visibility check: it's opt-in, and a name column missing from both maps would kill this
+  const nameScope = columnSummaryScopes?.['name'] ?? 'all'
+  // group entities sit on the primary scope, row entities on the secondary one
+  const nameScopeCoversEntity = ['folder', 'product'].includes(entity)
+    ? nameScope === 'all' || nameScope === 'primary'
+    : nameScope === 'all' || nameScope === 'secondary'
   const nameBreakdown =
     columnSummaries?.['name'] === 'breakdown' &&
-    isSummaryActive('name', columnSummaries, columnSummaryScopes)
+    isSummaryActive('name', columnSummaries, columnSummaryScopes) &&
+    nameScopeCoversEntity
   const subTypeField = SUB_TYPE_FIELD[entity]
   if (subTypeField && (isActive('subType') || nameBreakdown)) {
     targets.push({ field: subTypeField, aggregations: ENUM })


### PR DESCRIPTION
## Description of changes
Fixes #2270 frontend half, rendering fix is in ynput/ayon-power-pack#83

Name breakdown no longer requests subType stats for a scope that is toggled off.

## Technical details

`buildMetricTargets` gates the `nameBreakdown` subType target on the name column's scope: folder/product entities need `primary`, task/version need `secondary`. Unset scope stays `all`, so nothing changes for existing users.


<img width="225" height="340" alt="Screenshot 2026-08-24 at 16 22 47" src="https://github.com/user-attachments/assets/8ca7ef7d-441e-4fb4-a8d7-c78814770fd0" />

