### PR TITLE
Wait for server full boot before fetching data

### DIFF
--- a/shared/src/context/WebsocketContext.tsx
+++ b/shared/src/context/WebsocketContext.tsx
@@ -117,6 +117,17 @@ export const SocketProvider = ({
   // Using useRef to persist the closure state across renders
   const messageStatsRef = useRef({ callCount: 0, lastCall: Date.now() })
 
+
+  const debouncedResetCall = debounce(() => {
+    // all replicas should start about the same time, 
+    // so we can reset the API state after a short delay
+    console.log('Resetting API state due to server restart')
+    setServerRestartingVisible(false)
+    dispatch(api.util.resetApiState())
+  }, 1000)
+
+
+
   const onMessage = useCallback(
     (message: any) => {
       // If the function is called more than 100 times per second, return early.
@@ -136,7 +147,14 @@ export const SocketProvider = ({
         return
       }
 
-      const { topic, sender, summary } = data || {}
+      const { topic, sender, summary, status } = data || {}
+
+      if (serverRestartingVisible && topic === 'server.started' && status === 'finished') {
+        console.log('Server replica booted')
+        debouncedResetCall()
+        return
+      }
+
       if (topic === 'heartbeat') return
 
       if (topic === 'server.restart_requested') setServerRestartingVisible(true)
@@ -161,16 +179,16 @@ export const SocketProvider = ({
 
       PubSub.publish(topic, data)
     },
-    [setServerRestartingVisible],
+    [setServerRestartingVisible, serverRestartingVisible],
   )
 
   useEffect(() => {
     if (readyState === ReadyState.OPEN) {
-      if (serverRestartingVisible) {
-        setServerRestartingVisible(false)
-        // clear ayonApi
-        dispatch(api.util.resetApiState())
-      }
+      // if (serverRestartingVisible) {
+      //   setServerRestartingVisible(false)
+      //   // clear ayonApi
+      //   dispatch(api.util.resetApiState())
+      // }
       // @ts-ignore
       getWebSocket().onmessage = onMessage
       subscribe()

--- a/shared/src/context/WebsocketContext.tsx
+++ b/shared/src/context/WebsocketContext.tsx
@@ -149,7 +149,7 @@ export const SocketProvider = ({
 
       const { topic, sender, summary, status } = data || {}
 
-      if (serverRestartingVisible && topic === 'server.started' && status === 'finished') {
+      if (serverRestartingVisible && (topic === 'heartbeat' || (topic === 'server.started' && status === 'finished'))) {
         console.log('Server replica booted')
         debouncedResetCall()
         return

--- a/shared/src/context/WebsocketContext.tsx
+++ b/shared/src/context/WebsocketContext.tsx
@@ -47,6 +47,11 @@ export const SocketProvider = ({
   const [topics, setTopics] = useState([])
   const [getInfo] = useLazyGetSiteInfoQuery()
 
+  const isServerRestarting = useRef(false)
+  useEffect(() => {
+    isServerRestarting.current = serverRestartingVisible
+  }, [serverRestartingVisible])
+
   const wsOpts: Options = {
     shouldReconnect: () => {
       if (DISABLE_WS) return false
@@ -149,7 +154,7 @@ export const SocketProvider = ({
 
       const { topic, sender, summary, status } = data || {}
 
-      if (serverRestartingVisible && (topic === 'heartbeat' || (topic === 'server.started' && status === 'finished'))) {
+      if (isServerRestarting.current && (topic === 'heartbeat' || (topic === 'server.started' && status === 'finished'))) {
         console.log('Server replica booted')
         debouncedResetCall()
         return
@@ -157,7 +162,10 @@ export const SocketProvider = ({
 
       if (topic === 'heartbeat') return
 
-      if (topic === 'server.restart_requested') setServerRestartingVisible(true)
+      if (topic === 'server.restart_requested') {
+        console.log("Server restart requested")
+        setServerRestartingVisible(true)
+      }
 
       if (['import.data'].includes(topic)) {
         if (sender !== window.senderId) return // ignore import.data messages from other users
@@ -179,16 +187,11 @@ export const SocketProvider = ({
 
       PubSub.publish(topic, data)
     },
-    [setServerRestartingVisible, serverRestartingVisible],
+    [setServerRestartingVisible],
   )
 
   useEffect(() => {
     if (readyState === ReadyState.OPEN) {
-      // if (serverRestartingVisible) {
-      //   setServerRestartingVisible(false)
-      //   // clear ayonApi
-      //   dispatch(api.util.resetApiState())
-      // }
       // @ts-ignore
       getWebSocket().onmessage = onMessage
       subscribe()


### PR DESCRIPTION
Handles backend changes in https://github.com/ynput/ayon-backend/pull/1094

This pull request enhances the server restart handling logic in the `SocketProvider` component to ensure smoother state management when the backend server restarts. The main improvements involve debouncing the API state reset and making the logic more robust and less error-prone.

**Server restart handling improvements:**

* Introduced a debounced function `debouncedResetCall` to delay resetting the API state for 1 second after detecting a server restart, preventing unnecessary rapid resets and ensuring all replicas restart together.
* Updated the WebSocket message handler to trigger the debounced reset only when a `server.started` message with status `finished` is received and the server is marked as restarting, improving accuracy and reducing redundant resets.
* Removed the previous immediate API state reset logic from the `useEffect`, centralizing the reset logic within the WebSocket message handler for better control and predictability.