### PR TITLE
My Tasks: Show tags in list view

### DIFF
--- a/src/components/ListItem/ListItem.jsx
+++ b/src/components/ListItem/ListItem.jsx
@@ -1,6 +1,7 @@
 import React, { forwardRef } from 'react'
 import * as Styled from './ListItem.styled'
 import { Icon } from '@ynput/ayon-react-components'
+import { EnumCellValue } from '@shared/containers/ProjectTreeTable/widgets/EnumCellValue'
 import { addDays, formatDistanceToNow, isSameDay, isValid } from 'date-fns'
 import clsx from 'clsx'
 
@@ -39,6 +40,8 @@ const ListItem = forwardRef(
 
     // path but with last /folderName removed
     const hoverPath = `${task.projectName}/${task.folderPath.split('/').slice(0, -1).join('/')}`
+
+    const tags = task.tagsInfo || []
 
     const endDateDate = task.dueDate && new Date(task.dueDate)
 
@@ -87,6 +90,13 @@ const ListItem = forwardRef(
           multipleSelected={selectedLength}
           onChange={(v) => onUpdate('status', v)}
         />
+
+        <Styled.Tags
+          className="tags"
+          data-tooltip={tags.length ? tags.map((tag) => tag.label).join(', ') : undefined}
+        >
+          <EnumCellValue selectedOptions={tags} isMultiSelect isReadOnly />
+        </Styled.Tags>
 
         <Styled.ItemThumbnail src={task.thumbnailUrl} icon={task.taskIcon} />
 

--- a/src/components/ListItem/ListItem.jsx
+++ b/src/components/ListItem/ListItem.jsx
@@ -91,13 +91,6 @@ const ListItem = forwardRef(
           onChange={(v) => onUpdate('status', v)}
         />
 
-        <Styled.Tags
-          className="tags"
-          data-tooltip={tags.length ? tags.map((tag) => tag.label).join(', ') : undefined}
-        >
-          <EnumCellValue selectedOptions={tags} isMultiSelect isReadOnly />
-        </Styled.Tags>
-
         <Styled.ItemThumbnail src={task.thumbnailUrl} icon={task.taskIcon} />
 
         {/* FOLDER LABEL */}
@@ -112,6 +105,13 @@ const ListItem = forwardRef(
           </Styled.Name>
           <Styled.Name className="task-label">{task.label || task.name}</Styled.Name>
         </Styled.Task>
+
+        <Styled.Tags
+          className="tags"
+          data-tooltip={tags.length ? tags.map((tag) => tag.label).join(', ') : undefined}
+        >
+          <EnumCellValue selectedOptions={tags} isMultiSelect isReadOnly />
+        </Styled.Tags>
 
         {/* PATH SHOW ON HOVER */}
         <Styled.Path className="path">{hoverPath}</Styled.Path>

--- a/src/components/ListItem/ListItem.styled.ts
+++ b/src/components/ListItem/ListItem.styled.ts
@@ -126,6 +126,20 @@ export const ItemThumbnail = styled(ThumbnailSimple)`
   }
 `
 
+export const Tags = styled.div`
+  display: flex;
+  align-items: center;
+  height: 22px;
+  min-width: 160px;
+  max-width: 160px;
+  overflow: hidden;
+
+  /* keep leading tags readable and clip at the cell edge instead of squashing every chip */
+  .values > * {
+    flex-shrink: 0;
+  }
+`
+
 export const Folder = styled.span`
   max-width: 300px;
   overflow: hidden;

--- a/src/components/ListItem/ListItem.styled.ts
+++ b/src/components/ListItem/ListItem.styled.ts
@@ -130,8 +130,9 @@ export const Tags = styled.div`
   display: flex;
   align-items: center;
   height: 22px;
-  min-width: 160px;
-  max-width: 160px;
+  flex: 1 1 160px;
+  min-width: 60px;
+  max-width: 360px;
   overflow: hidden;
 
   /* keep leading tags readable and clip at the cell edge instead of squashing every chip */

--- a/src/pages/UserDashboardPage/UserDashboardTasks/transformKanbanTasks.ts
+++ b/src/pages/UserDashboardPage/UserDashboardTasks/transformKanbanTasks.ts
@@ -14,6 +14,7 @@ type ExtraInfo = {
   taskInfo: TaskType
   statusInfo: Status
   priorityInfo: EnumItem | undefined
+  tagsInfo: EnumItem[]
 }
 
 export interface TransformedKanbanTask extends KanbanNode, ExtraInfo {
@@ -48,6 +49,11 @@ const transformKanbanTasks = (
       (priorityItem) => priorityItem.value === task.priority,
     )
 
+    const tagsInfo: EnumItem[] = (task.tags || []).map((tag) => {
+      const tagAnatomy = projectInfo?.tags?.find((tagItem: $Any) => tagItem.name === tag)
+      return { value: tag, label: tag, color: tagAnatomy?.color }
+    })
+
     const pathParts = task.folderPath?.split('/').filter(Boolean) || []
     const parentFolder = pathParts.length >= 2 ? pathParts[pathParts.length - 2] : 'Root'
 
@@ -62,6 +68,7 @@ const transformKanbanTasks = (
       statusInfo,
       taskInfo,
       priorityInfo,
+      tagsInfo,
       parentFolder,
     }
   })


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Shows task tags as coloured chips in the Home -> My Tasks list, next to the status.

## Technical details
<!-- Please state any technical details such as limitations -->

- `transformKanbanTasks` resolves each task's tags to `tagsInfo`, taking colours from that task's own project anatomy.
- `ListItem` renders them with the shared `EnumCellValue` in a fixed 160px cell. Overflow is clipped and a tooltip lists every tag.
- Read-only. Tags are still edited in the Details panel, which already patches the kanban cache.

## Additional context
<!-- Add any other context or screenshots here. -->

<img width="1138" height="433" alt="image" src="https://github.com/user-attachments/assets/13891477-b169-40ff-8717-b9770d8d633b" />


<!-- TODO: attach screenshot of the list with tags -->

Closes #2278
Ticket: YN-1003
