### PR TITLE
Viewer: play latest version regardless of API order

### DIFF
--- a/src/containers/Viewer/Viewer.tsx
+++ b/src/containers/Viewer/Viewer.tsx
@@ -120,21 +120,23 @@ const ViewerBody = ({ onClose }: ViewerProps) => {
 
   // check if a specific product is selected
   const versionsAndReviewables: GetReviewablesResponse[] = useMemo(() => {
-    if (!hasMultipleProducts) return allVersionsAndReviewables
+    let filtered: GetReviewablesResponse[]
+    if (!hasMultipleProducts) filtered = allVersionsAndReviewables
     else if (selectedProductId) {
       // filter out the versions for the selected product
-      return allVersionsAndReviewables.filter((v) => v.productId === selectedProductId)
+      filtered = allVersionsAndReviewables.filter((v) => v.productId === selectedProductId)
     } else {
       // find the version (and therefor product) with the reviewable that was last createdAt
       const latestProductId = sortedVersionsReviewableDates[0].productId
       if (latestProductId) {
-        return allVersionsAndReviewables.filter((v) => v.productId === latestProductId)
+        filtered = allVersionsAndReviewables.filter((v) => v.productId === latestProductId)
       } else {
         // return first product
         const firstProduct = allVersionsAndReviewables[0]
-        return allVersionsAndReviewables.filter((v) => v.productId === firstProduct.productId)
+        filtered = allVersionsAndReviewables.filter((v) => v.productId === firstProduct.productId)
       }
     }
+   return [...filtered].sort((a, b) => parseInt(a.version, 10) - parseInt(b.version, 10))
   }, [allVersionsAndReviewables, selectedProductId])
   // if hasMultipleProducts and no selectedProductId, select the first product
   useEffect(() => {

--- a/src/pages/VersionsProductsPage/components/VersionsListTable/VersionsListTable.tsx
+++ b/src/pages/VersionsProductsPage/components/VersionsListTable/VersionsListTable.tsx
@@ -20,8 +20,6 @@ const VersionsListTable: FC<VersionsListTableProps> = ({}) => {
   const { versionsTableRef, focusGrid } = useVPFocusContext()
   const ratio = useMemo(() => guessImgRatio(rowHeight, columns), [rowHeight, columns])
 
-  console.log({ productsMap })
-
   const versionsTableData = useMemo(
     () => buildVersionsTableRows({ projectName, productsMap, productIds: selectedProducts }),
     [selectedProducts, productsMap, projectName],

--- a/src/pages/VersionsProductsPage/context/VPSelectionContext.tsx
+++ b/src/pages/VersionsProductsPage/context/VPSelectionContext.tsx
@@ -100,11 +100,13 @@ export const VersionsSelectionProvider: FC<VersionsSelectionProviderProps> = ({ 
 
   const [selectedVersions, setSelectedVersions] = useState<string[]>([])
 
+  const versionsKey = versions.join(',')
   useEffect(() => {
     if (showVersionDetails) {
       setSelectedVersions(versions)
     }
-  }, [versions])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [versionsKey])
 
   const clearSelection = useCallback(() => {
     setSelectedVersions([])

--- a/src/pages/VersionsProductsPage/util/buildVersionsTableRows.ts
+++ b/src/pages/VersionsProductsPage/util/buildVersionsTableRows.ts
@@ -18,7 +18,11 @@ export const buildVersionsTableRows = ({
     const product = productsMap.get(productId)
     if (!product) return []
 
-    return product.versions.map((version) => ({
+    const sortedVersions = [...product.versions].sort(
+      (a, b) => (Number(a.version) || 0) - (Number(b.version) || 0),
+    )
+
+    return sortedVersions.map((version) => ({
       id: version.id,
       name: version.name,
       label: `${version.name} ${version.heroVersionId ? HERO_SYMBOL : ''}`,


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Fixes viewer opening the oldest version and stacked versions not switching when grouped by product.

## Technical details
<!-- Please state any technical details such as limitations -->

- Sort versions by number client-side in `Viewer.tsx` and `buildVersionsTableRows.ts`, backend order flipped in ayon-backend#994.
- `VPSelectionContext.tsx`: sync effect keyed on version ids, refetch-driven ref changes no longer overwrite the clicked version.
- Remove stray `console.log` in `VersionsListTable.tsx`.

## Additional context
<!-- Add any other context or screenshots here. -->

Closes #2284
