### PR TITLE
Thumbnail: stop requesting thumbnails for products

### DIFF
--- a/shared/src/containers/ProjectTreeTable/types/table.ts
+++ b/shared/src/containers/ProjectTreeTable/types/table.ts
@@ -76,7 +76,7 @@ export type TableRow = {
   group?: GroupData // signals it is a group row and has some extra data like label, color, icon
   thumbnail?: {
     // if you want to use a thumbnail from a different entity, e.g. latest version of a product
-    entityId: string
+    entityId?: string
     entityType: string
     thumbnailHash?: string
   }

--- a/shared/src/containers/ProjectTreeTable/widgets/ThumbnailWidget.tsx
+++ b/shared/src/containers/ProjectTreeTable/widgets/ThumbnailWidget.tsx
@@ -36,7 +36,7 @@ const StyledPlayableIcon = styled(PlayableIcon)`
 interface ThumbnailWidgetProps extends React.HTMLAttributes<HTMLDivElement> {
   projectName: string
   entityType: string
-  entityId: string
+  entityId?: string
   thumbnailHash?: string
   icon?: string | null
   isPlayable?: boolean

--- a/shared/src/containers/ProjectTreeTable/widgets/ThumbnailWidget.tsx
+++ b/shared/src/containers/ProjectTreeTable/widgets/ThumbnailWidget.tsx
@@ -54,7 +54,8 @@ const ThumbnailWidgetWrapper: FC<ThumbnailWidgetProps> = ({
   id,
   ...props
 }) => {
-  const valid = projectName && entityType && entityId
+  // TODO: products have no thumbnail endpoint, resolve to the featured version's thumbnail instead
+  const valid = projectName && entityType && entityId && entityType !== 'product'
   const thumbnailUrl = getEntityThumbnailUrl({ projectName, entityType, entityId, thumbnailHash })
 
   return (

--- a/src/pages/ProjectListsPage/hooks/useBuildListItemsTableData.ts
+++ b/src/pages/ProjectListsPage/hooks/useBuildListItemsTableData.ts
@@ -64,8 +64,7 @@ const useBuildListItemsTableData = ({ listItemsData }: Props) => {
         folderId: extractFolderId(item, item.entityType),
         taskId: item.task?.id,
         versionEntityId: item.entityType === 'version' ? item.id : undefined,
-        // @ts-expect-error - thumbnailHash does exist on products, that's it
-        thumbnailHash: item.thumbnailHash,
+        thumbnailHash: 'thumbnailHash' in item ? item.thumbnailHash : undefined,
         folder: extractFolder(item, item.entityType),
         parents: item.parents || [],
         tags: item.tags,

--- a/src/pages/VersionsProductsPage/util/buildVPRows.ts
+++ b/src/pages/VersionsProductsPage/util/buildVPRows.ts
@@ -36,8 +36,8 @@ export const buildProductRow = (
   author: product.featuredVersion?.author || '',
   latestComments: product.featuredVersion?.latestComments || [],
   thumbnail: {
-    entityId: product.featuredVersion?.id || product.id,
-    entityType: product.featuredVersion ? 'version' : 'product',
+    entityId: product.featuredVersion?.id,
+    entityType: 'version',
     updatedAt: product.featuredVersion?.updatedAt || product.updatedAt,
     thumbnailHash: product.featuredVersion?.thumbnailHash,
   },


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Fixes 404 spam from products without a matching version.

## Technical details
<!-- Please state any technical details such as limitations -->

- `ThumbnailWidget` skips the request for `product` entity type, with a TODO to resolve to the featured version's thumbnail later.
- `buildVPRows.ts`: product rows always point at the featured version, no product fallback.

## Additional context
<!-- Add any other context or screenshots here. -->
