### PR TITLE
Search filter: breadcrumb shows wrong parent group

### DIFF
--- a/shared/src/components/SearchFilter/useBuildFilterOptions.tsx
+++ b/shared/src/components/SearchFilter/useBuildFilterOptions.tsx
@@ -1049,8 +1049,8 @@ const getOptionRoot = (
 
     rootOption.group = {
       name: groupName,
-      label: rootOption.label,
-      icon: rootOption.icon,
+      label: entityType ? upperFirst(entityType) : rootOption.label,
+      icon: entityType ? getEntityTypeIcon(entityType) : rootOption.icon,
     }
   }
 
@@ -1079,12 +1079,10 @@ const getAttributeFieldOptionRoot = (
     shouldGroup || entityType
       ? {
           name: entityType || attribute.name,
-          label,
-          icon: getAttributeIcon(
-            attribute.name,
-            attribute.data.type,
-            !!attribute.data.enum?.length,
-          ),
+          label: entityType ? upperFirst(entityType) : label,
+          icon: entityType
+            ? getEntityTypeIcon(entityType)
+            : getAttributeIcon(attribute.name, attribute.data.type, !!attribute.data.enum?.length),
         }
       : undefined
 


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Fixes the filter dropdown breadcrumb showing the same field twice, e.g. "Status / Status" instead of "Version / Status".

## Technical details
<!-- Please state any technical details such as limitations -->

- Grouped options in `useBuildFilterOptions` carried their own label/icon in `group`, so the breadcrumb read the field name as its parent
- Group label and icon now come from `entityType`, in both `getOptionRoot` and `getAttributeFieldOptionRoot`
- Root group menu, chips and menu row icons are unaffected

## Additional context
<!-- Add any other context or screenshots here. -->

Checked on Products (Version/Product groups), Overview (Folder attributes) and Task progress (single scope, no group segment).
