### PR TITLE
Access groups: fix saving permissions

### DIFF
--- a/shared/src/api/queries/accessGroups/getAccessGroups.ts
+++ b/shared/src/api/queries/accessGroups/getAccessGroups.ts
@@ -73,12 +73,22 @@ enhancedApi.enhanceEndpoints({
         { type: 'accessGroup', id: 'LIST' },
       ],
     },
+    getAccessGroups: {
+      providesTags: (result) =>
+        result
+          ? [
+              ...result.map(({ name }) => ({ type: 'accessGroup', id: name })),
+              { type: 'accessGroup', id: 'LIST' },
+            ]
+          : [{ type: 'accessGroup', id: 'LIST' }],
+    },
     getAccessGroupSchema: {},
   },
 })
 
 export const {
   useGetStudioAccessGroupsQuery,
+  useGetAccessGroupsQuery,
   useGetAccessGroupQuery,
   useGetAccessGroupSchemaQuery,
   useGetProjectsAccessQuery,

--- a/src/pages/SettingsPage/AccessGroups/AccessGroupDetail.jsx
+++ b/src/pages/SettingsPage/AccessGroups/AccessGroupDetail.jsx
@@ -13,7 +13,7 @@ import { isEqual } from 'lodash'
 import {
   useDeleteAccessGroupMutation,
   useSaveAccessGroupMutation,
-  useGetStudioAccessGroupsQuery,
+  useGetAccessGroupsQuery,
   useGetAccessGroupQuery,
   useGetAccessGroupSchemaQuery,
 } from '@shared/api'
@@ -34,8 +34,8 @@ const AccessGroupDetail = ({ projectName, accessGroupName }) => {
   )
   const { data: schema } = useGetAccessGroupSchemaQuery(projectName ? { projectName } : {})
 
-  const { data: accessGroupList = [] } = useGetStudioAccessGroupsQuery({
-    projectName: projectName,
+  const { data: accessGroupList = [] } = useGetAccessGroupsQuery({
+    projectName: projectName || '_',
   })
 
   const isProjectLevel = useMemo(() => {
@@ -64,7 +64,7 @@ const AccessGroupDetail = ({ projectName, accessGroupName }) => {
       await saveAccessGroup({
         accessGroupName,
         projectName: projectName || '_',
-        data: formData,
+        permissions: formData,
       }).unwrap()
       toast.success('Project access group settings saved')
     } catch (err) {

--- a/src/pages/SettingsPage/AccessGroups/AccessGroupList.jsx
+++ b/src/pages/SettingsPage/AccessGroups/AccessGroupList.jsx
@@ -3,7 +3,7 @@ import { useCreateContextMenu } from '@shared/containers/ContextMenu'
 import { DataTable } from 'primereact/datatable'
 import { Column } from 'primereact/column'
 import { Button, TablePanel, Section, Toolbar, Spacer } from '@ynput/ayon-react-components'
-import { useDeleteAccessGroupMutation, useGetStudioAccessGroupsQuery } from '@shared/api'
+import { useDeleteAccessGroupMutation, useGetAccessGroupsQuery } from '@shared/api'
 import NewAccessGroup from './NewAccessGroup'
 import { confirmDelete } from '@shared/util'
 import clsx from 'clsx'
@@ -18,8 +18,8 @@ const AccessGroupList = ({
   const [showNewAccessGroup, setShowNewAccessGroup] = useState(false)
 
   // Load user list
-  const { data: accessGroupList = [], isLoading } = useGetStudioAccessGroupsQuery({
-    projectName: projectName,
+  const { data: accessGroupList = [], isLoading } = useGetAccessGroupsQuery({
+    projectName: projectName || '_',
   })
 
   const [deleteAccessGroup] = useDeleteAccessGroupMutation()
@@ -46,7 +46,6 @@ const AccessGroupList = ({
     onSelectAccessGroup({ name, isProjectLevel: true })
   }
 
-  // FIXME: this doesn't update when access group details updates
   const getRowClass = (rowData) => {
     return { 'changed-project': rowData.isProjectLevel, loading: isLoading }
   }

--- a/tests/fixtures/permissionsPage.ts
+++ b/tests/fixtures/permissionsPage.ts
@@ -22,7 +22,32 @@ class PermissionsPage {
     await this.page.getByRole('button', { name: 'Read & Write' }).first().click();
     await this.page.getByRole('button', { name: 'Read & Write' }).nth(1).click();
     await this.page.getByRole('button', { name: 'Read & Write' }).nth(2).click();
+    const savedPermissions = this.page.waitForResponse(
+      (response) =>
+        response.request().method() === 'PUT' &&
+        response.url().includes('/api/accessGroups/') &&
+        response.ok(),
+    )
     await this.page.getByRole('button', { name: 'check Save Changes' }).click();
+    await savedPermissions
+    await expect(this.page.getByText('Project access group settings saved')).toBeVisible()
+
+    await this.expectProjectPermissionsPersisted(accessGroup)
+  }
+
+  // reload from the server so a save that never reached the backend fails here
+  async expectProjectPermissionsPersisted(accessGroup: string) {
+    const groupReloaded = this.page.waitForResponse(
+      (response) =>
+        response.request().method() === 'GET' &&
+        response.url().includes(`/api/accessGroups/${accessGroup}/`) &&
+        response.ok(),
+    )
+    await this.goto()
+    await this.page.getByRole('cell', { name: accessGroup }).click()
+
+    const permissions = await (await groupReloaded).json()
+    expect(permissions.project).toMatchObject({ anatomy: 2, access: 2, settings: 2 })
   }
 
   async delete(accessGroup: string) {


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Fixes saving access group permissions, which failed with a server validation error.

## Technical details
<!-- Please state any technical details such as limitations -->

- `saveAccessGroup` now gets `permissions` instead of `data` in `AccessGroupDetail.jsx` — codegen renamed the body arg, so the PUT went out with no body
- Project permissions list back on `getAccessGroups({ projectName })`; the studio endpoint hardcodes `isProjectLevel: false`, which left "Clear project overrides" permanently disabled
- Added `providesTags` to `getAccessGroups` so the list refreshes after a save

## Additional context
<!-- Add any other context or screenshots here. -->

Closes #2290
