### PR TITLE
Lists: fix Attributes row showing [object Object]

### DIFF
--- a/shared/src/components/ListMetaData/ListMetaData.tsx
+++ b/shared/src/components/ListMetaData/ListMetaData.tsx
@@ -11,12 +11,14 @@ interface ListMetaDataProps {
 }
 
 export const ListMetaData: FC<ListMetaDataProps> = ({ list, isLoading }) => {
-  const listData = { ...(list?.data || {}) }
-  // remove category and count from the meta data
-  // @ts-expect-error
-  delete listData.category
-  // @ts-expect-error
-  delete listData.count
+  // data also holds structured entries (list attribute definitions, review session
+  // sections/grouping) which have no meaningful string rendering
+  const listData = Object.fromEntries(
+    Object.entries(list?.data || {}).filter(
+      ([key, value]) =>
+        !['category', 'count'].includes(key) && value !== null && typeof value !== 'object',
+    ),
+  )
 
   const metaData = {
     Id: list?.id,


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

The list details panel printed `[object Object]` for lists with custom attributes.

## Technical details
<!-- Please state any technical details such as limitations -->

- `ListMetaData` spread all of `list.data` into string rows; custom attributes live in `data.attributes`. Now only primitive values are shown, which also covers review session `sections`.

## Additional context
<!-- Add any other context or screenshots here. -->
