### PR TITLE
GraphQL: Project pagination is broken

### DIFF
--- a/shared/src/api/generated/graphql.ts
+++ b/shared/src/api/generated/graphql.ts
@@ -2025,8 +2025,8 @@ export type GetProjectLatestQueryVariables = Exact<{
 export type GetProjectLatestQuery = { project: { name: string } };
 
 export type GetProjectsQueryVariables = Exact<{
-  last?: number | null | undefined;
-  before?: string | null | undefined;
+  first?: number | null | undefined;
+  after?: string | null | undefined;
 }>;
 
 
@@ -3730,8 +3730,8 @@ export const GetProjectLatestDocument = new TypedDocumentString(`
 }
     `);
 export const GetProjectsDocument = new TypedDocumentString(`
-    query GetProjects($last: Int, $before: String) {
-  projects(last: $last, before: $before, includeSkeleton: true) {
+    query GetProjects($first: Int, $after: String) {
+  projects(first: $first, after: $after, includeSkeleton: true) {
     edges {
       cursor
       node {

--- a/shared/src/api/queries/project/getProject.ts
+++ b/shared/src/api/queries/project/getProject.ts
@@ -59,7 +59,7 @@ type GQLDefinitions = DefinitionsFromApi<typeof gqlApi>
 type GQLUpdatedDefinitions = Omit<GQLDefinitions, 'GetProjects'> & {
   GetProjects: OverrideResultType<GQLDefinitions['GetProjects'], GetProjectsResult>
 }
-//  it is impossible to group by folder or search with pagination, so just load tons and hope no one has more than 5 k projects.
+// keep high until ayon-backend#1109: a page shortened by access filtering looks like the last page
 export const PROJECTS_PER_PAGE = 2000
 
 // enhance graphql - used only for the infinite query below
@@ -77,23 +77,23 @@ const enhancedGraphql = gqlApi.enhanceEndpoints<TagTypes, GQLUpdatedDefinitions>
   },
 })
 
-type ProjectsPageParam = { cursor: string; last?: number }
+type ProjectsPageParam = { cursor: string; first?: number }
 
 export const getProjectsGraphql = enhancedGraphql.injectEndpoints({
   endpoints: (build) => ({
     getProjectsInfinite: build.infiniteQuery<
       GetProjectsResult,
-      Omit<GetProjectsQueryVariables, 'last' | 'before'>,
+      Omit<GetProjectsQueryVariables, 'first' | 'after'>,
       ProjectsPageParam
     >({
       infiniteQueryOptions: {
-        initialPageParam: { cursor: '', last: PROJECTS_PER_PAGE },
+        initialPageParam: { cursor: '', first: PROJECTS_PER_PAGE },
         getNextPageParam: (lastPage) => {
           const { pageInfo } = lastPage
-          if (!pageInfo.hasPreviousPage || !pageInfo.endCursor) return undefined
+          if (!pageInfo.hasNextPage || !pageInfo.endCursor) return undefined
           return {
             cursor: pageInfo.endCursor,
-            last: PROJECTS_PER_PAGE,
+            first: PROJECTS_PER_PAGE,
           }
         },
       },
@@ -101,8 +101,8 @@ export const getProjectsGraphql = enhancedGraphql.injectEndpoints({
         try {
           const queryParams: GetProjectsQueryVariables = {
             ...queryArg,
-            before: pageParam?.cursor || undefined,
-            last: pageParam?.last,
+            after: pageParam?.cursor || undefined,
+            first: pageParam?.first,
           }
 
           const result = await api.dispatch(

--- a/shared/src/api/queries/project/gql/GetProjects.graphql
+++ b/shared/src/api/queries/project/gql/GetProjects.graphql
@@ -1,5 +1,5 @@
-query GetProjects($last: Int, $before: String) {
-  projects(last: $last, before: $before, includeSkeleton: true) {
+query GetProjects($first: Int, $after: String) {
+  projects(first: $first, after: $after, includeSkeleton: true) {
     edges {
       cursor
       node {

--- a/shared/src/api/queries/system/getSystem.ts
+++ b/shared/src/api/queries/system/getSystem.ts
@@ -20,12 +20,14 @@ const getSystemApi = systemApi.enhanceEndpoints<TagTypes, UpdatedDefinitions>({
         result
           ? [
               'info',
+              // setAttributeList invalidates the id-less tag, so provide it too
+              'attribute',
               ...(result.attributes || []).map((attr) => ({
                 type: 'attribute' as const,
                 id: attr.name,
               })),
             ]
-          : ['info'],
+          : ['info', 'attribute'],
     },
     listFrontendModules: {
       providesTags: ['info'],

--- a/src/pages/ProjectsPage/ProjectsPage.tsx
+++ b/src/pages/ProjectsPage/ProjectsPage.tsx
@@ -227,6 +227,7 @@ const ProjectsPageContent: FC<ProjectsPageProps> = ({ onNewProject }) => {
       </Toolbar>
       {hasReachedPageLimit && (
         <InfoMessage
+          role="status"
           variant="warning"
           message={`Showing ${projects.length} projects. Some projects are not listed.`}
         />

--- a/src/pages/ProjectsPage/ProjectsPage.tsx
+++ b/src/pages/ProjectsPage/ProjectsPage.tsx
@@ -22,19 +22,17 @@ import {
 import * as Styled from './ProjectsPage.styled'
 import {
   Button,
-  Dialog,
   SortCardType,
   SortingDropdown,
   Toolbar,
 } from '@ynput/ayon-react-components'
-import { PROJECTS_PER_PAGE } from '@shared/api'
 import { ProjectDetailsPanel } from './components/ProjectDetailsPanel/ProjectDetailsPanel'
 import { ProjectsPageTableSettings } from './components/ProjectsPageTableSettings'
 import { Splitter, SplitterPanel } from 'primereact/splitter'
 import DetailsPanelSplitter from '@components/DetailsPanelSplitter'
 import useShortcuts from '@hooks/useShortcuts'
 import { SettingsPanelProvider, usePowerpack, useSettingsPanel } from '@shared/context'
-import { CustomizeButton, PowerpackButton } from '@shared/components'
+import { CustomizeButton, InfoMessage, PowerpackButton } from '@shared/components'
 import { useSessionStorage } from '@shared/hooks'
 import { DEFAULT_COLUMNS_PROJECT, GROUP_BY_FOLDER_KEY } from './constants'
 import useProjectMenuController from '@containers/ProjectsList/hooks/useProjectMenuController'
@@ -58,9 +56,9 @@ const ProjectsPageContent: FC<ProjectsPageProps> = ({ onNewProject }) => {
   // Get all projects data
   const {
     projects,
-    fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
+    hasReachedPageLimit,
     projectsMap,
     foldersMap,
     projectFolders,
@@ -227,6 +225,12 @@ const ProjectsPageContent: FC<ProjectsPageProps> = ({ onNewProject }) => {
         />
         <CustomizeButton />
       </Toolbar>
+      {hasReachedPageLimit && (
+        <InfoMessage
+          variant="warning"
+          message={`Showing ${projects.length} projects. Some projects are not listed.`}
+        />
+      )}
       <Splitter
         layout="horizontal"
         stateKey="projects-splitter-settings"
@@ -302,20 +306,6 @@ const ProjectsPageContent: FC<ProjectsPageProps> = ({ onNewProject }) => {
           <SplitterPanel style={{ maxWidth: 0 }} />
         )}
       </Splitter>
-      {hasNextPage && (
-        <Dialog
-          size="sm"
-          isOpen={true}
-          onClose={() => {}}
-          hideCancelButton
-          showCloseButton={false}
-          header={`Congratulations you have more than ${projects.length} projects.`}
-        >
-          <Button onClick={() => fetchNextPage()} disabled={isFetchingNextPage}>
-            {isFetchingNextPage ? 'Loading...' : `Click here to load ${PROJECTS_PER_PAGE} more`}
-          </Button>
-        </Dialog>
-      )}
       <ProjectFolderFormDialog {...folderDialogProps} />
     </Styled.PageContainer>
   )

--- a/src/pages/ProjectsPage/hooks/useGetProjectsData.ts
+++ b/src/pages/ProjectsPage/hooks/useGetProjectsData.ts
@@ -61,8 +61,9 @@ export const useGetProjectsData = ({
   }, [projectFolders])
 
   // every project is needed up front: sorting, grouping, filtering and search all run client-side
-  const hasReachedPageLimit = pages.length >= MAX_PROJECT_PAGES
-  const isDraining = !!hasNextPage && !hasReachedPageLimit
+  const hasReachedPageLimit = !!hasNextPage && pages.length >= MAX_PROJECT_PAGES
+  // stop on error, otherwise a failing page retries forever
+  const isDraining = !!hasNextPage && !hasReachedPageLimit && !error
 
   useEffect(() => {
     if (!isDraining || isFetchingNextPage) return

--- a/src/pages/ProjectsPage/hooks/useGetProjectsData.ts
+++ b/src/pages/ProjectsPage/hooks/useGetProjectsData.ts
@@ -7,7 +7,9 @@ import {
   type ProjectFolderModel,
 } from '@shared/api'
 import { GROUP_BY_FOLDER_KEY } from '../constants'
-import { useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
+
+const MAX_PROJECT_PAGES = 10
 
 type Props = {
   groupBy?: string | null
@@ -23,9 +25,9 @@ type Value = {
   projectsMap: ProjectMap
   projectFolders: ProjectFolderModel[]
   foldersMap: FolderMap
-  fetchNextPage: () => void
   hasNextPage: boolean
   isFetchingNextPage: boolean
+  hasReachedPageLimit: boolean
   isLoading: boolean
   error: string
 }
@@ -58,6 +60,15 @@ export const useGetProjectsData = ({
     return map
   }, [projectFolders])
 
+  // every project is needed up front: sorting, grouping, filtering and search all run client-side
+  const hasReachedPageLimit = pages.length >= MAX_PROJECT_PAGES
+  const isDraining = !!hasNextPage && !hasReachedPageLimit
+
+  useEffect(() => {
+    if (!isDraining || isFetchingNextPage) return
+    fetchNextPage()
+  }, [isDraining, isFetchingNextPage, fetchNextPage])
+
   const projects = useMemo(() => pages.flatMap((page) => page.projects), [pages])
 
   const projectsMap = useMemo<ProjectMap>(() => {
@@ -73,9 +84,9 @@ export const useGetProjectsData = ({
     projectsMap,
     projectFolders,
     foldersMap,
-    fetchNextPage,
-    hasNextPage: hasNextPage ?? false,
+    hasNextPage: isDraining,
     isFetchingNextPage,
+    hasReachedPageLimit,
     isLoading,
     error: String(error),
   }


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Fixes projects missing from the projects browser: the page loaded only the last 2000 projects by name, then waited for a click to load more.

## Technical details
<!-- Please state any technical details such as limitations -->

- `GetProjects` pages forward (`first`/`after`) and follows `hasNextPage`/`endCursor`; `useGetProjectsData` drains every page.
- The "Congratulations you have more than N projects" dialog is gone, replaced by an `InfoMessage` warning at the 10-page cap.
- Page size stays at 2000 until ynput/ayon-backend#1109 — access filtering can shorten a page, which currently looks like the last page.
- Rider: `getSiteInfo` now provides the bare `attribute` tag, so `setAttributeList` invalidates it and filter dropdowns stop serving stale enum values.

## Additional context
<!-- Add any other context or screenshots here. -->

Ticket: YN-1062
Backend counterpart: ynput/ayon-backend#1109
