### PR TITLE
Allow remote addon pages to disable global AYON shortcuts

### DIFF
--- a/shared/src/context/AddonContext.tsx
+++ b/shared/src/context/AddonContext.tsx
@@ -10,6 +10,7 @@ export type RemoteAddon = {
   viewType?: string // if the addon is using views
   slicer?: { fields: string[] }
   projectList?: { multiSelect?: boolean; enabled: boolean }
+  disableGlobalShortcuts?: boolean
 }
 
 export interface RemoteAddonProps {

--- a/src/containers/AppRoutes.tsx
+++ b/src/containers/AppRoutes.tsx
@@ -1,4 +1,4 @@
-import { FC, lazy } from 'react'
+import { FC, lazy, PropsWithChildren, useEffect } from 'react'
 import { useParams, useNavigate, useLocation, useSearchParams } from 'react-router-dom'
 import { Navigate, Route, Routes } from 'react-router-dom'
 
@@ -21,8 +21,20 @@ import { useLoadRemotePages } from '../remote/useLoadRemotePages'
 import LoadingPage from '@pages/LoadingPage'
 import { RemoteAddon, useGlobalContext } from '@shared/context'
 import { toast } from 'react-toastify'
+import { useShortcutsContext } from '@context/ShortcutsContext'
 
 interface AppRoutesProps {}
+
+function RemotePageWrapper({ children, remote }: PropsWithChildren & { remote: RemoteAddon }) {
+  const { setAllDisabled } = useShortcutsContext()
+
+  useEffect(() => {
+    if (!remote.disableGlobalShortcuts) return
+    setAllDisabled(true)
+  }, [remote.disableGlobalShortcuts])
+
+  return <>{children}</>
+}
 
 const AppRoutes: FC<AppRoutesProps> = () => {
   const { user } = useGlobalContext()
@@ -43,12 +55,14 @@ const AppRoutes: FC<AppRoutesProps> = () => {
           key={remote.id}
           path={remote.path}
           element={
-            <remote.component
-              router={{
-                ...{ useParams, useNavigate, useLocation, useSearchParams },
-              }}
-              toast={toast}
-            />
+            <RemotePageWrapper remote={remote}>
+              <remote.component
+                router={{
+                  ...{ useParams, useNavigate, useLocation, useSearchParams },
+                }}
+                toast={toast}
+              />
+            </RemotePageWrapper>
           }
         />
       ))}

--- a/src/context/ShortcutsContext.jsx
+++ b/src/context/ShortcutsContext.jsx
@@ -34,6 +34,8 @@ function ShortcutsProvider(props) {
   // allow shortcuts
   const [allowed, setAllowed] = useState([])
 
+  const [allDisabled, setAllDisabled] = useState(false)
+
   // last key pressed should be reset after 200ms
   useEffect(() => {
     const timer = setTimeout(() => setLastPressed(null), 400)
@@ -166,12 +168,14 @@ function ShortcutsProvider(props) {
 
   // Add event listeners
   useEffect(() => {
+    if (allDisabled) return
+
     window.addEventListener('keydown', handleKeyPress)
     // Remove event listeners on cleanup
     return () => {
       window.removeEventListener('keydown', handleKeyPress)
     }
-  }, [handleKeyPress])
+  }, [handleKeyPress, allDisabled])
 
   // create function that can be used in components to add shortcuts, when the component mounts
   // and removes them when it unmounts
@@ -215,6 +219,7 @@ function ShortcutsProvider(props) {
         removeShortcuts,
         setDisabled,
         setAllowed,
+        setAllDisabled,
       }}
     >
       {props.children}


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Remote addon pages can now be configured to disable global AYON keyboard shortcuts (e.g. `b+b`). This can be useful if those shortcuts should be mapped to different things in the addon.

## Technical details
<!-- Please state any technical details such as limitations -->

Doing this via a `useEffect` is not 100% optimal but it allows us to keep the shortcuts support on all pages and addons which don't explicitly switch it off. The alternative would be to move the `ShortcutsContext` into each page + addon, but this would require a larger refactor because even some global components such as the project menu use this context.

## Additional context
<!-- Add any other context or screenshots here. -->

