### PR TITLE
Search filter: fix custom date range dialog

### DIFF
--- a/shared/src/components/SearchFilter/useDateRangeFilter.ts
+++ b/shared/src/components/SearchFilter/useDateRangeFilter.ts
@@ -123,12 +123,8 @@ export const useDateRangeFilter = (): UseDateRangeFilterReturn => {
     const chipEl = target.closest('.search-filter-item')
     if (!chipEl) return
 
-    const labelEl = chipEl.querySelector('.label')
-    const chipLabel = labelEl?.textContent?.replace(/:$/, '').trim()
-    if (!chipLabel) return
-
     const datetimeFilter = localFilters.find(
-      (f) => f.type === 'datetime' && f.label === chipLabel && f.values?.length,
+      (f) => f.id === chipEl.id && f.type === 'datetime' && f.values?.length,
     )
     if (!datetimeFilter) return
 

--- a/shared/src/components/SearchFilter/useDateRangeFilter.ts
+++ b/shared/src/components/SearchFilter/useDateRangeFilter.ts
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react'
+import { useState } from 'react'
 import { Filter, SearchFilterRef } from '@ynput/ayon-react-components'
 import { CUSTOM_RANGE_ID, CUSTOM_RANGE_ICON, detectRelativeDatePattern } from './filterDates'
 import { startOfDay, endOfDay, format, parse } from 'date-fns'
@@ -59,9 +59,6 @@ export const useDateRangeFilter = (): UseDateRangeFilterReturn => {
   const [customStartDate, setCustomStartDate] = useState('')
   const [customEndDate, setCustomEndDate] = useState('')
 
-  // Tracks the most recently activated datetime filter id
-  const activeDatetimeFilterRef = useRef<string | null>(null)
-
   const openCustomRangeForFilter = (filterId: string, localFilters: Filter[]) => {
     const filter = localFilters.find((f) => f.id === filterId)
     if (filter?.type === 'datetime' && filter.values?.length) {
@@ -90,11 +87,10 @@ export const useDateRangeFilter = (): UseDateRangeFilterReturn => {
     setCustomEndDate('')
   }
 
-  const findActiveDatetimeFilterId = (
+  const findFallbackDatetimeFilterId = (
     localFilters: Filter[],
     options: DateRangeOption[],
   ): string | null => {
-    if (activeDatetimeFilterRef.current) return activeDatetimeFilterRef.current
     const datetimeFilters = localFilters.filter((f) => f.type === 'datetime')
     const empty = datetimeFilters.find((f) => !f.values?.length)
     if (empty) return empty.id
@@ -104,15 +100,9 @@ export const useDateRangeFilter = (): UseDateRangeFilterReturn => {
 
   const wrapFilterChange = (
     newFilters: Filter[],
-    localFilters: Filter[],
+    _localFilters: Filter[],
     next: (cleaned: Filter[]) => void,
   ) => {
-    // Track newly added datetime filters
-    const newDatetime = newFilters.find(
-      (f) => f.type === 'datetime' && !localFilters.some((lf) => lf.id === f.id),
-    )
-    if (newDatetime) activeDatetimeFilterRef.current = newDatetime.id
-
     // Strip CUSTOM_RANGE_ID placeholder values that slip through, but keep empty
     // datetime filters so SearchFilter can maintain its intermediate state
     const cleaned = newFilters.map((f) => {
@@ -168,7 +158,9 @@ export const useDateRangeFilter = (): UseDateRangeFilterReturn => {
     const listItem = (event.target as HTMLElement).closest('li')
     if (!listItem) return true
     if (listItem.querySelector(`span[icon="${CUSTOM_RANGE_ICON}"]`)) {
-      const filterId = findActiveDatetimeFilterId(localFilters, options)
+      // data-parent is the id of the filter whose values panel is open (add or edit)
+      const filterId =
+        listItem.getAttribute('data-parent') || findFallbackDatetimeFilterId(localFilters, options)
       if (filterId) openCustomRangeForFilter(filterId, localFilters)
       return false
     }

--- a/src/pages/ProjectOverviewPage/containers/SearchFilterWrapper.tsx
+++ b/src/pages/ProjectOverviewPage/containers/SearchFilterWrapper.tsx
@@ -127,9 +127,6 @@ const SearchFilterWrapper: FC<SearchFilterWrapperProps> = ({
   // Custom date range
   const dateRange = useDateRangeFilter()
 
-  // Track which datetime filter the user is currently interacting with
-  const lastInteractedFilterRef = useRef<string | null>(null)
-
   // Active search-chip edit: set when user clicks a search chip to edit it.
   // The dropdown opens in edit mode; our Enter interceptor updates/removes the chip.
   const editingSearchChipRef = useRef<string | null>(null)
@@ -143,43 +140,10 @@ const SearchFilterWrapper: FC<SearchFilterWrapperProps> = ({
     setLocalFilters(filters)
   }, [JSON.stringify(filters)]) // Update filters when filters change
 
-  // Track the active datetime filter from onChange events
-  const handleFilterChange = (newFilters: Filter[]) => {
-    // Check if a relative date filter is being clicked to edit it
-    // If so, auto-open the edit dialog instead of allowing dropdown
-    const modifiedDatetimeFilter = newFilters.find(
-      (f) => f.type === 'datetime' && f.id !== lastInteractedFilterRef.current,
-    )
-    if (
-      modifiedDatetimeFilter &&
-      modifiedDatetimeFilter.values &&
-      modifiedDatetimeFilter.values.length > 0
-    ) {
-      const rangeValue = modifiedDatetimeFilter.values[0]
-      if (rangeValue.id && rangeValue.id.startsWith('custom-')) {
-        // This is a custom date range — check if it matches a relative pattern
-        const idParts = rangeValue.id.replace('custom-', '')
-        const firstEndIndex = idParts.indexOf('Z')
-        if (firstEndIndex > 0) {
-          const startISO = idParts.substring(0, firstEndIndex + 1)
-          const endISO = idParts.substring(firstEndIndex + 2)
-          const relativePattern = detectRelativeDatePattern(startISO, endISO)
-
-          if (relativePattern) {
-            // It's a relative date — auto-open edit dialog
-            handleOpenCustomRangeForFilter(modifiedDatetimeFilter.id)
-            lastInteractedFilterRef.current = modifiedDatetimeFilter.id
-            return
-          }
-        }
-      }
-    }
-    lastInteractedFilterRef.current = null
-
+  const handleFilterChange = (newFilters: Filter[]) =>
     dateRange.wrapFilterChange(newFilters, localFilters, (cleaned) =>
       validateFilters(cleaned, setLocalFilters),
     )
-  }
 
   const handleCustomRangeApply = () =>
     dateRange.handleCustomRangeApply(localFilters, options, handleFinish, searchFilterRef)

--- a/src/pages/ProjectOverviewPage/containers/SearchFilterWrapper.tsx
+++ b/src/pages/ProjectOverviewPage/containers/SearchFilterWrapper.tsx
@@ -372,15 +372,8 @@ const SearchFilterWrapper: FC<SearchFilterWrapperProps> = ({
       return
     }
 
-    // Find the label text from the chip (format: "Created At:")
-    const labelEl = chipEl.querySelector('.label')
-    if (!labelEl) return
-    const chipLabel = labelEl.textContent?.replace(/:$/, '').trim()
-    if (!chipLabel) return
-
-    // Match against datetime filters in localFilters
     const datetimeFilter = localFilters.find(
-      (f) => f.type === 'datetime' && f.label === chipLabel && f.values && f.values.length > 0,
+      (f) => f.id === chipId && f.type === 'datetime' && f.values && f.values.length > 0,
     )
 
     if (!datetimeFilter) return


### PR DESCRIPTION
<!-- PR TODO: -->
<!-- 1: Set assignee to you -->
<!-- 2: Set reviewer to: Luke Inderwick or Martin Wacker -->
<!-- 3: Set label -->
<!-- 4: Automations will set any required projects -->

## Description of changes 

Fixes the custom date range dialog popping up while you edit an unrelated filter, and makes it edit the date chip you actually clicked.

## Technical details
<!-- Please state any technical details such as limitations -->

- Dropped the auto-open block in `SearchFilterWrapper.handleFilterChange`; it ran on every `onChange`.
- `useDateRangeFilter` reads the clicked item's `data-parent` instead of a tracked filter id that goes stale after the query-filter round-trip.
- Both click-capture handlers match date chips by chip id, not label text, which carries a scope prefix on Overview, Lists and Products.

## Additional context
<!-- Add any other context or screenshots here. -->

Closes #2312
Ticket: YN-1076
